### PR TITLE
Add Ollama chat extra options

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.model.ollama.autoconfigure;
 
 import java.util.List;
+import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 
@@ -108,6 +109,8 @@ public class OllamaChatProperties {
 	private @Nullable List<String> stop;
 
 	private @Nullable Boolean internalToolExecutionEnabled;
+
+	private @Nullable Map<String, Object> extraOptions;
 
 	public String getModel() {
 		return this.model;
@@ -397,6 +400,14 @@ public class OllamaChatProperties {
 		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
 	}
 
+	public @Nullable Map<String, Object> getExtraOptions() {
+		return this.extraOptions;
+	}
+
+	public void setExtraOptions(@Nullable Map<String, Object> extraOptions) {
+		this.extraOptions = extraOptions;
+	}
+
 	public OllamaChatOptions toOptions() {
 		OllamaChatOptions.Builder builder = OllamaChatOptions.builder();
 		builder.model(this.model);
@@ -504,6 +515,9 @@ public class OllamaChatProperties {
 		}
 		if (this.internalToolExecutionEnabled != null) {
 			builder.internalToolExecutionEnabled(this.internalToolExecutionEnabled);
+		}
+		if (this.extraOptions != null) {
+			builder.extraOptions(this.extraOptions);
 		}
 		return builder.build();
 	}
@@ -880,6 +894,16 @@ public class OllamaChatProperties {
 
 		public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			OllamaChatProperties.this.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.ollama.chat.extra-options")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Map<String, Object> getExtraOptions() {
+			return OllamaChatProperties.this.getExtraOptions();
+		}
+
+		public void setExtraOptions(@Nullable Map<String, Object> extraOptions) {
+			OllamaChatProperties.this.setExtraOptions(extraOptions);
 		}
 
 	}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatAutoConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatAutoConfigurationTests.java
@@ -37,7 +37,9 @@ public class OllamaChatAutoConfigurationTests {
 				"spring.ai.ollama.chat.model=MODEL_XYZ",
 				"spring.ai.ollama.chat.temperature=0.55",
 				"spring.ai.ollama.chat.topP=0.56",
-				"spring.ai.ollama.chat.topK=123")
+				"spring.ai.ollama.chat.topK=123",
+				"spring.ai.ollama.chat.extra-options[custom_option]=value",
+				"spring.ai.ollama.chat.extra-options[num_ctx]=4096")
 			// @formatter:on
 
 			.withConfiguration(BaseOllamaIT.ollamaAutoConfig(OllamaChatAutoConfiguration.class))
@@ -53,6 +55,9 @@ public class OllamaChatAutoConfigurationTests {
 				assertThat(chatProperties.toOptions().getTopP()).isEqualTo(0.56);
 
 				assertThat(chatProperties.toOptions().getTopK()).isEqualTo(123);
+
+				assertThat(chatProperties.toOptions().getExtraOptions()).containsEntry("custom_option", "value")
+					.containsEntry("num_ctx", "4096");
 			});
 	}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
@@ -65,7 +65,7 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 			@Nullable Object format, @Nullable String keepAlive, @Nullable Boolean truncate,
 			@Nullable ThinkOption thinkOption, @Nullable Boolean internalToolExecutionEnabled,
 			@Nullable List<ToolCallback> toolCallbacks, @Nullable Set<String> toolNames,
-			@Nullable Map<String, Object> toolContext) {
+			@Nullable Map<String, Object> toolContext, @Nullable Map<String, Object> extraOptions) {
 		this.useNUMA = useNUMA;
 		this.numCtx = numCtx;
 		this.numBatch = numBatch;
@@ -105,6 +105,7 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 		this.toolCallbacks = toolCallbacks == null ? new ArrayList<>() : new ArrayList<>(toolCallbacks);
 		this.toolNames = toolNames == null ? new HashSet<>() : new HashSet<>(toolNames);
 		this.toolContext = toolContext == null ? new HashMap<>() : new HashMap<>(toolContext);
+		this.extraOptions = extraOptions == null ? null : new HashMap<>(extraOptions);
 	}
 
 	// Following fields are options which must be set when the model is loaded into
@@ -335,6 +336,11 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 	 * Defaults to true.
 	 */
 	private @Nullable Boolean truncate;
