### PR TITLE
Update tests and docs for MCP SDK 2.0.0-M3 breaking API changes

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/McpToolsConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/McpToolsConfigurationTests.java
@@ -143,8 +143,9 @@ class McpToolsConfigurationTests {
 			// In a real use-case, we would use the chat client to call the LLM again
 			logger.info("MCP SAMPLING: simulating using chat client {}", this.chatClient);
 
-			return McpSchema.CreateMessageResult.builder()
-				.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+			return McpSchema.CreateMessageResult
+				.builder(McpSchema.Role.ASSISTANT, "Response " + userPrompt + " with model hint " + modelHint,
+						modelHint)
 				.build();
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/SseWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/SseWebClientWebFluxServerIT.java
@@ -152,8 +152,7 @@ public class SseWebClientWebFluxServerIT {
 							.build());
 
 						// Call a tool that sends progress notifications
-						CallToolRequest toolRequest = CallToolRequest.builder()
-							.name("tool1")
+						CallToolRequest toolRequest = CallToolRequest.builder("tool1")
 							.arguments(Map.of())
 							.progressToken("test-progress-token")
 							.build();
@@ -320,26 +319,30 @@ public class SseWebClientWebFluxServerIT {
 
 					var progressToken = request.progressToken();
 
-					exchange.progressNotification(new ProgressNotification(progressToken, 0.0, 1.0, "tool call start"));
+					exchange.progressNotification(ProgressNotification.builder(progressToken, 0.0)
+						.total(1.0)
+						.message("tool call start")
+						.build());
 
 					exchange.ping(); // call client ping
 
 					// call elicitation
-					var elicitationRequest = McpSchema.ElicitRequest.builder()
-						.message("Test message")
-						.requestedSchema(
+					var elicitationRequest = McpSchema.ElicitRequest
+						.builder("Test message",
 								Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
 						.build();
 
 					ElicitResult elicitationResult = exchange.createElicitation(elicitationRequest);
 
-					exchange.progressNotification(
-							new ProgressNotification(progressToken, 0.50, 1.0, "elicitation completed"));
+					exchange.progressNotification(ProgressNotification.builder(progressToken, 0.50)
+						.total(1.0)
+						.message("elicitation completed")
+						.build());
 
 					// call sampling
-					var createMessageRequest = McpSchema.CreateMessageRequest.builder()
-						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-								new McpSchema.TextContent("Test Sampling Message"))))
+					var createMessageRequest = McpSchema.CreateMessageRequest
+						.builder(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
+								McpSchema.TextContent.builder("Test Sampling Message").build())), 500)
 						.modelPreferences(ModelPreferences.builder()
 							.hints(List.of(ModelHint.of("OpenAi"), ModelHint.of("Ollama")))
 							.costPriority(1.0)
@@ -350,12 +353,17 @@ public class SseWebClientWebFluxServerIT {
 
 					CreateMessageResult samplingResponse = exchange.createMessage(createMessageRequest);
 
-					exchange
-						.progressNotification(new ProgressNotification(progressToken, 1.0, 1.0, "sampling completed"));
+					exchange.progressNotification(ProgressNotification.builder(progressToken, 1.0)
+						.total(1.0)
+						.message("sampling completed")
+						.build());
 
 					return McpSchema.CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent(
-								"CALL RESPONSE: " + samplingResponse.toString() + ", " + elicitationResult.toString())))
+						.content(List.of(
+								McpSchema.TextContent
+									.builder("CALL RESPONSE: " + samplingResponse.toString() + ", "
+											+ elicitationResult.toString())
+									.build()))
 						.build();
 				})
 				.build();
@@ -403,15 +411,22 @@ public class SseWebClientWebFluxServerIT {
 						}
 
 						// send logging notification
-						exchange.loggingNotification(LoggingMessageNotification.builder()
-							// .level(LoggingLevel.DEBUG)
-							.logger("test-logger")
-							.data("User prompt: Hello " + languageArgument + "! How can I assist you today?")
-							.build());
+						exchange
+							.loggingNotification(
+									LoggingMessageNotification
+										.builder(LoggingLevel.INFO,
+												"User prompt: Hello " + languageArgument
+														+ "! How can I assist you today?")
+										// .level(LoggingLevel.DEBUG)
+										.logger("test-logger")
+										.build());
 
 						var userMessage = new PromptMessage(Role.USER,
-								new TextContent("Hello " + languageArgument + "! How can I assist you today?"));
-						return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+								TextContent.builder("Hello " + languageArgument + "! How can I assist you today?")
+									.build());
+						return GetPromptResult.builder(List.of(userMessage))
+							.description("A personalized greeting message")
+							.build();
 					});
 
 			return List.of(promptSpecification);
@@ -446,8 +461,10 @@ public class SseWebClientWebFluxServerIT {
 									System.getProperty("os.version"), "java_version",
 									System.getProperty("java.version"));
 							String jsonContent = new JsonMapper().writeValueAsString(systemInfo);
