### PR TITLE
Use class reference for tool auto-configuration order

### DIFF
--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
@@ -32,6 +32,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing</artifactId>
 			<optional>true</optional>
@@ -58,13 +65,6 @@
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
-			<version>${project.parent.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.ai.chat.client.observation.ChatClientObservationConve
 import org.springframework.ai.chat.client.observation.ChatClientPromptContentObservationHandler;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.observation.TracingAwareLoggingObservationHandler;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -60,7 +61,7 @@ import org.springframework.context.annotation.Scope;
  * @author Jonatan Ivanov
  * @since 1.0.0
  */
-@AutoConfiguration(afterName = "org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration")
+@AutoConfiguration(after = ToolCallingAutoConfiguration.class)
 @ConditionalOnClass(ChatClient.class)
 @EnableConfigurationProperties(ChatClientBuilderProperties.class)
 @ConditionalOnProperty(prefix = ChatClientBuilderProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfigurationTests.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfigurationTests.java
@@ -24,6 +24,7 @@ import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -42,6 +43,13 @@ class ChatClientAutoConfigurationTests {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(ChatClientAutoConfiguration.class))
 		.withBean(ChatModel.class, () -> mock(ChatModel.class));
+
+	@Test
+	void autoConfigurationOrdersAfterToolCallingAutoConfiguration() {
+		AutoConfiguration autoConfiguration = ChatClientAutoConfiguration.class.getAnnotation(AutoConfiguration.class);
+
+		assertThat(autoConfiguration.after()).containsExactly(ToolCallingAutoConfiguration.class);
+	}
 
 	@Test
 	void toolCallAdvisorBuilderBeanIsAutoConfigured() {


### PR DESCRIPTION
Closes #6119.

This updates `ChatClientAutoConfiguration` to order after `ToolCallingAutoConfiguration.class` directly instead of using a string-based `afterName` reference.

It also moves the tool auto-configuration module dependency from test scope to an optional main dependency so the class literal is available at compile time without adding a required transitive dependency for users.

Tests:
- `./mvnw -q -pl auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client -am -DskipITs -DskipDocs test`