### PR TITLE
Fix ToolCallback overload selection in ChatClient

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -223,6 +223,14 @@ public interface ChatClient {
 
 		ChatClientRequestSpec tools(Consumer<ToolSpec> consumer);
 
+		default ChatClientRequestSpec tools(ToolCallback... toolCallbacks) {
+			return tools(t -> t.callbacks(toolCallbacks));
+		}
+
+		default ChatClientRequestSpec tools(ToolCallbackProvider... toolCallbackProviders) {
+			return tools(t -> t.callbacks(toolCallbackProviders));
+		}
+
 		ChatClientRequestSpec tools(Object... toolObjects);
 
 		/**
@@ -336,6 +344,14 @@ public interface ChatClient {
 		Builder defaultTemplateRenderer(TemplateRenderer templateRenderer);
 
 		Builder defaultTools(Consumer<ToolSpec> consumer);
+
+		default Builder defaultTools(ToolCallback... toolCallbacks) {
+			return defaultTools(t -> t.callbacks(toolCallbacks));
+		}
+
+		default Builder defaultTools(ToolCallbackProvider... toolCallbackProviders) {
+			return defaultTools(t -> t.callbacks(toolCallbackProviders));
+		}
 
 		Builder defaultTools(Object... toolObjects);
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -84,6 +86,21 @@ class DefaultChatClientBuilderTests {
 		var advisorBuilder = (ToolCallAdvisor.Builder<?>) ReflectionTestUtils.getField(defaultRequest,
 				"toolCallAdvisorBuilder");
 		assertThat(ReflectionTestUtils.getField(advisorBuilder, "toolCallingManager")).isSameAs(manager);
+	}
+
+	@Test
+	void whenToolCallbackPassedDirectlyToDefaultToolsThenReturn() {
+		ToolCallback toolCallback = FunctionToolCallback.builder("directDefaultTool", input -> "hello")
+			.description("description")
+			.inputType(String.class)
+			.build();
+
+		var builder = new DefaultChatClientBuilder(mock(ChatModel.class));
+		builder.defaultTools(toolCallback);
+
+		var defaultRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ReflectionTestUtils.getField(builder,
+				"defaultRequest");
+		assertThat(defaultRequest.getToolCallbacks()).containsExactly(toolCallback);
 	}
 
 	@Test

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1788,6 +1788,21 @@ class DefaultChatClientTests {
 	}
 
 	@Test
+	void whenToolCallbackPassedDirectlyToToolsThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+		ToolCallback toolCallback = FunctionToolCallback.builder("directTool", input -> "hello")
+			.description("description")
+			.inputType(String.class)
+			.build();
+
+		spec = spec.tools(toolCallback);
+
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getToolCallbacks()).containsExactly(toolCallback);
+	}
+
+	@Test
 	void whenFunctionNameIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();


### PR DESCRIPTION
A direct ToolCallback argument to tools(...) binds to Object... today. That sends FunctionToolCallback through the @Tool method path and ends with "No @Tool annotated methods found".

This adds the specific ToolCallback and ToolCallbackProvider overloads for tools(...) and defaultTools(...), routed through the existing ToolSpec callback path.

Closes #2495

Tests:
- ./mvnw -Dmaven.build.cache.enabled=false -pl spring-ai-client-chat -Dtest=DefaultChatClientTests#whenToolCallbackPassedDirectlyToToolsThenReturn,DefaultChatClientBuilderTests#whenToolCallbackPassedDirectlyToDefaultToolsThenReturn test
- ./mvnw -Dmaven.build.cache.enabled=false -pl spring-ai-client-chat test
