### PR TITLE
Fix reasoning_content lost when tool calls present in multi-turn conversation to DeepSeek

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -430,14 +430,17 @@ public class DeepSeekChatModel implements ChatModel {
 					}).toList();
 				}
 				Boolean isPrefixAssistantMessage = null;
-				if (message instanceof DeepSeekAssistantMessage
-						&& Boolean.TRUE.equals(((DeepSeekAssistantMessage) message).getPrefix())) {
-					isPrefixAssistantMessage = true;
+				String reasoningContent = null;
+				if (message instanceof DeepSeekAssistantMessage deepSeekAssistantMessage) {
+					reasoningContent = deepSeekAssistantMessage.getReasoningContent();
+					if (Boolean.TRUE.equals(deepSeekAssistantMessage.getPrefix())) {
+						isPrefixAssistantMessage = true;
+					}
 				}
 				String text = assistantMessage.getText();
 				Assert.state(text != null, "text must not be null");
 				return List.of(new ChatCompletionMessage(text, ChatCompletionMessage.Role.ASSISTANT, null, null,
-						toolCalls, isPrefixAssistantMessage, null));
+						toolCalls, isPrefixAssistantMessage, reasoningContent));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
@@ -16,15 +16,20 @@
 
 package org.springframework.ai.deepseek;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Geng Rong