+
+	/**
+	 * Additional Ollama options sent under the request-level {@code options} object.
+	 */
+	private @Nullable Map<String, Object> extraOptions;
 
 	/**
 	 * The model should think before responding, if supported.
@@ -597,6 +603,11 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 	}
 
 
+	public @Nullable Map<String, Object> getExtraOptions() {
+		return this.extraOptions;
+	}
+
+
 	@Override
 	public List<ToolCallback> getToolCallbacks() {
 		return this.toolCallbacks;
@@ -671,6 +682,9 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 		map.put("format", this.format);
 		map.put("keep_alive", this.keepAlive);
 		map.put("truncate", this.truncate);
+		if (this.extraOptions != null) {
+			map.putAll(this.extraOptions);
+		}
 		return map.entrySet().stream().filter(kv -> kv.getValue() != null).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 		//return ModelOptionsUtils.objectToMap(this);
 	}
@@ -702,6 +716,7 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 			// Ollama Specific
 			.keepAlive(this.keepAlive)
 			.truncate(this.truncate)
+			.extraOptions(this.extraOptions != null ? new HashMap<>(this.extraOptions) : null)
 			.thinkOption(this.thinkOption)
 			.useNUMA(this.useNUMA)
 			.numCtx(this.numCtx)
@@ -758,6 +773,7 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 				&& Objects.equals(this.mirostat, that.mirostat) && Objects.equals(this.mirostatTau, that.mirostatTau)
 				&& Objects.equals(this.mirostatEta, that.mirostatEta)
 				&& Objects.equals(this.penalizeNewline, that.penalizeNewline) && Objects.equals(this.stop, that.stop)
+				&& Objects.equals(this.extraOptions, that.extraOptions)
 				&& Objects.equals(this.toolCallbacks, that.toolCallbacks)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
 				&& Objects.equals(this.toolNames, that.toolNames) && Objects.equals(this.toolContext, that.toolContext);
@@ -771,7 +787,7 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 				this.topK, this.topP, this.minP, this.tfsZ, this.typicalP, this.repeatLastN, this.temperature,
 				this.repeatPenalty, this.presencePenalty, this.frequencyPenalty, this.mirostat, this.mirostatTau,
 				this.mirostatEta, this.penalizeNewline, this.stop, this.toolCallbacks, this.toolNames,
-				this.internalToolExecutionEnabled, this.toolContext);
+				this.internalToolExecutionEnabled, this.toolContext, this.extraOptions);
 	}
 
 	// public Builder class exposed to users. Avoids having to deal with noisy generic
@@ -836,6 +852,8 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 		protected @Nullable Boolean truncate;
 
 		protected @Nullable ThinkOption thinkOption;
+
+		protected @Nullable Map<String, Object> extraOptions;
 
 		@Override
 		public B combineWith(ChatOptions.Builder<?> other) {
@@ -922,6 +940,12 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 				if (options.penalizeNewline != null) {
 					this.penalizeNewline = options.penalizeNewline;
 				}
+				if (options.extraOptions != null) {
+					if (this.extraOptions == null) {
+						this.extraOptions = new HashMap<>();
+					}
+					this.extraOptions.putAll(options.extraOptions);
+				}
 			}
 			return self();
 		}
@@ -960,6 +984,11 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 
 		public B truncate(@Nullable Boolean truncate) {
 			this.truncate = truncate;
+			return self();
+		}
+
+		public B extraOptions(@Nullable Map<String, Object> extraOptions) {
+			this.extraOptions = extraOptions;
 			return self();
 		}
 
@@ -1167,7 +1196,8 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 					this.typicalP, this.repeatLastN, this.temperature, this.repeatPenalty, this.presencePenalty,
 					this.frequencyPenalty, this.mirostat, this.mirostatTau, this.mirostatEta, this.penalizeNewline,
 					this.stopSequences, this.model, this.format, this.keepAlive, this.truncate, this.thinkOption,
-					this.internalToolExecutionEnabled, this.toolCallbacks, this.toolNames, this.toolContext);
+					this.internalToolExecutionEnabled, this.toolCallbacks, this.toolNames, this.toolContext,
+					this.extraOptions);
 		}
 
 	}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.ollama;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -65,6 +66,24 @@ class OllamaChatRequestTests {
 	}
 
 	@Test
+	void createRequestWithDefaultExtraOptions() {
+		OllamaChatModel chatModel = OllamaChatModel.builder()
+			.ollamaApi(OllamaApi.builder().build())
+			.defaultOptions(OllamaChatOptions.builder()
+				.model("MODEL_NAME")
+				.extraOptions(Map.of("custom_option", "value", "num_ctx", 4096))
+				.build())
+			.retryTemplate(RetryUtils.DEFAULT_RETRY_TEMPLATE)
+			.build();
+		var prompt = chatModel.buildRequestPrompt(new Prompt("Test message content"));
+
+		var request = chatModel.ollamaChatRequest(prompt, false);
+
+		assertThat(request.options()).containsEntry("custom_option", "value").containsEntry("num_ctx", 4096);
+		assertThat(request.options()).doesNotContainKey("extra_options");
+	}
+
+	@Test
 	void createRequestWithPromptOllamaOptions() {
 		// Runtime options should override the default options.
 		OllamaChatOptions promptOptions = OllamaChatOptions.builder()
@@ -85,6 +104,29 @@ class OllamaChatRequestTests {
 		assertThat(request.options()).containsEntry("top_k", 99);
 		assertThat(request.options()).containsEntry("num_gpu", 2);
 		assertThat(request.options()).containsEntry("top_p", 0.5);
+	}
+
+	@Test
+	void createRequestWithPromptExtraOptions() {
+		OllamaChatModel chatModel = OllamaChatModel.builder()
+			.ollamaApi(OllamaApi.builder().build())
+			.defaultOptions(OllamaChatOptions.builder()
+				.model("MODEL_NAME")
+				.extraOptions(Map.of("shared", "default", "default_only", true))
+				.build())
+			.retryTemplate(RetryUtils.DEFAULT_RETRY_TEMPLATE)
+			.build();
+		OllamaChatOptions promptOptions = OllamaChatOptions.builder()
+			.extraOptions(Map.of("shared", "runtime", "runtime_only", 42))
+			.build();
+		var prompt = chatModel.buildRequestPrompt(new Prompt("Test message content", promptOptions));
+
+		var request = chatModel.ollamaChatRequest(prompt, true);
+
+		assertThat(request.options()).containsEntry("shared", "runtime")
+			.containsEntry("default_only", true)
+			.containsEntry("runtime_only", 42);
+		assertThat(request.options()).doesNotContainKey("extra_options");
 	}
 
 	@Test

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaChatOptionsTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaChatOptionsTests.java
@@ -196,6 +196,7 @@ class OllamaChatOptionsTests extends AbstractChatOptionsTests<OllamaChatOptions,
 			.model("llama2")
 			.temperature(0.7)
 			.topK(40)
+			.extraOptions(Map.of("custom_option", "value"))
 			.toolNames(Set.of("function1"))
 			.build();
 
@@ -205,7 +206,61 @@ class OllamaChatOptionsTests extends AbstractChatOptionsTests<OllamaChatOptions,
 		assertThat(copiedOptions.getModel()).isEqualTo("llama2");
 		assertThat(copiedOptions.getTemperature()).isEqualTo(0.7);
 		assertThat(copiedOptions.getTopK()).isEqualTo(40);
+		assertThat(copiedOptions.getExtraOptions()).containsEntry("custom_option", "value");
 		assertThat(copiedOptions.getToolNames()).containsExactly("function1");
+	}
+
+	@Test
+	void testExtraOptions() {
+		var options = OllamaChatOptions.builder()
+			.model("llama2")
+			.extraOptions(Map.of("custom_option", "value", "num_ctx", 4096))
+			.build();
+
+		var optionsMap = options.toMap();
+
+		assertThat(options.getExtraOptions()).containsEntry("custom_option", "value").containsEntry("num_ctx", 4096);
+		assertThat(optionsMap).containsEntry("custom_option", "value").containsEntry("num_ctx", 4096);
+		assertThat(optionsMap).doesNotContainKey("extra_options");
+	}
+
+	@Test
+	void testNullAndEmptyExtraOptionsAreNotIncludedInMap() {
+		var nullOptions = OllamaChatOptions.builder().extraOptions(null).build();
+
+		assertThat(nullOptions.toMap()).doesNotContainKey("extra_options");
+
+		var emptyOptions = OllamaChatOptions.builder().extraOptions(Map.of()).build();
+
+		assertThat(emptyOptions.toMap()).doesNotContainKey("extra_options");
+	}
+
+	@Test
+	void testCopyPreservesExtraOptions() {
+		var options = OllamaChatOptions.builder().extraOptions(Map.of("custom_option", "value")).build();
+
+		var copiedOptions = options.copy();
+
+		assertThat(copiedOptions.getExtraOptions()).containsEntry("custom_option", "value");
+	}
+
+	@Test
+	void testCombineWithExtraOptions() {
+		var defaultOptions = OllamaChatOptions.builder()
+			.model("llama2")
+			.extraOptions(Map.of("shared", "default", "default_only", true))
+			.build();
+		var runtimeOptions = OllamaChatOptions.builder()
+			.temperature(0.7)
+			.extraOptions(Map.of("shared", "runtime", "runtime_only", 42));
+
+		var mergedOptions = defaultOptions.mutate().combineWith(runtimeOptions).build();
+
+		assertThat(mergedOptions.getExtraOptions()).containsEntry("shared", "runtime")
+			.containsEntry("default_only", true)
+			.containsEntry("runtime_only", 42);
+		assertThat(mergedOptions.getModel()).isEqualTo("llama2");
+		assertThat(mergedOptions.getTemperature()).isEqualTo(0.7);
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -149,10 +149,13 @@ The remaining `options` properties are based on the link:https://github.com/olla
 | spring.ai.ollama.chat.mirostat-eta      | Influences how quickly the algorithm responds to feedback from the generated text. A lower learning rate will result in slower adjustments, while a higher learning rate will make the algorithm more responsive. | 0.1
 | spring.ai.ollama.chat.penalize-newline  | -                                                             | true
 | spring.ai.ollama.chat.stop              | Sets the stop sequences to use. When this pattern is encountered the LLM will stop generating text and return. Multiple stop patterns may be set by specifying multiple separate stop parameters in a modelfile. | -
+| spring.ai.ollama.chat.extra-options     | Additional Ollama options to include in the request-level `options` object. Accepts any key-value pairs supported by the target Ollama model or server. | -
 | spring.ai.ollama.chat.tool-names         | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
 | spring.ai.ollama.chat.tool-callbacks     | Tool Callbacks to register with the ChatModel. | -
 | spring.ai.ollama.chat.internal-tool-execution-enabled | If false, the Spring AI will not handle the tool calls internally, but will proxy them to the client. Then it is the client's responsibility to handle the tool calls, dispatch them to the appropriate function, and return the results. If true (the default), the Spring AI will handle the function calls internally. Applicable only for chat models with function calling support | true
 |====
+
+The `extra-options` entries are serialized inside the Ollama request `options` object, not as top-level request fields.
 
 TIP: All properties prefixed with `spring.ai.ollama.chat` can be overridden at runtime by adding request-specific <<chat-options>> to the `Prompt` call.
 


### PR DESCRIPTION
## What changed

Adds `extraOptions` to `OllamaChatOptions` for Ollama/model-specific request options that are not yet represented as typed Spring AI options.

These entries are flattened into the existing Ollama request `options` object. They are not sent as a top-level `extra_options` field.

Closes gh-5928.

## Details

- Added `extraOptions` to `OllamaChatOptions`, builder, copy/mutate, equality/hashCode, and option merging.
- Added `spring.ai.ollama.chat.extra-options.*` configuration binding.
- Documented that these values serialize inside the Ollama request `options` object.
- Added tests for `toMap()`, request creation, default/prompt merging, copy/fromOptions, and property binding.

## Testing

- `mvn.cmd -s settings.xml -B -ntp -pl models/spring-ai-ollama -am -DskipITs -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OllamaChatOptionsTests,OllamaChatRequestTests test`
- `mvn.cmd -s settings.xml -B -ntp -pl auto-configurations/models/spring-ai-autoconfigure-model-ollama -am -DskipITs -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OllamaChatAutoConfigurationTests test`
- `mvn.cmd -s settings.xml -B -ntp -pl models/spring-ai-ollama,auto-configurations/models/spring-ai-autoconfigure-model-ollama -am -P checkstyle-check process-sources`
