### PR TITLE
Retire Pixtral Large model

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -259,8 +259,6 @@ public class MistralAiApi {
 		CODESTRAL("codestral-latest"),
 		DEVSTRAL_MEDIUM("devstral-medium-latest"),
 		MISTRAL_LARGE("mistral-large-latest"),
-		@Deprecated(forRemoval = true) // Retirement planed the 31st of May 2026
-		PIXTRAL_LARGE("pixtral-large-latest"),
 		// Free Models
 		MINISTRAL_3B("ministral-3b-latest"),
 		MINISTRAL_8B("ministral-8b-latest"),

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -265,7 +265,7 @@ Mistral AI supports text and vision modalities.
 
 === Vision
 
-Mistral AI models that offer vision multimodal support include `pixtral-large-latest`.
+Mistral AI models offer vision multimodal support.
 Refer to the link:https://docs.mistral.ai/capabilities/vision/[Vision] guide for more information.
 
 The Mistral AI link:https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post[User Message API] can incorporate a list of base64-encoded images or image urls with the message.
@@ -282,7 +282,7 @@ var userMessage = new UserMessage("Explain what do you see on this picture?",
         new Media(MimeTypeUtils.IMAGE_PNG, this.imageResource));
 
 ChatResponse response = chatModel.call(new Prompt(this.userMessage,
-        ChatOptions.builder().model(MistralAiApi.ChatModel.PIXTRAL_LARGE.getValue()).build()));
+        ChatOptions.builder().model(MistralAiApi.ChatModel.MISTRAL_LARGE.getValue()).build()));
 ----
 
 or the image URL equivalent:
@@ -294,7 +294,7 @@ var userMessage = new UserMessage("Explain what do you see on this picture?",
                 URI.create("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png")));
 
 ChatResponse response = chatModel.call(new Prompt(this.userMessage,
-        ChatOptions.builder().model(MistralAiApi.ChatModel.PIXTRAL_LARGE.getValue()).build()));
+        ChatOptions.builder().model(MistralAiApi.ChatModel.MISTRAL_LARGE.getValue()).build()));
 ----
 
 TIP: You can pass multiple images as well.


### PR DESCRIPTION
## Description

- Remove deprecated Pixtral Large model,
- Update Mistral AI chat documentation.

## Explanations

According to [Mistral AI's documentation](https://docs.mistral.ai/getting-started/models#legacy-models), Pixtral Large model will be retired the 31st of May 2026. I propose to remove it with milestones planned for the 29th of May 2026.

## Proposed milestones

- **2.0.0-RC1**,
- **1.1.8**,
- **1.0.9**.

## Related work

- #5736,
- #6148.