### PR TITLE
Enforce single ToolAdvisor invariant in DefaultChatClient

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsWithLLMIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsWithLLMIT.java
@@ -150,8 +150,8 @@ public class StreamableMcpAnnotationsWithLLMIT {
 
 						assertThat(builder).isNotNull();
 
-						ChatClient chatClient = builder.defaultToolCallbacks(tcp)
-							.defaultToolContext(Map.of("progressToken", "test-progress-token"))
+						ChatClient chatClient = builder
+							.defaultTools(t -> t.callbacks(tcp).context(Map.of("progressToken", "test-progress-token")))
 							.build();
 
 						String cResponse = chatClient.prompt()

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
@@ -94,7 +94,8 @@ public class ChatClientAutoConfiguration {
 			ToolCallingManager toolCallingManager) {
 		return ToolCallAdvisor.builder()
 			.toolCallingManager(toolCallingManager)
-			.advisorOrder(properties.getToolCalling().getAdvisorOrder());
+			.advisorOrder(properties.getToolCalling().getAdvisorOrder())
+			.streamToolCallResponses(properties.getToolCalling().isStreamToolCallResponses());
 	}
 
 	@Bean

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientBuilderProperties.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientBuilderProperties.java
@@ -70,12 +70,28 @@ public class ChatClientBuilderProperties {
 		 */
 		private int advisorOrder = ToolCallAdvisor.DEFAULT_ORDER;
 
+		/**
+		 * Whether intermediate tool-call responses are streamed back to the caller during
+		 * a {@code stream()} invocation. When {@code true}, each tool-call iteration
+		 * emits its chunks in real time before the recursive call is made. When
+		 * {@code false} (default), only the final answer is streamed.
+		 */
+		private boolean streamToolCallResponses = false;
+
 		public int getAdvisorOrder() {
 			return this.advisorOrder;
 		}
 
 		public void setAdvisorOrder(int advisorOrder) {
 			this.advisorOrder = advisorOrder;
+		}
+
+		public boolean isStreamToolCallResponses() {
+			return this.streamToolCallResponses;
+		}
+
+		public void setStreamToolCallResponses(boolean streamToolCallResponses) {
+			this.streamToolCallResponses = streamToolCallResponses;
 		}
 
 	}

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfigurationTests.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfigurationTests.java
@@ -100,6 +100,19 @@ class ChatClientAutoConfigurationTests {
 	}
 
 	@Test
+	void streamToolCallResponsesPropertyIsAppliedToToolCallAdvisorBuilder() {
+		var manager = mock(ToolCallingManager.class);
+
+		this.contextRunner.withBean(ToolCallingManager.class, () -> manager)
+			.withPropertyValues("spring.ai.chat.client.tool-calling.stream-tool-call-responses=true")
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				var advisorBuilder = context.getBean(ToolCallAdvisor.Builder.class);
+				assertThat(ReflectionTestUtils.getField(advisorBuilder, "streamToolCallResponses")).isEqualTo(true);
+			});
+	}
+
+	@Test
 	void customToolCallAdvisorBuilderBeanSuppressesAutoConfiguration() {
 		var manager = mock(ToolCallingManager.class);
 		var customAdvisorBuilder = ToolCallAdvisor.builder().toolCallingManager(manager);

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackInPrompt2IT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackInPrompt2IT.java
@@ -59,11 +59,11 @@ public class FunctionCallbackInPrompt2IT {
 
 			String content = ChatClient.builder(chatModel).build().prompt()
 					.user("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities.")
-					.toolCallbacks(FunctionToolCallback
+					.tools(t -> t.callbacks(FunctionToolCallback
 						.builder("CurrentWeatherService", new MockWeatherService())
 						.description("Get the weather in location")
 						.inputType(MockWeatherService.Request.class)
-						.build())
+						.build()))
 					.call().content();
 			// @formatter:on
 
@@ -87,14 +87,14 @@ public class FunctionCallbackInPrompt2IT {
 			// @formatter:off
 			String content = ChatClient.builder(chatModel).build().prompt()
 					.user("Turn the light on in the kitchen and in the living room!")
-					.toolCallbacks(FunctionToolCallback
+					.tools(t -> t.callbacks(FunctionToolCallback
 						.builder("turnLight", (LightInfo lightInfo) -> {
 							logger.info("Turning light to [" + lightInfo.isOn + "] in " + lightInfo.roomName());
 							state.put(lightInfo.roomName(), lightInfo.isOn());
 						})
 						.description("Turn light on or off in a room")
 						.inputType(LightInfo.class)
-						.build())
+						.build()))
 					.call().content();
 			// @formatter:on
 			logger.info("Response: {}", content);
@@ -112,11 +112,11 @@ public class FunctionCallbackInPrompt2IT {
 			// @formatter:off
 			String content = ChatClient.builder(chatModel).build().prompt()
 					.user("What's the weather like in Amsterdam?")
-					.toolCallbacks(FunctionToolCallback
+					.tools(t -> t.callbacks(FunctionToolCallback
 						.builder("CurrentWeatherService", input -> "18 degrees Celsius")
 						.description("Get the weather in location")
 						.inputType(MockWeatherService.Request.class)
-					.build())
+						.build()))
 					.call().content();
 			// @formatter:on
 			logger.info("Response: {}", content);
@@ -135,11 +135,11 @@ public class FunctionCallbackInPrompt2IT {
 			// @formatter:off
 			String content = ChatClient.builder(chatModel).build().prompt()
 					.user("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities.")
-					.toolCallbacks(FunctionToolCallback
+					.tools(t -> t.callbacks(FunctionToolCallback
 						.builder("CurrentWeatherService", new MockWeatherService())
 						.description("Get the weather in location")
 						.inputType(MockWeatherService.Request.class)
-						.build())
+						.build()))
 					.stream().content()
 					.collectList().block().stream().collect(Collectors.joining());
 			// @formatter:on

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatClientIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatClientIT.java
@@ -37,7 +37,6 @@ import org.springframework.ai.anthropic.AnthropicTestConfiguration;
 import org.springframework.ai.chat.client.AdvisorParams;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.converter.BeanOutputConverter;
@@ -228,9 +227,9 @@ class AnthropicChatClientIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco (California, USA), Tokyo (Japan), and Paris (France)? Use Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -244,9 +243,9 @@ class AnthropicChatClientIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Use Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeatherInLocation", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeatherInLocation", new MockWeatherService())
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -259,10 +258,10 @@ class AnthropicChatClientIT {
 	void defaultFunctionCallTest() {
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultToolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Use Celsius."))
 				.build()
 			.prompt()
@@ -279,10 +278,10 @@ class AnthropicChatClientIT {
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Use Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.stream()
 				.content();
 		// @formatter:on
@@ -351,7 +350,6 @@ class AnthropicChatClientIT {
 			.options(ToolCallingChatOptions.builder().model(modelName))
 			.tools(new MyTools())
 			.user("Get current weather in Amsterdam and Paris")
-			.advisors(ToolCallAdvisor.builder().suppressToolCallStreaming().build())
 			.stream()
 			.chatResponse();
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockConverseChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockConverseChatClientIT.java
@@ -235,10 +235,10 @@ class BedrockConverseChatClientIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel)
 				.prompt("What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -254,10 +254,10 @@ class BedrockConverseChatClientIT {
 		// @formatter:off
 		ChatResponse response = ChatClient.create(this.chatModel)
 				.prompt("What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.call()
 				.chatResponse();
 		// @formatter:on
@@ -288,10 +288,10 @@ class BedrockConverseChatClientIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel)
 				.prompt("What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.advisors(new SimpleLoggerAdvisor())
 				.call()
 				.content();
@@ -307,10 +307,10 @@ class BedrockConverseChatClientIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-			.defaultToolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+			.defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description("Get the weather in location")
 				.inputType(MockWeatherService.Request.class)
-				.build())
+				.build()))
 			.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius."))
 			.build()
 			.prompt()
@@ -329,10 +329,10 @@ class BedrockConverseChatClientIT {
 		// @formatter:off
 		Flux<ChatResponse> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.stream()
 				.chatResponse();
 		// @formatter:on
@@ -370,10 +370,10 @@ class BedrockConverseChatClientIT {
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in Paris? Return the temperature in Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.stream()
 				.content();
 		// @formatter:on

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
@@ -148,7 +148,7 @@ public class BedrockNovaChatClientIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris?  Use Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", (WeatherRequest request) -> {
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", (WeatherRequest request) -> {
 						if (request.location().contains("Paris")) {
 							return new WeatherResponse(15, request.unit());
 						}
@@ -162,7 +162,7 @@ public class BedrockNovaChatClientIT {
 					})
 					.description("Get the weather for a city in Celsius")
 					.inputType(WeatherRequest.class)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -219,10 +219,10 @@ public class BedrockNovaChatClientIT {
 		ChatClient chatClient = ChatClient.builder(this.chatModel).build();
 
 		WeatherService.Response response = chatClient.prompt()
-			.toolCallbacks(FunctionToolCallback.builder("weather", new WeatherService())
+			.tools(t -> t.callbacks(FunctionToolCallback.builder("weather", new WeatherService())
 				.description("Get the current weather")
 				.inputType(Void.class)
-				.build())
+				.build()))
 			.user("Get current weather in Amsterdam")
 			.call()
 			.entity(WeatherService.Response.class);
@@ -237,10 +237,10 @@ public class BedrockNovaChatClientIT {
 		ChatClient chatClient = ChatClient.builder(this.chatModel).build();
 
 		Flux<ChatResponse> responses = chatClient.prompt()
-			.toolCallbacks(FunctionToolCallback.builder("weather", new WeatherService())
+			.tools(t -> t.callbacks(FunctionToolCallback.builder("weather", new WeatherService())
 				.description("Get the current weather")
 				.inputType(Void.class)
-				.build())
+				.build()))
 			.user("Get current weather in Amsterdam")
 			.stream()
 			.chatResponse();

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/client/GoogleGenAiToolCallAdvisorIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/client/GoogleGenAiToolCallAdvisorIT.java
@@ -54,7 +54,7 @@ class GoogleGenAiToolCallAdvisorIT extends AbstractToolCallAdvisorIT {
 
 		Flux<String> response = chatClient.prompt()
 			.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
-			.toolCallbacks(createWeatherToolCallback())
+			.tools(t -> t.callbacks(createWeatherToolCallback()))
 			.stream()
 			.content();
 

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
@@ -241,10 +241,10 @@ class MistralAiChatClientIT {
 		String response = ChatClient.create(this.chatModel).prompt()
 				.options(MistralAiChatOptions.builder().model(MistralAiApi.ChatModel.MISTRAL_SMALL).toolChoice(ToolChoice.AUTO))
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Use parallel function calling if required. Response should be in Celsius."))
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -262,10 +262,10 @@ class MistralAiChatClientIT {
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
 				.defaultOptions(MistralAiChatOptions.builder().model(MistralAiApi.ChatModel.MISTRAL_SMALL))
-				.defaultToolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Use parallel function calling if required. Response should be in Celsius."))
 			.build()
 			.prompt().call().content();
@@ -285,10 +285,10 @@ class MistralAiChatClientIT {
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.options(MistralAiChatOptions.builder().model(MistralAiApi.ChatModel.MISTRAL_SMALL))
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Use parallel function calling if required. Response should be in Celsius.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.stream()
 				.content();
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelFunctionCallingIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelFunctionCallingIT.java
@@ -67,8 +67,8 @@ class OpenAiChatModelFunctionCallingIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("Turn the light on in the living room")
-				.toolCallbacks(FunctionToolCallback.builder("turnsLightOnInTheLivingRoom", () -> state.put("Light", "ON"))
-						.build())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("turnsLightOnInTheLivingRoom", () -> state.put("Light", "ON"))
+						.build()))
 				.call()
 				.content();
 		// @formatter:on

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
@@ -275,10 +275,10 @@ class OpenAiChatClientIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?"))
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -293,10 +293,10 @@ class OpenAiChatClientIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultToolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?"))
 			.build()
 			.prompt().call().content();
@@ -313,10 +313,10 @@ class OpenAiChatClientIT {
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.stream()
 				.content();
 		// @formatter:on

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMethodInvokingFunctionCallbackIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMethodInvokingFunctionCallbackIT.java
@@ -66,12 +66,12 @@ class OpenAiChatClientMethodInvokingFunctionCallbackIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris?  Use Celsius.")
-				.toolCallbacks(MethodToolCallback.builder()
+				.tools(t -> t.callbacks(MethodToolCallback.builder()
 					.toolDefinition(ToolDefinitions.builder(toolMethod)
 						.description("Get the weather in location")
 						.build())
 					.toolMethod(toolMethod)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -91,13 +91,13 @@ class OpenAiChatClientMethodInvokingFunctionCallbackIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("Turn light on in the living room.")
-				.toolCallbacks(MethodToolCallback.builder()
+				.tools(t -> t.callbacks(MethodToolCallback.builder()
 					.toolDefinition(ToolDefinitions.builder(toolMethod)
 						.description("Can turn lights on or off by room name")
 						.build())
 					.toolMethod(toolMethod)
 					.toolObject(targetObject)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -119,13 +119,13 @@ class OpenAiChatClientMethodInvokingFunctionCallbackIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris?  Use Celsius.")
-				.toolCallbacks(MethodToolCallback.builder()
+				.tools(t -> t.callbacks(MethodToolCallback.builder()
 					.toolDefinition(ToolDefinitions.builder(toolMethod)
 						.description("Get the weather in location")
 						.build())
 					.toolMethod(toolMethod)
 					.toolObject(targetObject)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -146,14 +146,14 @@ class OpenAiChatClientMethodInvokingFunctionCallbackIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris?  Use Celsius.")
-				.toolCallbacks(MethodToolCallback.builder()
-					.toolDefinition(ToolDefinitions.builder(toolMethod)
-						.description("Get the weather in location")
-						.build())
-					.toolMethod(toolMethod)
-					.toolObject(targetObject)
-					.build())
-				.toolContext(Map.of("tool", "value"))
+				.tools(t -> t.callbacks(MethodToolCallback.builder()
+								.toolDefinition(ToolDefinitions.builder(toolMethod)
+									.description("Get the weather in location")
+									.build())
+								.toolMethod(toolMethod)
+								.toolObject(targetObject)
+								.build())
+							.context(Map.of("tool", "value")))
 				.call()
 				.content();
 		// @formatter:on
@@ -175,7 +175,7 @@ class OpenAiChatClientMethodInvokingFunctionCallbackIT {
 		// @formatter:off
 		assertThatThrownBy(() -> ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris?  Use Celsius.")
-				.toolCallbacks(MethodToolCallback.builder()
+				.tools(MethodToolCallback.builder()
 					.toolDefinition(ToolDefinitions.builder(toolMethod)
 						.description("Get the weather in location")
 						.build())
@@ -199,13 +199,13 @@ class OpenAiChatClientMethodInvokingFunctionCallbackIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("Turn light on in the living room.")
-				.toolCallbacks(MethodToolCallback.builder()
+				.tools(t -> t.callbacks(MethodToolCallback.builder()
 					.toolDefinition(ToolDefinitions.builder(toolMethod)
 						.description("Can turn lights on in the Living Room")
 						.build())
 					.toolMethod(toolMethod)
 					.toolObject(targetObject)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
@@ -84,10 +84,10 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 		// @formatter:off
 		response = chatClientBuilder.build().prompt()
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities."))
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.call()
 				.content();
 		// @formatter:on
@@ -114,10 +114,10 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultToolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities."))
 			.build()
 			.prompt().call().content();
@@ -156,12 +156,11 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultToolCallbacks(FunctionToolCallback.builder("getCurrentWeather", biFunction)
+				.defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", biFunction)
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()).context(Map.of("sessionId", "123")))
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities."))
-				.defaultToolContext(Map.of("sessionId", "123"))
 			.build()
 			.prompt().call().content();
 		// @formatter:on
@@ -199,14 +198,13 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultToolCallbacks(FunctionToolCallback.builder("getCurrentWeather", biFunction)
+				.defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", biFunction)
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()).context(Map.of("sessionId", "123")))
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities."))
 				.build()
 			.prompt()
-			.toolContext(Map.of("sessionId", "123"))
 			.call().content();
 		// @formatter:on
 
@@ -221,10 +219,10 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities.")
-				.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build())
+					.build()))
 				.stream()
 				.content();
 		// @formatter:on
@@ -250,10 +248,10 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 
 		String content = chatClient.prompt()
 			.user("What's the weather like in Shanghai?")
-			.toolCallbacks(FunctionToolCallback.builder("currentTemp", function)
+			.tools(t -> t.callbacks(FunctionToolCallback.builder("currentTemp", function)
 				.description("get current temp")
 				.inputType(MyFunction.Req.class)
-				.build())
+				.build()))
 			.call()
 			.content();
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -234,28 +234,28 @@ public interface ChatClient {
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
-		 * {@link #tools(Object...)} To be removed in 3.0.0.
+		 * {@link #tools(Consumer<ToolSpec>)} To be removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolCallbacks(ToolCallback... toolCallbacks);
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
-		 * {@link #tools(Object...)} To be removed in 3.0.0.
+		 * {@link #tools(Consumer<ToolSpec>)} To be removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolCallbacks(List<ToolCallback> toolCallbacks);
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
-		 * {@link #tools(Object...)} To be removed in 3.0.0.
+		 * {@link #tools(Consumer<ToolSpec>)} To be removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolCallbacks(ToolCallbackProvider... toolCallbackProviders);
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
-		 * {@link #tools(Object...)} To be removed in 3.0.0.
+		 * {@link #tools(Consumer<ToolSpec>)} To be removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolContext(Map<String, Object> toolContext);
@@ -348,28 +348,28 @@ public interface ChatClient {
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
-		 * {@link #defaultTools(Object...)} To be removed in 3.0.0.
+		 * {@link #defaultTools(Consumer<ToolSpec>)} To be removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolCallbacks(ToolCallback... toolCallbacks);
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
-		 * {@link #defaultTools(Object...)} To be removed in 3.0.0.
+		 * {@link #defaultTools(Consumer<ToolSpec>)} To be removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolCallbacks(List<ToolCallback> toolCallbacks);
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
-		 * {@link #defaultTools(Object...)} To be removed in 3.0.0.
+		 * {@link #defaultTools(Consumer<ToolSpec>)} To be removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolCallbacks(ToolCallbackProvider... toolCallbackProviders);
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
-		 * {@link #defaultTools(Object...)} To be removed in 3.0.0.
+		 * {@link #defaultTools(Consumer<ToolSpec>)} To be removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolContext(Map<String, Object> toolContext);

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -929,9 +929,9 @@ public class DefaultChatClient implements ChatClient {
 				.builder(this.chatModel, this.observationRegistry, this.chatClientObservationConvention,
 						this.advisorObservationConvention, this.toolCallAdvisorBuilder)
 				.defaultTemplateRenderer(this.templateRenderer)
-				.defaultToolCallbacks(this.toolCallbacks)
-				.defaultToolCallbacks(this.toolCallbackProviders.toArray(new ToolCallbackProvider[0]))
-				.defaultToolContext(this.toolContext)
+				.defaultTools(t -> t.callbacks(this.toolCallbacks)
+					.callbacks(this.toolCallbackProviders.toArray(new ToolCallbackProvider[0]))
+					.context(this.toolContext))
 				.defaultToolNames(StringUtils.toStringArray(this.toolNames));
 
 			if (!CollectionUtils.isEmpty(this.advisors)) {
@@ -1035,18 +1035,12 @@ public class DefaultChatClient implements ChatClient {
 
 		@Override
 		public ChatClientRequestSpec toolCallbacks(ToolCallback... toolCallbacks) {
-			Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
-			Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
-			this.toolCallbacks.addAll(List.of(toolCallbacks));
-			return this;
+			return tools(t -> t.callbacks(toolCallbacks));
 		}
 
 		@Override
 		public ChatClientRequestSpec toolCallbacks(List<ToolCallback> toolCallbacks) {
-			Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
-			Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
-			this.toolCallbacks.addAll(toolCallbacks);
-			return this;
+			return tools(t -> t.callbacks(toolCallbacks));
 		}
 
 		@Override
@@ -1059,19 +1053,12 @@ public class DefaultChatClient implements ChatClient {
 
 		@Override
 		public ChatClientRequestSpec toolCallbacks(ToolCallbackProvider... toolCallbackProviders) {
-			Assert.notNull(toolCallbackProviders, "toolCallbackProviders cannot be null");
-			Assert.noNullElements(toolCallbackProviders, "toolCallbackProviders cannot contain null elements");
-			this.toolCallbackProviders.addAll(List.of(toolCallbackProviders));
-			return this;
+			return tools(t -> t.callbacks(toolCallbackProviders));
 		}
 
 		@Override
 		public ChatClientRequestSpec toolContext(Map<String, Object> toolContext) {
-			Assert.notNull(toolContext, "toolContext cannot be null");
-			Assert.noNullElements(toolContext.keySet(), "toolContext keys cannot contain null elements");
-			Assert.noNullElements(toolContext.values(), "toolContext values cannot contain null elements");
-			this.toolContext.putAll(toolContext);
-			return this;
+			return tools(t -> t.context(toolContext));
 		}
 
 		@Override
@@ -1162,20 +1149,21 @@ public class DefaultChatClient implements ChatClient {
 
 		@Override
 		public CallResponseSpec call() {
-			BaseAdvisorChain advisorChain = buildAdvisorChain(false);
+			BaseAdvisorChain advisorChain = buildAdvisorChain();
 			return new DefaultCallResponseSpec(DefaultChatClientUtils.toChatClientRequest(this), advisorChain,
 					this.observationRegistry, this.chatClientObservationConvention);
 		}
 
 		@Override
 		public StreamResponseSpec stream() {
-			BaseAdvisorChain advisorChain = buildAdvisorChain(true);
+			BaseAdvisorChain advisorChain = buildAdvisorChain();
 			return new DefaultStreamResponseSpec(DefaultChatClientUtils.toChatClientRequest(this), advisorChain,
 					this.observationRegistry, this.chatClientObservationConvention);
 		}
 
-		private BaseAdvisorChain buildAdvisorChain(boolean streaming) {
-			autoRegisterToolCallAdvisor(streaming);
+		private BaseAdvisorChain buildAdvisorChain() {
+			autoRegisterToolCallAdvisor();
+			validateSingleToolAdvisor();
 			warnOnMemoryAdvisorOrderMismatch();
 
 			// At the stack bottom add the model call advisors.
@@ -1196,10 +1184,10 @@ public class DefaultChatClient implements ChatClient {
 		 * downstream in the request direction) is already registered, since that memory
 		 * advisor will handle history for every tool-call iteration.
 		 * <p>
-		 * {@code streamToolCallResponses} is set automatically: {@code true} for
-		 * {@link #stream()} calls, {@code false} for {@link #call()}.
+		 * {@code streamToolCallResponses} must be pre-configured on the
+		 * {@code toolCallAdvisorBuilder} passed to {@link DefaultChatClient}.
 		 */
-		private void autoRegisterToolCallAdvisor(boolean streaming) {
+		private void autoRegisterToolCallAdvisor() {
 
 			boolean autoRegisterDisabled = Boolean.FALSE
 				.equals(this.advisorParams.get(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey()));
@@ -1224,10 +1212,8 @@ public class DefaultChatClient implements ChatClient {
 			boolean hasDownstreamMemoryAdvisor = this.advisors.stream()
 				.anyMatch(a -> a instanceof MemoryAdvisor && a.getOrder() > configuredOrder);
 
-			this.advisors.add(this.toolCallAdvisorBuilder.copy()
-				.conversationHistoryEnabled(!hasDownstreamMemoryAdvisor)
-				.streamToolCallResponses(streaming)
-				.build());
+			this.advisors.add(
+					this.toolCallAdvisorBuilder.copy().conversationHistoryEnabled(!hasDownstreamMemoryAdvisor).build());
 		}
 
 		private static boolean hasToolsInChatOptions(@Nullable Object options) {
@@ -1240,6 +1226,16 @@ public class DefaultChatClient implements ChatClient {
 			}
 			return tco != null && ((tco.getToolCallbacks() != null && !tco.getToolCallbacks().isEmpty())
 					|| (tco.getToolNames() != null && !tco.getToolNames().isEmpty()));
+		}
+
+		private void validateSingleToolAdvisor() {
+			List<Advisor> toolAdvisors = this.advisors.stream().filter(a -> a instanceof ToolAdvisor).toList();
+			if (toolAdvisors.size() > 1) {
+				String names = String.join(", ",
+						toolAdvisors.stream().map(a -> a.getName() + " (order=" + a.getOrder() + ")").toList());
+				throw new IllegalStateException("At most one ToolAdvisor is allowed in the advisor chain, but found "
+						+ toolAdvisors.size() + ": [" + names + "]");
+			}
 		}
 
 		/**

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -193,7 +193,7 @@ public class DefaultChatClientBuilder implements Builder {
 	@Deprecated(since = "2.0.0", forRemoval = true)
 	@Override
 	public Builder defaultToolCallbacks(ToolCallback... toolCallbacks) {
-		this.defaultRequest.toolCallbacks(toolCallbacks);
+		this.defaultRequest.tools(t -> t.callbacks(toolCallbacks));
 		return this;
 	}
 
@@ -204,7 +204,7 @@ public class DefaultChatClientBuilder implements Builder {
 	@Deprecated(since = "2.0.0", forRemoval = true)
 	@Override
 	public Builder defaultToolCallbacks(List<ToolCallback> toolCallbacks) {
-		this.defaultRequest.toolCallbacks(toolCallbacks);
+		this.defaultRequest.tools(t -> t.callbacks(toolCallbacks));
 		return this;
 	}
 
@@ -215,7 +215,7 @@ public class DefaultChatClientBuilder implements Builder {
 	@Deprecated(since = "2.0.0", forRemoval = true)
 	@Override
 	public Builder defaultToolCallbacks(ToolCallbackProvider... toolCallbackProviders) {
-		this.defaultRequest.toolCallbacks(toolCallbackProviders);
+		this.defaultRequest.tools(t -> t.callbacks(toolCallbackProviders));
 		return this;
 	}
 
@@ -226,7 +226,7 @@ public class DefaultChatClientBuilder implements Builder {
 	@Deprecated(since = "2.0.0", forRemoval = true)
 	@Override
 	public Builder defaultToolContext(Map<String, Object> toolContext) {
-		this.defaultRequest.toolContext(toolContext);
+		this.defaultRequest.tools(t -> t.context(toolContext));
 		return this;
 	}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -491,18 +491,6 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 		 * Disables internal conversation history. You need a ChatMemory Advisor
 		 * registered next in the chain.
 		 * @return this Builder instance for method chaining
-		 * @deprecated since 2.0.0-M3 in favor of
-		 * {@link #disableInternalConversationHistory()}
-		 */
-		@Deprecated(since = "2.0.0-M3", forRemoval = true)
-		public T disableMemory() {
-			return disableInternalConversationHistory();
-		}
-
-		/**
-		 * Disables internal conversation history. You need a ChatMemory Advisor
-		 * registered next in the chain.
-		 * @return this Builder instance for method chaining
 		 */
 		public T disableInternalConversationHistory() {
 			this.conversationHistoryEnabled = false;
@@ -520,16 +508,6 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 		 */
 		public T streamToolCallResponses(boolean streamToolCallResponses) {
 			this.streamToolCallResponses = streamToolCallResponses;
-			return self();
-		}
-
-		/**
-		 * Disables streaming of intermediate tool call responses. Only the final answer
-		 * will be streamed to downstream consumers.
-		 * @return this Builder instance for method chaining
-		 */
-		public T suppressToolCallStreaming() {
-			this.streamToolCallResponses = false;
 			return self();
 		}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1772,7 +1772,7 @@ class DefaultChatClientTests {
 	void whenToolCallbacksElementIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(mock(ToolCallback.class), null))
+		assertThatThrownBy(() -> spec.tools(t -> t.callbacks(mock(ToolCallback.class), null)))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("toolCallbacks cannot contain null elements");
 	}
@@ -1782,7 +1782,7 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		ToolCallback toolCallback = mock(ToolCallback.class);
-		spec = spec.toolCallbacks(toolCallback);
+		spec = spec.tools(t -> t.callbacks(toolCallback));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolCallbacks()).contains(toolCallback);
 	}
@@ -1791,20 +1791,20 @@ class DefaultChatClientTests {
 	void whenFunctionNameIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(FunctionToolCallback.builder(null, input -> "hello")
+		assertThatThrownBy(() -> spec.tools(t -> t.callbacks(FunctionToolCallback.builder(null, input -> "hello")
 			.description("description")
 			.inputType(String.class)
-			.build())).isInstanceOf(IllegalArgumentException.class).hasMessage("name cannot be null or empty");
+			.build()))).isInstanceOf(IllegalArgumentException.class).hasMessage("name cannot be null or empty");
 	}
 
 	@Test
 	void whenFunctionNameIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(FunctionToolCallback.builder("", input -> "hello")
+		assertThatThrownBy(() -> spec.tools(t -> t.callbacks(FunctionToolCallback.builder("", input -> "hello")
 			.description("description")
 			.inputType(String.class)
-			.build())).isInstanceOf(IllegalArgumentException.class).hasMessage("name cannot be null or empty");
+			.build()))).isInstanceOf(IllegalArgumentException.class).hasMessage("name cannot be null or empty");
 	}
 
 	@Test
@@ -1812,10 +1812,10 @@ class DefaultChatClientTests {
 	void whenFunctionDescriptionIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(FunctionToolCallback.builder("name", input -> "hello")
+		assertThatThrownBy(() -> spec.tools(t -> t.callbacks(FunctionToolCallback.builder("name", input -> "hello")
 			.description(null)
 			.inputType(String.class)
-			.build())).isInstanceOf(IllegalArgumentException.class).hasMessage("Description must not be empty");
+			.build()))).isInstanceOf(IllegalArgumentException.class).hasMessage("Description must not be empty");
 	}
 
 	@Test
@@ -1823,20 +1823,20 @@ class DefaultChatClientTests {
 	void whenFunctionDescriptionIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(
-				FunctionToolCallback.builder("name", input -> "hello").description("").inputType(String.class).build()))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("Description must not be empty");
+		assertThatThrownBy(() -> spec.tools(t -> t.callbacks(FunctionToolCallback.builder("name", input -> "hello")
+			.description("")
+			.inputType(String.class)
+			.build()))).isInstanceOf(IllegalArgumentException.class).hasMessage("Description must not be empty");
 	}
 
 	@Test
 	void whenFunctionThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		spec = spec.toolCallbacks(FunctionToolCallback.builder("name", input -> "hello")
+		spec = spec.tools(t -> t.callbacks(FunctionToolCallback.builder("name", input -> "hello")
 			.inputType(String.class)
 			.description("description")
-			.build());
+			.build()));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolCallbacks())
 			.anyMatch(callback -> callback.getToolDefinition().name().equals("name"));
@@ -1846,10 +1846,10 @@ class DefaultChatClientTests {
 	void whenFunctionAndInputTypeThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		spec = spec.toolCallbacks(FunctionToolCallback.builder("name", input -> "hello")
+		spec = spec.tools(t -> t.callbacks(FunctionToolCallback.builder("name", input -> "hello")
 			.inputType(String.class)
 			.description("description")
-			.build());
+			.build()));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolCallbacks())
 			.anyMatch(callback -> callback.getToolDefinition().name().equals("name"));
@@ -1859,8 +1859,8 @@ class DefaultChatClientTests {
 	void whenBiFunctionNameIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(
-				FunctionToolCallback.builder(null, (input, ctx) -> "hello").description("description").build()))
+		assertThatThrownBy(() -> spec.tools(t -> t
+			.callbacks(FunctionToolCallback.builder(null, (input, ctx) -> "hello").description("description").build())))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("name cannot be null or empty");
 	}
@@ -1869,8 +1869,8 @@ class DefaultChatClientTests {
 	void whenBiFunctionNameIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(
-				FunctionToolCallback.builder("", (input, ctx) -> "hello").description("description").build()))
+		assertThatThrownBy(() -> spec.tools(t -> t
+			.callbacks(FunctionToolCallback.builder("", (input, ctx) -> "hello").description("description").build())))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("name cannot be null or empty");
 	}
@@ -1880,10 +1880,13 @@ class DefaultChatClientTests {
 	void whenBiFunctionDescriptionIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(FunctionToolCallback.builder("name", (input, ctx) -> "hello")
-			.inputType(String.class)
-			.description(null)
-			.build())).isInstanceOf(IllegalArgumentException.class).hasMessage("Description must not be empty");
+		assertThatThrownBy(
+				() -> spec.tools(t -> t.callbacks(FunctionToolCallback.builder("name", (input, ctx) -> "hello")
+					.inputType(String.class)
+					.description(null)
+					.build())))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Description must not be empty");
 	}
 
 	@Test
@@ -1891,8 +1894,8 @@ class DefaultChatClientTests {
 	void whenBiFunctionDescriptionIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec
-			.toolCallbacks(FunctionToolCallback.builder("name", (input, ctx) -> "hello").description("").build()))
+		assertThatThrownBy(() -> spec.tools(t -> t
+			.callbacks(FunctionToolCallback.builder("name", (input, ctx) -> "hello").description("").build())))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Description must not be empty");
 	}
@@ -1901,10 +1904,10 @@ class DefaultChatClientTests {
 	void whenBiFunctionThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		spec = spec.toolCallbacks(FunctionToolCallback.builder("name", (input, ctx) -> "hello")
+		spec = spec.tools(t -> t.callbacks(FunctionToolCallback.builder("name", (input, ctx) -> "hello")
 			.description("description")
 			.inputType(String.class)
-			.build());
+			.build()));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolCallbacks())
 			.anyMatch(callback -> callback.getToolDefinition().name().equals("name"));
@@ -1932,7 +1935,7 @@ class DefaultChatClientTests {
 	void whenFunctionToolCallbacksElementIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(mock(FunctionToolCallback.class), null))
+		assertThatThrownBy(() -> spec.tools(t -> t.callbacks(mock(FunctionToolCallback.class), null)))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("toolCallbacks cannot contain null elements");
 	}
@@ -1942,7 +1945,7 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		FunctionToolCallback functionToolCallback = mock(FunctionToolCallback.class);
-		spec = spec.toolCallbacks(functionToolCallback);
+		spec = spec.tools(t -> t.callbacks(functionToolCallback));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolCallbacks()).contains(functionToolCallback);
 	}
@@ -1951,8 +1954,8 @@ class DefaultChatClientTests {
 	void whenToolContextIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolContext(null)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("toolContext cannot be null");
+		assertThatThrownBy(() -> spec.tools(t -> t.context(null))).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context cannot be null");
 	}
 
 	@Test
@@ -1961,8 +1964,8 @@ class DefaultChatClientTests {
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		Map<String, Object> toolContext = new HashMap<>();
 		toolContext.put(null, "value");
-		assertThatThrownBy(() -> spec.toolContext(toolContext)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("toolContext keys cannot contain null elements");
+		assertThatThrownBy(() -> spec.tools(t -> t.context(toolContext))).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context keys cannot contain null elements");
 	}
 
 	@Test
@@ -1971,8 +1974,8 @@ class DefaultChatClientTests {
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		Map<String, Object> toolContext = new HashMap<>();
 		toolContext.put("key", null);
-		assertThatThrownBy(() -> spec.toolContext(toolContext)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("toolContext values cannot contain null elements");
+		assertThatThrownBy(() -> spec.tools(t -> t.context(toolContext))).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values cannot contain null elements");
 	}
 
 	@Test
@@ -1980,7 +1983,7 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		Map<String, Object> toolContext = Map.of("key", "value");
-		spec = spec.toolContext(toolContext);
+		spec = spec.tools(t -> t.context(toolContext));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolContext()).containsEntry("key", "value");
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
@@ -240,7 +240,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.toolCallbacks(toolCallback);
+			.tools(t -> t.callbacks(toolCallback));
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -261,7 +261,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.toolContext(toolContext);
+			.tools(t -> t.context(toolContext));
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -305,7 +305,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.toolCallbacks(toolCallback2);
+			.tools(t -> t.callbacks(toolCallback2));
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -326,7 +326,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(ToolCallingChatOptions.builder().toolContext(toolContext1))
-			.toolContext(toolContext2);
+			.tools(t -> t.context(toolContext2));
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -369,7 +369,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.toolCallbacks(toolCallback1);
+			.tools(t -> t.callbacks(toolCallback1));
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -390,7 +390,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.toolContext(toolContext1);
+			.tools(t -> t.context(toolContext1));
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 		assertThat(result.prompt().getOptions()).isInstanceOf(ToolCallingChatOptions.class);
@@ -466,8 +466,7 @@ class DefaultChatClientUtilsTests {
 			.user(u -> u.text(userText).params(userParams).media(media))
 			.messages(messages)
 			.toolNames(toolNames.toArray(new String[0]))
-			.toolCallbacks(toolCallback)
-			.toolContext(toolContext)
+			.tools(t -> t.callbacks(toolCallback).context(toolContext))
 			.options(chatOptions)
 			.advisors(a -> a.params(advisorParams));
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ToolCallAdvisorAutoRegistrationTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ToolCallAdvisorAutoRegistrationTests.java
@@ -50,6 +50,7 @@ import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -147,7 +148,7 @@ class ToolCallAdvisorAutoRegistrationTests {
 				.prompt()
 				.advisors(counter)
 				.user("weather?")
-				.toolCallbacks(weatherTool)
+				.tools(t -> t.callbacks(weatherTool))
 				.call()
 				.content();
 
@@ -172,7 +173,7 @@ class ToolCallAdvisorAutoRegistrationTests {
 				.advisors(counter)
 				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
 				.user("weather?")
-				.toolCallbacks(weatherTool)
+				.tools(t -> t.callbacks(weatherTool))
 				.call()
 				.content();
 
@@ -242,7 +243,7 @@ class ToolCallAdvisorAutoRegistrationTests {
 				.prompt()
 				.advisors(ToolCallAdvisor.builder().build(), counter)
 				.user("weather?")
-				.toolCallbacks(weatherTool)
+				.tools(t -> t.callbacks(weatherTool))
 				.call()
 				.content();
 
@@ -267,13 +268,24 @@ class ToolCallAdvisorAutoRegistrationTests {
 				.build()
 				.prompt()
 				.user("weather?")
-				.toolCallbacks(weatherTool)
+				.tools(t -> t.callbacks(weatherTool))
 				.call()
 				.content();
 
 			// The injected manager — not the default — handled the tool call
 			verify(customManager).executeToolCalls(any(), any());
 			verify(chatModel, times(2)).call(any(Prompt.class));
+		}
+
+		@Test
+		void throwsWhenMultipleToolAdvisorsRegistered() {
+			assertThatThrownBy(() -> ChatClient.create(chatModel)
+				.prompt()
+				.advisors(ToolCallAdvisor.builder().build(), ToolCallAdvisor.builder().build())
+				.user("weather?")
+				.tools(t -> t.callbacks(weatherTool))
+				.call()
+				.content()).isInstanceOf(IllegalStateException.class).hasMessageContaining("At most one ToolAdvisor");
 		}
 
 		@Test
@@ -286,7 +298,7 @@ class ToolCallAdvisorAutoRegistrationTests {
 				.prompt()
 				.advisors(new NoOpToolCallHandlingAdvisor(), counter)
 				.user("weather?")
-				.toolCallbacks(weatherTool)
+				.tools(t -> t.callbacks(weatherTool))
 				.call()
 				.content();
 
@@ -312,7 +324,7 @@ class ToolCallAdvisorAutoRegistrationTests {
 				.prompt()
 				.advisors(counter)
 				.user("weather?")
-				.toolCallbacks(weatherTool)
+				.tools(t -> t.callbacks(weatherTool))
 				.stream()
 				.content()
 				.collectList()
@@ -334,7 +346,7 @@ class ToolCallAdvisorAutoRegistrationTests {
 				.advisors(counter)
 				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
 				.user("weather?")
-				.toolCallbacks(weatherTool)
+				.tools(t -> t.callbacks(weatherTool))
 				.stream()
 				.content()
 				.collectList()

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
@@ -614,13 +614,6 @@ public class ToolCallAdvisorTests {
 	}
 
 	@Test
-	void testSuppressToolCallStreamingBuilderMethod() {
-		ToolCallAdvisor.Builder<?> builder = ToolCallAdvisor.builder().suppressToolCallStreaming();
-
-		assertThat(builder.isStreamToolCallResponses()).isFalse();
-	}
-
-	@Test
 	void testAdviseStreamWithToolCallResponsesEnabled() {
 		// Create advisor with tool call streaming explicitly enabled
 		ToolCallAdvisor advisor = ToolCallAdvisor.builder()

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -86,6 +86,28 @@ var chatClient = ChatClient.builder(chatModel)
     .build();
 ----
 
+==== Streaming Intermediate Tool-Call Responses
+
+By default, only the final LLM answer is emitted when using `.stream()` — chunks from intermediate tool-call iterations are suppressed until the last iteration finishes.
+Set `streamToolCallResponses(true)` on the builder to stream each iteration's chunks in real time as they arrive:
+
+[source,java]
+----
+var toolCallAdvisor = ToolCallAdvisor.builder()
+    .toolCallingManager(toolCallingManager)
+    .streamToolCallResponses(true)
+    .build();
+----
+
+When using Spring Boot auto-configuration, set the equivalent property instead:
+
+[source,properties]
+----
+spring.ai.chat.client.tool-calling.stream-tool-call-responses=true
+----
+
+NOTE: Enabling this option increases the number of chunks the client receives but may interleave tool-call fragments with the final answer depending on how the client processes the stream.
+
 ==== Return Direct Functionality
 
 The "return direct" feature allows tools to bypass the LLM and return their results directly to the client application. This is useful when:

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -826,6 +826,16 @@ spring.ai.chat.client.tool-calling.advisor-order=0
 The value must be lower than the order of any advisor that should run _inside_ the tool-call loop (i.e., repeated on every iteration), and higher than any advisor that should run _outside_ it (i.e., executed only once per user request).
 The default is `ToolCallAdvisor.DEFAULT_ORDER`.
 
+===== Spring Boot: streaming intermediate tool-call responses
+
+By default, only the final answer is emitted during a `.stream()` call — intermediate tool-call chunks are suppressed until the last LLM iteration completes.
+Set `spring.ai.chat.client.tool-calling.stream-tool-call-responses=true` to stream each iteration's chunks in real time as they arrive:
+
+[source,properties]
+----
+spring.ai.chat.client.tool-calling.stream-tool-call-responses=true
+----
+
 ===== Spring Boot: custom `ToolCallAdvisor.Builder` bean
 
 For deeper customisation — for example to supply a custom `ToolCallingManager` — declare a `ToolCallAdvisor.Builder<?>` bean.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1152,6 +1152,7 @@ The `ToolCallAdvisor.Builder` supports the following configuration options:
 - `toolCallingManager`: The `ToolCallingManager` instance to use for executing tool calls. If not provided, a default instance is used.
 - `advisorOrder`: The order in which the advisor is applied in the chain. Must be between `BaseAdvisor.HIGHEST_PRECEDENCE` and `BaseAdvisor.LOWEST_PRECEDENCE`.
 - `conversationHistoryEnabled`: Controls whether the advisor maintains conversation history internally during tool call iterations. Default is `true`.
+- `streamToolCallResponses`: When `true`, each tool-call iteration streams its chunks in real time during a `.stream()` call. When `false` (default), only the final answer is streamed.
 
 ==== Conversation History Management
 

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/tool/FunctionToolCallbackTests.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/tool/FunctionToolCallbackTests.java
@@ -85,11 +85,11 @@ public class FunctionToolCallbackTests {
 			.build()
 			.prompt()
 			.user("Welcome the users to the library")
-			.toolCallbacks(FunctionToolCallback.builder("sayWelcome",
+			.tools(t -> t.callbacks(FunctionToolCallback.builder("sayWelcome",
 							(Consumer<Object>) input -> logger.info("CALLBACK - Welcoming users to the library"))
 					.description("Welcome users to the library")
 					.inputType(Void.class)
-					.build())
+					.build()))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty();
@@ -115,11 +115,11 @@ public class FunctionToolCallbackTests {
 			.build()
 			.prompt()
 			.user("Welcome %s to the library".formatted("James Bond"))
-			.toolCallbacks(FunctionToolCallback.builder("welcomeUser",
+			.tools(t -> t.callbacks(FunctionToolCallback.builder("welcomeUser",
 							(Consumer<Object>) user -> logger.info("CALLBACK - Welcoming {} to the library", ((User) user).name()))
 					.description("Welcome a specific user to the library")
 					.inputType(User.class)
-					.build())
+					.build()))
 			.call()
 			.content();
 		assertThat(content).contains("Bond");
@@ -152,10 +152,10 @@ public class FunctionToolCallbackTests {
 			.build()
 			.prompt()
 			.user("What books written by %s are available in the library?".formatted("J.R.R. Tolkien"))
-			.toolCallbacks(FunctionToolCallback.builder("availableBooksByAuthor", function)
+			.tools(t -> t.callbacks(FunctionToolCallback.builder("availableBooksByAuthor", function)
 				.description("Get the list of books written by the given author available in the library")
 				.inputType(Author.class)
-				.build())
+				.build()))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty()
@@ -188,10 +188,10 @@ public class FunctionToolCallbackTests {
 			.build()
 			.prompt()
 			.user("What authors wrote the books %s and %s available in the library?".formatted("The Hobbit", "The Lion, the Witch and the Wardrobe"))
-			.toolCallbacks(FunctionToolCallback.builder("authorsByAvailableBooks", function)
+			.tools(t -> t.callbacks(FunctionToolCallback.builder("authorsByAvailableBooks", function)
 				.description("Get the list of authors who wrote the given books available in the library")
 				.inputType(Books.class)
-				.build())
+				.build()))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty().contains("J.R.R. Tolkien").contains("C.S. Lewis");

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/tool/MethodToolCallbackTests.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/tool/MethodToolCallbackTests.java
@@ -112,7 +112,7 @@ public class MethodToolCallbackTests {
 			.prompt()
 			.user("What authors wrote the books %s and %s available in the library?".formatted("The Hobbit",
 					"The Lion, the Witch and the Wardrobe"))
-			.toolCallbacks(ToolCallbacks.from(this.tools))
+			.tools(t -> t.callbacks(ToolCallbacks.from(this.tools)))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty().contains("J.R.R. Tolkien").contains("C.S. Lewis");

--- a/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorAutoRegistrationIT.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorAutoRegistrationIT.java
@@ -101,7 +101,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 			String response = ChatClient.create(getChatModel())
 				.prompt()
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -117,7 +117,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 					.build())
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "auto-register-with-memory"))
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -133,7 +133,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 				.prompt()
 				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -147,7 +147,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 
 			String response = chatClient.prompt()
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -164,7 +164,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 			String response = chatClient.prompt()
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "default-advisors-memory"))
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -177,7 +177,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 			String response = ChatClient.create(getChatModel())
 				.prompt()
 				.user("What's the weather in Tokyo?")
-				.toolCallbacks(createReturnDirectWeatherToolCallback())
+				.tools(t -> t.callbacks(createReturnDirectWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -202,7 +202,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 				.prompt()
 				.advisors(counter)
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -221,7 +221,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 				.advisors(counter)
 				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -238,7 +238,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 				.prompt()
 				.advisors(counter)
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -273,7 +273,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 			String content = collect(ChatClient.create(getChatModel())
 				.prompt()
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.stream()
 				.content());
 
@@ -289,7 +289,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 					.build())
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "stream-auto-register-with-memory"))
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.stream()
 				.content());
 
@@ -303,7 +303,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 				.prompt()
 				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.stream()
 				.content());
 
@@ -316,7 +316,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 			String content = collect(ChatClient.create(getChatModel())
 				.prompt()
 				.user("What's the weather in Tokyo?")
-				.toolCallbacks(createReturnDirectWeatherToolCallback())
+				.tools(t -> t.callbacks(createReturnDirectWeatherToolCallback()))
 				.stream()
 				.content());
 
@@ -341,7 +341,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 				.prompt()
 				.advisors(counter)
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.stream()
 				.content());
 
@@ -359,7 +359,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 				.advisors(counter)
 				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.stream()
 				.content());
 
@@ -386,7 +386,7 @@ public abstract class AbstractToolCallAdvisorAutoRegistrationIT {
 				.advisors(counter)
 				.advisors(AdvisorParams.toolCallAdvisorAutoRegister(false))
 				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 

--- a/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorIT.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorIT.java
@@ -91,7 +91,7 @@ public abstract class AbstractToolCallAdvisorIT {
 				.prompt()
 				.advisors(ToolCallAdvisor.builder().build())
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?"))
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -109,7 +109,7 @@ public abstract class AbstractToolCallAdvisorIT {
 						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
 							.build())
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?"))
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "call-default-advisor-with-memory"))
 				.call()
 				.content();
@@ -128,7 +128,7 @@ public abstract class AbstractToolCallAdvisorIT {
 
 			String response = chatClient.prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -147,7 +147,7 @@ public abstract class AbstractToolCallAdvisorIT {
 
 			String response = chatClient.prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "call-default-advisor-with-memory"))
 				.call()
 				.content();
@@ -163,7 +163,7 @@ public abstract class AbstractToolCallAdvisorIT {
 				.prompt()
 				.advisors(ToolCallAdvisor.builder().build())
 				.user("What's the weather like in Tokyo?")
-				.toolCallbacks(createReturnDirectWeatherToolCallback())
+				.tools(t -> t.callbacks(createReturnDirectWeatherToolCallback()))
 				.call()
 				.content();
 
@@ -186,7 +186,7 @@ public abstract class AbstractToolCallAdvisorIT {
 				.prompt()
 				.advisors(ToolCallAdvisor.builder().build())
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.stream()
 				.content();
 
@@ -206,7 +206,7 @@ public abstract class AbstractToolCallAdvisorIT {
 						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
 							.build())
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "call-default-advisor-with-memory"))
 				.stream()
 				.content();
@@ -227,7 +227,7 @@ public abstract class AbstractToolCallAdvisorIT {
 
 			Flux<String> response = chatClient.prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.stream()
 				.content();
 
@@ -248,7 +248,7 @@ public abstract class AbstractToolCallAdvisorIT {
 
 			Flux<String> response = chatClient.prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "call-default-advisor-with-memory"))
 				.stream()
 				.content();
@@ -266,7 +266,7 @@ public abstract class AbstractToolCallAdvisorIT {
 				.prompt()
 				.advisors(ToolCallAdvisor.builder().build())
 				.user("What's the weather like in Tokyo?")
-				.toolCallbacks(createReturnDirectWeatherToolCallback())
+				.tools(t -> t.callbacks(createReturnDirectWeatherToolCallback()))
 				.stream()
 				.content();
 


### PR DESCRIPTION
- Add validateSingleToolAdvisor() to throw IllegalStateException when more than one ToolAdvisor is present in the advisor chain after auto-registration.
- Delegate legacy toolCallbacks/toolContext methods to tools(ToolSpec) to consolidate validation.
- Remove the streaming boolean from buildAdvisorChain since streamToolCallResponses is now pre-configured on the builder.