### PR TITLE
feat: Add reasoningContent to OpenAiChatModel chatResponse metadata

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -230,15 +230,14 @@ public final class OpenAiChatModel implements ChatModel {
 				}
 
 				List<Generation> generations = choices.stream().map(choice -> {
-					chatCompletion.id();
-					choice.finishReason();
 					Map<String, Object> metadata = Map.of("id", chatCompletion.id(), "role",
 							choice.message()._role().asString().isPresent() ? choice.message()._role().asStringOrThrow()
 									: "",
 							"index", choice.index(), "finishReason", choice.finishReason().value().toString(),
-							"refusal", choice.message().refusal().isPresent() ? choice.message().refusal() : "",
-							"annotations", choice.message().annotations().isPresent() ? choice.message().annotations()
-									: List.of(Map.of()));
+							"refusal", choice.message().refusal().isPresent() ? choice.message().refusal().get() : "",
+							"annotations", choice.message().annotations().isPresent()
+									? choice.message().annotations().get() : List.of(Map.of()),
+							"reasoningContent", getReasoningContent(choice));
 					return buildGeneration(choice, metadata, request);
 				}).toList();
 
@@ -336,10 +335,12 @@ public final class OpenAiChatModel implements ChatModel {
 
 							Map<String, Object> metadata = Map.of("id", id, "role", roleMap.getOrDefault(id, ""),
 									"index", choice.index(), "finishReason", choice.finishReason().value(), "refusal",
-									choice.message().refusal().isPresent() ? choice.message().refusal() : "",
-									"annotations", choice.message().annotations().isPresent()
-											? choice.message().annotations() : List.of(),
-									"chunkChoice", chunk.choices().get((int) choice.index()));
+									choice.message().refusal().isPresent() ? choice.message().refusal().get() : "",
+									"annotations",
+									choice.message().annotations().isPresent() ? choice.message().annotations().get()
+											: List.of(),
+									"chunkChoice", chunk.choices().get((int) choice.index()), "reasoningContent",
+									getReasoningContent(choice));
 
 							return buildGeneration(choice, metadata, request);
 						}).toList();
@@ -1139,6 +1140,22 @@ public final class OpenAiChatModel implements ChatModel {
 			return ChatCompletionTool
 				.ofFunction(ChatCompletionFunctionTool.builder().function(functionDefinition).build());
 		}).toList();
+	}
+
+	private String getReasoningContent(ChatCompletion.Choice choice) {
+		String reasoningContent = "";
+		Map<String, JsonValue> additionalProperties = choice._additionalProperties();
+		if (additionalProperties.get("reasoning_content") != null) {
+			reasoningContent = additionalProperties.get("reasoning_content").asString().isPresent()
+					? additionalProperties.get("reasoning_content").asString().get().toString() : "";
+		}
+		else {
+			if (additionalProperties.get("reasoning") != null) {
+				reasoningContent = additionalProperties.get("reasoning").asString().isPresent()
+						? additionalProperties.get("reasoning").asString().get().toString() : "";
+			}
+		}
+		return reasoningContent;
 	}
 
 	/**

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -226,4 +226,122 @@ class OpenAiChatModelTests {
 		assertThat((String) aggregatedMetadata.get("custom-key")).isEqualTo("custom-value");
 	}
 
+	@Test
+	void reasoningContentFromReasoningContentProperty() {
+		ChatService chatService = mock(ChatService.class);
+		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
+
+		when(this.openAiClient.chat()).thenReturn(chatService);
+		when(chatService.completions()).thenReturn(chatCompletionService);
+		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+			.id("gen-1888888888-XYZabc123NewId")
+			.created(1777799928)
+			.model("deepseek-reasoner")
+			.usage(CompletionUsage.builder().promptTokens(1).completionTokens(1).totalTokens(2).build())
+			.addChoice(ChatCompletion.Choice.builder()
+				.finishReason(ChatCompletion.Choice.FinishReason.STOP)
+				.index(0)
+				.logprobs(Optional.empty())
+				.message(ChatCompletionMessage.builder()
+					.content("hello")
+					.refusal(Optional.empty())
+					.role(JsonValue.from("assistant"))
+					.annotations(List.of())
+					.toolCalls(List.of())
+					.build())
+				.putAdditionalProperty("reasoning_content", JsonValue.from("Test reasoning content"))
+				.build())
+			.build());
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("deepseek-reasoner").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.call(new Prompt("hi", options));
+
+		assertThat(response.getResult().getOutput().getMetadata().get("reasoningContent"))
+			.isEqualTo("Test reasoning content");
+	}
+
+	@Test
+	void reasoningContentFromReasoningProperty() {
+		ChatService chatService = mock(ChatService.class);
+		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
+
+		when(this.openAiClient.chat()).thenReturn(chatService);
+		when(chatService.completions()).thenReturn(chatCompletionService);
+		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+			.id("gen-1888888888-XYZabc123NewId")
+			.created(1777799928)
+			.model("test-reasoner")
+			.usage(CompletionUsage.builder().promptTokens(1).completionTokens(1).totalTokens(2).build())
+			.addChoice(ChatCompletion.Choice.builder()
+				.finishReason(ChatCompletion.Choice.FinishReason.STOP)
+				.index(0)
+				.logprobs(Optional.empty())
+				.message(ChatCompletionMessage.builder()
+					.content("hello")
+					.refusal(Optional.empty())
+					.role(JsonValue.from("assistant"))
+					.annotations(List.of())
+					.toolCalls(List.of())
+					.build())
+				.putAdditionalProperty("reasoning", JsonValue.from("Test reasoning content"))
+				.build())
+			.build());
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-reasoner").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.call(new Prompt("hi", options));
+
+		assertThat(response.getResult().getOutput().getMetadata().get("reasoningContent"))
+			.isEqualTo("Test reasoning content");
+	}
+
+	@Test
+	void reasoningContentEmptyWhenNeitherPropertyPresent() {
+		ChatService chatService = mock(ChatService.class);
+		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
+
+		when(this.openAiClient.chat()).thenReturn(chatService);
+		when(chatService.completions()).thenReturn(chatCompletionService);
+		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+			.id("gen-1888888888-XYZabc123NewId")
+			.created(1777799928)
+			.model("test-model")
+			.usage(CompletionUsage.builder().promptTokens(1).completionTokens(1).totalTokens(2).build())
+			.addChoice(ChatCompletion.Choice.builder()
+				.finishReason(ChatCompletion.Choice.FinishReason.STOP)
+				.index(0)
+				.logprobs(Optional.empty())
+				.message(ChatCompletionMessage.builder()
+					.content("hello")
+					.refusal(Optional.empty())
+					.role(JsonValue.from("assistant"))
+					.annotations(List.of())
+					.toolCalls(List.of())
+					.build())
+				.build())
+			.build());
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.call(new Prompt("hi", options));
+
+		assertThat(response.getResult().getOutput().getMetadata().get("reasoningContent")).isEqualTo("");
+	}
+
 }


### PR DESCRIPTION
# Related Issues
* Closes: #6020 
# Changes
* Added reasoningContent to generation metadata, both for `call` and `stream` method.
* Compatible reasoning_content(such as openai) and reasoning(such as vllm) property for reasoningContent.
* Return the actual value instead of `Optional` wrapper for `refusal` and `annotations` property.