### PR TITLE
Add no-auth mode support via empty apiKey / NoopApiKey for OpenAI

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtil.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtil.java
@@ -32,8 +32,11 @@ public final class OpenAiAutoConfigurationUtil {
 		resolved.setBaseUrl(StringUtils.hasText(modelProperties.getBaseUrl()) ? modelProperties.getBaseUrl()
 				: commonProperties.getBaseUrl());
 
-		resolved.setApiKey(StringUtils.hasText(modelProperties.getApiKey()) ? modelProperties.getApiKey()
-				: commonProperties.getApiKey());
+		// An explicit empty string ("") is a deliberate no-auth signal (NoopApiKey
+		// behaviour) and must be preserved. Only fall back to commonProperties when the
+		// model-level key is null (i.e. not configured at all).
+		resolved.setApiKey(
+				modelProperties.getApiKey() != null ? modelProperties.getApiKey() : commonProperties.getApiKey());
 
 		String organizationId = StringUtils.hasText(modelProperties.getOrganizationId())
 				? modelProperties.getOrganizationId() : commonProperties.getOrganizationId();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtilTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtilTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.openai.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link OpenAiAutoConfigurationUtil#resolveCommonProperties}.
+ *
+ * Specifically verifies that an explicitly-set empty {@code apiKey} (the no-auth /
+ * {@code NoopApiKey} signal) is preserved and not silently replaced by the common-level
+ * key.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class OpenAiAutoConfigurationUtilTests {
+
+	@Test
+	void modelApiKeyTakesPrecedenceOverCommonApiKey() {
+		var common = properties("common-key");
+		var model = properties("model-key");
+
+		var resolved = OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model);
+
+		assertThat(resolved.getApiKey()).isEqualTo("model-key");
+	}
+
+	@Test
+	void commonApiKeyUsedWhenModelApiKeyIsNull() {
+		var common = properties("common-key");
+		var model = properties(null);
+
+		var resolved = OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model);
+
+		assertThat(resolved.getApiKey()).isEqualTo("common-key");
+	}
+
+	@Test
+	void emptyModelApiKeyIsPreservedAndNotReplacedByCommonKey() {
+		// An empty string is the no-auth (NoopApiKey) signal. It must be kept as-is
+		// and must NOT fall back to the common-level key.
+		var common = properties("common-key");
+		var model = properties("");
+
+		var resolved = OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model);
+
+		assertThat(resolved.getApiKey()).as("empty model apiKey must be preserved as the no-auth signal").isEmpty();
+	}
+
+	@Test
+	void emptyCommonApiKeyIsPreservedWhenModelApiKeyIsNull() {
+		// If the common key is explicitly empty and the model key is absent, the
+		// empty string should flow through (no-auth at the common level).
+		var common = properties("");
+		var model = properties(null);
+
+		var resolved = OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model);
+
+		assertThat(resolved.getApiKey()).as("empty common apiKey must be preserved when model apiKey is absent")
+			.isEmpty();
+	}
+
+	@Test
+	void bothApiKeysNullResolvesToNull() {
+		var common = properties(null);
+		var model = properties(null);
+
+		var resolved = OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model);
+
+		assertThat(resolved.getApiKey()).isNull();
+	}
+
+	private static OpenAiCommonProperties properties(String apiKey) {
+		var props = new OpenAiCommonProperties();
+		props.setApiKey(apiKey);
+		return props;
+	}
+
+}

