### PR TITLE
Add EntityParamSpec to ChatClient entity() methods

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -182,14 +182,14 @@ public interface ChatClient {
 		 * {@link org.springframework.ai.chat.model.ChatModel} does not support
 		 * {@link org.springframework.ai.model.tool.StructuredOutputChatOptions}.
 		 */
-		EntityParamSpec useProviderStructuredOutput();
+		EntityParamSpec delegateToProvider();
 
 		/**
 		 * Validates the model's JSON response against the entity schema and retries with
 		 * the error feedback on failure, up to {@code maxRepeatAttempts} times (default:
 		 * 3). Streaming is not supported.
 		 */
-		EntityParamSpec withSchemaValidation();
+		EntityParamSpec schemaValidation();
 
 	}
 
@@ -200,8 +200,8 @@ public interface ChatClient {
 		 * via the {@code entityParamSpecConsumer}.
 		 * @param type the target parameterized type
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
-		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * {@link EntityParamSpec#delegateToProvider()} and
+		 * {@link EntityParamSpec#schemaValidation()}
 		 * @return the deserialized entity, or {@code null} if the response is empty
 		 */
 		<T> @Nullable T entity(ParameterizedTypeReference<T> type, Consumer<EntityParamSpec> entityParamSpecConsumer);
@@ -219,8 +219,8 @@ public interface ChatClient {
 		 * @param structuredOutputConverter the converter for parsing and schema
 		 * resolution
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
-		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * {@link EntityParamSpec#delegateToProvider()} and
+		 * {@link EntityParamSpec#schemaValidation()}
 		 * @return the deserialized entity, or {@code null} if the response is empty
 		 */
 		<T> @Nullable T entity(StructuredOutputConverter<T> structuredOutputConverter,
@@ -239,8 +239,8 @@ public interface ChatClient {
 		 * via the {@code entityParamSpecConsumer}.
 		 * @param type the target class
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
-		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * {@link EntityParamSpec#delegateToProvider()} and
+		 * {@link EntityParamSpec#schemaValidation()}
 		 * @return the deserialized entity, or {@code null} if the response is empty
 		 */
 		<T> @Nullable T entity(Class<T> type, Consumer<EntityParamSpec> entityParamSpecConsumer);
@@ -264,8 +264,8 @@ public interface ChatClient {
 		 * configured via the {@code entityParamSpecConsumer}.
 		 * @param type the target class
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
-		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * {@link EntityParamSpec#delegateToProvider()} and
+		 * {@link EntityParamSpec#schemaValidation()}
 		 * @return the {@link ResponseEntity} containing both the complete
 		 * {@link ChatResponse} object and the deserialized entity
 		 */
@@ -287,8 +287,8 @@ public interface ChatClient {
 		 * configured via the {@code entityParamSpecConsumer}.
 		 * @param type the target parameterized type
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
-		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * {@link EntityParamSpec#delegateToProvider()} and
+		 * {@link EntityParamSpec#schemaValidation()}
 		 * @return the {@link ResponseEntity} containing both the complete
 		 * {@link ChatResponse} object and the deserialized entity
 		 */
@@ -312,8 +312,8 @@ public interface ChatClient {
 		 * @param structuredOutputConverter the converter for parsing and schema
 		 * resolution
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
-		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * {@link EntityParamSpec#delegateToProvider()} and
+		 * {@link EntityParamSpec#schemaValidation()}
 		 * @return the {@link ResponseEntity} containing both the complete
 		 * {@link ChatResponse} object and the deserialized entity
 		 */

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -182,14 +182,14 @@ public interface ChatClient {
 		 * {@link org.springframework.ai.chat.model.ChatModel} does not support
 		 * {@link org.springframework.ai.model.tool.StructuredOutputChatOptions}.
 		 */
-		EntityParamSpec delegateToProvider();
+		EntityParamSpec useProviderStructuredOutput();
 
 		/**
 		 * Validates the model's JSON response against the entity schema and retries with
 		 * the error feedback on failure, up to {@code maxRepeatAttempts} times (default:
 		 * 3). Streaming is not supported.
 		 */
-		EntityParamSpec schemaValidation();
+		EntityParamSpec validateSchema();
 
 	}
 
@@ -200,8 +200,8 @@ public interface ChatClient {
 		 * via the {@code entityParamSpecConsumer}.
 		 * @param type the target parameterized type
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#delegateToProvider()} and
-		 * {@link EntityParamSpec#schemaValidation()}
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#validateSchema()}
 		 * @return the deserialized entity, or {@code null} if the response is empty
 		 */
 		<T> @Nullable T entity(ParameterizedTypeReference<T> type, Consumer<EntityParamSpec> entityParamSpecConsumer);
@@ -219,8 +219,8 @@ public interface ChatClient {
 		 * @param structuredOutputConverter the converter for parsing and schema
 		 * resolution
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#delegateToProvider()} and
-		 * {@link EntityParamSpec#schemaValidation()}
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#validateSchema()}
 		 * @return the deserialized entity, or {@code null} if the response is empty
 		 */
 		<T> @Nullable T entity(StructuredOutputConverter<T> structuredOutputConverter,
@@ -239,8 +239,8 @@ public interface ChatClient {
 		 * via the {@code entityParamSpecConsumer}.
 		 * @param type the target class
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#delegateToProvider()} and
-		 * {@link EntityParamSpec#schemaValidation()}
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#validateSchema()}
 		 * @return the deserialized entity, or {@code null} if the response is empty
 		 */
 		<T> @Nullable T entity(Class<T> type, Consumer<EntityParamSpec> entityParamSpecConsumer);
@@ -264,8 +264,8 @@ public interface ChatClient {
 		 * configured via the {@code entityParamSpecConsumer}.
 		 * @param type the target class
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#delegateToProvider()} and
-		 * {@link EntityParamSpec#schemaValidation()}
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#validateSchema()}
 		 * @return the {@link ResponseEntity} containing both the complete
 		 * {@link ChatResponse} object and the deserialized entity
 		 */
@@ -287,8 +287,8 @@ public interface ChatClient {
 		 * configured via the {@code entityParamSpecConsumer}.
 		 * @param type the target parameterized type
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#delegateToProvider()} and
-		 * {@link EntityParamSpec#schemaValidation()}
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#validateSchema()}
 		 * @return the {@link ResponseEntity} containing both the complete
 		 * {@link ChatResponse} object and the deserialized entity
 		 */
@@ -312,8 +312,8 @@ public interface ChatClient {
 		 * @param structuredOutputConverter the converter for parsing and schema
 		 * resolution
 		 * @param entityParamSpecConsumer configures options such as
-		 * {@link EntityParamSpec#delegateToProvider()} and
-		 * {@link EntityParamSpec#schemaValidation()}
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#validateSchema()}
 		 * @return the {@link ResponseEntity} containing both the complete
 		 * {@link ChatResponse} object and the deserialized entity
 		 */

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.client;
 
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -169,12 +170,86 @@ public interface ChatClient {
 
 	}
 
+	/**
+	 * Configures optional behaviour for {@code entity(...)} calls. Options may be
+	 * combined.
+	 */
+	interface EntityParamSpec {
+
+		/**
+		 * Delivers the JSON schema to the AI provider as an API-level constraint rather
+		 * than appending it as prompt text. Has no effect if the underlying
+		 * {@link org.springframework.ai.chat.model.ChatModel} does not support
+		 * {@link org.springframework.ai.model.tool.StructuredOutputChatOptions}.
+		 */
+		EntityParamSpec useProviderStructuredOutput();
+
+		/**
+		 * Validates the model's JSON response against the entity schema and retries with
+		 * the error feedback on failure, up to {@code maxRepeatAttempts} times (default:
+		 * 3). Streaming is not supported.
+		 */
+		EntityParamSpec withSchemaValidation();
+
+	}
+
 	interface CallResponseSpec {
 
+		/**
+		 * Deserializes the response into a {@code T} instance, with behaviour configured
+		 * via the {@code entityParamSpecConsumer}.
+		 * @param type the target parameterized type
+		 * @param entityParamSpecConsumer configures options such as
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * @return the deserialized entity, or {@code null} if the response is empty
+		 */
+		<T> @Nullable T entity(ParameterizedTypeReference<T> type, Consumer<EntityParamSpec> entityParamSpecConsumer);
+
+		/**
+		 * Deserializes the response into a {@code T} instance.
+		 * @param type the target parameterized type
+		 * @return the deserialized entity, or {@code null} if the response is empty
+		 */
 		<T> @Nullable T entity(ParameterizedTypeReference<T> type);
 
+		/**
+		 * Deserializes the response using the given converter, with behaviour configured
+		 * via the {@code entityParamSpecConsumer}.
+		 * @param structuredOutputConverter the converter for parsing and schema
+		 * resolution
+		 * @param entityParamSpecConsumer configures options such as
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * @return the deserialized entity, or {@code null} if the response is empty
+		 */
+		<T> @Nullable T entity(StructuredOutputConverter<T> structuredOutputConverter,
+				Consumer<EntityParamSpec> entityParamSpecConsumer);
+
+		/**
+		 * Deserializes the response using the given converter.
+		 * @param structuredOutputConverter the converter for parsing and schema
+		 * resolution
+		 * @return the deserialized entity, or {@code null} if the response is empty
+		 */
 		<T> @Nullable T entity(StructuredOutputConverter<T> structuredOutputConverter);
 
+		/**
+		 * Deserializes the response into a {@code T} instance, with behaviour configured
+		 * via the {@code entityParamSpecConsumer}.
+		 * @param type the target class
+		 * @param entityParamSpecConsumer configures options such as
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * @return the deserialized entity, or {@code null} if the response is empty
+		 */
+		<T> @Nullable T entity(Class<T> type, Consumer<EntityParamSpec> entityParamSpecConsumer);
+
+		/**
+		 * Deserializes the response into a {@code T} instance.
+		 * @param type the target class
+		 * @return the deserialized entity, or {@code null} if the response is empty
+		 */
 		<T> @Nullable T entity(Class<T> type);
 
 		ChatClientResponse chatClientResponse();
@@ -183,10 +258,77 @@ public interface ChatClient {
 
 		@Nullable String content();
 
+		/**
+		 * Returns a {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and a specific entity type, with behaviour
+		 * configured via the {@code entityParamSpecConsumer}.
+		 * @param type the target class
+		 * @param entityParamSpecConsumer configures options such as
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * @return the {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and the deserialized entity
+		 */
+		<T> ResponseEntity<ChatResponse, T> responseEntity(Class<T> type,
+				Consumer<EntityParamSpec> entityParamSpecConsumer);
+
+		/**
+		 * Returns a {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and a specific entity type.
+		 * @param type the target class
+		 * @return the {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and the deserialized entity
+		 */
 		<T> ResponseEntity<ChatResponse, T> responseEntity(Class<T> type);
 
+		/**
+		 * Returns a {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and a specific entity type, with behaviour
+		 * configured via the {@code entityParamSpecConsumer}.
+		 * @param type the target parameterized type
+		 * @param entityParamSpecConsumer configures options such as
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * @return the {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and the deserialized entity
+		 */
+		<T> ResponseEntity<ChatResponse, T> responseEntity(ParameterizedTypeReference<T> type,
+				Consumer<EntityParamSpec> entityParamSpecConsumer);
+
+		/**
+		 * Returns a {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and a {@link Collection} of entity types.
+		 * @param type the target parameterized type
+		 * @return the {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and the deserialized entities
+		 */
 		<T> ResponseEntity<ChatResponse, T> responseEntity(ParameterizedTypeReference<T> type);
 
+		/**
+		 * Returns a {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and an entity converted using a specified
+		 * {@link StructuredOutputConverter}, with behaviour configured via the
+		 * {@code entityParamSpecConsumer}.
+		 * @param structuredOutputConverter the converter for parsing and schema
+		 * resolution
+		 * @param entityParamSpecConsumer configures options such as
+		 * {@link EntityParamSpec#useProviderStructuredOutput()} and
+		 * {@link EntityParamSpec#withSchemaValidation()}
+		 * @return the {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and the deserialized entity
+		 */
+		<T> ResponseEntity<ChatResponse, T> responseEntity(StructuredOutputConverter<T> structuredOutputConverter,
+				Consumer<EntityParamSpec> entityParamSpecConsumer);
+
+		/**
+		 * Returns a {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and an entity converted using a specified
+		 * {@link StructuredOutputConverter}.
+		 * @param structuredOutputConverter the converter for parsing and schema
+		 * resolution
+		 * @return the {@link ResponseEntity} containing both the complete
+		 * {@link ChatResponse} object and the deserialized entity
+		 */
 		<T> ResponseEntity<ChatResponse, T> responseEntity(StructuredOutputConverter<T> structuredOutputConverter);
 
 	}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -420,13 +420,13 @@ public class DefaultChatClient implements ChatClient {
 		}
 
 		@Override
-		public EntityParamSpec useProviderStructuredOutput() {
+		public EntityParamSpec delegateToProvider() {
 			this.enableNative = true;
 			return this;
 		}
 
 		@Override
-		public EntityParamSpec withSchemaValidation() {
+		public EntityParamSpec schemaValidation() {
 			this.validated = true;
 			return this;
 		}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -405,7 +405,7 @@ public class DefaultChatClient implements ChatClient {
 	/**
 	 * Default implementation of {@link EntityParamSpec}.
 	 */
-	public static class DefaultEntityParamSpec<T> implements EntityParamSpec {
+	public static class DefaultEntityParamSpec implements EntityParamSpec {
 
 		private boolean enableNative = false;
 
@@ -420,13 +420,13 @@ public class DefaultChatClient implements ChatClient {
 		}
 
 		@Override
-		public EntityParamSpec delegateToProvider() {
+		public EntityParamSpec useProviderStructuredOutput() {
 			this.enableNative = true;
 			return this;
 		}
 
 		@Override
-		public EntityParamSpec schemaValidation() {
+		public EntityParamSpec validateSchema() {
 			this.validated = true;
 			return this;
 		}
@@ -576,7 +576,7 @@ public class DefaultChatClient implements ChatClient {
 
 		private BaseAdvisorChain resolveAdvisorChain(Consumer<EntityParamSpec> consumer,
 				StructuredOutputConverter<?> converter) {
-			var spec = new DefaultEntityParamSpec<>();
+			var spec = new DefaultEntityParamSpec();
 			consumer.accept(spec);
 			if (spec.isEnableNative()) {
 				this.request.context().put(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey(), true);

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -40,6 +40,7 @@ import reactor.core.publisher.Flux;
 import org.springframework.ai.chat.client.advisor.ChatModelCallAdvisor;
 import org.springframework.ai.chat.client.advisor.ChatModelStreamAdvisor;
 import org.springframework.ai.chat.client.advisor.DefaultAroundAdvisorChain;
+import org.springframework.ai.chat.client.advisor.StructuredOutputValidationAdvisor;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.BaseAdvisorChain;
@@ -401,6 +402,37 @@ public class DefaultChatClient implements ChatClient {
 
 	}
 
+	/**
+	 * Default implementation of {@link EntityParamSpec}.
+	 */
+	public static class DefaultEntityParamSpec<T> implements EntityParamSpec {
+
+		private boolean enableNative = false;
+
+		private boolean validated = false;
+
+		public boolean isEnableNative() {
+			return this.enableNative;
+		}
+
+		public boolean isValidated() {
+			return this.validated;
+		}
+
+		@Override
+		public EntityParamSpec useProviderStructuredOutput() {
+			this.enableNative = true;
+			return this;
+		}
+
+		@Override
+		public EntityParamSpec withSchemaValidation() {
+			this.validated = true;
+			return this;
+		}
+
+	}
+
 	public static class DefaultCallResponseSpec implements CallResponseSpec {
 
 		private final ChatClientRequest request;
@@ -425,9 +457,27 @@ public class DefaultChatClient implements ChatClient {
 		}
 
 		@Override
+		public <T> ResponseEntity<ChatResponse, T> responseEntity(Class<T> type,
+				Consumer<EntityParamSpec> entityParamSpecConsumer) {
+			Assert.notNull(type, "type cannot be null");
+			Assert.notNull(entityParamSpecConsumer, "entityParamSpecConsumer cannot be null");
+			var converter = new BeanOutputConverter<>(type);
+			return doResponseEntity(converter, resolveAdvisorChain(entityParamSpecConsumer, converter));
+		}
+
+		@Override
 		public <T> ResponseEntity<ChatResponse, T> responseEntity(Class<T> type) {
 			Assert.notNull(type, "type cannot be null");
 			return doResponseEntity(new BeanOutputConverter<>(type));
+		}
+
+		@Override
+		public <T> ResponseEntity<ChatResponse, T> responseEntity(ParameterizedTypeReference<T> type,
+				Consumer<EntityParamSpec> entityParamSpecConsumer) {
+			Assert.notNull(type, "type cannot be null");
+			Assert.notNull(entityParamSpecConsumer, "entityParamSpecConsumer cannot be null");
+			var converter = new BeanOutputConverter<>(type);
+			return doResponseEntity(converter, resolveAdvisorChain(entityParamSpecConsumer, converter));
 		}
 
 		@Override
@@ -438,13 +488,30 @@ public class DefaultChatClient implements ChatClient {
 
 		@Override
 		public <T> ResponseEntity<ChatResponse, T> responseEntity(
+				StructuredOutputConverter<T> structuredOutputConverter,
+				Consumer<EntityParamSpec> entityParamSpecConsumer) {
+			Assert.notNull(structuredOutputConverter, "structuredOutputConverter cannot be null");
+			Assert.notNull(entityParamSpecConsumer, "entityParamSpecConsumer cannot be null");
+			return doResponseEntity(structuredOutputConverter,
+					resolveAdvisorChain(entityParamSpecConsumer, structuredOutputConverter));
+		}
+
+		@Override
+		public <T> ResponseEntity<ChatResponse, T> responseEntity(
 				StructuredOutputConverter<T> structuredOutputConverter) {
 			Assert.notNull(structuredOutputConverter, "structuredOutputConverter cannot be null");
 			return doResponseEntity(structuredOutputConverter);
 		}
 
 		protected <T> ResponseEntity<ChatResponse, T> doResponseEntity(StructuredOutputConverter<T> outputConverter) {
+			return this.doResponseEntity(outputConverter, this.advisorChain);
+		}
+
+		protected <T> ResponseEntity<ChatResponse, T> doResponseEntity(StructuredOutputConverter<T> outputConverter,
+				BaseAdvisorChain advisorChain) {
+
 			Assert.notNull(outputConverter, "structuredOutputConverter cannot be null");
+			Assert.notNull(advisorChain, "advisor chain cannot be null");
 
 			this.request.context().put(ChatClientAttributes.OUTPUT_FORMAT.getKey(), outputConverter.getFormat());
 
@@ -454,7 +521,7 @@ public class DefaultChatClient implements ChatClient {
 					.put(ChatClientAttributes.STRUCTURED_OUTPUT_SCHEMA.getKey(), outputConverter.getJsonSchema());
 			}
 
-			var chatResponse = doGetObservableChatClientResponse(this.request).chatResponse();
+			var chatResponse = doGetObservableChatClientResponse(this.request, advisorChain).chatResponse();
 			var responseContent = getContentFromChatResponse(chatResponse);
 			if (responseContent == null) {
 				return new ResponseEntity<>(chatResponse, null);
@@ -464,9 +531,35 @@ public class DefaultChatClient implements ChatClient {
 		}
 
 		@Override
+		public <T> @Nullable T entity(ParameterizedTypeReference<T> type,
+				Consumer<EntityParamSpec> entitySpecConsumer) {
+			Assert.notNull(type, "type cannot be null");
+			Assert.notNull(entitySpecConsumer, "entitySpecConsumer cannot be null");
+			var converter = new BeanOutputConverter<>(type);
+			return doSingleWithBeanOutputConverter(converter, resolveAdvisorChain(entitySpecConsumer, converter));
+		}
+
+		@Override
+		public <T> @Nullable T entity(Class<T> type, Consumer<EntityParamSpec> entitySpecConsumer) {
+			Assert.notNull(type, "type cannot be null");
+			Assert.notNull(entitySpecConsumer, "entitySpecConsumer cannot be null");
+			var converter = new BeanOutputConverter<>(type);
+			return doSingleWithBeanOutputConverter(converter, resolveAdvisorChain(entitySpecConsumer, converter));
+		}
+
+		@Override
 		public <T> @Nullable T entity(ParameterizedTypeReference<T> type) {
 			Assert.notNull(type, "type cannot be null");
 			return doSingleWithBeanOutputConverter(new BeanOutputConverter<>(type));
+		}
+
+		@Override
+		public <T> @Nullable T entity(StructuredOutputConverter<T> structuredOutputConverter,
+				Consumer<EntityParamSpec> entitySpecConsumer) {
+			Assert.notNull(structuredOutputConverter, "structuredOutputConverter cannot be null");
+			Assert.notNull(entitySpecConsumer, "entitySpecConsumer cannot be null");
+			return doSingleWithBeanOutputConverter(structuredOutputConverter,
+					resolveAdvisorChain(entitySpecConsumer, structuredOutputConverter));
 		}
 
 		@Override
@@ -478,11 +571,31 @@ public class DefaultChatClient implements ChatClient {
 		@Override
 		public <T> @Nullable T entity(Class<T> type) {
 			Assert.notNull(type, "type cannot be null");
-			var outputConverter = new BeanOutputConverter<>(type);
-			return doSingleWithBeanOutputConverter(outputConverter);
+			return doSingleWithBeanOutputConverter(new BeanOutputConverter<>(type));
+		}
+
+		private BaseAdvisorChain resolveAdvisorChain(Consumer<EntityParamSpec> consumer,
+				StructuredOutputConverter<?> converter) {
+			var spec = new DefaultEntityParamSpec<>();
+			consumer.accept(spec);
+			if (spec.isEnableNative()) {
+				this.request.context().put(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey(), true);
+			}
+			if (spec.isValidated()) {
+				var validationAdvisor = StructuredOutputValidationAdvisor.builder()
+					.outputJsonSchema(converter.getJsonSchema())
+					.build();
+				return this.advisorChain.mutate().push(validationAdvisor).build();
+			}
+			return this.advisorChain;
 		}
 
 		private <T> @Nullable T doSingleWithBeanOutputConverter(StructuredOutputConverter<T> outputConverter) {
+			return doSingleWithBeanOutputConverter(outputConverter, this.advisorChain);
+		}
+
+		private <T> @Nullable T doSingleWithBeanOutputConverter(StructuredOutputConverter<T> outputConverter,
+				BaseAdvisorChain advisorChain) {
 
 			if (StringUtils.hasText(outputConverter.getFormat())) {
 				// Used for default structured output format support, based on prompt
@@ -499,7 +612,7 @@ public class DefaultChatClient implements ChatClient {
 
 			}
 
-			var chatResponse = doGetObservableChatClientResponse(this.request).chatResponse();
+			var chatResponse = doGetObservableChatClientResponse(this.request, advisorChain).chatResponse();
 
 			var stringResponse = getContentFromChatResponse(chatResponse);
 			if (stringResponse == null) {
@@ -525,13 +638,18 @@ public class DefaultChatClient implements ChatClient {
 		}
 
 		private ChatClientResponse doGetObservableChatClientResponse(ChatClientRequest chatClientRequest) {
+			return doGetObservableChatClientResponse(chatClientRequest, this.advisorChain);
+		}
+
+		private ChatClientResponse doGetObservableChatClientResponse(ChatClientRequest chatClientRequest,
+				BaseAdvisorChain advisorChain) {
 
 			String outputFormat = (String) chatClientRequest.context()
 				.getOrDefault(ChatClientAttributes.OUTPUT_FORMAT.getKey(), null);
 
 			ChatClientObservationContext observationContext = ChatClientObservationContext.builder()
 				.request(chatClientRequest)
-				.advisors(this.advisorChain.getCallAdvisors())
+				.advisors(advisorChain.getCallAdvisors())
 				.stream(false)
 				.format(outputFormat)
 				.build();
@@ -542,7 +660,7 @@ public class DefaultChatClient implements ChatClient {
 			// CHECKSTYLE:OFF
 			var chatClientResponse = observation.observe(() -> {
 				// Apply the advisor chain that terminates with the ChatModelCallAdvisor.
-				var response = this.advisorChain.nextCall(chatClientRequest);
+				var response = advisorChain.nextCall(chatClientRequest);
 				observationContext.setResponse(response);
 				return response;
 			});

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.client.advisor;
 
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
@@ -195,7 +196,16 @@ public class DefaultAroundAdvisorChain implements BaseAdvisorChain {
 		return this.observationRegistry;
 	}
 
-	public static final class Builder {
+	@Override
+	public Builder mutate() {
+		LinkedHashSet<Advisor> all = new LinkedHashSet<>(this.originalCallAdvisors);
+		all.addAll(this.originalStreamAdvisors);
+		return DefaultAroundAdvisorChain.builder(this.observationRegistry)
+			.observationConvention(this.observationConvention)
+			.pushAll(new ArrayList<>(all));
+	}
+
+	public static final class Builder implements BaseAdvisorChain.Builder<Builder> {
 
 		private final ObservationRegistry observationRegistry;
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.client.advisor;
 
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.networknt.schema.Error;
@@ -43,19 +44,18 @@ import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.util.JacksonUtils;
 import org.springframework.ai.util.json.schema.JsonSchemaGenerator;
-import org.springframework.core.Ordered;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
- * Recursive Advisor that validates the structured JSON output of a chat client entity
- * response against a generated JSON schema for the expected output type.
+ * Advisor that validates the structured JSON output of a chat client response against a
+ * JSON schema derived from the configured output type or a pre-supplied schema string.
  * <p>
- * If the validation fails, the advisor will repeat the call up to a specified number of
- * attempts.
+ * When validation fails, the advisor appends the validation error to the user message and
+ * re-invokes the model, repeating up to {@code maxRepeatAttempts} times.
  * <p>
- * Note: This advisor does not support streaming responses and will throw an
- * UnsupportedOperationException if used in a streaming context.
+ * Streaming responses are not supported.
  *
  * @author Christian Tzolov
  */
@@ -63,13 +63,6 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 
 	private static final Logger logger = LoggerFactory.getLogger(StructuredOutputValidationAdvisor.class);
 
-	/**
-	 * Set the order close to {@link Ordered#LOWEST_PRECEDENCE} to ensure an advisor is
-	 * executed toward the last (but before the model call) in the chain (last for request
-	 * processing, first for response processing).
-	 * <p>
-	 * https://docs.spring.io/spring-ai/reference/api/advisors.html#_advisor_order
-	 */
 	private final int advisorOrder;
 
 	private final Schema jsonSchema;
@@ -78,10 +71,10 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 
 	private final int maxRepeatAttempts;
 
-	private StructuredOutputValidationAdvisor(int advisorOrder, Type outputType, int maxRepeatAttempts,
+	private StructuredOutputValidationAdvisor(int advisorOrder, String outputJsonSchema, int maxRepeatAttempts,
 			JsonMapper jsonMapper) {
 		Assert.notNull(advisorOrder, "advisorOrder must not be null");
-		Assert.notNull(outputType, "outputType must not be null");
+		Assert.notNull(outputJsonSchema, "outputJsonSchema must not be null");
 		Assert.isTrue(advisorOrder > BaseAdvisor.HIGHEST_PRECEDENCE && advisorOrder < BaseAdvisor.LOWEST_PRECEDENCE,
 				"advisorOrder must be between HIGHEST_PRECEDENCE and LOWEST_PRECEDENCE");
 		Assert.isTrue(maxRepeatAttempts >= 0, "repeatAttempts must be greater than or equal to 0");
@@ -90,13 +83,11 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		this.advisorOrder = advisorOrder;
 		this.jsonMapper = jsonMapper;
 
-		String jsonSchemaText = JsonSchemaGenerator.generateForType(outputType);
-
-		logger.info("Generated JSON Schema:\n{}", jsonSchemaText);
+		logger.debug("Generated JSON Schema:\n{}", outputJsonSchema);
 
 		JsonNode schemaNode;
 		try {
-			schemaNode = jsonMapper.readTree(jsonSchemaText);
+			schemaNode = jsonMapper.readTree(outputJsonSchema);
 		}
 		catch (Exception e) {
 			throw new IllegalArgumentException("Failed to parse JSON schema", e);
@@ -224,25 +215,18 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 	}
 
 	/**
-	 * Creates a new Builder for StructuredOutputValidationAdvisor.
-	 * @return a new Builder instance
+	 * Returns a new {@link Builder}.
+	 * @return a new builder instance
 	 */
 	public static Builder builder() {
 		return new Builder();
 	}
 
 	/**
-	 * Builder class for StructuredOutputValidationAdvisor.
+	 * Builder for {@link StructuredOutputValidationAdvisor}.
 	 */
 	public final static class Builder {
 
-		/**
-		 * Set the order close to {@link Ordered#LOWEST_PRECEDENCE} to ensure an advisor
-		 * is executed toward the last (but before the model call) in the chain (last for
-		 * request processing, first for response processing).
-		 * <p>
-		 * https://docs.spring.io/spring-ai/reference/api/advisors.html#_advisor_order
-		 */
 		private int advisorOrder = BaseAdvisor.LOWEST_PRECEDENCE - 2000;
 
 		private @Nullable Type outputType;
@@ -251,11 +235,16 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 
 		private JsonMapper jsonMapper = JacksonUtils.getDefaultJsonMapper();
 
+		private @Nullable String outputJsonSchema;
+
 		private Builder() {
 		}
 
 		/**
-		 * Sets the advisor order.
+		 * Sets the advisor order. Must be strictly between
+		 * {@link BaseAdvisor#HIGHEST_PRECEDENCE} and
+		 * {@link BaseAdvisor#LOWEST_PRECEDENCE}. Defaults to
+		 * {@code LOWEST_PRECEDENCE - 2000}.
 		 * @param advisorOrder the advisor order
 		 * @return this builder
 		 */
@@ -265,8 +254,9 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		}
 
 		/**
-		 * Sets the output type using a Type.
-		 * @param outputType the output type
+		 * Sets the expected output type; the JSON schema is derived automatically.
+		 * Mutually exclusive with {@link #outputJsonSchema(String)}.
+		 * @param outputType the expected output type
 		 * @return this builder
 		 */
 		public Builder outputType(Type outputType) {
@@ -275,9 +265,10 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		}
 
 		/**
-		 * Sets the output type using a TypeReference.
+		 * Sets the expected output type; the JSON schema is derived automatically.
+		 * Mutually exclusive with {@link #outputJsonSchema(String)}.
 		 * @param <T> the type parameter
-		 * @param outputType the output type
+		 * @param outputType the expected output type
 		 * @return this builder
 		 */
 		public <T> Builder outputType(TypeReference<T> outputType) {
@@ -286,9 +277,10 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		}
 
 		/**
-		 * Sets the output type using a ParameterizedTypeReference.
+		 * Sets the expected output type; the JSON schema is derived automatically.
+		 * Mutually exclusive with {@link #outputJsonSchema(String)}.
 		 * @param <T> the type parameter
-		 * @param outputType the output type
+		 * @param outputType the expected output type
 		 * @return this builder
 		 */
 		public <T> Builder outputType(ParameterizedTypeReference<T> outputType) {
@@ -297,8 +289,20 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		}
 
 		/**
-		 * Sets the number of repeat attempts.
-		 * @param repeatAttempts the number of repeat attempts
+		 * Sets a pre-generated JSON schema string to validate against. Mutually exclusive
+		 * with the {@code outputType} methods.
+		 * @param outputJsonSchema the JSON schema as a string
+		 * @return this builder
+		 */
+		public Builder outputJsonSchema(String outputJsonSchema) {
+			this.outputJsonSchema = outputJsonSchema;
+			return this;
+		}
+
+		/**
+		 * Sets the maximum number of retry attempts after a validation failure. Zero
+		 * means no retries; the model is called exactly once. Defaults to 3.
+		 * @param repeatAttempts the number of retry attempts, must be &gt;= 0
 		 * @return this builder
 		 */
 		public Builder maxRepeatAttempts(int repeatAttempts) {
@@ -307,8 +311,9 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		}
 
 		/**
-		 * Sets the JsonMapper to be used for JSON processing.
-		 * @param jsonMapper the JsonMapper
+		 * Sets the {@link JsonMapper} used for JSON parsing and validation. Defaults to
+		 * {@link JacksonUtils#getDefaultJsonMapper()}.
+		 * @param jsonMapper the JSON mapper
 		 * @return this builder
 		 */
 		public Builder jsonMapper(JsonMapper jsonMapper) {
@@ -319,14 +324,25 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		/**
 		 * Builds the StructuredOutputValidationAdvisor.
 		 * @return a new StructuredOutputValidationAdvisor instance
-		 * @throws IllegalArgumentException if outputType is not set
+		 * @throws IllegalArgumentException if neither outputType nor outputJsonSchema is
+		 * set, or if both are set
 		 */
 		public StructuredOutputValidationAdvisor build() {
-			if (this.outputType == null) {
-				throw new IllegalArgumentException("outputType must be set");
+
+			if (StringUtils.hasText(this.outputJsonSchema) && this.outputType != null) {
+				throw new IllegalArgumentException("Only outputType or outputJsonSchema can be set, not both.");
 			}
-			return new StructuredOutputValidationAdvisor(this.advisorOrder, this.outputType, this.maxRepeatAttempts,
-					this.jsonMapper);
+
+			if (!StringUtils.hasText(this.outputJsonSchema) && this.outputType == null) {
+				throw new IllegalArgumentException("Either outputType or outputJsonSchema must be set.");
+			}
+
+			if (this.outputType != null) {
+				this.outputJsonSchema = JsonSchemaGenerator.generateForType(this.outputType);
+			}
+
+			return new StructuredOutputValidationAdvisor(this.advisorOrder,
+					Objects.requireNonNull(this.outputJsonSchema), this.maxRepeatAttempts, this.jsonMapper);
 		}
 
 	}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/BaseAdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/BaseAdvisorChain.java
@@ -16,13 +16,73 @@
 
 package org.springframework.ai.chat.client.advisor.api;
 
+import java.util.List;
+
+import io.micrometer.observation.ObservationRegistry;
+
+import org.springframework.ai.chat.client.advisor.DefaultAroundAdvisorChain;
+
 /**
  * A base interface for advisor chains that can be used to chain multiple advisors
  * together, both for call and stream advisors.
  *
  * @author Thomas Vitale
+ * @author Christian Tzolov
  * @since 1.0.0
  */
 public interface BaseAdvisorChain extends CallAdvisorChain, StreamAdvisorChain {
+
+	/**
+	 * Returns a new {@link Builder} initialized with this chain's advisors and
+	 * configuration, allowing it to be selectively modified before building a new chain.
+	 *
+	 * <p>
+	 * Concrete {@link BaseAdvisorChain} classes must override this to return the most
+	 * concrete builder implementation.
+	 * @return a pre-populated {@link Builder}
+	 */
+	// TODO: change from default to abstract once all implementations override mutate()
+	default Builder<?> mutate() {
+		throw new UnsupportedOperationException("mutate() must be overridden to return the most concrete Builder");
+	}
+
+	/**
+	 * Creates a new {@link Builder} for the default {@link BaseAdvisorChain}
+	 * implementation.
+	 * @param observationRegistry the observation registry to use
+	 * @return a new {@link Builder}
+	 */
+	static Builder<?> builder(ObservationRegistry observationRegistry) {
+		return new DefaultAroundAdvisorChain.Builder(observationRegistry);
+	}
+
+	/**
+	 * Builder for creating a {@link BaseAdvisorChain} instance.
+	 *
+	 * @param <B> the concrete builder type, enabling fluent subtype chaining
+	 */
+	interface Builder<B extends Builder<B>> {
+
+		/**
+		 * Adds a single {@link Advisor} to the chain.
+		 * @param advisor the advisor to add; must not be null
+		 * @return this builder
+		 */
+		B push(Advisor advisor);
+
+		/**
+		 * Adds multiple {@link Advisor} instances to the chain.
+		 * @param advisors the advisors to add; must not be null or contain null elements
+		 * @return this builder
+		 */
+		B pushAll(List<? extends Advisor> advisors);
+
+		/**
+		 * Builds and returns the {@link BaseAdvisorChain}.
+		 * @return the constructed chain
+		 */
+		BaseAdvisorChain build();
+
+	}
 
 }

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
@@ -268,7 +268,7 @@ public class ChatClientResponseEntityTests {
 			.user("Tell me about John")
 			.call()
 			.entity(new ParameterizedTypeReference<MyBean>() {
-			}, spec -> spec.delegateToProvider());
+			}, spec -> spec.useProviderStructuredOutput());
 
 		assertThat(contextCatcher.getContext()).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
@@ -288,7 +288,7 @@ public class ChatClientResponseEntityTests {
 			.user("Tell me about John")
 			.call()
 			.entity(new ParameterizedTypeReference<MyBean>() {
-			}, spec -> spec.schemaValidation());
+			}, spec -> spec.validateSchema());
 
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
 		verify(this.chatModel, times(1)).call(any(Prompt.class));
@@ -308,7 +308,7 @@ public class ChatClientResponseEntityTests {
 			.user("Tell me about John")
 			.call()
 			.entity(new ParameterizedTypeReference<MyBean>() {
-			}, spec -> spec.schemaValidation());
+			}, spec -> spec.validateSchema());
 
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
 		verify(this.chatModel, times(2)).call(any(Prompt.class));
@@ -328,7 +328,7 @@ public class ChatClientResponseEntityTests {
 			.advisors(contextCatcher)
 			.user("Tell me about John")
 			.call()
-			.entity(MyBean.class, spec -> spec.delegateToProvider());
+			.entity(MyBean.class, spec -> spec.useProviderStructuredOutput());
 
 		assertThat(contextCatcher.getContext()).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
@@ -346,7 +346,7 @@ public class ChatClientResponseEntityTests {
 			.prompt()
 			.user("Tell me about John")
 			.call()
-			.entity(MyBean.class, spec -> spec.schemaValidation());
+			.entity(MyBean.class, spec -> spec.validateSchema());
 
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
 		verify(this.chatModel, times(1)).call(any(Prompt.class));
@@ -366,7 +366,7 @@ public class ChatClientResponseEntityTests {
 			.advisors(contextCatcher)
 			.user("Tell me about John")
 			.call()
-			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.delegateToProvider());
+			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.useProviderStructuredOutput());
 
 		assertThat(contextCatcher.getContext()).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
@@ -384,7 +384,7 @@ public class ChatClientResponseEntityTests {
 			.prompt()
 			.user("Tell me about John")
 			.call()
-			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.schemaValidation());
+			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.validateSchema());
 
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
 		verify(this.chatModel, times(1)).call(any(Prompt.class));

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
@@ -268,7 +268,7 @@ public class ChatClientResponseEntityTests {
 			.user("Tell me about John")
 			.call()
 			.entity(new ParameterizedTypeReference<MyBean>() {
-			}, spec -> spec.useProviderStructuredOutput());
+			}, spec -> spec.delegateToProvider());
 
 		assertThat(contextCatcher.getContext()).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
@@ -288,7 +288,7 @@ public class ChatClientResponseEntityTests {
 			.user("Tell me about John")
 			.call()
 			.entity(new ParameterizedTypeReference<MyBean>() {
-			}, spec -> spec.withSchemaValidation());
+			}, spec -> spec.schemaValidation());
 
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
 		verify(this.chatModel, times(1)).call(any(Prompt.class));
@@ -308,7 +308,7 @@ public class ChatClientResponseEntityTests {
 			.user("Tell me about John")
 			.call()
 			.entity(new ParameterizedTypeReference<MyBean>() {
-			}, spec -> spec.withSchemaValidation());
+			}, spec -> spec.schemaValidation());
 
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
 		verify(this.chatModel, times(2)).call(any(Prompt.class));
@@ -328,7 +328,7 @@ public class ChatClientResponseEntityTests {
 			.advisors(contextCatcher)
 			.user("Tell me about John")
 			.call()
-			.entity(MyBean.class, spec -> spec.useProviderStructuredOutput());
+			.entity(MyBean.class, spec -> spec.delegateToProvider());
 
 		assertThat(contextCatcher.getContext()).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
@@ -346,7 +346,7 @@ public class ChatClientResponseEntityTests {
 			.prompt()
 			.user("Tell me about John")
 			.call()
-			.entity(MyBean.class, spec -> spec.withSchemaValidation());
+			.entity(MyBean.class, spec -> spec.schemaValidation());
 
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
 		verify(this.chatModel, times(1)).call(any(Prompt.class));
@@ -366,7 +366,7 @@ public class ChatClientResponseEntityTests {
 			.advisors(contextCatcher)
 			.user("Tell me about John")
 			.call()
-			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.useProviderStructuredOutput());
+			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.delegateToProvider());
 
 		assertThat(contextCatcher.getContext()).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
@@ -384,7 +384,7 @@ public class ChatClientResponseEntityTests {
 			.prompt()
 			.user("Tell me about John")
 			.call()
-			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.withSchemaValidation());
+			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.schemaValidation());
 
 		assertThat(entity).isEqualTo(new MyBean("John", 30));
 		verify(this.chatModel, times(1)).call(any(Prompt.class));

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.client;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +27,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
@@ -35,12 +38,16 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.converter.MapOutputConverter;
 import org.springframework.core.ParameterizedTypeReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -245,7 +252,172 @@ public class ChatClientResponseEntityTests {
 		assertThat(responseEntity.getEntity()).isEqualTo(1);
 	}
 
+	@Test
+	public void entitySpecWithEnableNativeSetsContextAttribute() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("""
+				{"name":"John", "age":30}
+				"""))));
+		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
+
+		var contextCatcher = new ContextCatcherCallAdvisor();
+		MyBean entity = ChatClient.builder(this.chatModel)
+			.build()
+			.prompt()
+			.advisors(contextCatcher)
+			.user("Tell me about John")
+			.call()
+			.entity(new ParameterizedTypeReference<MyBean>() {
+			}, spec -> spec.useProviderStructuredOutput());
+
+		assertThat(contextCatcher.getContext()).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
+		assertThat(entity).isEqualTo(new MyBean("John", 30));
+	}
+
+	@Test
+	public void entitySpecWithValidatePassesOnFirstAttempt() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("""
+				{"name":"John", "age":30}
+				"""))));
+		given(this.chatModel.call(any(Prompt.class))).willReturn(chatResponse);
+
+		MyBean entity = ChatClient.builder(this.chatModel)
+			.build()
+			.prompt()
+			.user("Tell me about John")
+			.call()
+			.entity(new ParameterizedTypeReference<MyBean>() {
+			}, spec -> spec.withSchemaValidation());
+
+		assertThat(entity).isEqualTo(new MyBean("John", 30));
+		verify(this.chatModel, times(1)).call(any(Prompt.class));
+	}
+
+	@Test
+	public void entitySpecWithValidateRetriesOnInvalidJson() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		var invalidResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("{\"name\":\"John\"}"))));
+		var validResponse = new ChatResponse(
+				List.of(new Generation(new AssistantMessage("{\"name\":\"John\",\"age\":30}"))));
+		given(this.chatModel.call(any(Prompt.class))).willReturn(invalidResponse, validResponse);
+
+		MyBean entity = ChatClient.builder(this.chatModel)
+			.build()
+			.prompt()
+			.user("Tell me about John")
+			.call()
+			.entity(new ParameterizedTypeReference<MyBean>() {
+			}, spec -> spec.withSchemaValidation());
+
+		assertThat(entity).isEqualTo(new MyBean("John", 30));
+		verify(this.chatModel, times(2)).call(any(Prompt.class));
+	}
+
+	@Test
+	public void entityClassSpecWithEnableNativeSetsContextAttribute() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		var chatResponse = new ChatResponse(
+				List.of(new Generation(new AssistantMessage("{\"name\":\"John\",\"age\":30}"))));
+		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
+
+		var contextCatcher = new ContextCatcherCallAdvisor();
+		MyBean entity = ChatClient.builder(this.chatModel)
+			.build()
+			.prompt()
+			.advisors(contextCatcher)
+			.user("Tell me about John")
+			.call()
+			.entity(MyBean.class, spec -> spec.useProviderStructuredOutput());
+
+		assertThat(contextCatcher.getContext()).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
+		assertThat(entity).isEqualTo(new MyBean("John", 30));
+	}
+
+	@Test
+	public void entityClassSpecWithValidatePassesOnFirstAttempt() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		var chatResponse = new ChatResponse(
+				List.of(new Generation(new AssistantMessage("{\"name\":\"John\",\"age\":30}"))));
+		given(this.chatModel.call(any(Prompt.class))).willReturn(chatResponse);
+
+		MyBean entity = ChatClient.builder(this.chatModel)
+			.build()
+			.prompt()
+			.user("Tell me about John")
+			.call()
+			.entity(MyBean.class, spec -> spec.withSchemaValidation());
+
+		assertThat(entity).isEqualTo(new MyBean("John", 30));
+		verify(this.chatModel, times(1)).call(any(Prompt.class));
+	}
+
+	@Test
+	public void entityConverterSpecWithEnableNativeSetsContextAttribute() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		var chatResponse = new ChatResponse(
+				List.of(new Generation(new AssistantMessage("{\"name\":\"John\",\"age\":30}"))));
+		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
+
+		var contextCatcher = new ContextCatcherCallAdvisor();
+		MyBean entity = ChatClient.builder(this.chatModel)
+			.build()
+			.prompt()
+			.advisors(contextCatcher)
+			.user("Tell me about John")
+			.call()
+			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.useProviderStructuredOutput());
+
+		assertThat(contextCatcher.getContext()).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
+		assertThat(entity).isEqualTo(new MyBean("John", 30));
+	}
+
+	@Test
+	public void entityConverterSpecWithValidatePassesOnFirstAttempt() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		var chatResponse = new ChatResponse(
+				List.of(new Generation(new AssistantMessage("{\"name\":\"John\",\"age\":30}"))));
+		given(this.chatModel.call(any(Prompt.class))).willReturn(chatResponse);
+
+		MyBean entity = ChatClient.builder(this.chatModel)
+			.build()
+			.prompt()
+			.user("Tell me about John")
+			.call()
+			.entity(new BeanOutputConverter<>(MyBean.class), spec -> spec.withSchemaValidation());
+
+		assertThat(entity).isEqualTo(new MyBean("John", 30));
+		verify(this.chatModel, times(1)).call(any(Prompt.class));
+	}
+
 	record MyBean(String name, int age) {
+	}
+
+	private static class ContextCatcherCallAdvisor implements CallAdvisor {
+
+		private final Map<String, Object> context = new ConcurrentHashMap<>();
+
+		@Override
+		public String getName() {
+			return "ContextCatcher";
+		}
+
+		@Override
+		public int getOrder() {
+			return 0;
+		}
+
+		@Override
+		public ChatClientResponse adviseCall(ChatClientRequest chatClientRequest, CallAdvisorChain callAdvisorChain) {
+			var r = callAdvisorChain.nextCall(chatClientRequest);
+			this.context.putAll(r.context());
+			return r;
+		}
+
+		public Map<String, Object> getContext() {
+			return this.context;
+		}
+
 	}
 
 }

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChainTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChainTests.java
@@ -27,6 +27,7 @@ import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
@@ -289,6 +290,37 @@ class DefaultAroundAdvisorChainTests {
 
 		assertThat(ReflectionTestUtils.getField(newChain, "observationConvention"))
 			.isInstanceOf(DefaultAdvisorObservationConvention.class);
+	}
+
+	@Test
+	void mutateCopiesAllAdvisorsToNewChain() {
+		CallAdvisor advisor1 = createMockAdvisor("advisor1", 1);
+		CallAdvisor advisor2 = createMockAdvisor("advisor2", 2);
+
+		DefaultAroundAdvisorChain chain = (DefaultAroundAdvisorChain) DefaultAroundAdvisorChain
+			.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor1, advisor2))
+			.build();
+
+		BaseAdvisorChain mutated = chain.mutate().build();
+
+		assertThat(mutated.getCallAdvisors()).containsExactlyInAnyOrderElementsOf(chain.getCallAdvisors());
+	}
+
+	@Test
+	void mutateDoesNotAffectOriginalChain() {
+		CallAdvisor advisor1 = createMockAdvisor("advisor1", 1);
+		CallAdvisor advisor2 = createMockAdvisor("advisor2", 2);
+
+		DefaultAroundAdvisorChain chain = (DefaultAroundAdvisorChain) DefaultAroundAdvisorChain
+			.builder(ObservationRegistry.NOOP)
+			.push(advisor1)
+			.build();
+
+		chain.mutate().push(advisor2).build();
+
+		assertThat(chain.getCallAdvisors()).hasSize(1);
+		assertThat(chain.getCallAdvisors().get(0).getName()).isEqualTo("advisor1");
 	}
 
 	private CallAdvisor createMockAdvisor(String name, int order) {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
@@ -59,10 +59,31 @@ public class StructuredOutputValidationAdvisorTests {
 	private StreamAdvisorChain streamAdvisorChain;
 
 	@Test
-	void whenOutputTypeIsNullThenThrow() {
+	void whenNeitherOutputTypeNorSchemaIsSetThenThrow() {
 		assertThatThrownBy(() -> StructuredOutputValidationAdvisor.builder().build())
 			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("outputType must be set");
+			.hasMessageContaining("Either outputType or outputJsonSchema must be set");
+	}
+
+	@Test
+	void whenBothOutputTypeAndSchemaAreSetThenThrow() {
+		assertThatThrownBy(() -> StructuredOutputValidationAdvisor.builder().outputType(new TypeReference<Person>() {
+		}).outputJsonSchema("{\"type\":\"object\"}").build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Only outputType or outputJsonSchema can be set, not both");
+	}
+
+	@Test
+	void whenOutputJsonSchemaIsSetThenBuildSucceeds() {
+		String schema = """
+				{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}
+				""";
+		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
+			.outputJsonSchema(schema)
+			.build();
+
+		assertThat(advisor).isNotNull();
+		assertThat(advisor.getName()).isEqualTo("Structured Output Validation Advisor");
+		assertThat(advisor.getOrder()).isEqualTo(Ordered.LOWEST_PRECEDENCE - 2000);
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -169,5 +169,5 @@ Alternatively, you can enable schema validation directly on an `entity()` call w
 ActorFilms actorFilms = chatClient.prompt()
     .user("Generate the filmography for a random actor.")
     .call()
-    .entity(ActorFilms.class, spec -> spec.withSchemaValidation());
+    .entity(ActorFilms.class, spec -> spec.schemaValidation());
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -123,30 +123,51 @@ When a tool execution has `returnDirect=true`, the `ToolCallAdvisor` will:
 3. Break out of the tool calling loop
 4. Return the tool execution result directly to the client application as a `ChatResponse` with the tool's output as the generation content
 
+[[structured-output-validation-advisor]]
 === StructuredOutputValidationAdvisor
 
-The `StructuredOutputValidationAdvisor` validates the structured JSON output against a generated JSON schema and retries the call if validation fails, up to a specified number of attempts.
+The `StructuredOutputValidationAdvisor` validates the structured JSON output against a JSON schema and retries the call if validation fails, up to a specified number of attempts.
 
 Key features:
 
-* Automatically generates a JSON schema from the expected output type
+* Derives a JSON schema from the expected output type, or accepts a pre-supplied schema string
 * Validates the LLM response against the schema
-* Retries the call if validation fails, up to a configurable number of attempts
+* Retries the call if validation fails, up to a configurable number of attempts (default: 3)
 * Augments the prompt with validation error messages on retry attempts to help the LLM correct its output
 * Uses `callAdvisorChain.copy(this)` to create a sub-chain for recursive calls
 * Optionally supports a custom `JsonMapper` for JSON processing
 
-Example usage:
+The advisor can be configured via `outputType` (schema derived automatically) or `outputJsonSchema` (pre-supplied schema string); the two options are mutually exclusive.
+
+Example usage with `outputType`:
 
 [source,java]
 ----
 var validationAdvisor = StructuredOutputValidationAdvisor.builder()
     .outputType(MyResponseType.class)
     .maxRepeatAttempts(3)
-    .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 1000)
     .build();
 
 var chatClient = ChatClient.builder(chatModel)
     .defaultAdvisors(validationAdvisor)
     .build();
+----
+
+Example usage with a pre-supplied JSON schema:
+
+[source,java]
+----
+var validationAdvisor = StructuredOutputValidationAdvisor.builder()
+    .outputJsonSchema(myConverter.getJsonSchema())
+    .build();
+----
+
+Alternatively, you can enable schema validation directly on an `entity()` call without configuring the advisor manually, using xref:api/chatclient.adoc#_entityparamspec[EntityParamSpec]:
+
+[source,java]
+----
+ActorFilms actorFilms = chatClient.prompt()
+    .user("Generate the filmography for a random actor.")
+    .call()
+    .entity(ActorFilms.class, spec -> spec.withSchemaValidation());
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -280,7 +280,7 @@ All three `entity()` overloads accept an optional `Consumer<EntityParamSpec>` th
 ===== Provider-Native Structured Output
 
 By default, the JSON schema is appended to the user message as text instructions.
-When `useProviderStructuredOutput()` is set, the schema is instead passed directly to the AI provider API as a structured constraint (equivalent to setting `AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT`).
+When `delegateToProvider()` is set, the schema is instead passed directly to the AI provider API as a structured constraint (equivalent to setting `AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT`).
 This requires the underlying model to support `StructuredOutputChatOptions`.
 
 [source,java]
@@ -307,7 +307,7 @@ ActorFilms actorFilms = chatClient.prompt()
 
 ===== Schema Validation with Retry
 
-`withSchemaValidation()` validates the model's JSON response against the entity schema before returning it.
+`schemaValidation()` validates the model's JSON response against the entity schema before returning it.
 If validation fails, the error message is appended to the user prompt and the model is retried, up to `maxRepeatAttempts` times (default: 3).
 This uses xref:api/advisors-recursive.adoc#structured-output-validation-advisor[StructuredOutputValidationAdvisor] internally.
 
@@ -316,7 +316,7 @@ This uses xref:api/advisors-recursive.adoc#structured-output-validation-advisor[
 ActorFilms actorFilms = chatClient.prompt()
     .user("Generate the filmography for a random actor.")
     .call()
-    .entity(ActorFilms.class, spec -> spec.withSchemaValidation());
+    .entity(ActorFilms.class, spec -> spec.schemaValidation());
 ----
 
 Both options can be combined:
@@ -327,11 +327,11 @@ ActorFilms actorFilms = chatClient.prompt()
     .user("Generate the filmography for a random actor.")
     .call()
     .entity(ActorFilms.class, spec -> spec
-        .useProviderStructuredOutput()
-        .withSchemaValidation());
+        .delegateToProvider()
+        .schemaValidation());
 ----
 
-NOTE: Streaming is not supported when `withSchemaValidation()` is active.
+NOTE: Streaming is not supported when `schemaValidation()` is active.
 
 === Streaming Responses
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -280,7 +280,7 @@ All three `entity()` overloads accept an optional `Consumer<EntityParamSpec>` th
 ===== Provider-Native Structured Output
 
 By default, the JSON schema is appended to the user message as text instructions.
-When `delegateToProvider()` is set, the schema is instead passed directly to the AI provider API as a structured constraint (equivalent to setting `AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT`).
+When `useProviderStructuredOutput()` is set, the schema is instead passed directly to the AI provider API as a structured constraint (equivalent to setting `AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT`).
 This requires the underlying model to support `StructuredOutputChatOptions`.
 
 [source,java]
@@ -327,11 +327,11 @@ ActorFilms actorFilms = chatClient.prompt()
     .user("Generate the filmography for a random actor.")
     .call()
     .entity(ActorFilms.class, spec -> spec
-        .delegateToProvider()
-        .schemaValidation());
+        .useProviderStructuredOutput()
+        .validateSchema());
 ----
 
-NOTE: Streaming is not supported when `schemaValidation()` is active.
+NOTE: Streaming is not supported when `validateSchema()` is active.
 
 === Streaming Responses
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -273,10 +273,28 @@ List<ActorFilms> actorFilms = chatClient.prompt()
     .entity(new ParameterizedTypeReference<List<ActorFilms>>() {});
 ----
 
-==== Native Structured Output
+==== EntityParamSpec
 
-As more AI models support structured output natively, you can take advantage of this feature by using the `AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT` advisor parameter when calling the `ChatClient`.
-You can use the `defaultAdvisors()` method on the `ChatClient.Builder` to set this parameter globally for all calls or set it per call as shown below:
+All three `entity()` overloads accept an optional `Consumer<EntityParamSpec>` that enables two independent behaviours:
+
+===== Provider-Native Structured Output
+
+By default, the JSON schema is appended to the user message as text instructions.
+When `useProviderStructuredOutput()` is set, the schema is instead passed directly to the AI provider API as a structured constraint (equivalent to setting `AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT`).
+This requires the underlying model to support `StructuredOutputChatOptions`.
+
+[source,java]
+----
+ActorFilms actorFilms = chatClient.prompt()
+    .user("Generate the filmography for a random actor.")
+    .call()
+    .entity(ActorFilms.class, spec -> spec.useProviderStructuredOutput());
+----
+
+NOTE: Some AI models such as OpenAI don't support arrays of objects natively.
+In such cases, you can use the Spring AI default structured output conversion.
+
+You can still set this globally for all calls via the advisor parameter:
 
 [source,java]
 ----
@@ -287,8 +305,33 @@ ActorFilms actorFilms = chatClient.prompt()
     .entity(ActorFilms.class);
 ----
 
-NOTE: Some AI models such as OpenAI don't support arrays of objects natively.
-In such cases, you can use the Spring AI default structured output conversion.
+===== Schema Validation with Retry
+
+`withSchemaValidation()` validates the model's JSON response against the entity schema before returning it.
+If validation fails, the error message is appended to the user prompt and the model is retried, up to `maxRepeatAttempts` times (default: 3).
+This uses xref:api/advisors-recursive.adoc#structured-output-validation-advisor[StructuredOutputValidationAdvisor] internally.
+
+[source,java]
+----
+ActorFilms actorFilms = chatClient.prompt()
+    .user("Generate the filmography for a random actor.")
+    .call()
+    .entity(ActorFilms.class, spec -> spec.withSchemaValidation());
+----
+
+Both options can be combined:
+
+[source,java]
+----
+ActorFilms actorFilms = chatClient.prompt()
+    .user("Generate the filmography for a random actor.")
+    .call()
+    .entity(ActorFilms.class, spec -> spec
+        .useProviderStructuredOutput()
+        .withSchemaValidation());
+----
+
+NOTE: Streaming is not supported when `withSchemaValidation()` is active.
 
 === Streaming Responses
 
@@ -376,6 +419,9 @@ After specifying the `call()` method on `ChatClient`, there are a few different 
 ** `entity(ParameterizedTypeReference<T> type)`: used to return a `Collection` of entity types.
 ** `entity(Class<T> type)`:  used to return a specific entity type.
 ** `entity(StructuredOutputConverter<T> structuredOutputConverter)`: used to specify an instance of a `StructuredOutputConverter` to convert a `String` to an entity type.
+** `entity(ParameterizedTypeReference<T> type, Consumer<EntityParamSpec> spec)`: like above, with optional xref:api/chatclient.adoc#_entityparamspec[EntityParamSpec] configuration.
+** `entity(Class<T> type, Consumer<EntityParamSpec> spec)`: like above, with optional xref:api/chatclient.adoc#_entityparamspec[EntityParamSpec] configuration.
+** `entity(StructuredOutputConverter<T> converter, Consumer<EntityParamSpec> spec)`: like above, with optional xref:api/chatclient.adoc#_entityparamspec[EntityParamSpec] configuration.
 * `responseEntity()` to return both the `ChatResponse` and a Java type. This is useful when you need access to both the complete AI model response (with metadata and generations) and the structured output entity in a single call.
 ** `responseEntity(Class<T> type)`: used to return a `ResponseEntity` containing both the complete `ChatResponse` object and a specific entity type.
 ** `responseEntity(ParameterizedTypeReference<T> type)`: used to return a `ResponseEntity` containing both the complete `ChatResponse` object and a `Collection` of entity types.


### PR DESCRIPTION
Introduce EntityParamSpec, a fluent configuration interface for the entity() and responseEntity() overloads, enabling two opt-in behaviours per call:

- delegateToProvider(): passes the JSON schema to the AI provider as an API-level constraint instead of appending it as prompt text (equivalent to AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT).
- schemaValidation(): validates the model's JSON response against the entity schema via StructuredOutputValidationAdvisor, retrying with error feedback on failure (default: 3 attempts).

StructuredOutputValidationAdvisor.Builder gains an outputJsonSchema(String) alternative to outputType(), and BaseAdvisorChain gains mutate() and a nested Builder interface to support per-call advisor chain augmentation.

Resolves #6165