### PR TITLE
GH-6120: Add REQUIRED constant to ToolChoiceBuilder in DeepSeek and MiniMax APIs

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekApi.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekApi.java
@@ -547,6 +547,10 @@ public class DeepSeekApi {
 			 * Model will not call a function and instead generates a message
 			 */
 			public static final String NONE = "none";
+			/**
+			 * Model must call at least one tool, but it can choose which one.
+			 */
+			public static final String REQUIRED = "required";
 
 			/**
 			 * Specifying a particular function forces the model to call that function.

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
@@ -625,6 +625,10 @@ public class MiniMaxApi {
 			 * Model will not call a function and instead generates a message
 			 */
 			public static final String NONE = "none";
+			/**
+			 * Model must call at least one tool, but it can choose which one.
+			 */
+			public static final String REQUIRED = "required";
 
 			/**
 			 * Specifying a particular function forces the model to call that function.


### PR DESCRIPTION
## Summary

- Adds `REQUIRED` constant to `ToolChoiceBuilder` in `DeepSeekApi` and `MiniMaxApi`
- `REQUIRED` forces the model to call at least one tool, but allows it to choose which one
- Aligns with the OpenAI spec where `tool_choice: "required"` is a valid value

Fixes: #6120

## Test plan

- [ ] Build passes: `./mvnw -pl models/spring-ai-deepseek,models/spring-ai-minimax install -DskipTests`
- [ ] New constant is accessible as `DeepSeekApi.ChatCompletionRequest.ToolChoiceBuilder.REQUIRED`
- [ ] New constant is accessible as `MiniMaxApi.ChatCompletionRequest.ToolChoiceBuilder.REQUIRED`