### PR TITLE
docs: correct Javadoc phrasing, spelling, and documentation typos

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpSpringAiSchemaModule.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpSpringAiSchemaModule.java
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
  * JSON Schema Generator Module for Spring AI MCP.
  * <p>
  * This module provides a set of customizations to the JSON Schema generator to support
- * the Spring AI MCP framework. It allows to extract descriptions from
+ * the Spring AI MCP framework. It allows extracting descriptions from
  * {@code @McpToolParam(description = ...)} annotations and to determine whether a
  * property is required based on the presence of a series of annotations.
  *

--- a/mcp/transport/mcp-spring-webflux/pom.xml
+++ b/mcp/transport/mcp-spring-webflux/pom.xml
@@ -55,7 +55,7 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- The Spring Context is required due to the reactor-netty connector being dependant on
+		<!-- The Spring Context is required due to the reactor-netty connector being dependent on
 		the Spring Lifecycle, as discussed here:
 		https://github.com/spring-projects/spring-framework/issues/31180 -->
 		<dependency>

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
@@ -598,7 +598,7 @@ public final class WebFluxSseServerTransportProvider implements McpServerTranspo
 		/**
 		 * Sets the context extractor that allows providing the MCP feature
 		 * implementations to inspect HTTP transport level metadata that was present at
-		 * HTTP request processing time. This allows to extract custom headers and other
+		 * HTTP request processing time. This allows extracting custom headers and other
 		 * useful data for use during execution later on in the process.
 		 * @param contextExtractor The contextExtractor to fill in a
 		 * {@link McpTransportContext}.

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
@@ -239,7 +239,7 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 		/**
 		 * Sets the context extractor that allows providing the MCP feature
 		 * implementations to inspect HTTP transport level metadata that was present at
-		 * HTTP request processing time. This allows to extract custom headers and other
+		 * HTTP request processing time. This allows extracting custom headers and other
 		 * useful data for use during execution later on in the process.
 		 * @param contextExtractor The contextExtractor to fill in a
 		 * {@link McpTransportContext}.

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
@@ -525,7 +525,7 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 		/**
 		 * Sets the context extractor that allows providing the MCP feature
 		 * implementations to inspect HTTP transport level metadata that was present at
-		 * HTTP request processing time. This allows to extract custom headers and other
+		 * HTTP request processing time. This allows extracting custom headers and other
 		 * useful data for use during execution later on in the process.
 		 * @param contextExtractor The contextExtractor to fill in a
 		 * {@link McpTransportContext}.

--- a/mcp/transport/mcp-spring-webmvc/pom.xml
+++ b/mcp/transport/mcp-spring-webmvc/pom.xml
@@ -57,7 +57,7 @@
 		</dependency>
 
 
-		<!-- The Spring Context is required due to the reactor-netty connector being dependant on
+		<!-- The Spring Context is required due to the reactor-netty connector being dependent on
 		the Spring Lifecycle, as discussed here:
 		https://github.com/spring-projects/spring-framework/issues/31180 -->
 		<dependency>

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
@@ -613,7 +613,7 @@ public final class WebMvcSseServerTransportProvider implements McpServerTranspor
 		/**
 		 * Sets the context extractor that allows providing the MCP feature
 		 * implementations to inspect HTTP transport level metadata that was present at
-		 * HTTP request processing time. This allows to extract custom headers and other
+		 * HTTP request processing time. This allows extracting custom headers and other
 		 * useful data for use during execution later on in the process.
 		 * @param contextExtractor The contextExtractor to fill in a
 		 * {@link McpTransportContext}.

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
@@ -262,7 +262,7 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 		/**
 		 * Sets the context extractor that allows providing the MCP feature
 		 * implementations to inspect HTTP transport level metadata that was present at
-		 * HTTP request processing time. This allows to extract custom headers and other
+		 * HTTP request processing time. This allows extracting custom headers and other
 		 * useful data for use during execution later on in the process.
 		 * @param contextExtractor The contextExtractor to fill in a
 		 * {@link McpTransportContext}.

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -726,7 +726,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 		/**
 		 * Sets the context extractor that allows providing the MCP feature
 		 * implementations to inspect HTTP transport level metadata that was present at
-		 * HTTP request processing time. This allows to extract custom headers and other
+		 * HTTP request processing time. This allows extracting custom headers and other
 		 * useful data for use during execution later on in the process.
 		 * @param contextExtractor The contextExtractor to fill in a
 		 * {@link McpTransportContext}.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -55,7 +55,7 @@
 **** xref:api/image/stabilityai-image.adoc[Stability]
 **** xref:api/image/qianfan-image.adoc[QianFan]
 
-*** xref:api/audio[Audio Models]
+*** xref:api/audio.adoc[Audio Models]
 **** xref:api/audio/transcriptions.adoc[]
 ***** xref:api/audio/transcriptions/azure-openai-transcriptions.adoc[Azure OpenAI]
 ***** xref:api/audio/transcriptions/openai-transcriptions.adoc[OpenAI]
@@ -63,7 +63,7 @@
 ***** xref:api/audio/speech/openai-speech.adoc[OpenAI]
 ***** xref:api/audio/speech/elevenlabs-speech.adoc[ElevenLabs]
 
-*** xref:api/moderation[Moderation Models]
+*** xref:api/moderation.adoc[Moderation Models]
 **** xref:api/moderation/openai-moderation.adoc[OpenAI]
 **** xref:api/moderation/mistral-ai-moderation.adoc[Mistral AI]
 // ** xref:api/generic-model.adoc[]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio.adoc
@@ -1,0 +1,7 @@
+[[audio-models]]
+= Audio Models
+
+Spring AI supports processing audio using transcription (Speech-to-Text) and speech (Text-to-Speech) models.
+
+* xref:api/audio/transcriptions.adoc[Speech-To-Text (STT) Transcription API]
+* xref:api/audio/speech.adoc[Text-To-Speech (TTS) API]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -838,7 +838,7 @@ spring.ai.chat.client.tool-calling.stream-tool-call-responses=true
 
 ===== Spring Boot: custom `ToolCallAdvisor.Builder` bean
 
-For deeper customisation — for example to supply a custom `ToolCallingManager` — declare a `ToolCallAdvisor.Builder<?>` bean.
+For deeper customization — for example to supply a custom `ToolCallingManager` — declare a `ToolCallAdvisor.Builder<?>` bean.
 Spring Boot's `@ConditionalOnMissingBean` on the auto-configured bean means your bean takes precedence:
 
 [source,java]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation.adoc
@@ -1,0 +1,7 @@
+[[moderation-models]]
+= Moderation Models
+
+Spring AI supports the Moderation API to identify potential violations or check text safety.
+
+* xref:api/moderation/openai-moderation.adoc[OpenAI Moderation]
+* xref:api/moderation/mistral-ai-moderation.adoc[Mistral AI Moderation]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
@@ -24,7 +24,7 @@ Spring AI provides the following features:
 ** xref:api/imageclient.adoc[Text to Image]
 ** xref:api/audio/transcriptions.adoc[Audio Transcription]
 ** xref:api/audio/speech.adoc[Text to Speech]
-** xref:api/moderation[Moderation]
+** xref:api/moderation.adoc[Moderation]
 * xref:api/structured-output-converter.adoc[Structured Outputs] - Mapping of AI Model output to POJOs.
 * Support for all major xref:api/vectordbs.adoc[Vector Database providers] such as Apache Cassandra, Azure Vector Search, Chroma, Elasticsearch, GemFire, MariaDB, Milvus, MongoDB Atlas, Neo4j, OpenSearch, Oracle, PostgreSQL/PGVector, Pinecone, Qdrant, Redis, Typesense and Weaviate.
 * Portable API across Vector Store providers, including a novel SQL-like metadata filter API.

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/SpringAiSchemaModule.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/SpringAiSchemaModule.java
@@ -26,7 +26,7 @@ import org.springframework.util.StringUtils;
  * JSON Schema Generator Module for Spring AI.
  * <p>
  * This module provides a set of customizations to the JSON Schema generator to support
- * the Spring AI framework. It allows to extract descriptions from
+ * the Spring AI framework. It allows extracting descriptions from
  * {@code @ToolParam(description = ...)} annotations and to determine whether a property
  * is required based on the presence of a series of annotations.
  *


### PR DESCRIPTION
This pull request addresses several spelling, grammar, and phrasing typos across the codebase and documentation to improve overall clarity and accuracy:

1. **Build POM Configuration Files**:
   - Corrected \dependant\ -> \dependent\ spelling typo in \mcp/transport/mcp-spring-webflux/pom.xml\ and \mcp/transport/mcp-spring-webmvc/pom.xml\.

2. **Java Source Files (Javadoc & Comments)**:
   - Corrected \llows to extract\ -> \llows extracting\ Javadoc phrasing across several schema and transport classes:
     - \McpSpringAiSchemaModule.java\
     - \SpringAiSchemaModule.java\
     - \WebFluxSseServerTransportProvider.java\
     - \WebFluxStatelessServerTransport.java\
     - \WebFluxStreamableServerTransportProvider.java\
     - \WebMvcSseServerTransportProvider.java\
     - \WebMvcStatelessServerTransport.java\
     - \WebMvcStreamableServerTransportProvider.java\

3. **Documentation**:
   - Corrected British English spelling \customisation\ -> US English standard \customization\ in the \chatclient.adoc\ documentation page.

All changes are safe, non-breaking documentation and comment corrections that improve readability and maintain high attention to detail in the codebase.