### PR TITLE
docs: fix broken cross-references for audio and moderation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -55,7 +55,7 @@
 **** xref:api/image/stabilityai-image.adoc[Stability]
 **** xref:api/image/qianfan-image.adoc[QianFan]
 
-*** xref:api/audio[Audio Models]
+*** xref:api/audio.adoc[Audio Models]
 **** xref:api/audio/transcriptions.adoc[]
 ***** xref:api/audio/transcriptions/azure-openai-transcriptions.adoc[Azure OpenAI]
 ***** xref:api/audio/transcriptions/openai-transcriptions.adoc[OpenAI]
@@ -63,7 +63,7 @@
 ***** xref:api/audio/speech/openai-speech.adoc[OpenAI]
 ***** xref:api/audio/speech/elevenlabs-speech.adoc[ElevenLabs]
 
-*** xref:api/moderation[Moderation Models]
+*** xref:api/moderation.adoc[Moderation Models]
 **** xref:api/moderation/openai-moderation.adoc[OpenAI]
 **** xref:api/moderation/mistral-ai-moderation.adoc[Mistral AI]
 // ** xref:api/generic-model.adoc[]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio.adoc
@@ -1,0 +1,7 @@
+[[audio-models]]
+= Audio Models
+
+Spring AI supports processing audio using transcription (Speech-to-Text) and speech (Text-to-Speech) models.
+
+* xref:api/audio/transcriptions.adoc[Speech-To-Text (STT) Transcription API]
+* xref:api/audio/speech.adoc[Text-To-Speech (TTS) API]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation.adoc
@@ -1,0 +1,7 @@
+[[moderation-models]]
+= Moderation Models
+
+Spring AI supports the Moderation API to identify potential violations or check text safety.
+
+* xref:api/moderation/openai-moderation.adoc[OpenAI Moderation]
+* xref:api/moderation/mistral-ai-moderation.adoc[Mistral AI Moderation]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
@@ -24,7 +24,7 @@ Spring AI provides the following features:
 ** xref:api/imageclient.adoc[Text to Image]
 ** xref:api/audio/transcriptions.adoc[Audio Transcription]
 ** xref:api/audio/speech.adoc[Text to Speech]
-** xref:api/moderation[Moderation]
+** xref:api/moderation.adoc[Moderation]
 * xref:api/structured-output-converter.adoc[Structured Outputs] - Mapping of AI Model output to POJOs.
 * Support for all major xref:api/vectordbs.adoc[Vector Database providers] such as Apache Cassandra, Azure Vector Search, Chroma, Elasticsearch, GemFire, MariaDB, Milvus, MongoDB Atlas, Neo4j, OpenSearch, Oracle, PostgreSQL/PGVector, Pinecone, Qdrant, Redis, Typesense and Weaviate.
 * Portable API across Vector Store providers, including a novel SQL-like metadata filter API.


### PR DESCRIPTION
This PR fixes active broken cross-references in the Antora documentation for Spring AI.

Antora requires all cross-references to point directly to page files (\.adoc\) rather than directories. Currently, several references in the sidebar navigation (\
av.adoc\) and the introduction page (\index.adoc\) point to the \pi/audio\ and \pi/moderation\ folders, resulting in broken links on the published site.

To resolve this elegantly and maintain a consistent architecture:
1. Created two new overview/landing pages: \pi/audio.adoc\ and \pi/moderation.adoc\ that provide summaries and clear links to the provider-specific sub-pages.
2. Updated all \xref\ links in \
av.adoc\ and \index.adoc\ to point to these new landing pages.

This restores proper navigation and matches the design patterns used for other API modules like embeddings and image models.