### PR TITLE
GH-6130: Skip Google GenAI embedding auto-config when no credentials are configured

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -45,6 +46,7 @@ public class GoogleGenAiEmbeddingConnectionAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@Conditional(OnGoogleGenAiEmbeddingCredentials.class)
 	public GoogleGenAiEmbeddingConnectionDetails googleGenAiEmbeddingConnectionDetails(
 			GoogleGenAiEmbeddingConnectionProperties connectionProperties) throws IOException {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiTextEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiTextEmbeddingAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -51,6 +52,7 @@ public class GoogleGenAiTextEmbeddingAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnBean(GoogleGenAiEmbeddingConnectionDetails.class)
 	public GoogleGenAiTextEmbeddingModel googleGenAiTextEmbedding(
 			GoogleGenAiEmbeddingConnectionDetails connectionDetails,
 			GoogleGenAiTextEmbeddingProperties textEmbeddingProperties, ObjectProvider<RetryTemplate> retryTemplate,

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/OnGoogleGenAiEmbeddingCredentials.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/OnGoogleGenAiEmbeddingCredentials.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.embedding;
+
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.ConfigurationCondition;
+
+/**
+ * Condition that matches when any Google GenAI embedding credential is configured: either
+ * an API key (Gemini Developer API mode) or a project ID (Vertex AI mode).
+ *
+ * @author Gorre Surya
+ * @since 1.1.0
+ */
+class OnGoogleGenAiEmbeddingCredentials extends AnyNestedCondition {
+
+	OnGoogleGenAiEmbeddingCredentials() {
+		super(ConfigurationCondition.ConfigurationPhase.REGISTER_BEAN);
+	}
+
+	@ConditionalOnProperty(prefix = GoogleGenAiEmbeddingConnectionProperties.CONFIG_PREFIX, name = "api-key")
+	static class HasApiKey {
+
+	}
+
+	@ConditionalOnProperty(prefix = GoogleGenAiEmbeddingConnectionProperties.CONFIG_PREFIX, name = "project-id")
+	static class HasProjectId {
+
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfigurationTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.embedding;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails;
+import org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that {@link GoogleGenAiEmbeddingConnectionAutoConfiguration} does not activate
+ * when no embedding credentials are present, preventing startup failures when only the
+ * chat model is in use.
+ *
+ * @author Gorre Surya
+ */
+class GoogleGenAiEmbeddingConnectionAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(GoogleGenAiEmbeddingConnectionAutoConfiguration.class,
+				GoogleGenAiTextEmbeddingAutoConfiguration.class, SpringAiRetryAutoConfiguration.class));
+
+	@Test
+	void noEmbeddingBeansCreatedWhenNoCredentialsConfigured() {
+		this.contextRunner.run(context -> {
+			assertThat(context).doesNotHaveBean(GoogleGenAiEmbeddingConnectionDetails.class);
+			assertThat(context).doesNotHaveBean(GoogleGenAiTextEmbeddingModel.class);
+		});
+	}
+
+	@Test
+	void embeddingConnectionCreatedWhenApiKeyPresent() {
+		this.contextRunner.withPropertyValues("spring.ai.google.genai.embedding.api-key=test-api-key")
+			.run(context -> assertThat(context).hasSingleBean(GoogleGenAiEmbeddingConnectionDetails.class));
+	}
+
+	@Test
+	void embeddingModelNotCreatedWhenConnectionDetailsAbsent() {
+		this.contextRunner.run(context -> assertThat(context).doesNotHaveBean(GoogleGenAiTextEmbeddingModel.class));
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes #6130.

`GoogleGenAiEmbeddingConnectionAutoConfiguration` was creating the connection-details bean unconditionally and throwing `IllegalArgumentException` when neither `api-key` nor `project-id` was set. Users who included `spring-ai-starter-model-google-genai` but only wanted the chat model were forced to supply embedding credentials or exclude the two embedding auto-configuration classes manually.

**Changes:**

- Introduces `OnGoogleGenAiEmbeddingCredentials` — an `AnyNestedCondition` that evaluates to `true` when `spring.ai.google.genai.embedding.api-key` **or** `spring.ai.google.genai.embedding.project-id` is present.
- Annotates `GoogleGenAiEmbeddingConnectionAutoConfiguration#googleGenAiEmbeddingConnectionDetails` with `@Conditional(OnGoogleGenAiEmbeddingCredentials.class)` so the bean is skipped when no credentials are configured.
- Adds `@ConditionalOnBean(GoogleGenAiEmbeddingConnectionDetails.class)` to `GoogleGenAiTextEmbeddingAutoConfiguration#googleGenAiTextEmbedding` so the model bean is silently skipped when the connection bean is absent.

**Behaviour after the fix:**

| Scenario | Before | After |
|---|---|---|
| No embedding credentials, only chat | `IllegalArgumentException` at startup | Embedding beans absent, chat works normally |
| `api-key` set | Works | Works (unchanged) |
| `project-id` + `location` set | Works | Works (unchanged) |
| User-provided `GoogleGenAiEmbeddingConnectionDetails` bean | Works | Works (unchanged, `@ConditionalOnMissingBean` still respected) |

## Test plan

- [ ] `GoogleGenAiEmbeddingConnectionAutoConfigurationTests#noEmbeddingBeansCreatedWhenNoCredentialsConfigured` — context starts cleanly with no embedding beans
- [ ] `#embeddingConnectionCreatedWhenApiKeyPresent` — connection bean created when api-key property is set
- [ ] `#embeddingModelNotCreatedWhenConnectionDetailsAbsent` — embedding model bean absent when connection details are absent