### PR TITLE
fix: Avoid switchMap in OpenAiChatModel

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -834,7 +834,7 @@ public class BedrockProxyChatModel implements ChatModel {
 					converseStreamRequest, accumulatedUsage)
 				.stream();
 
-			Flux<ChatResponse> chatResponseFlux = chatResponses.switchMap(chatResponse -> {
+			Flux<ChatResponse> chatResponseFlux = chatResponses.concatMap(chatResponse -> {
 
 				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), chatResponse)
 						&& chatResponse.hasFinishReasons(Set.of(StopReason.TOOL_USE.toString()))) {

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -26,7 +26,6 @@ import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccess
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -252,8 +251,9 @@ public class DeepSeekChatModel implements ChatModel {
 
 			observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
 
+			// @formatter:off
 			Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
-				.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+				.map(chatCompletion2 -> {
 					try {
 						String id = chatCompletion2.id();
 
@@ -282,7 +282,7 @@ public class DeepSeekChatModel implements ChatModel {
 						return new ChatResponse(List.of());
 					}
 
-				}));
+				});
 
 			// @formatter:off
 			Flux<ChatResponse> flux = chatResponse.flatMap(response -> {

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelStreamingTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelStreamingTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.deepseek.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.deepseek.DeepSeekChatModel;
+import org.springframework.ai.deepseek.DeepSeekChatOptions;
+import org.springframework.ai.deepseek.api.DeepSeekApi;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionChunk;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionMessage;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionMessage.Role;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionRequest;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.retry.support.RetryTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class DeepSeekChatModelStreamingTests {
+
+	@Mock
+	private DeepSeekApi api;
+
+	private DeepSeekChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<ChatCompletionChunk> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			var choice = new ChunkChoice(null, 0, new ChatCompletionMessage(i + " ", Role.ASSISTANT), null);
+			ChatCompletionChunk chunk = new ChatCompletionChunk("id", List.of(choice), 666L, "model", null, null,
+					"chat.completion.chunk", null);
+			chunks.add(chunk);
+		}
+
+		given(this.api.chatCompletionStream(isA(ChatCompletionRequest.class)))
+			.willReturn(Flux.fromIterable(chunks).index().map(n -> {
+				if (n.getT1() == 256) {
+					latch.countDown();
+				}
+				return n.getT2();
+			}));
+
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		this.chatModel = DeepSeekChatModel.builder()
+				.deepSeekApi(this.api)
+				.defaultOptions(DeepSeekChatOptions.builder().build())
+				.toolCallingManager(toolCallingManager)
+				.retryTemplate(retryTemplate)
+				.observationRegistry(ObservationRegistry.NOOP)
+				.build();
+	}
+
+}

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -559,7 +559,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 				ResponseStream<GenerateContentResponse> responseStream = this.genAiClient.models
 					.generateContentStream(request.modelName, request.contents, request.config);
 
-				Flux<ChatResponse> chatResponseFlux = Flux.fromIterable(responseStream).switchMap(response -> {
+				Flux<ChatResponse> chatResponseFlux = Flux.fromIterable(responseStream).map(response -> {
 					List<Generation> generations = response.candidates()
 						.orElse(List.of())
 						.stream()
@@ -574,7 +574,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 					Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
 					ChatResponse chatResponse = new ChatResponse(generations,
 							toChatResponseMetadata(cumulativeUsage, response.modelVersion().get()));
-					return Flux.just(chatResponse);
+					return chatResponse;
 				});
 
 				// @formatter:off

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/chat/GoogleGenAiChatModelStreamingTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/chat/GoogleGenAiChatModelStreamingTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import com.google.genai.Client;
+import com.google.genai.Models;
+import com.google.genai.ResponseStream;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class GoogleGenAiChatModelStreamingTests {
+
+	@Mock
+	private Client client;
+
+	private GoogleGenAiChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+		Models models = Mockito.mock(Models.class);
+		ReflectionTestUtils.setField(this.client, "models", models);
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<GenerateContentResponse> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			Part part = Part.builder().text(i + " ").build();
+			Content content = Content.builder().parts(List.of(part)).build();
+			Candidate candidate = Candidate.builder().content(content).build();
+			GenerateContentResponse response = GenerateContentResponse.builder()
+				.candidates(List.of(candidate))
+				.modelVersion("v1")
+				.build();
+			chunks.add(response);
+		}
+
+		ResponseStream<GenerateContentResponse> iterable = Mockito.mock(ResponseStream.class);
+		given(iterable.iterator()).willReturn(chunks.stream().map(r -> {
+			int i = Integer
+				.parseInt(r.candidates().get().get(0).content().get().parts().get().get(0).text().get().trim());
+			if (i == 256) {
+				latch.countDown();
+			}
+			return r;
+		}).iterator());
+
+		given(models.generateContentStream(any(String.class), any(List.class), any())).willReturn(iterable);
+
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		this.chatModel = GoogleGenAiChatModel.builder()
+			.genAiClient(this.client)
+			.defaultOptions(GoogleGenAiChatOptions.builder().build())
+			.toolCallingManager(toolCallingManager)
+			.observationRegistry(ObservationRegistry.NOOP)
+			.build();
+	}
+
+}

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
@@ -27,7 +27,6 @@ import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccess
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -348,8 +347,9 @@ public class MiniMaxChatModel implements ChatModel {
 
 			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
 			// the function call handling logic.
+			// @formatter:off
 			Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
-				.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+				.map(chatCompletion2 -> {
 					try {
 						@SuppressWarnings("null")
 						String id = chatCompletion2.id();
@@ -371,7 +371,7 @@ public class MiniMaxChatModel implements ChatModel {
 							logger.error("Error processing chat completion", e);
 							return new ChatResponse(List.of());
 						}
-					}));
+					});
 
 			Flux<ChatResponse> flux = chatResponse.flatMap(response -> {
 						if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(requestPrompt.getOptions(), response)) {

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatModelStreamingTests.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatModelStreamingTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.minimax.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.minimax.MiniMaxChatModel;
+import org.springframework.ai.minimax.MiniMaxChatOptions;
+import org.springframework.ai.minimax.api.MiniMaxApi;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionChunk;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage.Role;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionRequest;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.retry.support.RetryTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class MiniMaxChatModelStreamingTests {
+
+	@Mock
+	private MiniMaxApi api;
+
+	private MiniMaxChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<ChatCompletionChunk> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			var choice = new ChunkChoice(null, 0, new ChatCompletionMessage(i + " ", Role.ASSISTANT), null);
+			ChatCompletionChunk chunk = new ChatCompletionChunk("id", List.of(choice), 666L, "model", null,
+					"chat.completion.chunk");
+			chunks.add(chunk);
+		}
+
+		given(this.api.chatCompletionStream(isA(ChatCompletionRequest.class)))
+			.willReturn(Flux.fromIterable(chunks).index().map(n -> {
+				if (n.getT1() == 256) {
+					latch.countDown();
+				}
+				return n.getT2();
+			}));
+
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		this.chatModel = new MiniMaxChatModel(this.api, MiniMaxChatOptions.builder().build(), toolCallingManager,
+				retryTemplate);
+	}
+
+}

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -29,7 +29,6 @@ import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccess
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -273,8 +272,9 @@ public class MistralAiChatModel implements ChatModel {
 
 			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
 			// the function call handling logic.
+			// @formatter:off
 			Flux<ChatResponse> chatResponse = completionChunks.map(this::toChatCompletion)
-				.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+				.map(chatCompletion2 -> {
 					try {
 						@SuppressWarnings("null")
 						String id = chatCompletion2.id();
@@ -306,7 +306,7 @@ public class MistralAiChatModel implements ChatModel {
 						logger.error("Error processing chat completion", e);
 						return new ChatResponse(List.of());
 					}
-				}));
+				});
 
 			// @formatter:off
 			Flux<ChatResponse> chatResponseFlux = chatResponse.flatMap(response -> {

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/chat/MistralAiChatModelStreamingTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/chat/MistralAiChatModelStreamingTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mistralai.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.mistralai.MistralAiChatModel;
+import org.springframework.ai.mistralai.MistralAiChatOptions;
+import org.springframework.ai.mistralai.api.MistralAiApi;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionChunk;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionMessage;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionMessage.Role;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.retry.support.RetryTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class MistralAiChatModelStreamingTests {
+
+	@Mock
+	private MistralAiApi api;
+
+	private MistralAiChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<ChatCompletionChunk> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			var choice = new ChunkChoice(0, new ChatCompletionMessage(i + " ", Role.ASSISTANT), null, null);
+			ChatCompletionChunk chunk = new ChatCompletionChunk("id", "chat.completion.chunk", 666L, "model",
+					List.of(choice), null);
+			chunks.add(chunk);
+		}
+
+		given(this.api.chatCompletionStream(isA(ChatCompletionRequest.class)))
+			.willReturn(Flux.fromIterable(chunks).index().map(n -> {
+				if (n.getT1() == 256) {
+					latch.countDown();
+				}
+				return n.getT2();
+			}));
+
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		this.chatModel = MistralAiChatModel.builder()
+			.mistralAiApi(this.api)
+			.defaultOptions(MistralAiChatOptions.builder().build())
+			.toolCallingManager(toolCallingManager)
+			.retryTemplate(retryTemplate)
+			.observationRegistry(ObservationRegistry.NOOP)
+			.build();
+	}
+
+}

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -304,12 +304,13 @@ public class OpenAiChatModel implements ChatModel {
 			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
 			// the function call handling logic.
 			Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
-				.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+//				.switchMap(chatCompletion2 -> Mono.just(chatCompletion2).map(chatCompletion -> {
+				.map(chatCompletion -> {
 					try {
 						// If an id is not provided, set to "NO_ID" (for compatible APIs).
-						String id = chatCompletion2.id() == null ? "NO_ID" : chatCompletion2.id();
+						String id = chatCompletion.id() == null ? "NO_ID" : chatCompletion.id();
 
-						List<Generation> generations = chatCompletion2.choices().stream().map(choice -> { // @formatter:off
+						List<Generation> generations = chatCompletion.choices().stream().map(choice -> { // @formatter:off
 							if (choice.message().role() != null) {
 								roleMap.putIfAbsent(id, choice.message().role().name());
 							}
@@ -324,11 +325,11 @@ public class OpenAiChatModel implements ChatModel {
 							return buildGeneration(choice, metadata, request);
 						}).toList();
 						// @formatter:on
-						OpenAiApi.Usage usage = chatCompletion2.usage();
+						OpenAiApi.Usage usage = chatCompletion.usage();
 						Usage currentChatResponseUsage = usage != null ? getDefaultUsage(usage) : new EmptyUsage();
 						Usage accumulatedUsage = UsageCalculator.getCumulativeUsage(currentChatResponseUsage,
 								previousChatResponse);
-						return new ChatResponse(generations, from(chatCompletion2, null, accumulatedUsage));
+						return new ChatResponse(generations, from(chatCompletion, null, accumulatedUsage));
 					}
 					catch (Exception e) {
 						logger.error("Error processing chat completion", e);
@@ -339,7 +340,8 @@ public class OpenAiChatModel implements ChatModel {
 					// final response. Hence, the following overlapping buffer is
 					// created to store both the current and the subsequent response
 					// to accumulate the usage from the subsequent response.
-				}))
+				})
+//				}))
 				.buffer(2, 1)
 				.map(bufferList -> {
 					ChatResponse firstResponse = bufferList.get(0);
@@ -363,7 +365,7 @@ public class OpenAiChatModel implements ChatModel {
 				});
 
 			// @formatter:off
-			Flux<ChatResponse> flux = chatResponse.flatMap(response -> {
+			Flux<ChatResponse> flux = chatResponse.concatMap(response -> {
 				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), response)) {
 					// FIXME: bounded elastic needs to be used since tool calling
 					//  is currently only synchronous

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -30,7 +30,6 @@ import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccess
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -303,8 +302,8 @@ public class OpenAiChatModel implements ChatModel {
 
 			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
 			// the function call handling logic.
+			// @formatter:off
 			Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
-//				.switchMap(chatCompletion2 -> Mono.just(chatCompletion2).map(chatCompletion -> {
 				.map(chatCompletion -> {
 					try {
 						// If an id is not provided, set to "NO_ID" (for compatible APIs).
@@ -341,7 +340,6 @@ public class OpenAiChatModel implements ChatModel {
 					// created to store both the current and the subsequent response
 					// to accumulate the usage from the subsequent response.
 				})
-//				}))
 				.buffer(2, 1)
 				.map(bufferList -> {
 					ChatResponse firstResponse = bufferList.get(0);
@@ -364,7 +362,6 @@ public class OpenAiChatModel implements ChatModel {
 					return firstResponse;
 				});
 
-			// @formatter:off
 			Flux<ChatResponse> flux = chatResponse.concatMap(response -> {
 				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), response)) {
 					// FIXME: bounded elastic needs to be used since tool calling

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -275,15 +275,10 @@ public class OpenAiApi {
 			// Merging the window chunks into a single chunk.
 			// Reduce the inner Flux<ChatCompletionChunk> window into a single
 			// Mono<ChatCompletionChunk>,
-			// Flux<Flux<ChatCompletionChunk>> -> Flux<Mono<ChatCompletionChunk>>
-			.concatMapIterable(window -> {
-				Mono<ChatCompletionChunk> monoChunk = window.reduce(
-						new ChatCompletionChunk(null, null, null, null, null, null, null, null),
-						(previous, current) -> this.chunkMerger.merge(previous, current));
-				return List.of(monoChunk);
-			})
-			// Flux<Mono<ChatCompletionChunk>> -> Flux<ChatCompletionChunk>
-			.flatMap(mono -> mono);
+			// Flux<Flux<ChatCompletionChunk>> -> Flux<ChatCompletionChunk>>
+			.concatMap(window -> window.reduce(
+					new ChatCompletionChunk(null, null, null, null, null, null, null, null),
+					(previous, current) -> this.chunkMerger.merge(previous, current)));
 	}
 
 	/**

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -35,7 +35,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import org.springframework.ai.model.ApiKey;
 import org.springframework.ai.model.ChatModelDescription;
@@ -276,9 +275,11 @@ public class OpenAiApi {
 			// Reduce the inner Flux<ChatCompletionChunk> window into a single
 			// Mono<ChatCompletionChunk>,
 			// Flux<Flux<ChatCompletionChunk>> -> Flux<ChatCompletionChunk>>
+			// @formatter:off
 			.concatMap(window -> window.reduce(
 					new ChatCompletionChunk(null, null, null, null, null, null, null, null),
 					(previous, current) -> this.chunkMerger.merge(previous, current)));
+			// @formatter:on
 	}
 
 	/**

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelStreamNumbersTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelStreamNumbersTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.chat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionChunk;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.Role;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.retry.support.RetryTemplate;
+import reactor.core.scheduler.Schedulers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class OpenAiChatModelStreamNumbersTests {
+
+	@Mock
+	private OpenAiApi openAiApi;
+
+	private OpenAiChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<ChatCompletionChunk> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			var choice = new ChunkChoice(null, 0, new ChatCompletionMessage(i + " ", Role.ASSISTANT), null);
+			ChatCompletionChunk chunk = new ChatCompletionChunk("id", List.of(choice), 666L, "model", null, null,
+					"chat.completion.chunk", null);
+			chunks.add(chunk);
+		}
+
+		given(this.openAiApi.chatCompletionStream(isA(ChatCompletionRequest.class), any()))
+			.willReturn(Flux.fromIterable(chunks).index().map(n -> {
+				if (n.getT1() == 256) {
+					latch.countDown();
+				}
+				return n.getT2();
+			}));
+
+		// Execute
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// Verify
+		List<ChatResponse> responses = result
+				.subscribeOn(Schedulers.boundedElastic())
+				.publishOn(Schedulers.boundedElastic(), 256)
+				.map(r -> {
+			try {
+				if (latch.await(5, TimeUnit.SECONDS)) {
+					return r;
+				} else {
+					throw new RuntimeException("Timed out waiting for completion response");
+				}
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException(e);
+			}
+		}).collectList().block();
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		this.chatModel = new OpenAiChatModel(this.openAiApi, OpenAiChatOptions.builder().build(), toolCallingManager,
+				retryTemplate, observationRegistry);
+	}
+
+}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelStreamingTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelStreamingTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.openai.chat;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -29,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -43,7 +43,6 @@ import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.Role;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.retry.support.RetryTemplate;
-import reactor.core.scheduler.Schedulers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,7 +50,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-public class OpenAiChatModelStreamNumbersTests {
+public class OpenAiChatModelStreamingTests {
 
 	@Mock
 	private OpenAiApi openAiApi;
@@ -81,25 +80,31 @@ public class OpenAiChatModelStreamNumbersTests {
 				return n.getT2();
 			}));
 
-		// Execute
 		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
 
-		// Verify
+		// @formatter:off
 		List<ChatResponse> responses = result
-				.subscribeOn(Schedulers.boundedElastic())
-				.publishOn(Schedulers.boundedElastic(), 256)
-				.map(r -> {
-			try {
-				if (latch.await(5, TimeUnit.SECONDS)) {
-					return r;
-				} else {
-					throw new RuntimeException("Timed out waiting for completion response");
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
 				}
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				throw new IllegalStateException(e);
-			}
-		}).collectList().block();
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
 		assertThat(responses).isNotNull();
 		assertThat(responses).isNotEmpty();
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -507,7 +507,7 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 				ResponseStream<GenerateContentResponse> responseStream = request.model
 					.generateContentStream(request.contents);
 
-				Flux<ChatResponse> chatResponseFlux = Flux.fromStream(responseStream.stream()).switchMap(response -> {
+				Flux<ChatResponse> chatResponseFlux = Flux.fromStream(responseStream.stream()).map(response -> {
 					List<Generation> generations = response.getCandidatesList()
 						.stream()
 						.map(this::responseCandidateToGeneration)
@@ -518,7 +518,7 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 					Usage currentUsage = getDefaultUsage(usage);
 					Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
 					ChatResponse chatResponse = new ChatResponse(generations, toChatResponseMetadata(cumulativeUsage));
-					return Flux.just(chatResponse);
+					return chatResponse;
 				});
 
 				// @formatter:off

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelStreamingTests.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelStreamingTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vertexai.gemini;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import com.google.cloud.vertexai.VertexAI;
+import com.google.cloud.vertexai.api.Candidate;
+import com.google.cloud.vertexai.api.Content;
+import com.google.cloud.vertexai.api.GenerateContentResponse;
+import com.google.cloud.vertexai.api.Part;
+import com.google.cloud.vertexai.generativeai.GenerativeModel;
+import com.google.cloud.vertexai.generativeai.ResponseStream;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class VertexAiGeminiChatModelStreamingTests {
+
+	@Mock
+	private VertexAI vertexAi;
+
+	private VertexAiGeminiChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() throws Exception {
+		// Setup
+		setupChatModel();
+		VertexAiGeminiChatModel spyChatModel = Mockito.spy(this.chatModel);
+
+		GenerativeModel generativeModel = Mockito.mock(GenerativeModel.class);
+		VertexAiGeminiChatModel.GeminiRequest geminiRequest = new VertexAiGeminiChatModel.GeminiRequest(List.of(),
+				generativeModel);
+		Mockito.doReturn(geminiRequest).when(spyChatModel).createGeminiRequest(any());
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<GenerateContentResponse> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			Part part = Part.newBuilder().setText(i + " ").build();
+			Content content = Content.newBuilder().addParts(part).build();
+			Candidate candidate = Candidate.newBuilder().setContent(content).build();
+			GenerateContentResponse response = GenerateContentResponse.newBuilder().addCandidates(candidate).build();
+			chunks.add(response);
+		}
+
+		ResponseStream<GenerateContentResponse> responseStream = Mockito.mock(ResponseStream.class);
+		given(responseStream.stream()).willReturn(chunks.stream().map(r -> {
+			int i = Integer.parseInt(r.getCandidates(0).getContent().getParts(0).getText().trim());
+			if (i == 256) {
+				latch.countDown();
+			}
+			return r;
+		}));
+
+		given(generativeModel.generateContentStream((List<Content>) any())).willReturn(responseStream);
+
+		Flux<ChatResponse> result = spyChatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		this.chatModel = VertexAiGeminiChatModel.builder()
+			.vertexAI(this.vertexAi)
+			.defaultOptions(VertexAiGeminiChatOptions.builder().build())
+			.toolCallingManager(toolCallingManager)
+			.observationRegistry(ObservationRegistry.NOOP)
+			.build();
+	}
+
+}

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -28,7 +28,6 @@ import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccess
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -337,8 +336,9 @@ public class ZhiPuAiChatModel implements ChatModel {
 
 			observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
 
+			// @formatter:off
 			Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
-				.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+				.map(chatCompletion2 -> {
 					try {
 						String id = chatCompletion2.id();
 
@@ -363,7 +363,7 @@ public class ZhiPuAiChatModel implements ChatModel {
 						return new ChatResponse(List.of());
 					}
 
-				}));
+				});
 
 			// @formatter:off
 			Flux<ChatResponse> flux = chatResponse.flatMap(response -> {

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/chat/ZhiPuAiChatModelStreamingTests.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/chat/ZhiPuAiChatModelStreamingTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.zhipuai.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.zhipuai.ZhiPuAiChatModel;
+import org.springframework.ai.zhipuai.ZhiPuAiChatOptions;
+import org.springframework.ai.zhipuai.api.ZhiPuAiApi;
+import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionChunk;
+import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionMessage;
+import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionMessage.Role;
+import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionRequest;
+import org.springframework.retry.support.RetryTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class ZhiPuAiChatModelStreamingTests {
+
+	@Mock
+	private ZhiPuAiApi api;
+
+	private ZhiPuAiChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<ChatCompletionChunk> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			var choice = new ChunkChoice(null, 0, new ChatCompletionMessage(i + " ", Role.ASSISTANT), null);
+			ChatCompletionChunk chunk = new ChatCompletionChunk("id", List.of(choice), 666L, "model", null, null,
+					"chat.completion.chunk", null);
+			chunks.add(chunk);
+		}
+
+		given(this.api.chatCompletionStream(isA(ChatCompletionRequest.class)))
+			.willReturn(Flux.fromIterable(chunks).index().map(n -> {
+				if (n.getT1() == 256) {
+					latch.countDown();
+				}
+				return n.getT2();
+			}));
+
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		this.chatModel = new ZhiPuAiChatModel(this.api, ZhiPuAiChatOptions.builder().build(), toolCallingManager,
+				retryTemplate, ObservationRegistry.NOOP);
+	}
+
+}


### PR DESCRIPTION
Reactive switchMap operator eagerly subscribes to the source requesting
unlimited data from the upstream. When the downstream is busy processing items
on another thread, the next incoming item will cause a previous one to be
discarded. That can force the streaming variant of ChatModel to silently drop
parts of the streamed response and is highly undesired.

Resolves https://github.com/spring-projects/spring-ai/issues/5120