### PR TITLE
Optimize Typesense vector query construction

### DIFF
--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -236,11 +235,8 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 		multiSearchCollectionParameters.collection(this.collectionName);
 		multiSearchCollectionParameters.q("*");
 
-		Stream<Float> floatStream = IntStream.range(0, embedding.length).mapToObj(i -> embedding[i]);
 		// typesense uses only cosine similarity
-		String vectorQuery = EMBEDDING_FIELD_NAME + ":(" + "["
-				+ String.join(",", floatStream.map(String::valueOf).toList()) + "], " + "k: " + request.getTopK() + ", "
-				+ "distance_threshold: " + (1 - request.getSimilarityThreshold()) + ")";
+		String vectorQuery = buildVectorQuery(embedding, request.getTopK(), request.getSimilarityThreshold());
 
 		multiSearchCollectionParameters.vectorQuery(vectorQuery);
 		multiSearchCollectionParameters.filterBy(nativeFilterExpressions);
@@ -278,6 +274,23 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 			logger.error("Failed to search documents", e);
 			return List.of();
 		}
+	}
+
+	static String buildVectorQuery(float[] embedding, int topK, double similarityThreshold) {
+		StringBuilder vectorQueryBuilder = new StringBuilder(EMBEDDING_FIELD_NAME.length() + embedding.length * 8 + 64);
+		vectorQueryBuilder.append(EMBEDDING_FIELD_NAME).append(":([");
+		for (int i = 0; i < embedding.length; i++) {
+			if (i > 0) {
+				vectorQueryBuilder.append(',');
+			}
+			vectorQueryBuilder.append(embedding[i]);
+		}
+		return vectorQueryBuilder.append("], k: ")
+			.append(topK)
+			.append(", distance_threshold: ")
+			.append(1 - similarityThreshold)
+			.append(')')
+			.toString();
 	}
 
 	int embeddingDimensions() {

--- a/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStoreTests.java
+++ b/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStoreTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.typesense;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link TypesenseVectorStore}.
+ *
+ * @author chabinhwang
+ */
+class TypesenseVectorStoreTests {
+
+	@Test
+	void buildVectorQuery() {
+		String vectorQuery = TypesenseVectorStore.buildVectorQuery(new float[] { 0.1f, -2.5f, 3.0E-4f }, 7, 0.75);
+
+		assertThat(vectorQuery).isEqualTo("embedding:([0.1,-2.5,3.0E-4], k: 7, distance_threshold: 0.25)");
+	}
+
+	@Test
+	void buildVectorQueryWithEmptyEmbedding() {
+		String vectorQuery = TypesenseVectorStore.buildVectorQuery(new float[0], 3, 0.5);
+
+		assertThat(vectorQuery).isEqualTo("embedding:([], k: 3, distance_threshold: 0.5)");
+	}
+
+}


### PR DESCRIPTION
## Summary

- Build the Typesense vector query directly from the embedding `float[]` instead of creating a boxed `Stream<Float>` and intermediate `List` before `String.join`.
- Add focused tests to lock the generated vector query format, including the empty-embedding edge case.

## Why

This preserves the existing Typesense vector query string format while reducing temporary allocations during similarity search request construction.

## Validation

- `./mvnw -pl vector-stores/spring-ai-typesense-store -Dtest=TypesenseVectorStoreTests test`
- `./mvnw -pl vector-stores/spring-ai-typesense-store package`
- `git diff --check`

## Notes

No associated issue; this is a small internal allocation optimization with behavior-preserving tests.
