### PR TITLE
Add JDBC starter dependency to PgVector starter

### DIFF
--- a/starters/spring-ai-starter-vector-store-pgvector/pom.xml
+++ b/starters/spring-ai-starter-vector-store-pgvector/pom.xml
@@ -40,6 +40,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-autoconfigure-vector-store-pgvector</artifactId>


### PR DESCRIPTION
## Summary

Adds `spring-boot-starter-jdbc` to `spring-ai-starter-vector-store-pgvector` so applications using the documented PgVector starter setup get Spring Boot JDBC auto-configuration, including the `JdbcTemplate` bean required by `PgVectorStoreAutoConfiguration`.

## Root Cause

`PgVectorStoreAutoConfiguration` creates the `PgVectorStore` with a `JdbcTemplate`, but the PgVector starter only pulled in `spring-boot-starter`, the PgVector auto-configuration, observation auto-configuration, and the PgVector store module. The store module provides `spring-jdbc` APIs, but it does not enable Boot's JDBC auto-configuration path by itself.

## Validation

- `git diff --check`
- `./mvnw -pl starters/spring-ai-starter-vector-store-pgvector dependency:tree -Dincludes=org.springframework.boot:spring-boot-starter-jdbc -DskipTests`

Fixes #6164