### PR TITLE
fix: Inject WebClient.Builder bean in MiniMaxApi

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * {@link AutoConfiguration Auto-configuration} for MiniMax Chat Model.
@@ -61,15 +62,16 @@ public class MiniMaxChatAutoConfiguration {
 	@ConditionalOnMissingBean
 	public MiniMaxChatModel miniMaxChatModel(MiniMaxConnectionProperties commonProperties,
 			MiniMaxChatProperties chatProperties, ObjectProvider<RestClient.Builder> restClientBuilderProvider,
-			ToolCallingManager toolCallingManager, ObjectProvider<RetryTemplate> retryTemplate,
-			ObjectProvider<ResponseErrorHandler> responseErrorHandler,
+			ObjectProvider<WebClient.Builder> webClientBuilderProvider, ToolCallingManager toolCallingManager,
+			ObjectProvider<RetryTemplate> retryTemplate, ObjectProvider<ResponseErrorHandler> responseErrorHandler,
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<ChatModelObservationConvention> observationConvention,
 			ObjectProvider<ToolExecutionEligibilityPredicate> openAiToolExecutionEligibilityPredicate) {
 
 		var miniMaxApi = miniMaxApi(chatProperties.getBaseUrl(), commonProperties.getBaseUrl(),
 				chatProperties.getApiKey(), commonProperties.getApiKey(),
-				restClientBuilderProvider.getIfAvailable(RestClient::builder), responseErrorHandler);
+				restClientBuilderProvider.getIfAvailable(RestClient::builder),
+				webClientBuilderProvider.getIfAvailable(WebClient::builder), responseErrorHandler);
 
 		var chatModel = new MiniMaxChatModel(miniMaxApi, chatProperties.toOptions(), toolCallingManager,
 				retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE),
@@ -81,7 +83,7 @@ public class MiniMaxChatAutoConfiguration {
 	}
 
 	private MiniMaxApi miniMaxApi(@Nullable String baseUrl, @Nullable String commonBaseUrl, @Nullable String apiKey,
-			@Nullable String commonApiKey, RestClient.Builder restClientBuilder,
+			@Nullable String commonApiKey, RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder,
 			ObjectProvider<ResponseErrorHandler> responseErrorHandler) {
 
 		String resolvedBaseUrl = StringUtils.hasText(baseUrl) ? baseUrl : commonBaseUrl;
@@ -90,7 +92,7 @@ public class MiniMaxChatAutoConfiguration {
 		String resolvedApiKey = StringUtils.hasText(apiKey) ? apiKey : commonApiKey;
 		Assert.hasText(resolvedApiKey, "MiniMax API key must be set");
 
-		return new MiniMaxApi(resolvedBaseUrl, resolvedApiKey, restClientBuilder,
+		return new MiniMaxApi(resolvedBaseUrl, resolvedApiKey, restClientBuilder, webClientBuilder,
 				responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER));
 	}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxEmbeddingAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * {@link AutoConfiguration Auto-configuration} for MiniMax Embedding Model.
@@ -56,14 +57,16 @@ public class MiniMaxEmbeddingAutoConfiguration {
 	@ConditionalOnMissingBean
 	public MiniMaxEmbeddingModel miniMaxEmbeddingModel(MiniMaxConnectionProperties commonProperties,
 			MiniMaxEmbeddingProperties embeddingProperties,
-			ObjectProvider<RestClient.Builder> restClientBuilderProvider, ObjectProvider<RetryTemplate> retryTemplate,
+			ObjectProvider<RestClient.Builder> restClientBuilderProvider,
+			ObjectProvider<WebClient.Builder> webClientBuilderProvider, ObjectProvider<RetryTemplate> retryTemplate,
 			ObjectProvider<ResponseErrorHandler> responseErrorHandler,
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<EmbeddingModelObservationConvention> observationConvention) {
 
 		var miniMaxApi = miniMaxApi(embeddingProperties.getBaseUrl(), commonProperties.getBaseUrl(),
 				embeddingProperties.getApiKey(), commonProperties.getApiKey(),
-				restClientBuilderProvider.getIfAvailable(RestClient::builder), responseErrorHandler);
+				restClientBuilderProvider.getIfAvailable(RestClient::builder),
+				webClientBuilderProvider.getIfAvailable(WebClient::builder), responseErrorHandler);
 
 		var embeddingModel = new MiniMaxEmbeddingModel(miniMaxApi, embeddingProperties.getMetadataMode(),
 				embeddingProperties.getOptions(), retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE),
@@ -75,7 +78,7 @@ public class MiniMaxEmbeddingAutoConfiguration {
 	}
 
 	private MiniMaxApi miniMaxApi(@Nullable String baseUrl, @Nullable String commonBaseUrl, @Nullable String apiKey,
-			@Nullable String commonApiKey, RestClient.Builder restClientBuilder,
+			@Nullable String commonApiKey, RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder,
 			ObjectProvider<ResponseErrorHandler> responseErrorHandler) {
 
 		String resolvedBaseUrl = StringUtils.hasText(baseUrl) ? baseUrl : commonBaseUrl;
@@ -84,7 +87,7 @@ public class MiniMaxEmbeddingAutoConfiguration {
 		String resolvedApiKey = StringUtils.hasText(apiKey) ? apiKey : commonApiKey;
 		Assert.hasText(resolvedApiKey, "MiniMax API key must be set");
 
-		return new MiniMaxApi(resolvedBaseUrl, resolvedApiKey, restClientBuilder,
+		return new MiniMaxApi(resolvedBaseUrl, resolvedApiKey, restClientBuilder, webClientBuilder,
 				responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER));
 	}
 

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
@@ -85,7 +85,19 @@ public class MiniMaxApi {
 	 * @param miniMaxToken MiniMax apiKey.
 	 */
 	public MiniMaxApi(String baseUrl, String miniMaxToken) {
-		this(baseUrl, miniMaxToken, RestClient.builder());
+		this(baseUrl, miniMaxToken, RestClient.builder(), WebClient.builder());
+	}
+
+	/**
+	 * Create a new chat completion api.
+	 *
+	 * @param baseUrl api base URL.
+	 * @param miniMaxToken MiniMax apiKey.
+	 * @param restClientBuilder RestClient builder.
+	 * @param webClientBuilder WebClient builder.
+	 */
+	public MiniMaxApi(String baseUrl, String miniMaxToken, RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder) {
+		this(baseUrl, miniMaxToken, restClientBuilder, webClientBuilder, RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER);
 	}
 
 	/**
@@ -95,8 +107,9 @@ public class MiniMaxApi {
 	 * @param miniMaxToken MiniMax apiKey.
 	 * @param restClientBuilder RestClient builder.
 	 */
+	@Deprecated
 	public MiniMaxApi(String baseUrl, String miniMaxToken, RestClient.Builder restClientBuilder) {
-		this(baseUrl, miniMaxToken, restClientBuilder, RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER);
+		this(baseUrl, miniMaxToken, restClientBuilder, WebClient.builder(), RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER);
 	}
 
 	/**
@@ -107,7 +120,21 @@ public class MiniMaxApi {
 	 * @param restClientBuilder RestClient builder.
 	 * @param responseErrorHandler Response error handler.
 	 */
+	@Deprecated
 	public MiniMaxApi(String baseUrl, String miniMaxToken, RestClient.Builder restClientBuilder, ResponseErrorHandler responseErrorHandler) {
+		this(baseUrl, miniMaxToken, restClientBuilder, WebClient.builder(), responseErrorHandler);
+	}
+
+	/**
+	 * Create a new chat completion api.
+	 *
+	 * @param baseUrl api base URL.
+	 * @param miniMaxToken MiniMax apiKey.
+	 * @param restClientBuilder RestClient builder.
+	 * @param webClientBuilder WebClient builder.
+	 * @param responseErrorHandler Response error handler.
+	 */
+	public MiniMaxApi(String baseUrl, String miniMaxToken, RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder, ResponseErrorHandler responseErrorHandler) {
 
 		Consumer<HttpHeaders> authHeaders = headers -> {
 			headers.setBearerAuth(miniMaxToken);
@@ -120,7 +147,7 @@ public class MiniMaxApi {
 				.defaultStatusHandler(responseErrorHandler)
 				.build();
 
-		this.webClient = WebClient.builder() // FIXME: use a bean instead
+		this.webClient = webClientBuilder.clone()
 				.baseUrl(baseUrl)
 				.defaultHeaders(authHeaders)
 				.build();


### PR DESCRIPTION
Inject WebClient.Builder bean in MiniMaxApi constructor instead of using static WebClient.builder() to allow proper customization, telemetry, and configuration sharing across Spring-managed beans. Clones the builder to avoid side-effects on shared bean instances, matching other APIs like ElevenLabsApi. Older constructors are deprecated to maintain full compatibility with existing custom instantiations. Closes #6137.