+ * @author Thomas Vitale
  */
 public class DeepSeekChatCompletionRequestTests {
 
@@ -52,6 +57,87 @@ public class DeepSeekChatCompletionRequestTests {
 
 		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
 		assertThat(request.temperature()).isEqualTo(99.9D);
+	}
+
+	@Test
+	public void createRequestWithReasoningContent() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		DeepSeekAssistantMessage assistantMessage = DeepSeekAssistantMessage.builder()
+			.content("The answer is 42")
+			.reasoningContent("Let me think about this step by step...")
+			.build();
+
+		var prompt = client.buildRequestPrompt(new Prompt(List.of(assistantMessage),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(1);
+		ChatCompletionMessage message = request.messages().get(0);
+		assertThat(message.role()).isEqualTo(ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(message.content()).isEqualTo("The answer is 42");
+		assertThat(message.reasoningContent()).isEqualTo("Let me think about this step by step...");
+	}
+
+	@Test
+	public void createRequestWithNullReasoningContent() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		DeepSeekAssistantMessage assistantMessage = DeepSeekAssistantMessage.builder()
+			.content("The answer is 42")
+			.build();
+
+		var prompt = client.buildRequestPrompt(new Prompt(List.of(assistantMessage),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(1);
+		ChatCompletionMessage message = request.messages().get(0);
+		assertThat(message.role()).isEqualTo(ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(message.content()).isEqualTo("The answer is 42");
+		assertThat(message.reasoningContent()).isNull();
+	}
+
+	@Test
+	public void createRequestWithRegularAssistantMessage() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		AssistantMessage assistantMessage = new AssistantMessage("The answer is 42");
+
+		var prompt = client.buildRequestPrompt(new Prompt(List.of(assistantMessage),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(1);
+		ChatCompletionMessage message = request.messages().get(0);
+		assertThat(message.role()).isEqualTo(ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(message.content()).isEqualTo("The answer is 42");
+		assertThat(message.reasoningContent()).isNull();
+	}
+
+	@Test
+	public void createRequestWithReasoningContentAndPrefix() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		DeepSeekAssistantMessage assistantMessage = DeepSeekAssistantMessage.builder()
+			.content("")
+			.reasoningContent("Thinking in progress...")
+			.prefix(true)
+			.build();
+
+		var prompt = client.buildRequestPrompt(new Prompt(List.of(assistantMessage),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(1);
+		ChatCompletionMessage message = request.messages().get(0);
+		assertThat(message.role()).isEqualTo(ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(message.prefix()).isTrue();
+		assertThat(message.reasoningContent()).isEqualTo("Thinking in progress...");
 	}
 
 }

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelFunctionCallingIT.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelFunctionCallingIT.java
@@ -35,6 +35,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.deepseek.DeepSeekAssistantMessage;
 import org.springframework.ai.deepseek.DeepSeekChatOptions;
 import org.springframework.ai.deepseek.DeepSeekTestConfiguration;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
@@ -178,6 +179,48 @@ class DeepSeekChatModelFunctionCallingIT {
 		assertThat(chatResponse).isNotNull();
 		assertThat(chatResponse.getMetadata()).isNotNull();
 		assertThat(chatResponse.getMetadata().getUsage()).isNotNull();
+	}
+
+	/**
+	 * Multi-round conversation with function calls, preserving the assistant message
+	 * (including any reasoningContent) across rounds. This verifies that
+	 * {@link DeepSeekAssistantMessage} with tool calls can be passed back to subsequent
+	 * requests without losing reasoningContent.
+	 */
+	@Test
+	void functionCallMultiRoundWithReasoningContentPreserved() {
+		UserMessage userMessage = new UserMessage(
+				"What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius.");
+
+		List<Message> messages = new ArrayList<>(List.of(userMessage));
+
+		var promptOptions = DeepSeekChatOptions.builder()
+			.model(DeepSeekApi.ChatModel.DEEPSEEK_CHAT.getValue())
+			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.description("Get the weather in location")
+				.inputType(MockWeatherService.Request.class)
+				.build()))
+			.build();
+
+		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
+
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
+
+		// Preserve the assistant message (may contain tool_calls and reasoningContent)
+		AssistantMessage firstAssistantMessage = response.getResult().getOutput();
+		messages.add(firstAssistantMessage);
+		messages.add(new UserMessage("Which of these cities has the highest temperature?"));
+
+		ChatResponse response2 = this.chatModel.call(new Prompt(messages, promptOptions));
+
+		assertThat(response2.getResult().getOutput().getText()).isNotEmpty();
+
+		// If the first response contained reasoningContent, the second round should also
+		// preserve it
+		if (firstAssistantMessage instanceof DeepSeekAssistantMessage) {
+			logger.info("First response has reasoningContent: {}",
+					((DeepSeekAssistantMessage) firstAssistantMessage).getReasoningContent());
+		}
 	}
 
 }

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelFunctionCallingIT.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelFunctionCallingIT.java
@@ -189,38 +189,56 @@ class DeepSeekChatModelFunctionCallingIT {
 	 */
 	@Test
 	void functionCallMultiRoundWithReasoningContentPreserved() {
+
 		UserMessage userMessage = new UserMessage(
 				"What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius.");
 
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = DeepSeekChatOptions.builder()
-			.model(DeepSeekApi.ChatModel.DEEPSEEK_CHAT.getValue())
-			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
-				.description("Get the weather in location")
-				.inputType(MockWeatherService.Request.class)
-				.build()))
-			.build();
+				.model(DeepSeekApi.ChatModel.DEEPSEEK_REASONER.getValue())
+				.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+						.description("Get the weather in location")
+						.inputType(MockWeatherService.Request.class)
+						.build()))
+				.build();
 
 		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
 
 		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
-		// Preserve the assistant message (may contain tool_calls and reasoningContent)
+		// This test must exercise the reasoner + tool-calling scenario.
+		// In this scenario, DeepSeek returns reasoning content on the assistant message.
 		AssistantMessage firstAssistantMessage = response.getResult().getOutput();
+
+		assertThat(firstAssistantMessage)
+				.as("The first assistant message should be a DeepSeek assistant message")
+				.isInstanceOf(DeepSeekAssistantMessage.class);
+
+		DeepSeekAssistantMessage firstDeepSeekAssistantMessage = (DeepSeekAssistantMessage) firstAssistantMessage;
+
+		assertThat(firstDeepSeekAssistantMessage.getReasoningContent())
+				.as("The first assistant message should contain reasoning content")
+				.isNotBlank();
+
+		// Add the previous assistant message back to the conversation history.
+		// Since this message was produced by a reasoner model in a tool-calling round,
+		// its reasoning content must be sent back in all subsequent requests.
 		messages.add(firstAssistantMessage);
 		messages.add(new UserMessage("Which of these cities has the highest temperature?"));
 
+		// The second request is the actual regression check.
+		//
+		// Without the fix, Spring AI drops the reasoning content when building this
+		// follow-up request. DeepSeek then rejects the request with HTTP 400.
+		//
+		// With the fix applied, the reasoning content is preserved in the follow-up
+		// request, so the API accepts it and the second round succeeds.
 		ChatResponse response2 = this.chatModel.call(new Prompt(messages, promptOptions));
 
-		assertThat(response2.getResult().getOutput().getText()).isNotEmpty();
-
-		// If the first response contained reasoningContent, the second round should also
-		// preserve it
-		if (firstAssistantMessage instanceof DeepSeekAssistantMessage) {
-			logger.info("First response has reasoningContent: {}",
-					((DeepSeekAssistantMessage) firstAssistantMessage).getReasoningContent());
-		}
+		assertThat(response2.getResult().getOutput().getText())
+				.as("The second round should succeed when the previous reasoning content is preserved")
+				.isNotBlank();
 	}
 
 }

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelIT.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelIT.java
@@ -279,6 +279,39 @@ class DeepSeekChatModelIT {
 		assertThat(deepSeekAssistantMessage2.getText()).isNotEmpty();
 	}
 
+	/**
+	 * Multi-round conversation with deepseek-reasoner model where the reasoningContent is
+	 * preserved across rounds by adding the DeepSeekAssistantMessage directly instead of
+	 * converting to a plain AssistantMessage. This verifies that reasoningContent is
+	 * correctly passed through to subsequent requests.
+	 */
+	@Test
+	void reasonerModelMultiRoundWithReasoningContentPreserved() {
+		List<Message> messages = new ArrayList<>();
+		messages.add(new UserMessage("9.11 and 9.8, which is greater?"));
+		var promptOptions = DeepSeekChatOptions.builder()
+			.model(DeepSeekApi.ChatModel.DEEPSEEK_REASONER.getValue())
+			.build();
+
+		Prompt prompt = new Prompt(messages, promptOptions);
+		ChatResponse response = this.chatModel.call(prompt);
+
+		DeepSeekAssistantMessage firstMessage = (DeepSeekAssistantMessage) response.getResult().getOutput();
+		assertThat(firstMessage.getReasoningContent()).isNotEmpty();
+		assertThat(firstMessage.getText()).isNotEmpty();
+
+		// Preserve reasoningContent by adding the DeepSeekAssistantMessage directly
+		messages.add(firstMessage);
+		messages.add(new UserMessage("How many Rs are there in the word 'strawberry'?"));
+
+		Prompt prompt2 = new Prompt(messages, promptOptions);
+		ChatResponse response2 = this.chatModel.call(prompt2);
+
+		DeepSeekAssistantMessage secondMessage = (DeepSeekAssistantMessage) response2.getResult().getOutput();
+		assertThat(secondMessage.getReasoningContent()).isNotEmpty();
+		assertThat(secondMessage.getText()).isNotEmpty();
+	}
+
 	record ActorsFilmsRecord(String actor, List<String> movies) {
 	}
 


### PR DESCRIPTION
Closes #6118

## Problem
When DeepSeek model makes a tool call, the reasoning_content field must be included in subsequent requests according to DeepSeek API docs. 
Currently reasoning_content is silently dropped, causing incorrect behavior in multi-turn conversations with tool calls.

## Solution
Preserve reasoning_content in AssistantMessage when tool calls are present, so it can be passed back in follow-up requests.

## Testing
Added unit tests to verify reasoning_content is correctly handled in tool call scenarios.