### PR TITLE
GH-5987: Fix OpenAiChatModel.stream() buffering all chunks before emission

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai;
 
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import com.openai.client.OpenAIClient;
@@ -349,136 +351,152 @@ public final class OpenAiChatModel implements ChatModel {
 						sink.complete();
 					}
 				});
-			}).buffer(2, 1).map(buffer -> {
-				ChatResponse first = buffer.get(0);
-				if (request.streamOptions().isPresent() && buffer.size() == 2) {
-					ChatResponse second = buffer.get(1);
-					if (second != null) {
-						Usage usage = second.getMetadata().getUsage();
-						if (!UsageCalculator.isEmpty(usage)) {
-							return new ChatResponse(first.getResults(), from(first.getMetadata(), usage));
-						}
-					}
-				}
-				return first;
 			});
 
 			Flux<ChatResponse> flux = chatResponses
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 
-			return flux.collectList().flatMapMany(list -> {
-				if (list.isEmpty()) {
+			List<ChatResponse> streamedResponses = Collections.synchronizedList(new ArrayList<>());
+			AtomicReference<ChatResponse> aggregatedResponse = new AtomicReference<>();
+
+			return flux.doOnNext(streamedResponses::add).filter(this::shouldStreamResponse).doOnComplete(() -> {
+				ChatResponse aggregated = aggregateStreamingResponses(streamedResponses);
+				if (aggregated != null) {
+					aggregatedResponse.set(aggregated);
+					observationContext.setResponse(aggregated);
+				}
+			}).concatWith(Flux.defer(() -> {
+				ChatResponse aggregated = aggregatedResponse.get();
+				if (aggregated == null) {
 					return Flux.empty();
 				}
-				boolean hasToolCalls = list.stream()
-					.map(this::safeAssistantMessage)
-					.filter(Objects::nonNull)
-					.anyMatch(am -> !CollectionUtils.isEmpty(am.getToolCalls()));
-				if (!hasToolCalls) {
-					if (list.size() > 2) {
-						ChatResponse penultimateResponse = list.get(list.size() - 2); // Get
-																						// the
-																						// finish
-																						// reason
-						ChatResponse lastResponse = list.get(list.size() - 1); // Get the
-																				// usage
-						Usage usage = lastResponse.getMetadata().getUsage();
-						observationContext.setResponse(new ChatResponse(penultimateResponse.getResults(),
-								from(penultimateResponse.getMetadata(), usage)));
-					}
-					return Flux.fromIterable(list);
-				}
-				Map<String, ToolCallBuilder> builders = new HashMap<>();
-				StringBuilder text = new StringBuilder();
-				ChatResponseMetadata finalMetadata = null;
-				ChatGenerationMetadata finalGenMetadata = null;
-				Map<String, Object> props = new HashMap<>();
-				for (ChatResponse chatResponse : list) {
-					AssistantMessage am = safeAssistantMessage(chatResponse);
-					if (am == null) {
-						continue;
-					}
-					if (am.getText() != null) {
-						text.append(am.getText());
-					}
-					props.putAll(am.getMetadata());
-					if (!CollectionUtils.isEmpty(am.getToolCalls())) {
-						Object ccObj = am.getMetadata().get("chunkChoice");
-						if (ccObj instanceof ChatCompletionChunk.Choice chunkChoice
-								&& chunkChoice.delta().toolCalls().isPresent()) {
-							List<ChatCompletionChunk.Choice.Delta.ToolCall> deltaCalls = chunkChoice.delta()
-								.toolCalls()
-								.get();
-							for (int i = 0; i < am.getToolCalls().size() && i < deltaCalls.size(); i++) {
-								AssistantMessage.ToolCall tc = am.getToolCalls().get(i);
-								ChatCompletionChunk.Choice.Delta.ToolCall dtc = deltaCalls.get(i);
-								String key = chunkChoice.index() + "-" + dtc.index();
-								ToolCallBuilder toolCallBuilder = builders.computeIfAbsent(key,
-										k -> new ToolCallBuilder());
-								toolCallBuilder.merge(tc);
-							}
-						}
-						else {
-							for (AssistantMessage.ToolCall tc : am.getToolCalls()) {
-								ToolCallBuilder toolCallBuilder = builders.computeIfAbsent(tc.id(),
-										k -> new ToolCallBuilder());
-								toolCallBuilder.merge(tc);
-							}
-						}
-					}
-					Generation generation = chatResponse.getResult();
-					if (generation != null && generation.getMetadata() != ChatGenerationMetadata.NULL) {
-						finalGenMetadata = generation.getMetadata();
-					}
-					finalMetadata = chatResponse.getMetadata();
-				}
-				List<AssistantMessage.ToolCall> merged = builders.values()
-					.stream()
-					.map(ToolCallBuilder::build)
-					.filter(tc -> StringUtils.hasText(tc.name()))
-					.toList();
-				AssistantMessage.Builder assistantMessageBuilder = AssistantMessage.builder()
-					.content(text.toString())
-					.properties(props);
-				if (!merged.isEmpty()) {
-					assistantMessageBuilder.toolCalls(merged);
-				}
-				AssistantMessage assistantMessage = assistantMessageBuilder.build();
-				Generation finalGen = new Generation(assistantMessage,
-						finalGenMetadata != null ? finalGenMetadata : ChatGenerationMetadata.NULL);
-				ChatResponse aggregated = new ChatResponse(List.of(finalGen),
-						finalMetadata != null ? finalMetadata : ChatResponseMetadata.builder().build());
-				observationContext.setResponse(aggregated);
-				Assert.state(prompt.getOptions() != null, "ChatOptions must not be null");
-				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), aggregated)) {
-					if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-						logger.warn(
-								"Internal tool execution in OpenAiChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-										+ "Use ChatClient with ToolCallAdvisor instead.");
-					}
-					return Flux.deferContextual(ctx -> {
-						ToolExecutionResult tetoolExecutionResult;
-						try {
-							ToolCallReactiveContextHolder.setContext(ctx);
-							tetoolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, aggregated);
-						}
-						finally {
-							ToolCallReactiveContextHolder.clearContext();
-						}
-						if (tetoolExecutionResult.returnDirect()) {
-							return Flux.just(ChatResponse.builder()
-								.from(aggregated)
-								.generations(ToolExecutionResult.buildGenerations(tetoolExecutionResult))
-								.build());
-						}
-						return this.internalStream(
-								new Prompt(tetoolExecutionResult.conversationHistory(), prompt.getOptions()),
-								aggregated);
-					}).subscribeOn(Schedulers.boundedElastic());
-				}
-				return Flux.just(aggregated);
-			}).doOnError(observation::error).doFinally(s -> observation.stop());
+				return handleStreamingToolExecution(prompt, aggregated);
+			})).doOnError(observation::error).doFinally(s -> observation.stop());
 		});
