### PR TITLE
GH-6119: Use class literal for ChatClient autoconf ordering

### DIFF
--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
@@ -32,6 +32,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing</artifactId>
 			<optional>true</optional>
@@ -58,13 +65,6 @@
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
-			<version>${project.parent.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.ai.chat.client.observation.ChatClientObservationConve
 import org.springframework.ai.chat.client.observation.ChatClientPromptContentObservationHandler;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.observation.TracingAwareLoggingObservationHandler;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -60,7 +61,7 @@ import org.springframework.context.annotation.Scope;
  * @author Jonatan Ivanov
  * @since 1.0.0
  */
-@AutoConfiguration(afterName = "org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration")
+@AutoConfiguration(after = ToolCallingAutoConfiguration.class)
 @ConditionalOnClass(ChatClient.class)
 @EnableConfigurationProperties(ChatClientBuilderProperties.class)
 @ConditionalOnProperty(prefix = ChatClientBuilderProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",


### PR DESCRIPTION
## Summary

`ChatClientAutoConfiguration` references `ToolCallingAutoConfiguration` for ordering via `afterName` with a hardcoded fully qualified string. A rename or package move of `ToolCallingAutoConfiguration` would silently break the ordering without any compile-time signal. Per #6119, switching to a `.class` literal makes the reference type-safe.

This change promotes the dependency on `spring-ai-autoconfigure-model-tool` from test to optional main scope so the class is visible to the chat-client autoconf module. The dependency stays `optional` and `spring-ai-autoconfigure-model-tool` itself marks its transitive deps optional, so consumers that do not opt in are unaffected.

## Changes

- `spring-ai-autoconfigure-model-chat-client/pom.xml`: move the `spring-ai-autoconfigure-model-tool` dependency from `test` scope to optional main scope.
- `ChatClientAutoConfiguration`: replace `afterName = "org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration"` with `after = ToolCallingAutoConfiguration.class` and add the corresponding import.

The existing `toolCallAdvisorBuilderUsesAutoConfiguredToolCallingManager` test continues to verify the ordering is honored.

Fixes #6119