### PR TITLE
fix: Avoid switchMap in ChatModel streaming

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -818,7 +818,7 @@ public class BedrockProxyChatModel implements ChatModel {
 			ChatOptions options = prompt.getOptions();
 			Assert.state(options != null, "Prompt options must not be null");
 
-			Flux<ChatResponse> chatResponseFlux = chatResponses.switchMap(chatResponse -> {
+			Flux<ChatResponse> chatResponseFlux = chatResponses.concatMap(chatResponse -> {
 
 				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(options, chatResponse)
 						&& chatResponse.hasFinishReasons(Set.of(StopReason.TOOL_USE.toString()))) {

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -28,7 +28,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -264,8 +263,9 @@ public class DeepSeekChatModel implements ChatModel {
 
 			observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
 
+			// @formatter:off
 			Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
-				.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+				.map(chatCompletion2 -> {
 					try {
 						String id = chatCompletion2.id();
 
@@ -294,7 +294,7 @@ public class DeepSeekChatModel implements ChatModel {
 						return new ChatResponse(List.of());
 					}
 
-				}));
+				});
 
 			// @formatter:off
 			Flux<ChatResponse> flux = chatResponse.flatMap(response -> {

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelStreamingTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelStreamingTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.deepseek.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.deepseek.DeepSeekChatModel;
+import org.springframework.ai.deepseek.DeepSeekChatOptions;
+import org.springframework.ai.deepseek.api.DeepSeekApi;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionChunk;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionMessage;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionMessage.Role;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionRequest;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.core.retry.RetryTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class DeepSeekChatModelStreamingTests {
+
+	@Mock
+	private DeepSeekApi api;
+
+	private DeepSeekChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<ChatCompletionChunk> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			var choice = new ChunkChoice(null, 0, new ChatCompletionMessage(i + " ", Role.ASSISTANT), null);
+			ChatCompletionChunk chunk = new ChatCompletionChunk("id", List.of(choice), 666L, "model", null, null,
+					"chat.completion.chunk", null);
+			chunks.add(chunk);
+		}
+
+		given(this.api.chatCompletionStream(isA(ChatCompletionRequest.class)))
+			.willReturn(Flux.fromIterable(chunks).index().map(n -> {
+				if (n.getT1() == 256) {
+					latch.countDown();
+				}
+				return n.getT2();
+			}));
+
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		this.chatModel = DeepSeekChatModel.builder()
+			.deepSeekApi(this.api)
+			.defaultOptions(DeepSeekChatOptions.builder().build())
+			.toolCallingManager(toolCallingManager)
+			.retryTemplate(retryTemplate)
+			.observationRegistry(ObservationRegistry.NOOP)
+			.build();
+	}
+
+}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/chat/GoogleGenAiChatModelStreamingTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/chat/GoogleGenAiChatModelStreamingTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import com.google.genai.Client;
+import com.google.genai.Models;
+import com.google.genai.ResponseStream;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class GoogleGenAiChatModelStreamingTests {
+
+	@Mock
+	private Client client;
+
+	private GoogleGenAiChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+		Models models = Mockito.mock(Models.class);
+		ReflectionTestUtils.setField(this.client, "models", models);
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<GenerateContentResponse> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			Part part = Part.builder().text(i + " ").build();
+			Content content = Content.builder().parts(List.of(part)).build();
+			Candidate candidate = Candidate.builder().content(content).build();
+			GenerateContentResponse response = GenerateContentResponse.builder()
+				.candidates(List.of(candidate))
+				.modelVersion("v1")
+				.build();
+			chunks.add(response);
+		}
+
+		ResponseStream<GenerateContentResponse> iterable = Mockito.mock(ResponseStream.class);
+		given(iterable.iterator()).willReturn(chunks.stream().map(r -> {
+			int i = Integer
+				.parseInt(r.candidates().get().get(0).content().get().parts().get().get(0).text().get().trim());
+			if (i == 256) {
+				latch.countDown();
+			}
+			return r;
+		}).iterator());
+		given(iterable.spliterator()).willCallRealMethod();
+
+		given(models.generateContentStream(any(String.class), any(List.class), any())).willReturn(iterable);
+
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		this.chatModel = GoogleGenAiChatModel.builder()
+			.genAiClient(this.client)
+			.defaultOptions(
+					GoogleGenAiChatOptions.builder().model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH).build())
+			.toolCallingManager(toolCallingManager)
+			.observationRegistry(ObservationRegistry.NOOP)
+			.build();
+	}
+
+}

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
@@ -30,7 +30,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -361,8 +360,9 @@ public class MiniMaxChatModel implements ChatModel {
 
 			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
 			// the function call handling logic.
+			// @formatter:off
 			Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
-				.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+				.map(chatCompletion2 -> {
 					try {
 						String id = chatCompletion2.id() != null ? chatCompletion2.id() : "";
 						List<Choice> chunkChoices = chatCompletion2.choices() != null
@@ -386,7 +386,7 @@ public class MiniMaxChatModel implements ChatModel {
 							logger.error("Error processing chat completion", e);
 							return new ChatResponse(List.of());
 						}
-					}));
+					});
 
 			Flux<ChatResponse> flux = chatResponse.flatMap(response -> {
 						ChatOptions promptOptions = Objects.requireNonNull(requestPrompt.getOptions());

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatModelStreamingTests.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatModelStreamingTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.minimax.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.minimax.MiniMaxChatModel;
+import org.springframework.ai.minimax.MiniMaxChatOptions;
+import org.springframework.ai.minimax.api.MiniMaxApi;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionChunk;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage.Role;
+import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionRequest;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.core.retry.RetryTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class MiniMaxChatModelStreamingTests {
+
+	@Mock
+	private MiniMaxApi api;
+
+	private MiniMaxChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<ChatCompletionChunk> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			var choice = new ChunkChoice(null, 0, new ChatCompletionMessage(i + " ", Role.ASSISTANT), null);
+			ChatCompletionChunk chunk = new ChatCompletionChunk("id", List.of(choice), 666L, "model", null,
+					"chat.completion.chunk");
+			chunks.add(chunk);
+		}
+
+		given(this.api.chatCompletionStream(isA(ChatCompletionRequest.class)))
+			.willReturn(Flux.fromIterable(chunks).index().map(n -> {
+				if (n.getT1() == 256) {
+					latch.countDown();
+				}
+				return n.getT2();
+			}));
+
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		this.chatModel = new MiniMaxChatModel(this.api, MiniMaxChatOptions.builder().build(), toolCallingManager,
+				retryTemplate);
+	}
+
+}

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -32,7 +32,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -289,8 +288,9 @@ public class MistralAiChatModel implements ChatModel {
 
 			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
 			// the function call handling logic.
+			// @formatter:off
 			Flux<ChatResponse> chatResponse = completionChunks.map(this::toChatCompletion)
-				.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+				.map(chatCompletion2 -> {
 					try {
 						@SuppressWarnings("null")
 						String id = chatCompletion2.id();
@@ -322,7 +322,7 @@ public class MistralAiChatModel implements ChatModel {
 						logger.error("Error processing chat completion", e);
 						return new ChatResponse(List.of());
 					}
-				}));
+				});
 
 			// @formatter:off
 			Flux<ChatResponse> chatResponseFlux = chatResponse.flatMap(response -> {

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/chat/MistralAiChatModelStreamingTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/chat/MistralAiChatModelStreamingTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mistralai.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.mistralai.MistralAiChatModel;
+import org.springframework.ai.mistralai.MistralAiChatOptions;
+import org.springframework.ai.mistralai.api.MistralAiApi;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionChunk;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionMessage;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionMessage.Role;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.core.retry.RetryTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class MistralAiChatModelStreamingTests {
+
+	@Mock
+	private MistralAiApi api;
+
+	private MistralAiChatModel chatModel;
+
+	@Test
+	void testStreamingWithNumbers() {
+		// Setup
+		setupChatModel();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		List<ChatCompletionChunk> chunks = new ArrayList<>();
+		for (int i = 1; i <= 300; i++) {
+			var choice = new ChunkChoice(0, new ChatCompletionMessage(i + " ", Role.ASSISTANT), null, null);
+			ChatCompletionChunk chunk = new ChatCompletionChunk("id", "chat.completion.chunk", 666L, "model",
+					List.of(choice), null);
+			chunks.add(chunk);
+		}
+
+		given(this.api.chatCompletionStream(isA(ChatCompletionRequest.class)))
+			.willReturn(Flux.fromIterable(chunks).index().map(n -> {
+				if (n.getT1() == 256) {
+					latch.countDown();
+				}
+				return n.getT2();
+			}));
+
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("Count to 300"));
+
+		// @formatter:off
+		List<ChatResponse> responses = result
+			// Produce independently
+			.subscribeOn(Schedulers.boundedElastic())
+			// Fill the buffer of 256 items
+			.publishOn(Schedulers.boundedElastic(), 256)
+			.map(r -> {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						return r;
+					}
+					else {
+						throw new RuntimeException("Timed out waiting for completion response");
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			})
+			.collectList()
+			.block();
+		// @formatter:on
+		assertThat(responses).isNotNull();
+		assertThat(responses).isNotEmpty();
+
+		StringBuilder fullContent = new StringBuilder();
+		for (ChatResponse response : responses) {
+			fullContent.append(response.getResult().getOutput().getText());
+		}
+
+		String expectedContent = IntStream.rangeClosed(1, 300).mapToObj(i -> i + " ").reduce("", String::concat);
+
+		assertThat(fullContent.toString()).isEqualTo(expectedContent);
+	}
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		this.chatModel = MistralAiChatModel.builder()
+			.mistralAiApi(this.api)
+			.defaultOptions(MistralAiChatOptions.builder().build())
+			.toolCallingManager(toolCallingManager)
+			.retryTemplate(retryTemplate)
+			.observationRegistry(ObservationRegistry.NOOP)
+			.build();
+	}
+
+}


### PR DESCRIPTION
Reactive switchMap operator eagerly subscribes to the source requesting unlimited data from the upstream. When the downstream is busy processing items on another thread, the next incoming item will cause a previous one to be discarded. That can force the streaming variant of ChatModel to silently drop parts of the streamed response and is highly undesired.

This is a port of #6106 and #6123