### PR TITLE
fix: Inject WebClient.Builder bean in GemFireVectorStore

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-gemfire/src/main/java/org/springframework/ai/vectorstore/gemfire/autoconfigure/GemFireVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-gemfire/src/main/java/org/springframework/ai/vectorstore/gemfire/autoconfigure/GemFireVectorStoreAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * {@link AutoConfiguration Auto-configuration} for GemFire Vector Store.
@@ -67,7 +68,7 @@ public class GemFireVectorStoreAutoConfiguration {
 	public GemFireVectorStore gemfireVectorStore(EmbeddingModel embeddingModel, GemFireVectorStoreProperties properties,
 			GemFireConnectionDetails gemFireConnectionDetails, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
-			BatchingStrategy batchingStrategy) {
+			BatchingStrategy batchingStrategy, ObjectProvider<WebClient.Builder> webClientBuilderProvider) {
 
 		Builder builder = GemFireVectorStore.builder(embeddingModel)
 			.host(gemFireConnectionDetails.getHost())
@@ -82,7 +83,8 @@ public class GemFireVectorStoreAutoConfiguration {
 			.initializeSchema(properties.isInitializeSchema())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))
-			.batchingStrategy(batchingStrategy);
+			.batchingStrategy(batchingStrategy)
+			.webClientBuilder(webClientBuilderProvider.getIfAvailable(WebClient::builder));
 		if (gemFireConnectionDetails.getUsername() != null) {
 			builder.username(gemFireConnectionDetails.getUsername());
 		}

--- a/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/gemfire/GemFireVectorStore.java
+++ b/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/gemfire/GemFireVectorStore.java
@@ -139,7 +139,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		String base = UriComponentsBuilder.fromUriString(DEFAULT_URI)
 			.build(builder.sslEnabled ? "s" : "", builder.host, builder.port)
 			.toString();
-		WebClient.Builder webClientBuilder = WebClient.builder().baseUrl(base);
+		WebClient.Builder webClientBuilder = builder.webClientBuilder.clone().baseUrl(base);
 
 		ExchangeFilterFunction authenticationFilterFunction = null;
 
@@ -590,8 +590,21 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 
 		private @Nullable String token;
 
+		private WebClient.Builder webClientBuilder = WebClient.builder();
+
 		private Builder(EmbeddingModel embeddingModel) {
 			super(embeddingModel);
+		}
+
+		/**
+		 * Sets the WebClient.Builder to use.
+		 * @param webClientBuilder the webClientBuilder to use
+		 * @return the builder instance
+		 */
+		public Builder webClientBuilder(WebClient.Builder webClientBuilder) {
+			Assert.notNull(webClientBuilder, "webClientBuilder must not be null");
+			this.webClientBuilder = webClientBuilder;
+			return this;
 		}
 
 		/**


### PR DESCRIPTION
Inject WebClient.Builder bean in GemFireVectorStore.Builder instead of using static WebClient.builder() to allow proper customization, SSL, proxy setup, and Micrometer telemetry sharing across Spring-managed beans. Clones the builder to avoid side-effects on shared bean instances, aligning with standard Spring AI patterns. Also updates the autoconfiguration class to inject and supply this builder.