-							return new McpSchema.ReadResourceResult(List.of(new McpSchema.TextResourceContents(
-									request.uri(), "application/json", jsonContent)));
+							return McpSchema.ReadResourceResult
+								.builder(List.of(new McpSchema.TextResourceContents(request.uri(), "application/json",
+										jsonContent)))
+								.build();
 						}
 						catch (Exception e) {
 							throw new RuntimeException("Failed to generate system info", e);
@@ -492,8 +509,8 @@ public class SseWebClientWebFluxServerIT {
 				Function<McpSchema.CreateMessageRequest, CreateMessageResult> samplingHandler = llmRequest -> {
 					String userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
 					String modelHint = llmRequest.modelPreferences().hints().get(0).name();
-					return CreateMessageResult.builder()
-						.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+					return CreateMessageResult
+						.builder(Role.ASSISTANT, "Response " + userPrompt + " with model hint " + modelHint, modelHint)
 						.build();
 				};
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StatelessWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StatelessWebClientWebFluxServerIT.java
@@ -145,10 +145,7 @@ public class StatelessWebClientWebFluxServerIT {
 							.build());
 
 						// Call a tool that sends progress notifications
-						CallToolRequest toolRequest = CallToolRequest.builder()
-							.name("tool1")
-							.arguments(Map.of())
-							.build();
+						CallToolRequest toolRequest = CallToolRequest.builder("tool1").arguments(Map.of()).build();
 
 						CallToolResult response = mcpClient.callTool(toolRequest);
 
@@ -269,8 +266,9 @@ public class StatelessWebClientWebFluxServerIT {
 							"properties": {}
 						}
 						""").build())
-				.callHandler((exchange,
-						request) -> CallToolResult.builder().content(List.of(new TextContent("CALL RESPONSE"))).build())
+				.callHandler((exchange, request) -> CallToolResult.builder()
+					.content(List.of(TextContent.builder("CALL RESPONSE").build()))
+					.build())
 				.build();
 
 			// Tool 2
@@ -327,8 +325,11 @@ public class StatelessWebClientWebFluxServerIT {
 						}
 
 						var userMessage = new PromptMessage(Role.USER,
-								new TextContent("Hello " + languageArgument + "! How can I assist you today?"));
-						return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+								TextContent.builder("Hello " + languageArgument + "! How can I assist you today?")
+									.build());
+						return GetPromptResult.builder(List.of(userMessage))
+							.description("A personalized greeting message")
+							.build();
 					});
 
 			return List.of(promptSpecification);
@@ -363,8 +364,10 @@ public class StatelessWebClientWebFluxServerIT {
 									System.getProperty("os.version"), "java_version",
 									System.getProperty("java.version"));
 							String jsonContent = new JsonMapper().writeValueAsString(systemInfo);
-							return new McpSchema.ReadResourceResult(List.of(new McpSchema.TextResourceContents(
-									request.uri(), "application/json", jsonContent)));
+							return McpSchema.ReadResourceResult
+								.builder(List.of(new McpSchema.TextResourceContents(request.uri(), "application/json",
+										jsonContent)))
+								.build();
 						}
 						catch (Exception e) {
 							throw new RuntimeException("Failed to generate system info", e);

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotations2IT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotations2IT.java
@@ -160,8 +160,7 @@ public class StreamableMcpAnnotations2IT {
 						assertThat(mcpClient.listTools().tools()).hasSize(2);
 
 						// Call a tool that sends progress notifications
-						CallToolRequest toolRequest = CallToolRequest.builder()
-							.name("tool1")
+						CallToolRequest toolRequest = CallToolRequest.builder("tool1")
 							.arguments(Map.of("input", "Test Input"))
 							.progressToken("test-progress-token")
 							.build();
@@ -378,8 +377,10 @@ public class StreamableMcpAnnotations2IT {
 					var systemInfo = Map.of("os", System.getProperty("os.name"), "os_version",
 							System.getProperty("os.version"), "java_version", System.getProperty("java.version"));
 					String jsonContent = JsonMapper.shared().writeValueAsString(systemInfo);
-					return new ReadResourceResult(List
-						.of(new McpSchema.TextResourceContents(request.uri(), "application/json", jsonContent)));
+					return ReadResourceResult
+						.builder(List
+							.of(new McpSchema.TextResourceContents(request.uri(), "application/json", jsonContent)))
+						.build();
 				}
 				catch (Exception e) {
 					throw new RuntimeException("Failed to generate system info", e);
@@ -395,9 +396,11 @@ public class StreamableMcpAnnotations2IT {
 
 				ctx.log(l -> l.logger("test-logger").message(message));
 
-				var userMessage = new PromptMessage(Role.USER, new TextContent(message));
+				var userMessage = new PromptMessage(Role.USER, TextContent.builder(message).build());
 
-				return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+				return GetPromptResult.builder(List.of(userMessage))
+					.description("A personalized greeting message")
+					.build();
 			}
 
 			// the code-completion is a reference to the prompt code completion
@@ -468,8 +471,8 @@ public class StreamableMcpAnnotations2IT {
 				String userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
 				String modelHint = llmRequest.modelPreferences().hints().get(0).name();
 
-				return CreateMessageResult.builder()
-					.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+				return CreateMessageResult
+					.builder(Role.ASSISTANT, "Response " + userPrompt + " with model hint " + modelHint, modelHint)
 					.build();
 			}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsIT.java
@@ -161,8 +161,7 @@ public class StreamableMcpAnnotationsIT {
 						assertThat(mcpClient.listTools().tools()).hasSize(2);
 
 						// Call a tool that sends progress notifications
-						CallToolRequest toolRequest = CallToolRequest.builder()
-							.name("tool1")
+						CallToolRequest toolRequest = CallToolRequest.builder("tool1")
 							.arguments(Map.of("input", "Test Input"))
 							.progressToken("test-progress-token")
 							.build();
@@ -316,28 +315,31 @@ public class StreamableMcpAnnotationsIT {
 			public String toolWithSamplingAndElicitation(McpSyncServerExchange exchange, @McpToolParam String input,
 					@McpProgressToken String progressToken) {
 
-				exchange.loggingNotification(LoggingMessageNotification.builder().data("Tool1 Started!").build());
+				exchange.loggingNotification(
+						LoggingMessageNotification.builder(LoggingLevel.INFO, "Tool1 Started!").build());
 
-				exchange.progressNotification(new ProgressNotification(progressToken, 0.0, 1.0, "tool call start"));
+				exchange.progressNotification(
+						ProgressNotification.builder(progressToken, 0.0).total(1.0).message("tool call start").build());
 
 				exchange.ping(); // call client ping
 
 				// call elicitation
-				var elicitationRequest = McpSchema.ElicitRequest.builder()
-					.message("Test message")
-					.requestedSchema(
+				var elicitationRequest = McpSchema.ElicitRequest
+					.builder("Test message",
 							Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
 					.build();
 
 				ElicitResult elicitationResult = exchange.createElicitation(elicitationRequest);
 
-				exchange
-					.progressNotification(new ProgressNotification(progressToken, 0.50, 1.0, "elicitation completed"));
+				exchange.progressNotification(ProgressNotification.builder(progressToken, 0.50)
+					.total(1.0)
+					.message("elicitation completed")
+					.build());
 
 				// call sampling
-				var createMessageRequest = McpSchema.CreateMessageRequest.builder()
-					.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-							new McpSchema.TextContent("Test Sampling Message"))))
+				var createMessageRequest = McpSchema.CreateMessageRequest
+					.builder(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
+							McpSchema.TextContent.builder("Test Sampling Message").build())), 500)
 					.modelPreferences(ModelPreferences.builder()
 						.hints(List.of(ModelHint.of("OpenAi"), ModelHint.of("Ollama")))
 						.costPriority(1.0)
@@ -348,9 +350,13 @@ public class StreamableMcpAnnotationsIT {
 
 				CreateMessageResult samplingResponse = exchange.createMessage(createMessageRequest);
 
-				exchange.progressNotification(new ProgressNotification(progressToken, 1.0, 1.0, "sampling completed"));
+				exchange.progressNotification(ProgressNotification.builder(progressToken, 1.0)
+					.total(1.0)
+					.message("sampling completed")
+					.build());
 
-				exchange.loggingNotification(LoggingMessageNotification.builder().data("Tool1 Done!").build());
+				exchange
+					.loggingNotification(LoggingMessageNotification.builder(LoggingLevel.INFO, "Tool1 Done!").build());
 
 				return "CALL RESPONSE: " + samplingResponse.toString() + ", " + elicitationResult.toString();
 			}
@@ -383,8 +389,10 @@ public class StreamableMcpAnnotationsIT {
 					var systemInfo = Map.of("os", System.getProperty("os.name"), "os_version",
 							System.getProperty("os.version"), "java_version", System.getProperty("java.version"));
 					String jsonContent = JsonMapper.shared().writeValueAsString(systemInfo);
-					return new McpSchema.ReadResourceResult(List
-						.of(new McpSchema.TextResourceContents(request.uri(), "application/json", jsonContent)));
+					return McpSchema.ReadResourceResult
+						.builder(List
+							.of(new McpSchema.TextResourceContents(request.uri(), "application/json", jsonContent)))
+						.build();
 				}
 				catch (Exception e) {
 					throw new RuntimeException("Failed to generate system info", e);
@@ -399,15 +407,18 @@ public class StreamableMcpAnnotationsIT {
 					languageArgument = "java";
 				}
 
-				exchange.loggingNotification(LoggingMessageNotification.builder()
+				exchange.loggingNotification(LoggingMessageNotification
+					.builder(LoggingLevel.INFO,
+							"User prompt: Hello " + languageArgument + "! How can I assist you today?")
 					.logger("test-logger")
-					.data("User prompt: Hello " + languageArgument + "! How can I assist you today?")
 					.build());
 
 				var userMessage = new PromptMessage(Role.USER,
-						new TextContent("Hello " + languageArgument + "! How can I assist you today?"));
+						TextContent.builder("Hello " + languageArgument + "! How can I assist you today?").build());
 
-				return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+				return GetPromptResult.builder(List.of(userMessage))
+					.description("A personalized greeting message")
+					.build();
 			}
 
 			@McpComplete(prompt = "code-completion") // the code-completion is a reference
@@ -477,8 +488,8 @@ public class StreamableMcpAnnotationsIT {
 				String userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
 				String modelHint = llmRequest.modelPreferences().hints().get(0).name();
 
-				return CreateMessageResult.builder()
-					.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+				return CreateMessageResult
+					.builder(Role.ASSISTANT, "Response " + userPrompt + " with model hint " + modelHint, modelHint)
 					.build();
 			}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsManualIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsManualIT.java
@@ -168,8 +168,7 @@ public class StreamableMcpAnnotationsManualIT {
 						assertThat(mcpClient.listTools().tools()).hasSize(2);
 
 						// Call a tool that sends progress notifications
-						CallToolRequest toolRequest = CallToolRequest.builder()
-							.name("tool1")
+						CallToolRequest toolRequest = CallToolRequest.builder("tool1")
 							.arguments(Map.of("input", "Test Input"))
 							.progressToken("test-progress-token")
 							.build();
@@ -323,28 +322,31 @@ public class StreamableMcpAnnotationsManualIT {
 			public String toolWithSamplingAndElicitation(McpSyncServerExchange exchange, @McpToolParam String input,
 					@McpProgressToken String progressToken) {
 
-				exchange.loggingNotification(LoggingMessageNotification.builder().data("Tool1 Started!").build());
+				exchange.loggingNotification(
+						LoggingMessageNotification.builder(LoggingLevel.INFO, "Tool1 Started!").build());
 
-				exchange.progressNotification(new ProgressNotification(progressToken, 0.0, 1.0, "tool call start"));
+				exchange.progressNotification(
+						ProgressNotification.builder(progressToken, 0.0).total(1.0).message("tool call start").build());
 
 				exchange.ping(); // call client ping
 
 				// call elicitation
-				var elicitationRequest = McpSchema.ElicitRequest.builder()
-					.message("Test message")
-					.requestedSchema(
+				var elicitationRequest = McpSchema.ElicitRequest
+					.builder("Test message",
 							Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
 					.build();
 
 				ElicitResult elicitationResult = exchange.createElicitation(elicitationRequest);
 
-				exchange
-					.progressNotification(new ProgressNotification(progressToken, 0.50, 1.0, "elicitation completed"));
+				exchange.progressNotification(ProgressNotification.builder(progressToken, 0.50)
+					.total(1.0)
+					.message("elicitation completed")
+					.build());
 
 				// call sampling
-				var createMessageRequest = McpSchema.CreateMessageRequest.builder()
-					.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-							new McpSchema.TextContent("Test Sampling Message"))))
+				var createMessageRequest = McpSchema.CreateMessageRequest
+					.builder(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
+							McpSchema.TextContent.builder("Test Sampling Message").build())), 500)
 					.modelPreferences(ModelPreferences.builder()
 						.hints(List.of(ModelHint.of("OpenAi"), ModelHint.of("Ollama")))
 						.costPriority(1.0)
@@ -355,9 +357,13 @@ public class StreamableMcpAnnotationsManualIT {
 
 				CreateMessageResult samplingResponse = exchange.createMessage(createMessageRequest);
 
-				exchange.progressNotification(new ProgressNotification(progressToken, 1.0, 1.0, "sampling completed"));
+				exchange.progressNotification(ProgressNotification.builder(progressToken, 1.0)
+					.total(1.0)
+					.message("sampling completed")
+					.build());
 
-				exchange.loggingNotification(LoggingMessageNotification.builder().data("Tool1 Done!").build());
+				exchange
+					.loggingNotification(LoggingMessageNotification.builder(LoggingLevel.INFO, "Tool1 Done!").build());
 
 				return "CALL RESPONSE: " + samplingResponse.toString() + ", " + elicitationResult.toString();
 			}
@@ -390,8 +396,10 @@ public class StreamableMcpAnnotationsManualIT {
 					var systemInfo = Map.of("os", System.getProperty("os.name"), "os_version",
 							System.getProperty("os.version"), "java_version", System.getProperty("java.version"));
 					String jsonContent = JsonMapper.shared().writeValueAsString(systemInfo);
-					return new McpSchema.ReadResourceResult(List
-						.of(new McpSchema.TextResourceContents(request.uri(), "application/json", jsonContent)));
+					return McpSchema.ReadResourceResult
+						.builder(List
+							.of(new McpSchema.TextResourceContents(request.uri(), "application/json", jsonContent)))
+						.build();
 				}
 				catch (Exception e) {
 					throw new RuntimeException("Failed to generate system info", e);
@@ -406,15 +414,18 @@ public class StreamableMcpAnnotationsManualIT {
 					languageArgument = "java";
 				}
 
-				exchange.loggingNotification(LoggingMessageNotification.builder()
+				exchange.loggingNotification(LoggingMessageNotification
+					.builder(LoggingLevel.INFO,
+							"User prompt: Hello " + languageArgument + "! How can I assist you today?")
 					.logger("test-logger")
-					.data("User prompt: Hello " + languageArgument + "! How can I assist you today?")
 					.build());
 
 				var userMessage = new PromptMessage(Role.USER,
-						new TextContent("Hello " + languageArgument + "! How can I assist you today?"));
+						TextContent.builder("Hello " + languageArgument + "! How can I assist you today?").build());
 
-				return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+				return GetPromptResult.builder(List.of(userMessage))
+					.description("A personalized greeting message")
+					.build();
 			}
 
 			@McpComplete(prompt = "code-completion") // the code-completion is a reference
@@ -503,8 +514,8 @@ public class StreamableMcpAnnotationsManualIT {
 				// a joke").call().content();
 				String joke = this.chatClient().prompt("Tell me a joke").call().content();
 				logger.info("Received joke from chat client: {}", joke);
-				return CreateMessageResult.builder()
-					.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+				return CreateMessageResult
+					.builder(Role.ASSISTANT, "Response " + userPrompt + " with model hint " + modelHint, modelHint)
 					.build();
 			}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableWebClientWebFluxServerIT.java
@@ -160,8 +160,7 @@ public class StreamableWebClientWebFluxServerIT {
 							.build());
 
 						// Call a tool that sends progress notifications
-						CallToolRequest toolRequest = CallToolRequest.builder()
-							.name("tool1")
+						CallToolRequest toolRequest = CallToolRequest.builder("tool1")
 							.arguments(Map.of())
 							.progressToken("test-progress-token")
 							.build();
@@ -319,26 +318,30 @@ public class StreamableWebClientWebFluxServerIT {
 				.callHandler((exchange, request) -> {
 					var progressToken = request.progressToken();
 
-					exchange.progressNotification(new ProgressNotification(progressToken, 0.0, 1.0, "tool call start"));
+					exchange.progressNotification(ProgressNotification.builder(progressToken, 0.0)
+						.total(1.0)
+						.message("tool call start")
+						.build());
 
 					exchange.ping(); // call client ping
 
 					// call elicitation
-					var elicitationRequest = McpSchema.ElicitRequest.builder()
-						.message("Test message")
-						.requestedSchema(
+					var elicitationRequest = McpSchema.ElicitRequest
+						.builder("Test message",
 								Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
 						.build();
 
 					ElicitResult elicitationResult = exchange.createElicitation(elicitationRequest);
 
-					exchange.progressNotification(
-							new ProgressNotification(progressToken, 0.50, 1.0, "elicitation completed"));
+					exchange.progressNotification(ProgressNotification.builder(progressToken, 0.50)
+						.total(1.0)
+						.message("elicitation completed")
+						.build());
 
 					// call sampling
-					var createMessageRequest = McpSchema.CreateMessageRequest.builder()
-						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-								new McpSchema.TextContent("Test Sampling Message"))))
+					var createMessageRequest = McpSchema.CreateMessageRequest
+						.builder(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
+								McpSchema.TextContent.builder("Test Sampling Message").build())), 500)
 						.modelPreferences(ModelPreferences.builder()
 							.hints(List.of(ModelHint.of("OpenAi"), ModelHint.of("Ollama")))
 							.costPriority(1.0)
@@ -349,12 +352,17 @@ public class StreamableWebClientWebFluxServerIT {
 
 					CreateMessageResult samplingResponse = exchange.createMessage(createMessageRequest);
 
-					exchange
-						.progressNotification(new ProgressNotification(progressToken, 1.0, 1.0, "sampling completed"));
+					exchange.progressNotification(ProgressNotification.builder(progressToken, 1.0)
+						.total(1.0)
+						.message("sampling completed")
+						.build());
 
 					return McpSchema.CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent(
-								"CALL RESPONSE: " + samplingResponse.toString() + ", " + elicitationResult.toString())))
+						.content(List.of(
+								McpSchema.TextContent
+									.builder("CALL RESPONSE: " + samplingResponse.toString() + ", "
+											+ elicitationResult.toString())
+									.build()))
 						.build();
 				})
 				.build();
@@ -402,15 +410,22 @@ public class StreamableWebClientWebFluxServerIT {
 						}
 
 						// send logging notification
-						exchange.loggingNotification(LoggingMessageNotification.builder()
-							// .level(LoggingLevel.DEBUG)
-							.logger("test-logger")
-							.data("User prompt: Hello " + languageArgument + "! How can I assist you today?")
-							.build());
+						exchange
+							.loggingNotification(
+									LoggingMessageNotification
+										.builder(LoggingLevel.INFO,
+												"User prompt: Hello " + languageArgument
+														+ "! How can I assist you today?")
+										// .level(LoggingLevel.DEBUG)
+										.logger("test-logger")
+										.build());
 
 						var userMessage = new PromptMessage(Role.USER,
-								new TextContent("Hello " + languageArgument + "! How can I assist you today?"));
-						return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+								TextContent.builder("Hello " + languageArgument + "! How can I assist you today?")
+									.build());
+						return GetPromptResult.builder(List.of(userMessage))
+							.description("A personalized greeting message")
+							.build();
 					});
 
 			return List.of(promptSpecification);
@@ -445,8 +460,10 @@ public class StreamableWebClientWebFluxServerIT {
 									System.getProperty("os.version"), "java_version",
 									System.getProperty("java.version"));
 							String jsonContent = new JsonMapper().writeValueAsString(systemInfo);
-							return new McpSchema.ReadResourceResult(List.of(new McpSchema.TextResourceContents(
-									request.uri(), "application/json", jsonContent)));
+							return McpSchema.ReadResourceResult
+								.builder(List.of(new McpSchema.TextResourceContents(request.uri(), "application/json",
+										jsonContent)))
+								.build();
 						}
 						catch (Exception e) {
 							throw new RuntimeException("Failed to generate system info", e);
@@ -501,8 +518,8 @@ public class StreamableWebClientWebFluxServerIT {
 				Function<McpSchema.CreateMessageRequest, CreateMessageResult> samplingHandler = llmRequest -> {
 					String userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
 					String modelHint = llmRequest.modelPreferences().hints().get(0).name();
-					return CreateMessageResult.builder()
-						.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+					return CreateMessageResult
+						.builder(Role.ASSISTANT, "Response " + userPrompt + " with model hint " + modelHint, modelHint)
 						.build();
 				};
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/capabilities/McpHandlerService.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/capabilities/McpHandlerService.java
@@ -44,8 +44,8 @@ public class McpHandlerService {
 		// In a real use-case, we would use the chat client to call the LLM again
 		logger.info("MCP SAMPLING: simulating using chat client {}", this.client);
 
-		return McpSchema.CreateMessageResult.builder()
-			.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+		return McpSchema.CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT, "Response " + userPrompt + " with model hint " + modelHint, modelHint)
 			.build();
 	}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-client.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-client.adoc
@@ -53,10 +53,7 @@ public class SamplingHandler {
         // Process the request and generate a response
         String response = generateLLMResponse(request);
         
-        return CreateMessageResult.builder()
-            .role(Role.ASSISTANT)
-            .content(new TextContent(response))
-            .model("gpt-4")
+        return CreateMessageResult.builder(Role.ASSISTANT, response, "gpt-4")
             .build();
     }
 }
@@ -73,11 +70,8 @@ public class AsyncSamplingHandler {
     public Mono<CreateMessageResult> handleAsyncSampling(CreateMessageRequest request) {
         return Mono.fromCallable(() -> {
             String response = generateLLMResponse(request);
-            
-            return CreateMessageResult.builder()
-                .role(Role.ASSISTANT)
-                .content(new TextContent(response))
-                .model("gpt-4")
+
+            return CreateMessageResult.builder(Role.ASSISTANT, response, "gpt-4")
                 .build();
         }).subscribeOn(Schedulers.boundedElastic());
     }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-examples.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-examples.adoc
@@ -116,26 +116,26 @@ public class DocumentServer {
         Document doc = documents.get(id);
 
         if (doc == null) {
-            return new ReadResourceResult(List.of(
+            return ReadResourceResult.builder(List.of(
                 new TextResourceContents("document://" + id,
                     "text/plain", "Document not found")
-            ));
+            )).build();
         }
 
         // Check access permissions from metadata
         String accessLevel = (String) meta.get("accessLevel");
         if ("restricted".equals(doc.getClassification()) &&
             !"admin".equals(accessLevel)) {
-            return new ReadResourceResult(List.of(
+            return ReadResourceResult.builder(List.of(
                 new TextResourceContents("document://" + id,
                     "text/plain", "Access denied")
-            ));
+            )).build();
         }
 
-        return new ReadResourceResult(List.of(
+        return ReadResourceResult.builder(List.of(
             new TextResourceContents("document://" + id,
                 doc.getMimeType(), doc.getContent())
-        ));
+        )).build();
     }
 
     @McpTool(name = "analyze-document",
@@ -177,9 +177,10 @@ public class DocumentServer {
 
         Document doc = documents.get(docId);
         if (doc == null) {
-            return new GetPromptResult("Error",
-                List.of(new PromptMessage(Role.SYSTEM,
-                    new TextContent("Document not found"))));
+            return GetPromptResult.builder(List.of(new PromptMessage(Role.SYSTEM,
+                    TextContent.builder("Document not found").build())))
+                .description("Error")
+                .build();
         }
 
         String promptText = String.format(
@@ -188,8 +189,9 @@ public class DocumentServer {
             doc.getContent()
         );
 
-        return new GetPromptResult("Document Summary",
-            List.of(new PromptMessage(Role.USER, new TextContent(promptText))));
+        return GetPromptResult.builder(List.of(new PromptMessage(Role.USER, TextContent.builder(promptText).build())))
+            .description("Document Summary")
+            .build();
     }
 
     @McpComplete(prompt = "document-summary")
@@ -261,10 +263,9 @@ public class ClientHandlers {
 
         ChatResponse response = chatModel.call(new Prompt(messages));
 
-        return CreateMessageResult.builder()
-            .role(Role.ASSISTANT)
-            .content(new TextContent(response.getResult().getOutput().getText()))
-            .model(request.modelPreferences().hints().get(0).name())
+        return CreateMessageResult.builder(Role.ASSISTANT,
+                response.getResult().getOutput().getText(),
+                request.modelPreferences().hints().get(0).name())
             .build();
     }
 
@@ -403,10 +404,10 @@ public class AsyncDataProcessor {
     public Mono<ReadResourceResult> getAsyncData(String id) {
         return Mono.fromCallable(() -> loadDataAsync(id))
             .subscribeOn(Schedulers.boundedElastic())
-            .map(data -> new ReadResourceResult(List.of(
+            .map(data -> ReadResourceResult.builder(List.of(
                 new TextResourceContents("async-data://" + id,
                     "application/json", data)
-            )));
+            )).build());
     }
 }
 ----
@@ -426,10 +427,7 @@ public class AsyncClientHandlers {
             return prompt;
         })
         .flatMap(prompt -> callLLMAsync(prompt))
-        .map(response -> CreateMessageResult.builder()
-            .role(Role.ASSISTANT)
-            .content(new TextContent(response))
-            .model("gpt-4")
+        .map(response -> CreateMessageResult.builder(Role.ASSISTANT, response, "gpt-4")
             .build())
         .timeout(Duration.ofSeconds(30));
     }
@@ -520,8 +518,9 @@ public class StatelessTools {
             template = substituteVariables(template, variables);
         }
 
-        return new GetPromptResult("Template: " + templateName,
-            List.of(new PromptMessage(Role.USER, new TextContent(template))));
+        return GetPromptResult.builder(List.of(new PromptMessage(Role.USER, TextContent.builder(template).build())))
+            .description("Template: " + templateName)
+            .build();
     }
 }
 ----
@@ -567,19 +566,17 @@ public class WeatherService {
         StringBuilder anthropicWeatherPoem = new StringBuilder();
 
         // Send logging notification
-        exchange.loggingNotification(LoggingMessageNotification.builder()
-                .level(LoggingLevel.INFO)
-                .data("Start sampling")
+        exchange.loggingNotification(LoggingMessageNotification.builder(LoggingLevel.INFO, "Start sampling")
                 .build());
 
         // Check if client supports sampling
         if (exchange.getClientCapabilities().sampling() != null) {
-            var messageRequestBuilder = McpSchema.CreateMessageRequest.builder()
-                    .systemPrompt("You are a poet!")
-                    .messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-                            new McpSchema.TextContent(
-                                    "Please write a poem about this weather forecast (temperature is in Celsius). Use markdown format :\n "
-                                            + ModelOptionsUtils.toJsonStringPrettyPrinter(weatherResponse)))));
+            var samplingMessages = List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
+                    McpSchema.TextContent.builder(
+                            "Please write a poem about this weather forecast (temperature is in Celsius). Use markdown format :\n "
+                                    + ModelOptionsUtils.toJsonStringPrettyPrinter(weatherResponse)).build()));
+            var messageRequestBuilder = McpSchema.CreateMessageRequest.builder(samplingMessages, 500)
+                    .systemPrompt("You are a poet!");
 
             // Request poem from OpenAI
             var openAiLlmMessageRequest = messageRequestBuilder
@@ -596,9 +593,7 @@ public class WeatherService {
             anthropicWeatherPoem.append(((McpSchema.TextContent) anthropicAiLlmResponse.content()).text());
         }
 
-        exchange.loggingNotification(LoggingMessageNotification.builder()
-                .level(LoggingLevel.INFO)
-                .data("Finish Sampling")
+        exchange.loggingNotification(LoggingMessageNotification.builder(LoggingLevel.INFO, "Finish Sampling")
                 .build());
 
         // Combine results
@@ -659,8 +654,7 @@ public class McpClientHandlers {
                 .call()
                 .content();
 
-        return CreateMessageResult.builder()
-                .content(new McpSchema.TextContent(response))
+        return CreateMessageResult.builder(Role.ASSISTANT, response, modelHint)
                 .build();
     }
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
@@ -267,12 +267,12 @@ public class ResourceProvider {
 public ReadResourceResult getUserProfile(String username) {
     String profileData = loadUserProfile(username);
     
-    return new ReadResourceResult(List.of(
+    return ReadResourceResult.builder(List.of(
         new TextResourceContents(
             "user-profile://" + username,
-            "application/json", 
+            "application/json",
             profileData)
-    ));
+    )).build();
 }
 ----
 
@@ -296,9 +296,9 @@ public ReadResourceResult getData(
     
     String data = fetchData(id);
     
-    return new ReadResourceResult(List.of(
+    return ReadResourceResult.builder(List.of(
         new TextResourceContents("data://" + id, "text/plain", data)
-    ));
+    )).build();
 }
 ----
 
@@ -346,10 +346,9 @@ public class PromptProvider {
         
         String message = "Hello, " + name + "! How can I help you today?";
         
-        return new GetPromptResult(
-            "Greeting",
-            List.of(new PromptMessage(Role.ASSISTANT, new TextContent(message)))
-        );
+        return GetPromptResult.builder(List.of(new PromptMessage(Role.ASSISTANT, TextContent.builder(message).build())))
+            .description("Greeting")
+            .build();
     }
 }
 ----
@@ -379,10 +378,9 @@ public GetPromptResult personalizedMessage(
         // Add interest-specific content
     }
     
-    return new GetPromptResult(
-        "Personalized Message",
-        List.of(new PromptMessage(Role.ASSISTANT, new TextContent(message.toString())))
-    );
+    return GetPromptResult.builder(List.of(new PromptMessage(Role.ASSISTANT, TextContent.builder(message.toString()).build())))
+        .description("Personalized Message")
+        .build();
 }
 ----
 
@@ -773,9 +771,9 @@ public class AsyncTools {
     public Mono<ReadResourceResult> asyncResource(String id) {
         return Mono.fromCallable(() -> {
             String data = loadData(id);
-            return new ReadResourceResult(List.of(
+            return ReadResourceResult.builder(List.of(
                 new TextResourceContents("async-data://" + id, "text/plain", data)
-            ));
+            )).build();
         }).delayElements(Duration.ofMillis(100));
     }
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-special-params.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-special-params.adoc
@@ -87,17 +87,17 @@ public ReadResourceResult getSecureData(String id, McpMeta meta) {
     
     // Check access permissions using metadata
     if (!"admin".equals(accessLevel)) {
-        return new ReadResourceResult(List.of(
-            new TextResourceContents("secure-data://" + id, 
+        return ReadResourceResult.builder(List.of(
+            new TextResourceContents("secure-data://" + id,
                 "text/plain", "Access denied")
-        ));
+        )).build();
     }
-    
+
     String data = loadSecureData(id);
-    return new ReadResourceResult(List.of(
-        new TextResourceContents("secure-data://" + id, 
+    return ReadResourceResult.builder(List.of(
+        new TextResourceContents("secure-data://" + id,
             "text/plain", data)
-    ));
+    )).build();
 }
 ----
 
@@ -116,9 +116,9 @@ public GetPromptResult localizedPrompt(
     // Generate localized content based on metadata
     String message = generateLocalizedMessage(topic, language, region);
     
-    return new GetPromptResult("Localized Prompt",
-        List.of(new PromptMessage(Role.ASSISTANT, new TextContent(message)))
-    );
+    return GetPromptResult.builder(List.of(new PromptMessage(Role.ASSISTANT, TextContent.builder(message).build())))
+        .description("Localized Prompt")
+        .build();
 }
 ----
 
@@ -147,17 +147,16 @@ public String performLongOperation(
     
     if (progressToken != null) {
         // Send initial progress
-        exchange.progressNotification(new ProgressNotification(
-            progressToken, 0.0, 1.0, "Starting " + operation));
-        
+        exchange.progressNotification(ProgressNotification.builder(progressToken, 0.0)
+            .total(1.0).message("Starting " + operation).build());
+
         // Simulate work with progress updates
         for (int i = 1; i <= duration; i++) {
             Thread.sleep(1000);
             double progress = (double) i / duration;
-            
-            exchange.progressNotification(new ProgressNotification(
-                progressToken, progress, 1.0, 
-                String.format("Processing... %d%%", (int)(progress * 100))));
+
+            exchange.progressNotification(ProgressNotification.builder(progressToken, progress)
+                .total(1.0).message(String.format("Processing... %d%%", (int)(progress * 100))).build());
         }
     }
     
@@ -180,20 +179,20 @@ public ReadResourceResult getLargeFile(
     
     if (progressToken != null) {
         // Track file reading progress
-        exchange.progressNotification(new ProgressNotification(
-            progressToken, 0.0, fileSize, "Reading file"));
+        exchange.progressNotification(ProgressNotification.builder(progressToken, 0.0)
+            .total(fileSize).message("Reading file").build());
     }
-    
+
     String content = readFileWithProgress(file, progressToken, exchange);
-    
+
     if (progressToken != null) {
-        exchange.progressNotification(new ProgressNotification(
-            progressToken, fileSize, fileSize, "File read complete"));
+        exchange.progressNotification(ProgressNotification.builder(progressToken, fileSize)
+            .total(fileSize).message("File read complete").build());
     }
-    
-    return new ReadResourceResult(List.of(
+
+    return ReadResourceResult.builder(List.of(
         new TextResourceContents("large-file://" + path, "text/plain", content)
-    ));
+    )).build();
 }
 ----
 
@@ -360,9 +359,9 @@ public ReadResourceResult statelessResource(
     // Access transport context if needed
     String data = loadData(id);
     
-    return new ReadResourceResult(List.of(
+    return ReadResourceResult.builder(List.of(
         new TextResourceContents("stateless://" + id, "text/plain", data)
-    ));
+    )).build();
 }
 ----
 
@@ -444,18 +443,18 @@ public CallToolResult flexibleWithProgress(
     Map<String, Object> args = request.arguments();
     
     if (progressToken != null) {
-        exchange.progressNotification(new ProgressNotification(
-            progressToken, 0.0, 1.0, "Processing dynamic request"));
+        exchange.progressNotification(ProgressNotification.builder(progressToken, 0.0)
+            .total(1.0).message("Processing dynamic request").build());
     }
-    
+
     // Process dynamic arguments
     String result = processDynamicArgs(args);
-    
+
     if (progressToken != null) {
-        exchange.progressNotification(new ProgressNotification(
-            progressToken, 1.0, 1.0, "Complete"));
+        exchange.progressNotification(ProgressNotification.builder(progressToken, 1.0)
+            .total(1.0).message("Complete").build());
     }
-    
+
     return CallToolResult.builder()
         .addTextContent(result)
         .build();
@@ -523,15 +522,15 @@ public String safeProgress(
     
     // Always check if progress token is available
     if (progressToken != null) {
-        exchange.progressNotification(new ProgressNotification(
-            progressToken, 0.0, 1.0, "Starting"));
+        exchange.progressNotification(ProgressNotification.builder(progressToken, 0.0)
+            .total(1.0).message("Starting").build());
     }
-    
+
     // Perform work...
-    
+
     if (progressToken != null) {
-        exchange.progressNotification(new ProgressNotification(
-            progressToken, 1.0, 1.0, "Complete"));
+        exchange.progressNotification(ProgressNotification.builder(progressToken, 1.0)
+            .total(1.0).message("Complete").build());
     }
     
     return "Task completed";

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -824,10 +824,7 @@ public class McpClientHandlers {
         // Process the request and generate a response
         String response = generateLLMResponse(request);
 
-        return CreateMessageResult.builder()
-            .role(Role.ASSISTANT)
-            .content(new TextContent(response))
-            .model("gpt-4")
+        return CreateMessageResult.builder(Role.ASSISTANT, response, "gpt-4")
             .build();
     }
 
@@ -861,10 +858,7 @@ public void handleServer1Logs(LoggingMessageNotification notification) {
 public Mono<CreateMessageResult> handleAsyncSampling(CreateMessageRequest request) {
     return Mono.fromCallable(() -> {
         String response = generateLLMResponse(request);
-        return CreateMessageResult.builder()
-            .role(Role.ASSISTANT)
-            .content(new TextContent(response))
-            .model("gpt-4")
+        return CreateMessageResult.builder(Role.ASSISTANT, response, "gpt-4")
             .build();
     }).subscribeOn(Schedulers.boundedElastic());
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
@@ -198,8 +198,8 @@ public List<McpStatelessServerFeatures.SyncPromptSpecification> myPrompts() {
     var promptSpecification = new McpStatelessServerFeatures.SyncPromptSpecification(prompt, (context, getPromptRequest) -> {
         String nameArgument = (String) getPromptRequest.arguments().get("name");
         if (nameArgument == null) { nameArgument = "friend"; }
-        var userMessage = new PromptMessage(Role.USER, new TextContent("Hello " + nameArgument + "! How can I assist you today?"));
-        return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+        var userMessage = new PromptMessage(Role.USER, TextContent.builder("Hello " + nameArgument + "! How can I assist you today?").build());
+        return GetPromptResult.builder(List.of(userMessage)).description("A personalized greeting message").build();
     });
 
     return List.of(promptSpecification);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
@@ -221,8 +221,8 @@ public List<McpServerFeatures.SyncPromptSpecification> myPrompts() {
     var promptSpecification = new McpServerFeatures.SyncPromptSpecification(prompt, (exchange, getPromptRequest) -> {
         String nameArgument = (String) getPromptRequest.arguments().get("name");
         if (nameArgument == null) { nameArgument = "friend"; }
-        var userMessage = new PromptMessage(Role.USER, new TextContent("Hello " + nameArgument + "! How can I assist you today?"));
-        return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+        var userMessage = new PromptMessage(Role.USER, TextContent.builder("Hello " + nameArgument + "! How can I assist you today?").build());
+        return GetPromptResult.builder(List.of(userMessage)).description("A personalized greeting message").build();
     });
 
     return List.of(promptSpecification);
@@ -261,10 +261,8 @@ From within the tool, resource, prompt or completion call handler use the provid
 [source,java]
 ----
 (exchange, request) -> {
-        exchange.loggingNotification(LoggingMessageNotification.builder()
-            .level(LoggingLevel.INFO)
+        exchange.loggingNotification(LoggingMessageNotification.builder(LoggingLevel.INFO, "This is a test log message")
             .logger("test-logger")
-            .data("This is a test log message")
             .build());
 }
 ----
@@ -286,9 +284,7 @@ From within the tool, resource, prompt or completion call handler use the provid
 [source,java]
 ----
 (exchange, request) -> {
-        exchange.progressNotification(ProgressNotification.builder()
-            .progressToken("test-progress-token")
-            .progress(0.25)
+        exchange.progressNotification(ProgressNotification.builder("test-progress-token", 0.25)
             .total(1.0)
             .message("tool call in progress")
             .build());

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc
@@ -206,8 +206,8 @@ public List<McpServerFeatures.SyncPromptSpecification> myPrompts() {
     var promptSpecification = new McpServerFeatures.SyncPromptSpecification(prompt, (exchange, getPromptRequest) -> {
         String nameArgument = (String) getPromptRequest.arguments().get("name");
         if (nameArgument == null) { nameArgument = "friend"; }
-        var userMessage = new PromptMessage(Role.USER, new TextContent("Hello " + nameArgument + "! How can I assist you today?"));
-        return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+        var userMessage = new PromptMessage(Role.USER, TextContent.builder("Hello " + nameArgument + "! How can I assist you today?").build());
+        return GetPromptResult.builder(List.of(userMessage)).description("A personalized greeting message").build();
     });
 
     return List.of(promptSpecification);
@@ -246,10 +246,8 @@ From within the tool, resource, prompt or completion call handler use the provid
 [source,java]
 ----
 (exchange, request) -> {
-        exchange.loggingNotification(LoggingMessageNotification.builder()
-            .level(LoggingLevel.INFO)
+        exchange.loggingNotification(LoggingMessageNotification.builder(LoggingLevel.INFO, "This is a test log message")
             .logger("test-logger")
-            .data("This is a test log message")
             .build());
 }
 ----
@@ -271,9 +269,7 @@ From within the tool, resource, prompt or completion call handler use the provid
 [source,java]
 ----
 (exchange, request) -> {
-        exchange.progressNotification(ProgressNotification.builder()
-            .progressToken("test-progress-token")
-            .progress(0.25)
+        exchange.progressNotification(ProgressNotification.builder("test-progress-token", 0.25)
             .total(1.0)
             .message("tool call in progress")
             .build());

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -185,6 +185,55 @@ The Azure Cosmos DB vector store (`spring-ai-azure-cosmos-db-store`) and chat me
 Azure Cosmos DB support is now available as an external module maintained by the Azure Cosmos DB team.
 See https://azurecosmosdb.github.io/spring-ai/docs/index.html for documentation and dependency coordinates.
 
+=== MCP SDK 2.0.0-M3
+
+Spring AI now depends on MCP SDK 2.0.0-M3, which makes previously optional fields mandatory and enforces them at construction time via `Assert.notNull()` in compact record constructors.
+
+==== Breaking: `CreateMessageResult` — `model` now required
+
+[source,java]
+----
+// Before
+CreateMessageResult.builder()
+    .content(new TextContent(response))
+    .build();
+
+// After
+CreateMessageResult.builder(Role.ASSISTANT, response, modelHint)
+    .build();
+----
+
+==== Breaking: `CreateMessageRequest` — `maxTokens` now required
+
+[source,java]
+----
+// Before
+CreateMessageRequest.builder()
+    .messages(messages)
+    .build();
+
+// After
+CreateMessageRequest.builder(messages, 500)
+    .build();
+----
+
+==== Deprecated Builder APIs
+
+The following no-arg constructors and `builder()` methods are deprecated in favour of factory methods that require mandatory arguments upfront:
+
+[cols="1,1"]
+|===
+|Deprecated |Replacement
+
+|`new TextContent(text)` |`TextContent.builder(text).build()`
+|`new ReadResourceResult(contents)` |`ReadResourceResult.builder(contents).build()`
+|`new GetPromptResult(description, messages)` |`GetPromptResult.builder(messages).description(description).build()`
+|`new ProgressNotification(token, progress, total, message)` |`ProgressNotification.builder(token, progress).total(total).message(message).build()`
+|`LoggingMessageNotification.builder()` |`LoggingMessageNotification.builder(level, data)`
+|`ElicitRequest.builder()` |`ElicitRequest.builder(message, requestedSchema)`
+|`CallToolRequest.builder()` |`CallToolRequest.builder(name)`
+|===
+
 [[upgrading-to-2-0-0-M6]]
 == Upgrading to 2.0.0-M6
 


### PR DESCRIPTION
MCP SDK 2.0.0-M3 makes `model` on `CreateMessageResult` and `maxTokens` on `CreateMessageRequest` mandatory, throwing `IllegalArgumentException` at construction time if omitted.
All other builders now require their mandatory arguments upfront in the factory method.

- Fix affected test files to use M3 builder APIs
- Update MCP documentation code samples to match
- Add MCP SDK 2.0.0-M3 section to upgrade-notes.adoc
