### PR TITLE
Consolidate JSON Schema generation documentation between Tool Calling and Structured Output

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/structured-output/converters.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/structured-output/converters.adoc
@@ -164,8 +164,8 @@ ActorsFilms actorsFilms = this.beanOutputConverter.convert(this.generation.getOu
 
 You can provide a description for the properties of the target type using one of the following annotations:
 
-* `@JsonClassDescription(description = "...")` — Jackson
-* `@JsonPropertyDescription(description = "...")` — Jackson
+* `@JsonClassDescription("...")` — Jackson
+* `@JsonPropertyDescription("...")` — Jackson
 * `@Schema(description = "...")` — Swagger
 
 This also works recursively for nested types.
@@ -181,11 +181,11 @@ record ActorsFilms(
 
 **Required vs optional**
 
-By default, each property is considered required. You can make a property optional using one of the following annotations, in this order of precedence:
+By default, each property is considered required. You can make a property optional using any of the following annotations:
 
 * `@JsonProperty(required = false)` — Jackson
-* `@Schema(required = false)` — Swagger
-* `@Nullable` — Spring Framework / JSpecify
+* `@Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)` — Swagger
+* `@Nullable` — JSpecify / Jakarta Annotations
 
 This also works recursively for nested types.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/structured-output/converters.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/structured-output/converters.adoc
@@ -155,6 +155,51 @@ Generation generation = chatModel.call(
 ActorsFilms actorsFilms = this.beanOutputConverter.convert(this.generation.getOutput().getText());
 ----
 
+[[json-schema-customization]]
+==== JSON Schema Customization
+
+`BeanOutputConverter` delegates JSON Schema generation to `JsonSchemaGenerator`, the same class used by xref:api/tools.adoc#json-schema[Tool Calling]. This means you can customize the generated schema using the same set of annotations.
+
+**Descriptions**
+
+You can provide a description for the properties of the target type using one of the following annotations:
+
+* `@JsonClassDescription(description = "...")` — Jackson
+* `@JsonPropertyDescription(description = "...")` — Jackson
+* `@Schema(description = "...")` — Swagger
+
+This also works recursively for nested types.
+
+[source,java]
+----
+@JsonClassDescription("Represents an actor and their filmography")
+record ActorsFilms(
+        @JsonPropertyDescription("The name of the actor") String actor,
+        @JsonPropertyDescription("List of movies") List<String> movies) {
+}
+----
+
+**Required vs optional**
+
+By default, each property is considered required. You can make a property optional using one of the following annotations, in this order of precedence:
+
+* `@JsonProperty(required = false)` — Jackson
+* `@Schema(required = false)` — Swagger
+* `@Nullable` — Spring Framework / JSpecify
+
+This also works recursively for nested types.
+
+[source,java]
+----
+record CustomerInfo(
+        String name,
+        @JsonProperty(required = false) String email,
+        @Nullable String phone) {
+}
+----
+
+NOTE: For the full reference on JSON Schema generation, including additional examples, see xref:api/tools.adoc#json-schema[JSON Schema] in the Tool Calling documentation.
+
 ==== Property Ordering in Generated Schema
 
 The `BeanOutputConverter` supports custom property ordering in the generated JSON schema through the `@JsonPropertyOrder` annotation.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -659,6 +659,8 @@ For method-based tools, `ToolDefinitions.from(method)` generates a definition au
 
 The input schema tells the model how to call the tool. Spring AI's `JsonSchemaGenerator` produces the schema from a method or function's parameter list and supports several customization annotations.
 
+NOTE: The same `JsonSchemaGenerator` is also used by xref:api/structured-output/converters.adoc#json-schema-customization[`BeanOutputConverter`] for structured output conversion. The Jackson, Swagger, and nullability annotations described below apply to both tool calling and structured output schemas (`@ToolParam` applies to tool calling only).
+
 **Parameter descriptions**
 
 Use any of these (Spring AI's annotation has highest precedence):

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -659,15 +659,15 @@ For method-based tools, `ToolDefinitions.from(method)` generates a definition au
 
 The input schema tells the model how to call the tool. Spring AI's `JsonSchemaGenerator` produces the schema from a method or function's parameter list and supports several customization annotations.
 
-NOTE: The same `JsonSchemaGenerator` is also used by xref:api/structured-output/converters.adoc#json-schema-customization[`BeanOutputConverter`] for structured output conversion. The Jackson, Swagger, and nullability annotations described below apply to both tool calling and structured output schemas (`@ToolParam` applies to tool calling only).
+NOTE: The same `JsonSchemaGenerator` is also used by xref:api/structured-output/converters.adoc#json-schema-customization[`BeanOutputConverter`] for structured output conversion. The Jackson, Swagger, and nullability annotations described below apply to both tool calling and structured output schemas (`@ToolParam` is intended for tool calling).
 
 **Parameter descriptions**
 
 Use any of these (Spring AI's annotation has highest precedence):
 
 * `@ToolParam(description = "...")` — Spring AI
-* `@JsonClassDescription(description = "...")` — Jackson
-* `@JsonPropertyDescription(description = "...")` — Jackson
+* `@JsonClassDescription("...")` — Jackson
+* `@JsonPropertyDescription("...")` — Jackson
 * `@Schema(description = "...")` — Swagger
 
 [source,java]
@@ -690,8 +690,8 @@ By default every parameter is required. Make a parameter optional via (in order 
 
 * `@ToolParam(required = false)` — Spring AI
 * `@JsonProperty(required = false)` — Jackson
-* `@Schema(required = false)` — Swagger
-* `@Nullable` — Spring Framework / JSpecify
+* `@Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)` — Swagger
+* `@Nullable` — JSpecify / Jakarta Annotations
 
 WARNING: Defining the correct required status is critical for reducing hallucinations. A parameter marked required forces the model to provide a value; an optional one lets it omit. If you mark a parameter required but the model has no way to determine its value, it will make one up.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -663,10 +663,9 @@ NOTE: The same `JsonSchemaGenerator` is also used by xref:api/structured-output/
 
 **Parameter descriptions**
 
-Use any of these (Spring AI's annotation has highest precedence):
+Use any of these (for a tool method's own parameters, Spring AI's annotation has highest precedence):
 
 * `@ToolParam(description = "...")` — Spring AI
-* `@JsonClassDescription("...")` — Jackson
 * `@JsonPropertyDescription("...")` — Jackson
 * `@Schema(description = "...")` — Swagger
 
@@ -686,7 +685,7 @@ class CustomerTools {
 
 **Required vs optional**
 
-By default every parameter is required. Make a parameter optional via (in order of precedence):
+By default every parameter is required. Make a parameter optional via one of the following (for a tool method's own parameters, in this order of precedence):
 
 * `@ToolParam(required = false)` — Spring AI
 * `@JsonProperty(required = false)` — Jackson


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-ai/issues/5915

Following the consolidation in #5897, `BeanOutputConverter` now delegates to `JsonSchemaGenerator` for schema generation, aligning the behavior between tool calling and structured output conversion.

However, the documentation for these two features remained separate — the supported annotations and default required-property behavior were only documented in the Tool Calling page.
- Add a "JSON Schema Customization" section to `structured-output-converter.adoc` documenting the supported annotations for description (`@JsonClassDescription`, `@JsonPropertyDescription`, `@Schema`) and required/optional status (`@JsonProperty`, `@Schema`, `@Nullable`)
- Add a cross-reference from `tools.adoc` to `structured-output-converter.adoc`, noting that `BeanOutputConverter` shares the same `JsonSchemaGenerator`