### PR TITLE
GH-6098: Expose Bedrock Cohere embedding token usage from HTTP headers

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
@@ -320,6 +321,43 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 		return eventSink.asFlux();
 	}
 
+	/**
+	 * Internal method to invoke the model and return the response along with the HTTP
+	 * response headers. Use this when the caller needs access to HTTP response headers
+	 * (e.g. bedrock invocation metrics not included in the JSON response body).
+	 * @param request Model invocation request.
+	 * @param clazz The response class type
+	 * @return The invocation response wrapper containing both the response body and the
+	 * HTTP response headers.
+	 */
+	protected BedrockResponse<O> internalInvocationForModel(I request, Class<O> clazz) {
+
+		SdkBytes body;
+		try {
+			body = SdkBytes.fromUtf8String(this.jsonMapper.writeValueAsString(request));
+		}
+		catch (JacksonException e) {
+			throw new IllegalArgumentException("Invalid JSON format for the input request: " + request, e);
+		}
+
+		InvokeModelRequest invokeRequest = InvokeModelRequest.builder()
+			.modelId(this.modelId)
+			.body(body)
+			.build();
+
+		InvokeModelResponse response = this.client.invokeModel(invokeRequest);
+
+		String responseBody = response.body().asString(StandardCharsets.UTF_8);
+
+		try {
+			O result = this.jsonMapper.readValue(responseBody, clazz);
+			return new BedrockResponse<>(result, response.sdkHttpResponse());
+		}
+		catch (JacksonException e) {
+			throw new IllegalArgumentException("Invalid JSON format for the response: " + responseBody, e);
+		}
+	}
+
 	private Region getRegion(Region region) {
 		if (ObjectUtils.isEmpty(region)) {
 			try {
@@ -332,6 +370,17 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 		else {
 			return region;
 		}
+	}
+
+	/**
+	 * Wrapper for the model invocation result containing both the parsed response body
+	 * and the HTTP response for header access.
+	 *
+	 * @param <T> The response body type
+	 * @param result The parsed response body
+	 * @param httpResponse The raw HTTP response containing headers
+	 */
+	public record BedrockResponse<T>(T result, SdkHttpResponse httpResponse) {
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModel.java
@@ -22,23 +22,27 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi;
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingModelResponse;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest.InputType;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest.Truncate;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingResponse;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
 import org.springframework.ai.embedding.Embedding;
 import org.springframework.ai.embedding.EmbeddingOptions;
 import org.springframework.ai.embedding.EmbeddingRequest;
 import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.embedding.EmbeddingResponseMetadata;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.util.Assert;
 
 /**
  * {@link org.springframework.ai.embedding.EmbeddingModel} implementation that uses the
- * Bedrock Cohere Embedding API. Note: The invocation metrics are not exposed by AWS for
- * this API. If this change in the future we will add it as metadata.
+ * Bedrock Cohere Embedding API. Token usage is extracted from the
+ * {@code x-amzn-bedrock-input-token-count} HTTP response header provided by Bedrock.
  *
  * @author Christian Tzolov
  * @author Soby Chacko
@@ -117,13 +121,18 @@ public class BedrockCohereEmbeddingModel extends AbstractEmbeddingModel {
 		}).toList();
 
 		var apiRequest = new CohereEmbeddingRequest(truncatedInstructions, inputType, truncate);
-		CohereEmbeddingResponse apiResponse = this.embeddingApi.embedding(apiRequest);
+		CohereEmbeddingModelResponse modelResponse = this.embeddingApi.embeddingForModel(apiRequest);
+		CohereEmbeddingResponse apiResponse = modelResponse.response();
 		var indexCounter = new AtomicInteger(0);
 		List<Embedding> embeddings = apiResponse.embeddings()
 			.stream()
 			.map(e -> new Embedding(e, indexCounter.getAndIncrement()))
 			.toList();
-		return new EmbeddingResponse(embeddings);
+
+		Usage usage = modelResponse.inputTokenCount() != null ? new DefaultUsage(modelResponse.inputTokenCount(), 0)
+				: new DefaultUsage(0, 0);
+		EmbeddingResponseMetadata metadata = new EmbeddingResponseMetadata("", usage);
+		return new EmbeddingResponse(embeddings, metadata);
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import tools.jackson.databind.json.JsonMapper;
@@ -43,6 +44,8 @@ import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.Coher
  */
 public class CohereEmbeddingBedrockApi
 		extends AbstractBedrockApi<CohereEmbeddingRequest, CohereEmbeddingResponse, CohereEmbeddingResponse> {
+
+	private static final String INPUT_TOKEN_COUNT_HEADER = "x-amzn-bedrock-input-token-count";
 
 	/**
 	 * Create a new CohereEmbeddingBedrockApi instance using the default credentials
@@ -117,6 +120,22 @@ public class CohereEmbeddingBedrockApi
 	@Override
 	public CohereEmbeddingResponse embedding(CohereEmbeddingRequest request) {
 		return this.internalInvocation(request, CohereEmbeddingResponse.class);
+	}
+
+	/**
+	 * Creates an embedding response for the given request, including the input token
+	 * count extracted from the Bedrock HTTP response headers.
+	 * @param request The embedding request.
+	 * @return The embedding model response containing both the embedding result and the
+	 * input token count.
+	 */
+	public CohereEmbeddingModelResponse embeddingForModel(CohereEmbeddingRequest request) {
+		var bedrockResponse = this.internalInvocationForModel(request, CohereEmbeddingResponse.class);
+		Integer inputTokenCount = bedrockResponse.httpResponse()
+			.firstMatchingHeader(INPUT_TOKEN_COUNT_HEADER)
+			.map(Integer::parseInt)
+			.orElse(null);
+		return new CohereEmbeddingModelResponse(bedrockResponse.result(), inputTokenCount);
 	}
 
 	/**
@@ -241,6 +260,16 @@ public class CohereEmbeddingBedrockApi
 			// For future use: Currently bedrock doesn't return invocationMetrics for the
 			// cohere embedding model.
 			@JsonProperty("amazon-bedrock-invocationMetrics") AmazonBedrockInvocationMetrics amazonBedrockInvocationMetrics) {
+	}
+
+	/**
+	 * Wraps the Cohere embedding response with the input token count extracted from the
+	 * Bedrock HTTP response headers.
+	 *
+	 * @param response The Cohere embedding response.
+	 * @param inputTokenCount The input token count, or null if not available.
+	 */
+	public record CohereEmbeddingModelResponse(CohereEmbeddingResponse response, @Nullable Integer inputTokenCount) {
 	}
 
 }

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModelIT.java
@@ -62,6 +62,7 @@ class BedrockCohereEmbeddingModelIT {
 		assertThat(embeddingResponse.getResults()).hasSize(1);
 		assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
 		assertThat(this.embeddingModel.dimensions()).isEqualTo(1024);
+		assertTokenUsageNotEmpty(embeddingResponse);
 	}
 
 	@Test
@@ -98,7 +99,7 @@ class BedrockCohereEmbeddingModelIT {
 
 		EmbeddingResponse embeddingResponse = this.embeddingModel.embedForResponse(List.of(longText));
 
-		verify(this.embeddingApi).embedding(requestCaptor.capture());
+		verify(this.embeddingApi).embeddingForModel(requestCaptor.capture());
 		CohereEmbeddingBedrockApi.CohereEmbeddingRequest capturedRequest = requestCaptor.getValue();
 
 		assertThat(capturedRequest.texts()).hasSize(1);
@@ -123,7 +124,7 @@ class BedrockCohereEmbeddingModelIT {
 		EmbeddingResponse embeddingResponse = this.embeddingModelStartTruncate.embedForResponse(List.of(longText));
 
 		// Verify truncation behavior
-		verify(this.embeddingApi).embedding(requestCaptor.capture());
+		verify(this.embeddingApi).embeddingForModel(requestCaptor.capture());
 		String truncatedText = requestCaptor.getValue().texts().get(0);
 		assertThat(truncatedText.length()).isLessThanOrEqualTo(2048);
 		assertThat(truncatedText).doesNotContain(startMarker);
@@ -147,6 +148,7 @@ class BedrockCohereEmbeddingModelIT {
 		assertThat(embeddingResponse.getResults().get(1).getIndex()).isEqualTo(1);
 
 		assertThat(this.embeddingModel.dimensions()).isEqualTo(1024);
+		assertTokenUsageNotEmpty(embeddingResponse);
 	}
 
 	@Test
@@ -162,6 +164,13 @@ class BedrockCohereEmbeddingModelIT {
 		assertThat(embeddingResponse.getResults().get(1).getIndex()).isEqualTo(1);
 
 		assertThat(this.embeddingModel.dimensions()).isEqualTo(1024);
+	}
+
+	private static void assertTokenUsageNotEmpty(EmbeddingResponse response) {
+		assertThat(response.getMetadata()).isNotNull();
+		assertThat(response.getMetadata().getUsage()).isNotNull();
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isNotNull();
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isPositive();
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModelTest.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModelTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.cohere;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi;
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingModelResponse;
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest;
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingResponse;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for {@link BedrockCohereEmbeddingModel}.
+ *
+ * @author Christian Tzolov
+ */
+@ExtendWith(MockitoExtension.class)
+public class BedrockCohereEmbeddingModelTest {
+
+	@Mock
+	private CohereEmbeddingBedrockApi api;
+
+	private BedrockCohereEmbeddingModel model;
+
+	@BeforeEach
+	void setUp() {
+		this.model = new BedrockCohereEmbeddingModel(this.api,
+				BedrockCohereEmbeddingOptions.builder()
+					.inputType(CohereEmbeddingRequest.InputType.SEARCH_DOCUMENT)
+					.truncate(CohereEmbeddingRequest.Truncate.NONE)
+					.build());
+	}
+
+	@Test
+	void shouldReturnTokenUsageFromBedrockInputTokenCountHeader() {
+		given(this.api.embeddingForModel(any(CohereEmbeddingRequest.class)))
+			.willReturn(new CohereEmbeddingModelResponse(new CohereEmbeddingResponse("id",
+					List.of(new float[] { 0.1f, 0.2f }), List.of("Hello"), "embeddings", null), 743));
+
+		EmbeddingResponse response = this.model.call(new EmbeddingRequest(List.of("Hello"), null));
+
+		assertThat(response.getResults()).hasSize(1);
+		assertThat(response.getResults().get(0).getOutput()).hasSize(2);
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isEqualTo(743);
+		assertThat(response.getMetadata().getUsage().getCompletionTokens()).isZero();
+		assertThat(response.getMetadata().getUsage().getTotalTokens()).isEqualTo(743);
+	}
+
+	@Test
+	void shouldReturnZeroTokenUsageWhenHeaderIsMissing() {
+		given(this.api.embeddingForModel(any(CohereEmbeddingRequest.class)))
+			.willReturn(new CohereEmbeddingModelResponse(new CohereEmbeddingResponse("id",
+					List.of(new float[] { 0.1f, 0.2f }), List.of("Hello"), "embeddings", null), null));
+
+		EmbeddingResponse response = this.model.call(new EmbeddingRequest(List.of("Hello"), null));
+
+		assertThat(response.getResults()).hasSize(1);
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isZero();
+		assertThat(response.getMetadata().getUsage().getCompletionTokens()).isZero();
+		assertThat(response.getMetadata().getUsage().getTotalTokens()).isZero();
+	}
+
+	@Test
+	void shouldReturnBatchEmbeddingsWithTokenUsage() {
+		given(this.api.embeddingForModel(any(CohereEmbeddingRequest.class)))
+			.willReturn(new CohereEmbeddingModelResponse(
+					new CohereEmbeddingResponse("id", List.of(new float[] { 0.1f, 0.2f }, new float[] { 0.3f, 0.4f }),
+							List.of("Hello", "World"), "embeddings", null),
+					25));
+
+		EmbeddingResponse response = this.model.call(new EmbeddingRequest(List.of("Hello", "World"), null));
+
+		assertThat(response.getResults()).hasSize(2);
+		assertThat(response.getResults().get(0).getIndex()).isEqualTo(0);
+		assertThat(response.getResults().get(1).getIndex()).isEqualTo(1);
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isEqualTo(25);
+		assertThat(response.getMetadata().getUsage().getCompletionTokens()).isZero();
+		assertThat(response.getMetadata().getUsage().getTotalTokens()).isEqualTo(25);
+	}
+
+}


### PR DESCRIPTION
## Problem
Bedrock Cohere embedding API returns input token count in the \`x-amzn-bedrock-input-token-count\` HTTP response header, but Spring AI's \`AbstractBedrockApi.internalInvocation()\` only processes the response body, discarding the headers. This means \`EmbeddingResponse\` metadata contains no token usage (all zeros).
## Changes
- Added \`BedrockResponse<T>\` record and \`internalInvocationForModel()\` to \`AbstractBedrockApi\` that returns both the parsed response body and the \`SdkHttpResponse\` headers
- Added \`CohereEmbeddingModelResponse\` record and \`embeddingForModel()\` to \`CohereEmbeddingBedrockApi\` that extracts the input token count from the \`x-amzn-bedrock-input-token-count\` header
- Updated \`BedrockCohereEmbeddingModel.call()\` to pass token usage via \`EmbeddingResponseMetadata\` + \`DefaultUsage\`
- Added 3 unit tests in \`BedrockCohereEmbeddingModelTest\` covering: token usage from header present, missing header, and batch embeddings
- Updated IT tests with token usage assertions
## Reference
Same issue was fixed in LangChain4j: https://github.com/langchain4j/langchain4j/pull/5064
Closes GH-6098