--- a/models/spring-ai-openai/pom.xml
+++ b/models/spring-ai-openai/pom.xml
@@ -53,6 +53,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>${okhttp3.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>com.azure</groupId>
 			<artifactId>azure-identity</artifactId>
 			<version>${azure-identity.version}</version>

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/AbstractOpenAiOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/AbstractOpenAiOptions.java
@@ -25,6 +25,9 @@ import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.credential.Credential;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.ai.model.ApiKey;
+import org.springframework.ai.model.NoopApiKey;
+
 public class AbstractOpenAiOptions {
 
 	/**
@@ -227,6 +230,17 @@ public class AbstractOpenAiOptions {
 
 		public B apiKey(@Nullable String apiKey) {
 			this.apiKey = apiKey;
+			return self();
+		}
+
+		/**
+		 * Sets the API key using an {@link ApiKey} instance. Pass a {@link NoopApiKey} to
+		 * disable authentication (no {@code Authorization} header will be sent), which is
+		 * the same behavior as setting an empty string via {@link #apiKey(String)}.
+		 * @param apiKey the API key instance; if {@code null}, the key is cleared
+		 */
+		public B apiKey(@Nullable ApiKey apiKey) {
+			this.apiKey = (apiKey != null) ? apiKey.getValue() : null;
 			return self();
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -36,6 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.model.ApiKey;
+import org.springframework.ai.model.NoopApiKey;
 import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
 import org.springframework.ai.model.tool.StructuredOutputChatOptions;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
@@ -947,6 +949,17 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 
 		public B apiKey(@Nullable String apiKey) {
 			this.apiKey = apiKey;
+			return self();
+		}
+
+		/**
+		 * Sets the API key using an {@link ApiKey} instance. Pass a {@link NoopApiKey} to
+		 * disable authentication (no {@code Authorization} header will be sent), which is
+		 * the same behavior as setting an empty string via {@link #apiKey(String)}.
+		 * @param apiKey the API key instance; if {@code null}, the key is cleared
+		 */
+		public B apiKey(@Nullable ApiKey apiKey) {
+			this.apiKey = (apiKey != null) ? apiKey.getValue() : null;
 			return self();
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/setup/OpenAiSetup.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/setup/OpenAiSetup.java
@@ -26,8 +26,12 @@ import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.azure.credential.AzureApiKeyCredential;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
+import com.openai.client.OpenAIClientAsyncImpl;
+import com.openai.client.OpenAIClientImpl;
+import com.openai.client.okhttp.OkHttpClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.client.okhttp.OpenAIOkHttpClientAsync;
+import com.openai.core.ClientOptions;
 import com.openai.credential.Credential;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -50,6 +54,17 @@ public final class OpenAiSetup {
 	static final String GITHUB_TOKEN = "GITHUB_TOKEN";
 	static final String DEFAULT_USER_AGENT = "spring-ai-openai";
 
+	/**
+	 * Placeholder API key used internally when no-auth mode is requested (empty apiKey /
+	 * {@link org.springframework.ai.model.NoopApiKey}). The OpenAI Java SDK requires a
+	 * non-empty string to pass its credential validation at both construction and
+	 * per-request time — an empty string causes an {@link IllegalStateException} in
+	 * {@code securityHeaders()}. The OkHttp interceptor registered in
+	 * {@link #buildNoAuthClientOptions} guarantees this placeholder value is stripped
+	 * from the {@code Authorization} header before any request leaves the JVM.
+	 */
+	private static final String NO_AUTH_PLACEHOLDER_KEY = "no-auth-placeholder";
+
 	private static final Logger logger = LoggerFactory.getLogger(OpenAiSetup.class);
 
 	private OpenAiSetup() {
@@ -61,6 +76,17 @@ public final class OpenAiSetup {
 
 	}
 
+	/**
+	 * Sets up a synchronous OpenAI client.
+	 * <p>
+	 * When {@code apiKey} is an empty string, the client is configured in no-auth mode:
+	 * no {@code Authorization} header is sent with any request. This is useful for
+	 * connecting to custom OpenAI-compatible servers that use cookie-based or other
+	 * non-bearer-token authentication. To enable this mode, set
+	 * {@code spring.ai.openai.api-key=} (empty value) in your application properties, or
+	 * pass a {@link org.springframework.ai.model.NoopApiKey} via
+	 * {@link org.springframework.ai.openai.AbstractOpenAiOptions.AbstractBuilder#apiKey(org.springframework.ai.model.ApiKey)}.
+	 */
 	public static OpenAIClient setupSyncClient(@Nullable String baseUrl, @Nullable String apiKey,
 			@Nullable Credential credential, @Nullable String azureDeploymentName,
 			@Nullable AzureOpenAIServiceVersion azureOpenAiServiceVersion, @Nullable String organizationId,
@@ -70,10 +96,20 @@ public final class OpenAiSetup {
 		baseUrl = detectBaseUrlFromEnv(baseUrl);
 		var modelProvider = detectModelProvider(isAzure, isGitHubModels, baseUrl, azureDeploymentName,
 				azureOpenAiServiceVersion);
+
+		String calculatedApiKey = apiKey != null ? apiKey : detectApiKey(modelProvider);
+		if (calculatedApiKey != null && calculatedApiKey.isEmpty()) {
+			// No-auth mode: build the client directly via ClientOptions so we can inject
+			// a
+			// custom HttpClient that strips the Authorization header before sending
+			// requests.
+			return new OpenAIClientImpl(buildNoAuthClientOptions(baseUrl, modelProvider, modelName, azureDeploymentName,
+					azureOpenAiServiceVersion, organizationId, timeout, maxRetries, proxy, customHeaders));
+		}
+
 		OpenAIOkHttpClient.Builder builder = OpenAIOkHttpClient.builder();
 		builder.baseUrl(calculateBaseUrl(baseUrl, modelProvider, modelName, azureDeploymentName));
 
-		String calculatedApiKey = apiKey != null ? apiKey : detectApiKey(modelProvider);
 		if (calculatedApiKey != null) {
 			if (modelProvider == ModelProvider.MICROSOFT_FOUNDRY) {
 				builder.credential(AzureApiKeyCredential.create(calculatedApiKey));
@@ -88,8 +124,7 @@ public final class OpenAiSetup {
 			}
 			else if (modelProvider == ModelProvider.MICROSOFT_FOUNDRY) {
 				// If no API key is provided for Microsoft Foundry, we try to use
-				// passwordless
-				// authentication
+				// passwordless authentication
 				builder.credential(azureAuthentication());
 			}
 		}
@@ -128,10 +163,20 @@ public final class OpenAiSetup {
 		baseUrl = detectBaseUrlFromEnv(baseUrl);
 		var modelProvider = detectModelProvider(isAzure, isGitHubModels, baseUrl, azureDeploymentName,
 				azureOpenAiServiceVersion);
+
+		String calculatedApiKey = apiKey != null ? apiKey : detectApiKey(modelProvider);
+		if (calculatedApiKey != null && calculatedApiKey.isEmpty()) {
+			// No-auth mode: build the client directly via ClientOptions so we can inject
+			// a custom HttpClient that strips the Authorization header before
+			// sending requests.
+			return new OpenAIClientAsyncImpl(
+					buildNoAuthClientOptions(baseUrl, modelProvider, modelName, azureDeploymentName,
+							azureOpenAiServiceVersion, organizationId, timeout, maxRetries, proxy, customHeaders));
+		}
+
 		OpenAIOkHttpClientAsync.Builder builder = OpenAIOkHttpClientAsync.builder();
 		builder.baseUrl(calculateBaseUrl(baseUrl, modelProvider, modelName, azureDeploymentName));
 
-		String calculatedApiKey = apiKey != null ? apiKey : detectApiKey(modelProvider);
 		if (calculatedApiKey != null) {
 			if (modelProvider == ModelProvider.MICROSOFT_FOUNDRY) {
 				builder.credential(AzureApiKeyCredential.create(calculatedApiKey));
@@ -146,8 +191,7 @@ public final class OpenAiSetup {
 			}
 			else if (modelProvider == ModelProvider.MICROSOFT_FOUNDRY) {
 				// If no API key is provided for Microsoft Foundry, we try to use
-				// passwordless
-				// authentication
+				// passwordless authentication
 				builder.credential(azureAuthentication());
 			}
 		}
@@ -171,6 +215,47 @@ public final class OpenAiSetup {
 		builder.timeout(timeout);
 		builder.maxRetries(maxRetries);
 		return builder.build();
+	}
+
+	/**
+	 * Builds a {@link ClientOptions} instance with a custom {@link OkHttpClient} that
+	 * removes the {@code Authorization} header from every outgoing request. Used when an
+	 * empty API key is provided to signal no-auth mode.
+	 */
+	private static ClientOptions buildNoAuthClientOptions(@Nullable String baseUrl, ModelProvider modelProvider,
+			@Nullable String modelName, @Nullable String azureDeploymentName,
+			@Nullable AzureOpenAIServiceVersion azureOpenAiServiceVersion, @Nullable String organizationId,
+			Duration timeout, int maxRetries, @Nullable Proxy proxy, @Nullable Map<String, String> customHeaders) {
+
+		okhttp3.OkHttpClient.Builder okHttpBuilder = new okhttp3.OkHttpClient.Builder();
+		if (proxy != null) {
+			okHttpBuilder.proxy(proxy);
+		}
+		okHttpBuilder.addInterceptor(chain -> {
+			okhttp3.Request request = chain.request().newBuilder().removeHeader("Authorization").build();
+			return chain.proceed(request);
+		});
+		OkHttpClient httpClient = new OkHttpClient(okHttpBuilder.build());
+
+		ClientOptions.Builder clientOptions = ClientOptions.builder()
+			.httpClient(httpClient)
+			.apiKey(NO_AUTH_PLACEHOLDER_KEY)
+			.baseUrl(calculateBaseUrl(baseUrl, modelProvider, modelName, azureDeploymentName))
+			.organization(organizationId)
+			.timeout(timeout)
+			.maxRetries(maxRetries)
+			.putHeader("User-Agent", DEFAULT_USER_AGENT);
+
+		if (azureOpenAiServiceVersion != null) {
+			clientOptions.azureServiceVersion(azureOpenAiServiceVersion);
+		}
+		if (customHeaders != null) {
+			clientOptions.putAllHeaders(customHeaders.entrySet()
+				.stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, entry -> Collections.singletonList(entry.getValue()))));
+		}
+
+		return clientOptions.build();
 	}
 
 	static @Nullable String detectBaseUrlFromEnv(@Nullable String baseUrl) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelNoOpApiKeysIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelNoOpApiKeysIT.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai.chat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import org.springframework.ai.model.NoopApiKey;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
@@ -48,7 +49,7 @@ public class OpenAiChatModelNoOpApiKeysIT {
 		@Bean
 		public OpenAiChatModel openAiClient() {
 			return OpenAiChatModel.builder()
-				.options(org.springframework.ai.openai.OpenAiChatOptions.builder().apiKey("noop").build())
+				.options(org.springframework.ai.openai.OpenAiChatOptions.builder().apiKey(new NoopApiKey()).build())
 				.build();
 		}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/moderation/OpenAiModerationModelNoOpApiKeysIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/moderation/OpenAiModerationModelNoOpApiKeysIT.java
@@ -19,8 +19,10 @@ package org.springframework.ai.openai.moderation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import org.springframework.ai.model.NoopApiKey;
 import org.springframework.ai.moderation.ModerationPrompt;
 import org.springframework.ai.openai.OpenAiModerationModel;
+import org.springframework.ai.openai.OpenAiModerationOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -53,7 +55,7 @@ public class OpenAiModerationModelNoOpApiKeysIT {
 		@Bean
 		public OpenAiModerationModel openAiModerationClient() {
 			return OpenAiModerationModel.builder()
-				.options(org.springframework.ai.openai.OpenAiModerationOptions.builder().apiKey("noop").build())
+				.options(OpenAiModerationOptions.builder().apiKey(new NoopApiKey()).build())
 				.build();
 		}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/setup/OpenAiSetupEmptyApiKeyTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/setup/OpenAiSetupEmptyApiKeyTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.setup;
+
+import java.time.Duration;
+
+import com.openai.client.OpenAIClient;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.model.NoopApiKey;
+import org.springframework.ai.openai.OpenAiChatOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that an empty API key (or {@link NoopApiKey}) results in no {@code Authorization}
+ * header being sent to the server.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class OpenAiSetupEmptyApiKeyTests {
+
+	private static final String CHAT_COMPLETION_RESPONSE = "{\"id\":\"chatcmpl-test\",\"object\":\"chat.completion\","
+			+ "\"created\":1700000000,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,"
+			+ "\"message\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"finish_reason\":\"stop\"}],"
+			+ "\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1,\"total_tokens\":6}}";
+
+	@Test
+	void emptyApiKeyDoesNotSendAuthorizationHeader() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.enqueue(new MockResponse().setResponseCode(200)
+				.setHeader("Content-Type", "application/json")
+				.setBody(CHAT_COMPLETION_RESPONSE));
+			server.start();
+
+			OpenAIClient client = OpenAiSetup.setupSyncClient(server.url("/v1").toString(), "", null, null, null, null,
+					false, false, "gpt-4", Duration.ofSeconds(10), 0, null, null);
+
+			assertThat(client).isNotNull();
+
+			// Trigger an actual HTTP request so we can inspect received headers.
+			client.chat()
+				.completions()
+				.create(ChatCompletionCreateParams.builder()
+					.model(com.openai.models.ChatModel.GPT_4)
+					.addUserMessage("Hi")
+					.build());
+
+			RecordedRequest request = server.takeRequest();
+			assertThat(request.getHeader("Authorization")).as("Authorization header must be absent in no-auth mode")
+				.isNull();
+		}
+	}
+
+	@Test
+	void noopApiKeyDoesNotSendAuthorizationHeader() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.enqueue(new MockResponse().setResponseCode(200)
+				.setHeader("Content-Type", "application/json")
+				.setBody(CHAT_COMPLETION_RESPONSE));
+			server.start();
+
+			// NoopApiKey is the 1.x migration path: users who previously relied on
+			// NoopApiKey can now pass it via the ApiKey-typed builder overload.
+			OpenAiChatOptions options = OpenAiChatOptions.builder()
+				.baseUrl(server.url("/v1").toString())
+				.apiKey(new NoopApiKey())
+				.model("gpt-4")
+				.build();
+
+			assertThat(options.getApiKey()).as("NoopApiKey.getValue() should return empty string").isEmpty();
+
+			OpenAIClient client = OpenAiSetup.setupSyncClient(options.getBaseUrl(), options.getApiKey(), null, null,
+					null, null, false, false, "gpt-4", Duration.ofSeconds(10), 0, null, null);
+
+			client.chat()
+				.completions()
+				.create(ChatCompletionCreateParams.builder()
+					.model(com.openai.models.ChatModel.GPT_4)
+					.addUserMessage("Hi")
+					.build());
+
+			RecordedRequest request = server.takeRequest();
+			assertThat(request.getHeader("Authorization"))
+				.as("Authorization header must be absent when NoopApiKey is used")
+				.isNull();
+		}
+	}
+
+}


### PR DESCRIPTION
   - Fixes #6150
   - Users connecting to custom OpenAI-compatible servers with cookie/session-based auth (no bearer token) were broken in 2.x because the OpenAI Java SDK always injects an Authorization header
   - When apiKey is set to an empty string (spring.ai.openai.api-key= in properties, or .apiKey(new NoopApiKey()) in code), the client is now configured in no-auth mode: a custom OkHttp interceptor strips the Authorization header from every outgoing request