### PR TITLE
Fix DeepSeek dropping assistant reasoning_content on multi-turn requests

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -430,14 +430,24 @@ public class DeepSeekChatModel implements ChatModel {
 					}).toList();
 				}
 				Boolean isPrefixAssistantMessage = null;
-				if (message instanceof DeepSeekAssistantMessage
-						&& Boolean.TRUE.equals(((DeepSeekAssistantMessage) message).getPrefix())) {
-					isPrefixAssistantMessage = true;
+				// In thinking mode, DeepSeek requires the previous assistant message's
+				// reasoning_content to be passed back; otherwise subsequent turns
+				// (especially the second hop of a tool-calling round) fail with
+				// "The reasoning_content in the thinking mode must be passed back to
+				// the API." (400). buildGeneration already captures reasoningContent
+				// into DeepSeekAssistantMessage; this outbound path must forward it
+				// instead of passing null.
+				String reasoningContent = null;
+				if (message instanceof DeepSeekAssistantMessage deepSeekAssistantMessage) {
+					if (Boolean.TRUE.equals(deepSeekAssistantMessage.getPrefix())) {
+						isPrefixAssistantMessage = true;
+					}
+					reasoningContent = deepSeekAssistantMessage.getReasoningContent();
 				}
 				String text = assistantMessage.getText();
 				Assert.state(text != null, "text must not be null");
 				return List.of(new ChatCompletionMessage(text, ChatCompletionMessage.Role.ASSISTANT, null, null,
-						toolCalls, isPrefixAssistantMessage, null));
+						toolCalls, isPrefixAssistantMessage, reasoningContent));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
@@ -16,8 +16,11 @@
 
 package org.springframework.ai.deepseek;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
 
@@ -52,6 +55,54 @@ public class DeepSeekChatCompletionRequestTests {
 
 		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
 		assertThat(request.temperature()).isEqualTo(99.9D);
+	}
+
+	// gh-5038: DeepSeek thinking mode requires the previous assistant message's
+	// reasoning_content to be passed back, otherwise the next request fails with
+	// "The reasoning_content in the thinking mode must be passed back to the API." (400).
+	// inbound (buildGeneration) already captures reasoningContent into
+	// DeepSeekAssistantMessage; this test pins outbound roundtrip in createRequest.
+	@Test
+	public void createRequestPreservesReasoningContentFromDeepSeekAssistantMessage() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		var assistantMessage = DeepSeekAssistantMessage.builder()
+			.content("final answer")
+			.reasoningContent("step-by-step thinking trace")
+			.build();
+
+		var prompt = client.buildRequestPrompt(
+				new Prompt(List.of(new UserMessage("question"), assistantMessage, new UserMessage("follow-up")),
+						DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(3);
+		var serializedAssistant = request.messages().get(1);
+		assertThat(serializedAssistant.role()).isEqualTo(DeepSeekApi.ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(serializedAssistant.content()).isEqualTo("final answer");
+		assertThat(serializedAssistant.reasoningContent()).isEqualTo("step-by-step thinking trace");
+	}
+
+	// Plain AssistantMessage (not a DeepSeekAssistantMessage) has no reasoningContent
+	// to forward; verify the outbound field stays null and we don't NPE.
+	@Test
+	public void createRequestKeepsReasoningContentNullForPlainAssistantMessage() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		var assistantMessage = new org.springframework.ai.chat.messages.AssistantMessage("final answer");
+
+		var prompt = client.buildRequestPrompt(
+				new Prompt(List.of(new UserMessage("question"), assistantMessage, new UserMessage("follow-up")),
+						DeepSeekChatOptions.builder().model("deepseek-chat").build()));
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(3);
+		var serializedAssistant = request.messages().get(1);
+		assertThat(serializedAssistant.role()).isEqualTo(DeepSeekApi.ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(serializedAssistant.content()).isEqualTo("final answer");
+		assertThat(serializedAssistant.reasoningContent()).isNull();
 	}
 
 }


### PR DESCRIPTION
`DeepSeekChatModel#buildGeneration` already captures `reasoning_content` from the response into `DeepSeekAssistantMessage`, but `createRequest` then drops it when serializing the next outbound request — it hardcodes `reasoning_content = null` even when the prompt's assistant message is a `DeepSeekAssistantMessage` carrying a real reasoning trace. DeepSeek's API rejects subsequent turns that drop the field with `HTTP 400 — The reasoning_content in the thinking mode must be passed back to the API.`, which is most visible during a tool-calling round (user → assistant(tool_calls, reasoning_content) → tool result → second model call without reasoning_content → 400).

This PR forwards `reasoningContent` (and `prefix`, already special-cased) from a `DeepSeekAssistantMessage` back into the outbound `ChatCompletionMessage` record. Plain `AssistantMessage` instances continue to serialize with `reasoning_content = null` — no behavior change for non-thinking flows.

Tests:
- `createRequestPreservesReasoningContentFromDeepSeekAssistantMessage` pins the outbound roundtrip.
- `createRequestKeepsReasoningContentNullForPlainAssistantMessage` guards plain `AssistantMessage` behavior.

Related: gh-5038