+	}
+
+	private boolean shouldStreamResponse(ChatResponse response) {
+		return !response.hasToolCalls();
+	}
+
+	private @Nullable ChatResponse aggregateStreamingResponses(List<ChatResponse> responses) {
+		if (responses.isEmpty()) {
+			return null;
+		}
+
+		Map<String, ToolCallBuilder> builders = new HashMap<>();
+		StringBuilder text = new StringBuilder();
+		ChatGenerationMetadata finalGenMetadata = ChatGenerationMetadata.NULL;
+		Map<String, Object> props = new HashMap<>();
+		ChatResponse lastResponseWithResult = null;
+
+		for (ChatResponse chatResponse : responses) {
+			AssistantMessage assistantMessage = safeAssistantMessage(chatResponse);
+			if (assistantMessage == null) {
+				continue;
+			}
+
+			lastResponseWithResult = chatResponse;
+
+			if (assistantMessage.getText() != null) {
+				text.append(assistantMessage.getText());
+			}
+			if (assistantMessage.getMetadata() != null) {
+				props.putAll(assistantMessage.getMetadata());
+			}
+			mergeToolCalls(builders, assistantMessage);
+
+			Generation generation = chatResponse.getResult();
+			if (generation != null && generation.getMetadata() != ChatGenerationMetadata.NULL) {
+				finalGenMetadata = generation.getMetadata();
+			}
+		}
+
+		List<AssistantMessage.ToolCall> mergedToolCalls = builders.values()
+			.stream()
+			.map(ToolCallBuilder::build)
+			.filter(toolCall -> StringUtils.hasText(toolCall.name()))
+			.toList();
+
+		AssistantMessage.Builder assistantMessageBuilder = AssistantMessage.builder()
+			.content(text.toString())
+			.properties(props);
+		if (!mergedToolCalls.isEmpty()) {
+			assistantMessageBuilder.toolCalls(mergedToolCalls);
+		}
+
+		ChatResponseMetadata finalMetadata = aggregateStreamingMetadata(responses, lastResponseWithResult);
+		return new ChatResponse(List.of(new Generation(assistantMessageBuilder.build(), finalGenMetadata)),
+				finalMetadata);
+	}
+
+	private void mergeToolCalls(Map<String, ToolCallBuilder> builders, AssistantMessage assistantMessage) {
+		if (CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
+			return;
+		}
+
+		Object chunkChoiceObject = assistantMessage.getMetadata().get("chunkChoice");
+		if (chunkChoiceObject instanceof ChatCompletionChunk.Choice chunkChoice
+				&& chunkChoice.delta().toolCalls().isPresent()) {
+			List<ChatCompletionChunk.Choice.Delta.ToolCall> deltaToolCalls = chunkChoice.delta().toolCalls().get();
+			for (int i = 0; i < assistantMessage.getToolCalls().size() && i < deltaToolCalls.size(); i++) {
+				AssistantMessage.ToolCall toolCall = assistantMessage.getToolCalls().get(i);
+				ChatCompletionChunk.Choice.Delta.ToolCall deltaToolCall = deltaToolCalls.get(i);
+				String key = chunkChoice.index() + "-" + deltaToolCall.index();
+				builders.computeIfAbsent(key, keyValue -> new ToolCallBuilder()).merge(toolCall);
+			}
+			return;
+		}
+
+		for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
+			builders.computeIfAbsent(toolCall.id(), key -> new ToolCallBuilder()).merge(toolCall);
+		}
+	}
+
+	private ChatResponseMetadata aggregateStreamingMetadata(List<ChatResponse> responses,
+			@Nullable ChatResponse lastResponseWithResult) {
+
+		ChatResponse lastResponse = responses.get(responses.size() - 1);
+		if (lastResponseWithResult != null) {
+			Usage usage = lastResponse.getMetadata().getUsage();
+			if (!UsageCalculator.isEmpty(usage)) {
+				return from(lastResponseWithResult.getMetadata(), usage);
+			}
+			return lastResponseWithResult.getMetadata();
+		}
+		return lastResponse.getMetadata() != null ? lastResponse.getMetadata() : ChatResponseMetadata.builder().build();
+	}
+
+	private Flux<ChatResponse> handleStreamingToolExecution(Prompt prompt, ChatResponse aggregated) {
+		ChatOptions options = prompt.getOptions();
+		Assert.state(options != null, "ChatOptions must not be null");
+		if (!this.toolExecutionEligibilityPredicate.isToolExecutionRequired(options, aggregated)) {
+			return aggregated.hasToolCalls() ? Flux.just(aggregated) : Flux.empty();
+		}
+
+		if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
+			logger.warn(
+					"Internal tool execution in OpenAiChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
+							+ "Use ChatClient with ToolCallAdvisor instead.");
+		}
+
+		return Flux.deferContextual(ctx -> {
+			ToolExecutionResult toolExecutionResult;
+			try {
+				ToolCallReactiveContextHolder.setContext(ctx);
+				toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, aggregated);
+			}
+			finally {
+				ToolCallReactiveContextHolder.clearContext();
+			}
+			if (toolExecutionResult.returnDirect()) {
+				return Flux.just(ChatResponse.builder()
+					.from(aggregated)
+					.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
+					.build());
+			}
+			return this.internalStream(new Prompt(toolExecutionResult.conversationHistory(), options), aggregated);
+		}).subscribeOn(Schedulers.boundedElastic());
 	}
 
 	private Generation buildGeneration(ChatCompletion.Choice choice, Map<String, Object> metadata,

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -21,14 +21,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
+import com.openai.core.http.AsyncStreamResponse;
 import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessage;
 import com.openai.models.completions.CompletionUsage;
+import com.openai.services.async.ChatServiceAsync;
+import com.openai.services.async.chat.ChatCompletionServiceAsync;
 import com.openai.services.blocking.ChatService;
 import com.openai.services.blocking.chat.ChatCompletionService;
 import org.junit.jupiter.api.Test;
@@ -36,6 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.PromptMetadata;
 import org.springframework.ai.chat.metadata.RateLimit;
@@ -224,6 +232,141 @@ class OpenAiChatModelTests {
 		assertThat(aggregatedMetadata.getRateLimit()).isSameAs(rateLimit);
 		assertThat(aggregatedMetadata.getPromptMetadata()).isSameAs(promptMetadata);
 		assertThat((String) aggregatedMetadata.get("custom-key")).isEqualTo("custom-value");
+	}
+
+	@Test
+	void streamContentChunksAsTheyArrive() {
+		TestAsyncStreamResponse streamResponse = new TestAsyncStreamResponse();
+		prepareStreamingResponse(streamResponse);
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+				.openAiClient(this.openAiClient)
+				.openAiClientAsync(this.openAiClientAsync)
+				.options(options)
+				.build();
+		AtomicReference<String> firstContent = new AtomicReference<>();
+
+		chatModel.stream(new Prompt("hi", options))
+				.mapNotNull(response -> response.getResult().getOutput().getText())
+				.filter(content -> !content.isEmpty())
+				.subscribe(firstContent::set);
+
+		streamResponse.emit(contentChunk("hel"));
+
+		assertThat(firstContent).hasValue("hel");
+		assertThat(streamResponse.onCompleteFuture()).isNotDone();
+	}
+
+	@Test
+	void emitMergedToolCallAfterStreamCompletes() {
+		TestAsyncStreamResponse streamResponse = new TestAsyncStreamResponse();
+		prepareStreamingResponse(streamResponse);
+		OpenAiChatOptions options = OpenAiChatOptions.builder()
+				.model("test-model")
+				.internalToolExecutionEnabled(false)
+				.build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+				.openAiClient(this.openAiClient)
+				.openAiClientAsync(this.openAiClientAsync)
+				.options(options)
+				.build();
+		AtomicReference<ChatResponse> toolCallResponse = new AtomicReference<>();
+
+		chatModel.stream(new Prompt("hi", options)).filter(ChatResponse::hasToolCalls).subscribe(toolCallResponse::set);
+
+		streamResponse.emit(toolCallChunk("call-1", "getWeather", "{\"city\""));
+		assertThat(toolCallResponse).hasNullValue();
+
+		streamResponse.emit(toolCallChunk("", "", ":\"Paris\"}"));
+		streamResponse.complete();
+
+		assertThat(toolCallResponse.get()).isNotNull();
+		AssistantMessage.ToolCall toolCall = toolCallResponse.get().getResult().getOutput().getToolCalls().get(0);
+		assertThat(toolCall.id()).isEqualTo("call-1");
+		assertThat(toolCall.name()).isEqualTo("getWeather");
+		assertThat(toolCall.arguments()).isEqualTo("{\"city\":\"Paris\"}");
+	}
+
+	private void prepareStreamingResponse(TestAsyncStreamResponse streamResponse) {
+		ChatServiceAsync chatService = mock(ChatServiceAsync.class);
+		ChatCompletionServiceAsync completionService = mock(ChatCompletionServiceAsync.class);
+		when(this.openAiClientAsync.chat()).thenReturn(chatService);
+		when(chatService.completions()).thenReturn(completionService);
+		when(completionService.createStreaming(any(ChatCompletionCreateParams.class))).thenReturn(streamResponse);
+	}
+
+	private ChatCompletionChunk contentChunk(String content) {
+		return ChatCompletionChunk.builder()
+			.id("chatcmpl-test")
+			.created(1)
+			.model("test-model")
+			.addChoice(ChatCompletionChunk.Choice.builder()
+				.index(0)
+				.finishReason(Optional.empty())
+				.delta(ChatCompletionChunk.Choice.Delta.builder().content(content).build())
+				.build())
+			.build();
+	}
+
+	private ChatCompletionChunk toolCallChunk(String id, String name, String arguments) {
+		return ChatCompletionChunk.builder()
+			.id("chatcmpl-test")
+			.created(1)
+			.model("test-model")
+			.addChoice(ChatCompletionChunk.Choice.builder()
+				.index(0)
+				.finishReason(Optional.empty())
+				.delta(ChatCompletionChunk.Choice.Delta.builder()
+					.addToolCall(ChatCompletionChunk.Choice.Delta.ToolCall.builder()
+						.index(0)
+						.id(id)
+						.function(ChatCompletionChunk.Choice.Delta.ToolCall.Function.builder()
+							.name(name)
+							.arguments(arguments)
+							.build())
+						.build())
+					.build())
+				.build())
+			.build();
+	}
+
+	private static final class TestAsyncStreamResponse implements AsyncStreamResponse<ChatCompletionChunk> {
+
+		private final CompletableFuture<Void> completeFuture = new CompletableFuture<>();
+
+		private Handler<? super ChatCompletionChunk> handler;
+
+		@Override
+		public AsyncStreamResponse<ChatCompletionChunk> subscribe(Handler<? super ChatCompletionChunk> handler) {
+			this.handler = handler;
+			return this;
+		}
+
+		@Override
+		public AsyncStreamResponse<ChatCompletionChunk> subscribe(Handler<? super ChatCompletionChunk> handler,
+				Executor executor) {
+			this.handler = value -> executor.execute(() -> handler.onNext(value));
+			return this;
+		}
+
+		@Override
+		public CompletableFuture<Void> onCompleteFuture() {
+			return this.completeFuture;
+		}
+
+		@Override
+		public void close() {
+			this.completeFuture.complete(null);
+		}
+
+		void emit(ChatCompletionChunk chunk) {
+			this.handler.onNext(chunk);
+		}
+
+		void complete() {
+			this.completeFuture.complete(null);
+		}
+
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -240,16 +240,16 @@ class OpenAiChatModelTests {
 		prepareStreamingResponse(streamResponse);
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
-				.openAiClient(this.openAiClient)
-				.openAiClientAsync(this.openAiClientAsync)
-				.options(options)
-				.build();
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
 		AtomicReference<String> firstContent = new AtomicReference<>();
 
 		chatModel.stream(new Prompt("hi", options))
-				.mapNotNull(response -> response.getResult().getOutput().getText())
-				.filter(content -> !content.isEmpty())
-				.subscribe(firstContent::set);
+			.mapNotNull(response -> response.getResult().getOutput().getText())
+			.filter(content -> !content.isEmpty())
+			.subscribe(firstContent::set);
 
 		streamResponse.emit(contentChunk("hel"));
 
@@ -262,14 +262,14 @@ class OpenAiChatModelTests {
 		TestAsyncStreamResponse streamResponse = new TestAsyncStreamResponse();
 		prepareStreamingResponse(streamResponse);
 		OpenAiChatOptions options = OpenAiChatOptions.builder()
-				.model("test-model")
-				.internalToolExecutionEnabled(false)
-				.build();
+			.model("test-model")
+			.internalToolExecutionEnabled(false)
+			.build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
-				.openAiClient(this.openAiClient)
-				.openAiClientAsync(this.openAiClientAsync)
-				.options(options)
-				.build();
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
 		AtomicReference<ChatResponse> toolCallResponse = new AtomicReference<>();
 
 		chatModel.stream(new Prompt("hi", options)).filter(ChatResponse::hasToolCalls).subscribe(toolCallResponse::set);


### PR DESCRIPTION
Closes GH-5987

This PR fixes `OpenAiChatModel.stream()` so regular content chunks are emitted as they arrive instead of being buffered until the OpenAI stream completes.

## Background

`OpenAiChatModel.stream()` previously collected the entire stream before continuing with response aggregation and tool-call handling. This caused a real streaming request to behave like a buffered response: clients would not receive partial content chunks incrementally, and all chunks were emitted only after the upstream stream completed.

The terminal aggregation flow made sense for reconstructing tool calls, because OpenAI tool-call deltas can arrive across multiple chunks and need to be merged before execution or final emission. However, the same full-stream buffering was also applied to regular content chunks. As a result, even content chunks that did not require aggregation were blocked behind stream completion.

This was especially visible for normal text streaming scenarios, where the expected behavior is that each content delta is propagated immediately.

## Solution

This change separates the streaming path into two responsibilities:

1. Emit regular content chunks immediately.
2. Keep end-of-stream aggregation only for cases that actually need it, such as tool-call reconstruction, final usage metadata, and internal tool execution.

The implementation now creates the streaming `Flux<ChatResponse>` from the async OpenAI streaming client and records received responses in a synchronized list for final aggregation. While the stream is active, responses that do not contain tool calls are passed downstream immediately.

At stream completion, the collected responses are aggregated once to preserve behavior that depends on full-stream context, including metadata, usage, tool-call reconstruction, and internal tool execution.

This change also:

- Removes the `collectList()`-based streaming path that delayed downstream emissions.
- Emits non-tool-call content chunks immediately as they are received.
- Keeps aggregation at stream completion for metadata, usage, and tool-call reconstruction.
- Preserves tool-call behavior by emitting the merged tool call only after all tool-call delta chunks have arrived.
- Extracts streaming aggregation and tool execution handling into smaller helper methods.

For tool-call chunks, the implementation intentionally does not emit partial tool-call responses immediately. Tool-call arguments can be split across multiple chunks, so emitting them early would expose incomplete tool-call data. Instead, tool calls are merged and emitted after the stream completes, matching the previous logical behavior while avoiding unnecessary buffering for normal content streaming.

## Tests

- All tests passed.

- run `./mvnw -pl models/spring-ai-openai -Dtest=OpenAiChatModelTests test`