### PR TITLE
feat(mcp-annotations): add SEP-1865 MCP Apps support

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpAppResult.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpAppResult.java
@@ -22,10 +22,19 @@ import java.util.Map;
  * Convenience return type for MCP App tool methods that need to provide both model-facing
  * content and widget-facing structured content.
  *
- * @param text plain-text content sent to the LLM in content[]
- * @param structuredContent map sent to the widget UI as structuredContent
+ * @param text plain-text content sent to the LLM in content[]; may be {@code null} when
+ * {@code structuredContent} is provided
+ * @param structuredContent map sent to the widget UI as structuredContent; may be
+ * {@code null} when {@code text} is provided
+ * @author Alexandros Pappas
  */
 public record McpAppResult(String text, Map<String, Object> structuredContent) {
+
+	public McpAppResult {
+		if (text == null && structuredContent == null) {
+			throw new IllegalArgumentException("At least one of text or structuredContent must be provided");
+		}
+	}
 
 	public static McpAppResult of(String text, Map<String, Object> structuredContent) {
 		return new McpAppResult(text, structuredContent);

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpAppResult.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpAppResult.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation;
+
+import java.util.Map;
+
+/**
+ * Convenience return type for MCP App tool methods that need to provide both model-facing
+ * content and widget-facing structured content.
+ *
+ * @param text plain-text content sent to the LLM in content[]
+ * @param structuredContent map sent to the widget UI as structuredContent
+ */
+public record McpAppResult(String text, Map<String, Object> structuredContent) {
+
+	public static McpAppResult of(String text, Map<String, Object> structuredContent) {
+		return new McpAppResult(text, structuredContent);
+	}
+
+}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpCsp.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpCsp.java
@@ -31,6 +31,10 @@ import java.lang.annotation.Target;
  * requests.
  *
  * <p>
+ * Domain entries must be full origins including the scheme, for example
+ * {@code "https://api.example.com"}.
+ *
+ * <p>
  * On the wire, these are serialized into {@code _meta.ui.csp} as:
  *
  * <pre>

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpCsp.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpCsp.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Content Security Policy configuration for MCP App tools (SEP-1865).
+ *
+ * <p>
+ * Declares which external domains the MCP App iframe is allowed to access. All external
+ * network access must be declared — missing declarations result in silently blocked
+ * requests.
+ *
+ * <p>
+ * On the wire, these are serialized into {@code _meta.ui.csp} as:
+ *
+ * <pre>
+ * {
+ *   "csp": {
+ *     "connectDomains": ["https://api.example.com"],
+ *     "resourceDomains": ["https://cdn.example.com"],
+ *     "redirectDomains": ["https://auth.example.com"]
+ *   }
+ * }
+ * </pre>
+ *
+ * @author Alexandros Pappas
+ * @see McpTool#csp()
+ */
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface McpCsp {
+
+	/**
+	 * Domains the iframe can make API calls to (fetch, XHR, WebSocket).
+	 */
+	String[] connectDomains() default {};
+
+	/**
+	 * Domains the iframe can load static assets from (scripts, images, stylesheets).
+	 */
+	String[] resourceDomains() default {};
+
+	/**
+	 * Domains the iframe can navigate or redirect to.
+	 */
+	String[] redirectDomains() default {};
+
+}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpTool.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpTool.java
@@ -72,6 +72,34 @@ public @interface McpTool {
 	Class<? extends MetaProvider> metaProvider() default DefaultMetaProvider.class;
 
 	/**
+	 * The {@code ui://} resource URI for the MCP App widget associated with this tool
+	 * (SEP-1865). When set, the tool's {@code _meta} will include {@code ui.resourceUri}
+	 * and the flat alias {@code ui/resourceUri}.
+	 *
+	 * <p>
+	 * Example: {@code "ui://my-server/dashboard.html"}
+	 */
+	String resourceUri() default "";
+
+	/**
+	 * Visibility of this tool per SEP-1865. Controls which consumers can see and invoke
+	 * the tool. Default is empty (no visibility constraint — tool is visible to LLM only,
+	 * same as {@link Visibility#MODEL}).
+	 *
+	 * <p>
+	 * On the wire, serialized as a JSON array: {@code ["model"]}, {@code ["app"]}, or
+	 * {@code ["model", "app"]}.
+	 */
+	Visibility[] visibility() default {};
+
+	/**
+	 * Content Security Policy for the MCP App iframe (SEP-1865). Declares which external
+	 * domains the widget is allowed to access. Only relevant when {@link #resourceUri()}
+	 * is set.
+	 */
+	McpCsp csp() default @McpCsp;
+
+	/**
 	 * Additional properties describing a Tool to clients.
 	 *
 	 * All properties in ToolAnnotations are hints. They are not guaranteed to provide a

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpTool.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpTool.java
@@ -72,6 +72,34 @@ public @interface McpTool {
 	Class<? extends MetaProvider> metaProvider() default DefaultMetaProvider.class;
 
 	/**
+	 * The {@code ui://} resource URI for the MCP App widget associated with this tool
+	 * (SEP-1865). When set, the tool's {@code _meta} will include {@code ui.resourceUri}
+	 * and the flat alias {@code ui/resourceUri}.
+	 *
+	 * <p>
+	 * Example: {@code "ui://my-server/dashboard.html"}
+	 */
+	String resourceUri() default "";
+
+	/**
+	 * Visibility of this tool per SEP-1865. Controls which consumers can see and invoke
+	 * the tool. Default is empty (no visibility constraint — tool is visible to LLM only,
+	 * same as {@link Visibility#MODEL}).
+	 *
+	 * <p>
+	 * On the wire, serialized as a JSON array: {@code ["model"]}, {@code ["app"]}, or
+	 * {@code ["model", "app"]}.
+	 */
+	Visibility[] visibility() default {};
+
+	/**
+	 * Content Security Policy for the MCP App iframe (SEP-1865). Declares which external
+	 * domains the widget is allowed to access. Only relevant when {@link #resourceUri()}
+	 * is set.
+	 */
+	McpCsp csp() default @McpCsp;
+
+	/**
 	 * Additional properties describing a Tool to clients.
 	 *
 	 * all properties in ToolAnnotations are hints. They are not guaranteed to provide a

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/Visibility.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/Visibility.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation;
+
+/**
+ * Defines the visibility of an MCP App tool per SEP-1865.
+ *
+ * <p>
+ * The visibility controls which consumers can see and invoke the tool:
+ * <ul>
+ * <li>{@link #MODEL} — visible to the LLM agent (default for all tools)</li>
+ * <li>{@link #APP} — visible to the MCP App iframe (backend tools called by the UI)</li>
+ * </ul>
+ *
+ * <p>
+ * On the wire, visibility is serialized as a JSON array of lowercase strings in
+ * {@code _meta.ui.visibility}, e.g. {@code ["model"]} or {@code ["app"]} or
+ * {@code ["model", "app"]}.
+ *
+ * @author Alexandros Pappas
+ * @see McpTool#visibility()
+ */
+public enum Visibility {
+
+	/**
+	 * Tool is visible to the LLM agent.
+	 */
+	MODEL("model"),
+
+	/**
+	 * Tool is visible to the MCP App iframe (backend tool called by UI, not the LLM).
+	 */
+	APP("app");
+
+	private final String wireValue;
+
+	Visibility(String wireValue) {
+		this.wireValue = wireValue;
+	}
+
+	/**
+	 * Returns the lowercase wire-format string used in {@code _meta.ui.visibility}.
+	 * @return the wire value, e.g. "model" or "app"
+	 */
+	public String getWireValue() {
+		return this.wireValue;
+	}
+
+}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapter.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapter.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.annotation.adapter;
 
 import java.util.List;
+import java.util.Locale;
 
 import io.modelcontextprotocol.spec.McpSchema;
 
@@ -43,6 +44,35 @@ public final class ResourceAdapter {
 
 	private static final String MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
 
+	private static final String UI_URI_SCHEME = "ui://";
+
+	private static void validateMcpAppResource(String uri, String mimeType) {
+		boolean uiUri = isUiUri(uri);
+		boolean mcpAppMimeType = isMcpAppMimeType(mimeType);
+		if (uiUri && !mcpAppMimeType) {
+			throw new IllegalArgumentException(
+					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
+		}
+		if (mcpAppMimeType && !uiUri) {
+			throw new IllegalArgumentException(
+					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
+		}
+	}
+
+	private static boolean isUiUri(String uri) {
+		// URI schemes are case-insensitive (RFC 3986)
+		return uri != null && uri.regionMatches(true, 0, UI_URI_SCHEME, 0, UI_URI_SCHEME.length());
+	}
+
+	private static boolean isMcpAppMimeType(String mimeType) {
+		if (mimeType == null) {
+			return false;
+		}
+		// MIME types are case-insensitive and allow whitespace around parameters
+		String normalized = mimeType.replace(" ", "").replace("\t", "").toLowerCase(Locale.ROOT);
+		return MCP_APP_MIME_TYPE.equals(normalized);
+	}
+
 	private ResourceAdapter() {
 	}
 
@@ -53,16 +83,7 @@ public final class ResourceAdapter {
 		}
 		var meta = MetaUtils.getMeta(mcpResourceAnnotation.metaProvider());
 
-		String uri = mcpResourceAnnotation.uri();
-		String mimeType = mcpResourceAnnotation.mimeType();
-		if (uri.startsWith("ui://") && !MCP_APP_MIME_TYPE.equals(mimeType)) {
-			throw new IllegalArgumentException(
-					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
-		}
-		if (MCP_APP_MIME_TYPE.equals(mimeType) && !uri.startsWith("ui://")) {
-			throw new IllegalArgumentException(
-					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
-		}
+		validateMcpAppResource(mcpResourceAnnotation.uri(), mcpResourceAnnotation.mimeType());
 
 		var resourceBuilder = McpSchema.Resource.builder(mcpResourceAnnotation.uri(), name)
 			.title(mcpResourceAnnotation.title())
@@ -91,16 +112,7 @@ public final class ResourceAdapter {
 		}
 		var meta = MetaUtils.getMeta(mcpResource.metaProvider());
 
-		String uri = mcpResource.uri();
-		String mimeType = mcpResource.mimeType();
-		if (uri.startsWith("ui://") && !MCP_APP_MIME_TYPE.equals(mimeType)) {
-			throw new IllegalArgumentException(
-					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
-		}
-		if (MCP_APP_MIME_TYPE.equals(mimeType) && !uri.startsWith("ui://")) {
-			throw new IllegalArgumentException(
-					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
-		}
+		validateMcpAppResource(mcpResource.uri(), mcpResource.mimeType());
 
 		return McpSchema.ResourceTemplate.builder(mcpResource.uri(), name)
 			.description(mcpResource.description())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapter.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapter.java
@@ -29,12 +29,19 @@ import org.springframework.ai.mcp.annotation.common.MetaUtils;
  * {@link McpSchema.ResourceTemplate} instances from annotation metadata, including URI,
  * name, description, MIME type, annotations, and optional {@code _meta} fields.
  *
+ * <p>
+ * Enforces SEP-1865 (MCP Apps) constraints: resources with a {@code ui://} URI must use
+ * the MIME type {@code text/html;profile=mcp-app}, and resources with that MIME type must
+ * use a {@code ui://} URI.
+ *
  * @author Christian Tzolov
  * @author Alexandros Pappas
  * @author Vadzim Shurmialiou
  * @author Craig Walls
  */
 public final class ResourceAdapter {
+
+	private static final String MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
 
 	private ResourceAdapter() {
 	}
@@ -45,6 +52,17 @@ public final class ResourceAdapter {
 			name = "resource"; // Default name when not specified
 		}
 		var meta = MetaUtils.getMeta(mcpResourceAnnotation.metaProvider());
+
+		String uri = mcpResourceAnnotation.uri();
+		String mimeType = mcpResourceAnnotation.mimeType();
+		if (uri.startsWith("ui://") && !MCP_APP_MIME_TYPE.equals(mimeType)) {
+			throw new IllegalArgumentException(
+					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
+		}
+		if (MCP_APP_MIME_TYPE.equals(mimeType) && !uri.startsWith("ui://")) {
+			throw new IllegalArgumentException(
+					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
+		}
 
 		var resourceBuilder = McpSchema.Resource.builder(mcpResourceAnnotation.uri(), name)
 			.title(mcpResourceAnnotation.title())
@@ -72,6 +90,17 @@ public final class ResourceAdapter {
 			name = "resource"; // Default name when not specified
 		}
 		var meta = MetaUtils.getMeta(mcpResource.metaProvider());
+
+		String uri = mcpResource.uri();
+		String mimeType = mcpResource.mimeType();
+		if (uri.startsWith("ui://") && !MCP_APP_MIME_TYPE.equals(mimeType)) {
+			throw new IllegalArgumentException(
+					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
+		}
+		if (MCP_APP_MIME_TYPE.equals(mimeType) && !uri.startsWith("ui://")) {
+			throw new IllegalArgumentException(
+					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
+		}
 
 		return McpSchema.ResourceTemplate.builder(mcpResource.uri(), name)
 			.description(mcpResource.description())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapter.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapter.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.annotation.adapter;
 
 import java.util.List;
+import java.util.Locale;
 
 import io.modelcontextprotocol.spec.McpSchema;
 
@@ -43,6 +44,35 @@ public final class ResourceAdapter {
 
 	private static final String MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
 
+	private static final String UI_URI_SCHEME = "ui://";
+
+	private static void validateMcpAppResource(String uri, String mimeType) {
+		boolean uiUri = isUiUri(uri);
+		boolean mcpAppMimeType = isMcpAppMimeType(mimeType);
+		if (uiUri && !mcpAppMimeType) {
+			throw new IllegalArgumentException(
+					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
+		}
+		if (mcpAppMimeType && !uiUri) {
+			throw new IllegalArgumentException(
+					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
+		}
+	}
+
+	private static boolean isUiUri(String uri) {
+		// URI schemes are case-insensitive (RFC 3986)
+		return uri != null && uri.regionMatches(true, 0, UI_URI_SCHEME, 0, UI_URI_SCHEME.length());
+	}
+
+	private static boolean isMcpAppMimeType(String mimeType) {
+		if (mimeType == null) {
+			return false;
+		}
+		// MIME types are case-insensitive and allow whitespace around parameters
+		String normalized = mimeType.replace(" ", "").replace("\t", "").toLowerCase(Locale.ROOT);
+		return MCP_APP_MIME_TYPE.equals(normalized);
+	}
+
 	private ResourceAdapter() {
 	}
 
@@ -53,16 +83,7 @@ public final class ResourceAdapter {
 		}
 		var meta = MetaUtils.getMeta(mcpResourceAnnotation.metaProvider());
 
-		String uri = mcpResourceAnnotation.uri();
-		String mimeType = mcpResourceAnnotation.mimeType();
-		if (uri.startsWith("ui://") && !MCP_APP_MIME_TYPE.equals(mimeType)) {
-			throw new IllegalArgumentException(
-					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
-		}
-		if (MCP_APP_MIME_TYPE.equals(mimeType) && !uri.startsWith("ui://")) {
-			throw new IllegalArgumentException(
-					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
-		}
+		validateMcpAppResource(mcpResourceAnnotation.uri(), mcpResourceAnnotation.mimeType());
 
 		var resourceBuilder = McpSchema.Resource.builder(mcpResourceAnnotation.uri(), name)
 			.title(mcpResourceAnnotation.title())
@@ -93,16 +114,7 @@ public final class ResourceAdapter {
 		}
 		var meta = MetaUtils.getMeta(mcpResource.metaProvider());
 
-		String uri = mcpResource.uri();
-		String mimeType = mcpResource.mimeType();
-		if (uri.startsWith("ui://") && !MCP_APP_MIME_TYPE.equals(mimeType)) {
-			throw new IllegalArgumentException(
-					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
-		}
-		if (MCP_APP_MIME_TYPE.equals(mimeType) && !uri.startsWith("ui://")) {
-			throw new IllegalArgumentException(
-					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
-		}
+		validateMcpAppResource(mcpResource.uri(), mcpResource.mimeType());
 
 		return McpSchema.ResourceTemplate.builder(mcpResource.uri(), name)
 			.description(mcpResource.description())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapter.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapter.java
@@ -29,12 +29,19 @@ import org.springframework.ai.mcp.annotation.common.MetaUtils;
  * {@link McpSchema.ResourceTemplate} instances from annotation metadata, including URI,
  * name, description, MIME type, annotations, and optional {@code _meta} fields.
  *
+ * <p>
+ * Enforces SEP-1865 (MCP Apps) constraints: resources with a {@code ui://} URI must use
+ * the MIME type {@code text/html;profile=mcp-app}, and resources with that MIME type must
+ * use a {@code ui://} URI.
+ *
  * @author Christian Tzolov
  * @author Alexandros Pappas
  * @author Vadzim Shurmialiou
  * @author Craig Walls
  */
 public final class ResourceAdapter {
+
+	private static final String MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
 
 	private ResourceAdapter() {
 	}
@@ -45,6 +52,17 @@ public final class ResourceAdapter {
 			name = "resource"; // Default name when not specified
 		}
 		var meta = MetaUtils.getMeta(mcpResourceAnnotation.metaProvider());
+
+		String uri = mcpResourceAnnotation.uri();
+		String mimeType = mcpResourceAnnotation.mimeType();
+		if (uri.startsWith("ui://") && !MCP_APP_MIME_TYPE.equals(mimeType)) {
+			throw new IllegalArgumentException(
+					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
+		}
+		if (MCP_APP_MIME_TYPE.equals(mimeType) && !uri.startsWith("ui://")) {
+			throw new IllegalArgumentException(
+					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
+		}
 
 		var resourceBuilder = McpSchema.Resource.builder(mcpResourceAnnotation.uri(), name)
 			.title(mcpResourceAnnotation.title())
@@ -74,6 +92,17 @@ public final class ResourceAdapter {
 			name = "resource"; // Default name when not specified
 		}
 		var meta = MetaUtils.getMeta(mcpResource.metaProvider());
+
+		String uri = mcpResource.uri();
+		String mimeType = mcpResource.mimeType();
+		if (uri.startsWith("ui://") && !MCP_APP_MIME_TYPE.equals(mimeType)) {
+			throw new IllegalArgumentException(
+					"Resource with ui:// URI must use MIME type 'text/html;profile=mcp-app', but got: " + mimeType);
+		}
+		if (MCP_APP_MIME_TYPE.equals(mimeType) && !uri.startsWith("ui://")) {
+			throw new IllegalArgumentException(
+					"Resource with MIME type 'text/html;profile=mcp-app' must use a ui:// URI, but got: " + uri);
+		}
 
 		return McpSchema.ResourceTemplate.builder(mcpResource.uri(), name)
 			.description(mcpResource.description())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/common/MetaUtils.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/common/MetaUtils.java
@@ -124,7 +124,7 @@ public final class MetaUtils {
 	 * @return the {@code _meta} map, or {@code null} if no SEP-1865 fields are set
 	 */
 	public static Map<String, Object> buildUiMeta(String resourceUri, Visibility[] visibility, McpCsp csp) {
-		if (resourceUri == null || resourceUri.isEmpty()) {
+		if (resourceUri == null || resourceUri.isBlank()) {
 			return null;
 		}
 
@@ -197,6 +197,15 @@ public final class MetaUtils {
 			}
 			else {
 				merged.put(key, providerValue);
+			}
+		}
+
+		// Re-derive the flat "ui/resourceUri" alias from the merged nested value so the
+		// two never diverge when a MetaProvider overrides ui.resourceUri.
+		if (merged.containsKey("ui/resourceUri") && merged.get("ui") instanceof Map<?, ?> uiMap) {
+			Object mergedResourceUri = uiMap.get("resourceUri");
+			if (mergedResourceUri != null) {
+				merged.put("ui/resourceUri", mergedResourceUri);
 			}
 		}
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/common/MetaUtils.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/common/MetaUtils.java
@@ -18,9 +18,15 @@ package org.springframework.ai.mcp.annotation.common;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.springframework.ai.mcp.annotation.McpCsp;
+import org.springframework.ai.mcp.annotation.Visibility;
 import org.springframework.ai.mcp.annotation.context.MetaProvider;
 
 /**
@@ -101,6 +107,100 @@ public final class MetaUtils {
 		catch (NoSuchMethodException ex) {
 			return metaProviderClass.getConstructor();
 		}
+	}
+
+	/**
+	 * Build the {@code _meta} map for an MCP App tool from SEP-1865 annotation fields.
+	 * <p>
+	 * Produces the wire format: <pre>
+	 * {
+	 *   "ui": { "resourceUri": "ui://...", "visibility": ["model"], "csp": {...} },
+	 *   "ui/resourceUri": "ui://..."
+	 * }
+	 * </pre>
+	 * @param resourceUri the {@code ui://} resource URI; if blank, returns {@code null}
+	 * @param visibility the visibility array from the annotation
+	 * @param csp the CSP annotation, or {@code null}
+	 * @return the {@code _meta} map, or {@code null} if no SEP-1865 fields are set
+	 */
+	public static Map<String, Object> buildUiMeta(String resourceUri, Visibility[] visibility, McpCsp csp) {
+		if (resourceUri == null || resourceUri.isEmpty()) {
+			return null;
+		}
+
+		var uiMap = new LinkedHashMap<String, Object>();
+		uiMap.put("resourceUri", resourceUri);
+
+		if (visibility != null && visibility.length > 0) {
+			uiMap.put("visibility",
+					Arrays.stream(visibility).map(Visibility::getWireValue).collect(Collectors.toList()));
+		}
+
+		if (csp != null) {
+			var cspMap = new LinkedHashMap<String, Object>();
+			if (csp.connectDomains().length > 0) {
+				cspMap.put("connectDomains", List.of(csp.connectDomains()));
+			}
+			if (csp.resourceDomains().length > 0) {
+				cspMap.put("resourceDomains", List.of(csp.resourceDomains()));
+			}
+			if (csp.redirectDomains().length > 0) {
+				cspMap.put("redirectDomains", List.of(csp.redirectDomains()));
+			}
+			if (!cspMap.isEmpty()) {
+				uiMap.put("csp", cspMap);
+			}
+		}
+
+		var meta = new LinkedHashMap<String, Object>();
+		meta.put("ui", uiMap);
+		meta.put("ui/resourceUri", resourceUri);
+		return meta;
+	}
+
+	/**
+	 * Merge two metadata maps with provider-wins-on-conflict semantics.
+	 * <p>
+	 * Top-level keys from both maps are combined. For the {@code "ui"} key specifically,
+	 * the nested maps are deep-merged so annotation-derived fields (like
+	 * {@code visibility}) survive even when the provider also sets {@code "ui"}. Provider
+	 * values win for any key present in both.
+	 * @param providerMeta metadata from {@link MetaProvider}, may be {@code null}
+	 * @param annotationMeta metadata built from annotation fields, may be {@code null}
+	 * @return the merged map, or {@code null} if both inputs are {@code null}
+	 */
+	@SuppressWarnings("unchecked")
+	public static Map<String, Object> mergeMeta(Map<String, Object> providerMeta, Map<String, Object> annotationMeta) {
+		if (providerMeta == null && annotationMeta == null) {
+			return null;
+		}
+		if (providerMeta == null) {
+			return annotationMeta;
+		}
+		if (annotationMeta == null) {
+			return providerMeta;
+		}
+
+		var merged = new LinkedHashMap<String, Object>();
+		merged.putAll(annotationMeta);
+
+		for (var entry : providerMeta.entrySet()) {
+			String key = entry.getKey();
+			Object providerValue = entry.getValue();
+			Object existingValue = merged.get(key);
+
+			if ("ui".equals(key) && providerValue instanceof Map && existingValue instanceof Map) {
+				var deepMerged = new LinkedHashMap<String, Object>();
+				deepMerged.putAll((Map<String, Object>) existingValue);
+				deepMerged.putAll((Map<String, Object>) providerValue);
+				merged.put(key, deepMerged);
+			}
+			else {
+				merged.put(key, providerValue);
+			}
+		}
+
+		return merged;
 	}
 
 }

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -176,18 +176,13 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 			return CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build();
 		}
 
-		if (this.returnMode == ReturnMode.STRUCTURED) {
-			String jsonOutput = jsonHelper.toJson(result);
-			Object structuredOutput = jsonHelper.fromJson(jsonOutput, Object.class);
-			return CallToolResult.builder().structuredContent(structuredOutput).build();
-		}
-
-		// Default to text output
 		if (result == null) {
 			return CallToolResult.builder().addTextContent("null").build();
 		}
 
-		// For McpAppResult, split text into content[] and structuredContent
+		// McpAppResult splits text into content[] and structuredContent. Must be
+		// handled before the STRUCTURED branch so the container record is never
+		// re-serialized whole into structuredContent.
 		if (result instanceof McpAppResult appResult) {
 			var builder = CallToolResult.builder();
 			if (appResult.text() != null) {
@@ -198,6 +193,14 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 			}
 			return builder.build();
 		}
+
+		if (this.returnMode == ReturnMode.STRUCTURED) {
+			String jsonOutput = jsonHelper.toJson(result);
+			Object structuredOutput = jsonHelper.fromJson(jsonOutput, Object.class);
+			return CallToolResult.builder().structuredContent(structuredOutput).build();
+		}
+
+		// Default to text output
 
 		// For string results in TEXT mode, return the string directly without JSON
 		// serialization

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -28,6 +28,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpMeta;
 import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpTool;
@@ -184,6 +185,18 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 		// Default to text output
 		if (result == null) {
 			return CallToolResult.builder().addTextContent("null").build();
+		}
+
+		// For McpAppResult, split text into content[] and structuredContent
+		if (result instanceof McpAppResult appResult) {
+			var builder = CallToolResult.builder();
+			if (appResult.text() != null) {
+				builder.addTextContent(appResult.text());
+			}
+			if (appResult.structuredContent() != null) {
+				builder.structuredContent(appResult.structuredContent());
+			}
+			return builder.build();
 		}
 
 		// For string results in TEXT mode, return the string directly without JSON

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -181,18 +181,13 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 			return CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build();
 		}
 
-		if (this.returnMode == ReturnMode.STRUCTURED) {
-			String jsonOutput = jsonHelper.toJson(result);
-			Object structuredOutput = jsonHelper.fromJson(jsonOutput, Object.class);
-			return CallToolResult.builder().structuredContent(structuredOutput).build();
-		}
-
-		// Default to text output
 		if (result == null) {
 			return CallToolResult.builder().addTextContent("null").build();
 		}
 
-		// For McpAppResult, split text into content[] and structuredContent
+		// McpAppResult splits text into content[] and structuredContent. Must be
+		// handled before the STRUCTURED branch so the container record is never
+		// re-serialized whole into structuredContent.
 		if (result instanceof McpAppResult appResult) {
 			var builder = CallToolResult.builder();
 			if (appResult.text() != null) {
@@ -203,6 +198,14 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 			}
 			return builder.build();
 		}
+
+		if (this.returnMode == ReturnMode.STRUCTURED) {
+			String jsonOutput = jsonHelper.toJson(result);
+			Object structuredOutput = jsonHelper.fromJson(jsonOutput, Object.class);
+			return CallToolResult.builder().structuredContent(structuredOutput).build();
+		}
+
+		// Default to text output
 
 		// For string results in TEXT mode, return the string directly without JSON
 		// serialization

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -29,6 +29,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpMeta;
 import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpTool;
@@ -189,6 +190,18 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 		// Default to text output
 		if (result == null) {
 			return CallToolResult.builder().addTextContent("null").build();
+		}
+
+		// For McpAppResult, split text into content[] and structuredContent
+		if (result instanceof McpAppResult appResult) {
+			var builder = CallToolResult.builder();
+			if (appResult.text() != null) {
+				builder.addTextContent(appResult.text());
+			}
+			if (appResult.structuredContent() != null) {
+				builder.structuredContent(appResult.structuredContent());
+			}
+			return builder.build();
 		}
 
 		// For string results in TEXT mode, return the string directly without JSON

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -83,7 +83,10 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 
 					String inputSchema = McpJsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
-					var meta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var providerMeta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var annotationMeta = MetaUtils.buildUiMeta(toolJavaAnnotation.resourceUri(),
+							toolJavaAnnotation.visibility(), toolJavaAnnotation.csp());
+					var meta = MetaUtils.mergeMeta(providerMeta, annotationMeta);
 
 					var toolBuilder = McpSchema.Tool.builder()
 						.name(toolName)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
 import org.springframework.ai.mcp.annotation.common.MetaUtils;
@@ -121,7 +122,7 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,
-					// CallToolResult, simple value types (String, etc.)
+					// CallToolResult, McpAppResult, simple value types (String, etc.)
 					// or if generateOutputSchema attribute is set to false.
 					if (toolJavaAnnotation.generateOutputSchema()
 							&& !ReactiveUtils.isReactiveReturnTypeOfVoid(mcpToolMethod)
@@ -130,7 +131,8 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 						ReactiveUtils.getReactiveReturnTypeArgument(mcpToolMethod).ifPresent(typeArgument -> {
 							Class<?> methodReturnType = typeArgument instanceof Class<?> ? (Class<?>) typeArgument
 									: null;
-							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+							if (methodReturnType != McpAppResult.class
+									&& !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 								toolBuilder.outputSchema(this.getJsonMapper(),
 										McpJsonSchemaGenerator.generateFromClass((Class<?>) typeArgument));

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -83,7 +83,10 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 
 					String inputSchema = McpJsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
-					var meta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var providerMeta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var annotationMeta = MetaUtils.buildUiMeta(toolJavaAnnotation.resourceUri(),
+							toolJavaAnnotation.visibility(), toolJavaAnnotation.csp());
+					var meta = MetaUtils.mergeMeta(providerMeta, annotationMeta);
 
 					var toolBuilder = McpSchema.Tool.builder(toolName, this.getJsonMapper(), inputSchema)
 						.description(toolDescription)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
 import org.springframework.ai.mcp.annotation.common.MetaUtils;
@@ -123,7 +124,7 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,
-					// CallToolResult, simple value types (String, etc.)
+					// CallToolResult, McpAppResult, simple value types (String, etc.)
 					// or if generateOutputSchema attribute is set to false.
 					if (toolJavaAnnotation.generateOutputSchema()
 							&& !ReactiveUtils.isReactiveReturnTypeOfVoid(mcpToolMethod)
@@ -132,7 +133,8 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 						ReactiveUtils.getReactiveReturnTypeArgument(mcpToolMethod).ifPresent(typeArgument -> {
 							Class<?> methodReturnType = typeArgument instanceof Class<?> ? (Class<?>) typeArgument
 									: null;
-							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+							if (methodReturnType != McpAppResult.class
+									&& !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 								toolBuilder.outputSchema(this.getJsonMapper(),
 										McpJsonSchemaGenerator.generateFromClass((Class<?>) typeArgument));

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
 import org.springframework.ai.mcp.annotation.common.MetaUtils;
@@ -126,7 +127,7 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,
-					// CallToolResult, simple value types (String, etc.)
+					// CallToolResult, McpAppResult, simple value types (String, etc.)
 					// or if generateOutputSchema attribute is set to false.
 					if (toolJavaAnnotation.generateOutputSchema()
 							&& !ReactiveUtils.isReactiveReturnTypeOfVoid(mcpToolMethod)
@@ -135,7 +136,8 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 						ReactiveUtils.getReactiveReturnTypeArgument(mcpToolMethod).ifPresent(typeArgument -> {
 							Class<?> methodReturnType = typeArgument instanceof Class<?> ? (Class<?>) typeArgument
 									: null;
-							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+							if (methodReturnType != McpAppResult.class
+									&& !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 								toolBuilder.outputSchema(this.getJsonMapper(),
 										McpJsonSchemaGenerator.generateFromType(typeArgument));

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -88,7 +88,10 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 
 					String inputSchema = McpJsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
-					var meta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var providerMeta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var annotationMeta = MetaUtils.buildUiMeta(toolJavaAnnotation.resourceUri(),
+							toolJavaAnnotation.visibility(), toolJavaAnnotation.csp());
+					var meta = MetaUtils.mergeMeta(providerMeta, annotationMeta);
 
 					var toolBuilder = McpSchema.Tool.builder()
 						.name(toolName)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
 import org.springframework.ai.mcp.annotation.common.MetaUtils;
@@ -128,7 +129,7 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,
-					// CallToolResult, simple value types (String, etc.)
+					// CallToolResult, McpAppResult, simple value types (String, etc.)
 					// or if generateOutputSchema attribute is set to false.
 					if (toolJavaAnnotation.generateOutputSchema()
 							&& !ReactiveUtils.isReactiveReturnTypeOfVoid(mcpToolMethod)
@@ -137,7 +138,8 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 						ReactiveUtils.getReactiveReturnTypeArgument(mcpToolMethod).ifPresent(typeArgument -> {
 							Class<?> methodReturnType = typeArgument instanceof Class<?> ? (Class<?>) typeArgument
 									: null;
-							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+							if (methodReturnType != McpAppResult.class
+									&& !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 								toolBuilder.outputSchema(this.getJsonMapper(),
 										McpJsonSchemaGenerator.generateFromType(typeArgument));

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -88,7 +88,10 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 
 					String inputSchema = McpJsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
-					var meta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var providerMeta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var annotationMeta = MetaUtils.buildUiMeta(toolJavaAnnotation.resourceUri(),
+							toolJavaAnnotation.visibility(), toolJavaAnnotation.csp());
+					var meta = MetaUtils.mergeMeta(providerMeta, annotationMeta);
 
 					var toolBuilder = McpSchema.Tool.builder(toolName, this.getJsonMapper(), inputSchema)
 						.description(toolDescription)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
@@ -81,7 +81,10 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 
 					String inputSchema = McpJsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
-					var meta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var providerMeta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var annotationMeta = MetaUtils.buildUiMeta(toolJavaAnnotation.resourceUri(),
+							toolJavaAnnotation.visibility(), toolJavaAnnotation.csp());
+					var meta = MetaUtils.mergeMeta(providerMeta, annotationMeta);
 
 					var toolBuilder = McpSchema.Tool.builder()
 						.name(toolName)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
@@ -31,6 +31,7 @@ import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
 import org.springframework.ai.mcp.annotation.common.MetaUtils;
@@ -119,12 +120,13 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,
-					// CallToolResult, simple value types (String, etc.)
+					// CallToolResult, McpAppResult, simple value types (String, etc.)
 					// or if generateOutputSchema attribute is set to false.
 					Class<?> methodReturnType = mcpToolMethod.getReturnType();
 					if (toolJavaAnnotation.generateOutputSchema() && methodReturnType != null
-							&& methodReturnType != CallToolResult.class && methodReturnType != Void.class
-							&& methodReturnType != void.class && !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+							&& methodReturnType != CallToolResult.class && methodReturnType != McpAppResult.class
+							&& methodReturnType != Void.class && methodReturnType != void.class
+							&& !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 							&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 
 						toolBuilder.outputSchema(this.getJsonMapper(),

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
@@ -31,6 +31,7 @@ import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
 import org.springframework.ai.mcp.annotation.common.MetaUtils;
@@ -121,12 +122,13 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,
-					// CallToolResult, simple value types (String, etc.)
+					// CallToolResult, McpAppResult, simple value types (String, etc.)
 					// or if generateOutputSchema attribute is set to false.
 					Class<?> methodReturnType = mcpToolMethod.getReturnType();
 					if (toolJavaAnnotation.generateOutputSchema() && methodReturnType != null
-							&& methodReturnType != CallToolResult.class && methodReturnType != Void.class
-							&& methodReturnType != void.class && !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+							&& methodReturnType != CallToolResult.class && methodReturnType != McpAppResult.class
+							&& methodReturnType != Void.class && methodReturnType != void.class
+							&& !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 							&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 
 						toolBuilder.outputSchema(this.getJsonMapper(),

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
@@ -81,7 +81,10 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 
 					String inputSchema = McpJsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
-					var meta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var providerMeta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var annotationMeta = MetaUtils.buildUiMeta(toolJavaAnnotation.resourceUri(),
+							toolJavaAnnotation.visibility(), toolJavaAnnotation.csp());
+					var meta = MetaUtils.mergeMeta(providerMeta, annotationMeta);
 
 					var toolBuilder = McpSchema.Tool.builder(toolName, this.getJsonMapper(), inputSchema)
 						.description(toolDescription)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
@@ -85,7 +85,10 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 
 					String inputSchema = McpJsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
-					var meta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var providerMeta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var annotationMeta = MetaUtils.buildUiMeta(toolJavaAnnotation.resourceUri(),
+							toolJavaAnnotation.visibility(), toolJavaAnnotation.csp());
+					var meta = MetaUtils.mergeMeta(providerMeta, annotationMeta);
 
 					var toolBuilder = McpSchema.Tool.builder()
 						.name(toolName)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
@@ -31,6 +31,7 @@ import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
 import org.springframework.ai.mcp.annotation.common.MetaUtils;
@@ -123,12 +124,13 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,
-					// CallToolResult, simple value types (String, etc.)
+					// CallToolResult, McpAppResult, simple value types (String, etc.)
 					// or if generateOutputSchema attribute is set to false.
 					Class<?> methodReturnType = mcpToolMethod.getReturnType();
 					if (toolJavaAnnotation.generateOutputSchema() && methodReturnType != null
-							&& methodReturnType != CallToolResult.class && methodReturnType != Void.class
-							&& methodReturnType != void.class && !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+							&& methodReturnType != CallToolResult.class && methodReturnType != McpAppResult.class
+							&& methodReturnType != Void.class && methodReturnType != void.class
+							&& !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 							&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 
 						toolBuilder.outputSchema(this.getJsonMapper(),

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
@@ -31,6 +31,7 @@ import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
 import org.springframework.ai.mcp.annotation.common.MetaUtils;
@@ -125,12 +126,13 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,
-					// CallToolResult, simple value types (String, etc.)
+					// CallToolResult, McpAppResult, simple value types (String, etc.)
 					// or if generateOutputSchema attribute is set to false.
 					Class<?> methodReturnType = mcpToolMethod.getReturnType();
 					if (toolJavaAnnotation.generateOutputSchema() && methodReturnType != null
-							&& methodReturnType != CallToolResult.class && methodReturnType != Void.class
-							&& methodReturnType != void.class && !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+							&& methodReturnType != CallToolResult.class && methodReturnType != McpAppResult.class
+							&& methodReturnType != Void.class && methodReturnType != void.class
+							&& !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 							&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 
 						toolBuilder.outputSchema(this.getJsonMapper(),

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
@@ -85,7 +85,10 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 
 					String inputSchema = McpJsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
-					var meta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var providerMeta = MetaUtils.getMeta(toolJavaAnnotation.metaProvider());
+					var annotationMeta = MetaUtils.buildUiMeta(toolJavaAnnotation.resourceUri(),
+							toolJavaAnnotation.visibility(), toolJavaAnnotation.csp());
+					var meta = MetaUtils.mergeMeta(providerMeta, annotationMeta);
 
 					var toolBuilder = McpSchema.Tool.builder(toolName, this.getJsonMapper(), inputSchema)
 						.description(toolDescription)

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/McpAppResultTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/McpAppResultTests.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class McpAppResultTests {
 
@@ -41,10 +42,23 @@ class McpAppResultTests {
 	}
 
 	@Test
-	void testNullValues() {
-		var result = McpAppResult.of(null, null);
+	void testNullTextAllowed() {
+		var result = McpAppResult.of(null, Map.of("key", "value"));
 		assertThat(result.text()).isNull();
+		assertThat(result.structuredContent()).containsEntry("key", "value");
+	}
+
+	@Test
+	void testNullStructuredContentAllowed() {
+		var result = McpAppResult.of("text only", null);
+		assertThat(result.text()).isEqualTo("text only");
 		assertThat(result.structuredContent()).isNull();
+	}
+
+	@Test
+	void testBothNullThrows() {
+		assertThatIllegalArgumentException().isThrownBy(() -> McpAppResult.of(null, null))
+			.withMessageContaining("At least one of text or structuredContent");
 	}
 
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/McpAppResultTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/McpAppResultTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpAppResultTests {
+
+	@Test
+	void testConstructor() {
+		var structured = Map.<String, Object>of("key", "value");
+		var result = new McpAppResult("hello", structured);
+		assertThat(result.text()).isEqualTo("hello");
+		assertThat(result.structuredContent()).isEqualTo(structured);
+	}
+
+	@Test
+	void testStaticFactory() {
+		var structured = Map.<String, Object>of("count", 42);
+		var result = McpAppResult.of("done", structured);
+		assertThat(result.text()).isEqualTo("done");
+		assertThat(result.structuredContent()).containsEntry("count", 42);
+	}
+
+	@Test
+	void testNullValues() {
+		var result = McpAppResult.of(null, null);
+		assertThat(result.text()).isNull();
+		assertThat(result.structuredContent()).isNull();
+	}
+
+}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapterTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapterTests.java
@@ -60,6 +60,27 @@ class ResourceAdapterTests {
 		assertThat(resource.uri()).isEqualTo("https://example.com/data");
 	}
 
+	@Test
+	void asResource_uiUriWithMimeTypeContainingWhitespace_succeeds() {
+		McpResource annotation = mockResource("ui://my-server/app.html", "text/html; profile=mcp-app");
+		McpSchema.Resource resource = ResourceAdapter.asResource(annotation);
+		assertThat(resource.mimeType()).isEqualTo("text/html; profile=mcp-app");
+	}
+
+	@Test
+	void asResource_uiUriWithMixedCaseMimeType_succeeds() {
+		McpResource annotation = mockResource("ui://my-server/app.html", "Text/HTML;profile=mcp-app");
+		McpSchema.Resource resource = ResourceAdapter.asResource(annotation);
+		assertThat(resource.mimeType()).isEqualTo("Text/HTML;profile=mcp-app");
+	}
+
+	@Test
+	void asResource_upperCaseUiSchemeWithWrongMimeType_throwsIllegalArgumentException() {
+		McpResource annotation = mockResource("UI://my-server/app.html", "text/plain");
+		assertThatIllegalArgumentException().isThrownBy(() -> ResourceAdapter.asResource(annotation))
+			.withMessageContaining("ui:// URI must use MIME type 'text/html;profile=mcp-app'");
+	}
+
 	// ---------------------------------------------------------------------------
 	// asResource — invalid cases
 	// ---------------------------------------------------------------------------

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapterTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/adapter/ResourceAdapterTests.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.adapter;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.mcp.annotation.McpResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for SEP-1865 URI / MIME type validation in {@link ResourceAdapter}.
+ *
+ * @author Alexandros Pappas
+ */
+class ResourceAdapterTests {
+
+	private static final String MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
+
+	// ---------------------------------------------------------------------------
+	// asResource — valid cases
+	// ---------------------------------------------------------------------------
+
+	@Test
+	void asResource_uiUriWithCorrectMimeType_succeeds() {
+		McpResource annotation = mockResource("ui://my-server/app.html", MCP_APP_MIME_TYPE);
+		McpSchema.Resource resource = ResourceAdapter.asResource(annotation);
+		assertThat(resource.uri()).isEqualTo("ui://my-server/app.html");
+		assertThat(resource.mimeType()).isEqualTo(MCP_APP_MIME_TYPE);
+	}
+
+	@Test
+	void asResource_regularUriWithRegularMimeType_succeeds() {
+		McpResource annotation = mockResource("file://data/doc.txt", "text/plain");
+		McpSchema.Resource resource = ResourceAdapter.asResource(annotation);
+		assertThat(resource.uri()).isEqualTo("file://data/doc.txt");
+		assertThat(resource.mimeType()).isEqualTo("text/plain");
+	}
+
+	@Test
+	void asResource_regularUriWithNullMimeType_succeeds() {
+		McpResource annotation = mockResource("https://example.com/data", "");
+		McpSchema.Resource resource = ResourceAdapter.asResource(annotation);
+		assertThat(resource.uri()).isEqualTo("https://example.com/data");
+	}
+
+	// ---------------------------------------------------------------------------
+	// asResource — invalid cases
+	// ---------------------------------------------------------------------------
+
+	@Test
+	void asResource_uiUriWithWrongMimeType_throwsIllegalArgumentException() {
+		McpResource annotation = mockResource("ui://my-server/app.html", "text/plain");
+		assertThatIllegalArgumentException().isThrownBy(() -> ResourceAdapter.asResource(annotation))
+			.withMessageContaining("ui:// URI must use MIME type 'text/html;profile=mcp-app'")
+			.withMessageContaining("text/plain");
+	}
+
+	@Test
+	void asResource_uiUriWithEmptyMimeType_throwsIllegalArgumentException() {
+		McpResource annotation = mockResource("ui://my-server/app.html", "");
+		assertThatIllegalArgumentException().isThrownBy(() -> ResourceAdapter.asResource(annotation))
+			.withMessageContaining("ui:// URI must use MIME type 'text/html;profile=mcp-app'");
+	}
+
+	@Test
+	void asResource_mcpAppMimeTypeWithNonUiUri_throwsIllegalArgumentException() {
+		McpResource annotation = mockResource("https://example.com/app.html", MCP_APP_MIME_TYPE);
+		assertThatIllegalArgumentException().isThrownBy(() -> ResourceAdapter.asResource(annotation))
+			.withMessageContaining("MIME type 'text/html;profile=mcp-app' must use a ui:// URI")
+			.withMessageContaining("https://example.com/app.html");
+	}
+
+	// ---------------------------------------------------------------------------
+	// asResourceTemplate — valid cases
+	// ---------------------------------------------------------------------------
+
+	@Test
+	void asResourceTemplate_uiUriWithCorrectMimeType_succeeds() {
+		McpResource annotation = mockResource("ui://my-server/{id}.html", MCP_APP_MIME_TYPE);
+		McpSchema.ResourceTemplate template = ResourceAdapter.asResourceTemplate(annotation);
+		assertThat(template.uriTemplate()).isEqualTo("ui://my-server/{id}.html");
+		assertThat(template.mimeType()).isEqualTo(MCP_APP_MIME_TYPE);
+	}
+
+	@Test
+	void asResourceTemplate_regularUriWithRegularMimeType_succeeds() {
+		McpResource annotation = mockResource("file://data/{name}.txt", "text/plain");
+		McpSchema.ResourceTemplate template = ResourceAdapter.asResourceTemplate(annotation);
+		assertThat(template.uriTemplate()).isEqualTo("file://data/{name}.txt");
+	}
+
+	// ---------------------------------------------------------------------------
+	// asResourceTemplate — invalid cases
+	// ---------------------------------------------------------------------------
+
+	@Test
+	void asResourceTemplate_uiUriWithWrongMimeType_throwsIllegalArgumentException() {
+		McpResource annotation = mockResource("ui://my-server/{id}.html", "application/json");
+		assertThatIllegalArgumentException().isThrownBy(() -> ResourceAdapter.asResourceTemplate(annotation))
+			.withMessageContaining("ui:// URI must use MIME type 'text/html;profile=mcp-app'")
+			.withMessageContaining("application/json");
+	}
+
+	@Test
+	void asResourceTemplate_mcpAppMimeTypeWithNonUiUri_throwsIllegalArgumentException() {
+		McpResource annotation = mockResource("https://example.com/{page}.html", MCP_APP_MIME_TYPE);
+		assertThatIllegalArgumentException().isThrownBy(() -> ResourceAdapter.asResourceTemplate(annotation))
+			.withMessageContaining("MIME type 'text/html;profile=mcp-app' must use a ui:// URI")
+			.withMessageContaining("https://example.com/{page}.html");
+	}
+
+	// ---------------------------------------------------------------------------
+	// Helper
+	// ---------------------------------------------------------------------------
+
+	private McpResource mockResource(String uri, String mimeType) {
+		return new McpResource() {
+			@Override
+			public Class<? extends java.lang.annotation.Annotation> annotationType() {
+				return McpResource.class;
+			}
+
+			@Override
+			public String uri() {
+				return uri;
+			}
+
+			@Override
+			public String name() {
+				return "test-resource";
+			}
+
+			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
+			public String description() {
+				return "";
+			}
+
+			@Override
+			public String mimeType() {
+				return mimeType;
+			}
+
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public io.modelcontextprotocol.spec.McpSchema.Role[] audience() {
+						return new io.modelcontextprotocol.spec.McpSchema.Role[] {
+								io.modelcontextprotocol.spec.McpSchema.Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
+			}
+
+			@Override
+			public Class<? extends org.springframework.ai.mcp.annotation.context.MetaProvider> metaProvider() {
+				return org.springframework.ai.mcp.annotation.context.DefaultMetaProvider.class;
+			}
+		};
+	}
+
+}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/common/MetaUtilsTest.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/common/MetaUtilsTest.java
@@ -142,6 +142,12 @@ final class MetaUtilsTest {
 	}
 
 	@Test
+	void testBuildUiMetaWithBlankResourceUri() {
+		Map<String, Object> uiMeta = MetaUtils.buildUiMeta("   ", new Visibility[0], null);
+		assertThat(uiMeta).isNull();
+	}
+
+	@Test
 	void testMergeMetaProviderWinsOnConflict() {
 		Map<String, Object> providerMeta = Map.of("ui",
 				Map.of("resourceUri", "ui://provider/override.html", "custom", "value"), "other", "data");
@@ -158,6 +164,20 @@ final class MetaUtilsTest {
 		assertThat(ui.get("resourceUri")).isEqualTo("ui://provider/override.html");
 		assertThat(ui.get("custom")).isEqualTo("value");
 		assertThat(ui.get("visibility")).isEqualTo(List.of("app"));
+	}
+
+	@Test
+	void testMergeMetaKeepsFlatAliasConsistentWithNestedUi() {
+		Map<String, Object> providerMeta = Map.of("ui", Map.of("resourceUri", "ui://provider/override.html"));
+		Map<String, Object> annotationMeta = MetaUtils.buildUiMeta("ui://annotation/view.html", new Visibility[0],
+				null);
+
+		Map<String, Object> merged = MetaUtils.mergeMeta(providerMeta, annotationMeta);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) merged.get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://provider/override.html");
+		assertThat(merged.get("ui/resourceUri")).isEqualTo("ui://provider/override.html");
 	}
 
 	@Test

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/common/MetaUtilsTest.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/common/MetaUtilsTest.java
@@ -16,15 +16,20 @@
 
 package org.springframework.ai.mcp.annotation.common;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.mcp.annotation.McpCsp;
+import org.springframework.ai.mcp.annotation.Visibility;
 import org.springframework.ai.mcp.annotation.context.DefaultMetaProvider;
 import org.springframework.ai.mcp.annotation.context.MetaProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 final class MetaUtilsTest {
 
@@ -76,6 +81,103 @@ final class MetaUtilsTest {
 		Map<String, Object> actual = MetaUtils.getMeta(null);
 
 		assertThat(actual).isNull();
+	}
+
+	@Test
+	void testBuildUiMetaWithResourceUri() {
+		Map<String, Object> uiMeta = MetaUtils.buildUiMeta("ui://test/view.html", new Visibility[0], null);
+
+		assertThat(uiMeta).isNotNull();
+		assertThat(uiMeta).containsKey("ui");
+		assertThat(uiMeta).containsKey("ui/resourceUri");
+		assertThat(uiMeta.get("ui/resourceUri")).isEqualTo("ui://test/view.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) uiMeta.get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test/view.html");
+	}
+
+	@Test
+	void testBuildUiMetaWithVisibility() {
+		Map<String, Object> uiMeta = MetaUtils.buildUiMeta("ui://test/view.html", new Visibility[] { Visibility.APP },
+				null);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) uiMeta.get("ui");
+		assertThat(ui.get("visibility")).isEqualTo(List.of("app"));
+	}
+
+	@Test
+	void testBuildUiMetaWithMultipleVisibility() {
+		Map<String, Object> uiMeta = MetaUtils.buildUiMeta("ui://test/view.html",
+				new Visibility[] { Visibility.MODEL, Visibility.APP }, null);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) uiMeta.get("ui");
+		assertThat(ui.get("visibility")).isEqualTo(List.of("model", "app"));
+	}
+
+	@Test
+	void testBuildUiMetaWithCsp() {
+		McpCsp csp = mock(McpCsp.class);
+		when(csp.connectDomains()).thenReturn(new String[] { "https://api.example.com" });
+		when(csp.resourceDomains()).thenReturn(new String[] { "https://cdn.example.com" });
+		when(csp.redirectDomains()).thenReturn(new String[] {});
+
+		Map<String, Object> uiMeta = MetaUtils.buildUiMeta("ui://test/view.html", new Visibility[0], csp);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) uiMeta.get("ui");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> cspMap = (Map<String, Object>) ui.get("csp");
+		assertThat(cspMap.get("connectDomains")).isEqualTo(List.of("https://api.example.com"));
+		assertThat(cspMap.get("resourceDomains")).isEqualTo(List.of("https://cdn.example.com"));
+		assertThat(cspMap).doesNotContainKey("redirectDomains");
+	}
+
+	@Test
+	void testBuildUiMetaWithEmptyResourceUri() {
+		Map<String, Object> uiMeta = MetaUtils.buildUiMeta("", new Visibility[0], null);
+		assertThat(uiMeta).isNull();
+	}
+
+	@Test
+	void testMergeMetaProviderWinsOnConflict() {
+		Map<String, Object> providerMeta = Map.of("ui",
+				Map.of("resourceUri", "ui://provider/override.html", "custom", "value"), "other", "data");
+
+		Map<String, Object> annotationMeta = Map.of("ui",
+				Map.of("resourceUri", "ui://annotation/view.html", "visibility", List.of("app")), "ui/resourceUri",
+				"ui://annotation/view.html");
+
+		Map<String, Object> merged = MetaUtils.mergeMeta(providerMeta, annotationMeta);
+
+		assertThat(merged).containsKey("other");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) merged.get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://provider/override.html");
+		assertThat(ui.get("custom")).isEqualTo("value");
+		assertThat(ui.get("visibility")).isEqualTo(List.of("app"));
+	}
+
+	@Test
+	void testMergeMetaBothNull() {
+		Map<String, Object> merged = MetaUtils.mergeMeta(null, null);
+		assertThat(merged).isNull();
+	}
+
+	@Test
+	void testMergeMetaOnlyProvider() {
+		Map<String, Object> providerMeta = Map.of("key", "value");
+		Map<String, Object> merged = MetaUtils.mergeMeta(providerMeta, null);
+		assertThat(merged).isEqualTo(providerMeta);
+	}
+
+	@Test
+	void testMergeMetaOnlyAnnotation() {
+		Map<String, Object> annotationMeta = Map.of("ui", Map.of("resourceUri", "ui://test/view.html"));
+		Map<String, Object> merged = MetaUtils.mergeMeta(null, annotationMeta);
+		assertThat(merged).isEqualTo(annotationMeta);
 	}
 
 	static class MetaProviderWithDefaultConstructor implements MetaProvider {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
@@ -34,7 +34,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.Visibility;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1019,6 +1021,67 @@ public class AsyncMcpToolProviderTests {
 		assertThat(toolSpec.tool().inputSchema()).isNotNull();
 		// Output schema should be generated for complex return types
 		assertThat(toolSpec.tool().outputSchema()).isNotNull();
+	}
+
+	@Test
+	void testToolReturningMcpAppResultSplitsTextAndStructuredContent() {
+		class AppResultTool {
+
+			@McpTool(name = "app-result-tool", description = "Tool returning McpAppResult",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public Mono<McpAppResult> appResultTool(String input) {
+				return Mono.just(McpAppResult.of("text for the LLM", Map.of("key", "value")));
+			}
+
+		}
+
+		AppResultTool toolObject = new AppResultTool();
+		AsyncMcpToolProvider provider = new AsyncMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		// McpAppResult is a wire-format container: no output schema must be generated
+		assertThat(toolSpecs.get(0).tool().outputSchema()).isNull();
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("app-result-tool", Map.of("input", "hello"));
+
+		StepVerifier.create(toolSpecs.get(0).callHandler().apply(exchange, request)).assertNext(result -> {
+			assertThat(result.content()).hasSize(1);
+			assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+			assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
+		}).verifyComplete();
+	}
+
+	@Test
+	void testToolWithResourceUriAddsUiMeta() {
+		class ResourceUriTool {
+
+			@McpTool(name = "uri-tool", description = "Tool with resourceUri",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP)
+			public Mono<String> uriTool(String input) {
+				return Mono.just("result: " + input);
+			}
+
+		}
+
+		ResourceUriTool toolObject = new ResourceUriTool();
+		AsyncMcpToolProvider provider = new AsyncMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		var tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui");
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui.get("visibility")).isEqualTo(List.of("app"));
 	}
 
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
@@ -34,7 +34,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.Visibility;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1022,6 +1024,67 @@ public class AsyncMcpToolProviderTests {
 		assertThat(toolSpec.tool().inputSchema()).isNotNull();
 		// Output schema should be generated for complex return types
 		assertThat(toolSpec.tool().outputSchema()).isNotNull();
+	}
+
+	@Test
+	void testToolReturningMcpAppResultSplitsTextAndStructuredContent() {
+		class AppResultTool {
+
+			@McpTool(name = "app-result-tool", description = "Tool returning McpAppResult",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public Mono<McpAppResult> appResultTool(String input) {
+				return Mono.just(McpAppResult.of("text for the LLM", Map.of("key", "value")));
+			}
+
+		}
+
+		AppResultTool toolObject = new AppResultTool();
+		AsyncMcpToolProvider provider = new AsyncMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		// McpAppResult is a wire-format container: no output schema must be generated
+		assertThat(toolSpecs.get(0).tool().outputSchema()).isNull();
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("app-result-tool", Map.of("input", "hello"));
+
+		StepVerifier.create(toolSpecs.get(0).callHandler().apply(exchange, request)).assertNext(result -> {
+			assertThat(result.content()).hasSize(1);
+			assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+			assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
+		}).verifyComplete();
+	}
+
+	@Test
+	void testToolWithResourceUriAddsUiMeta() {
+		class ResourceUriTool {
+
+			@McpTool(name = "uri-tool", description = "Tool with resourceUri",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP)
+			public Mono<String> uriTool(String input) {
+				return Mono.just("result: " + input);
+			}
+
+		}
+
+		ResourceUriTool toolObject = new ResourceUriTool();
+		AsyncMcpToolProvider provider = new AsyncMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		var tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui");
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui.get("visibility")).isEqualTo(List.of("app"));
 	}
 
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
@@ -30,7 +30,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.Visibility;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1006,6 +1008,67 @@ public class AsyncStatelessMcpToolProviderTests {
 		assertThat(toolSpec.tool().inputSchema()).isNotNull();
 		// Output schema should be generated for complex return types
 		assertThat(toolSpec.tool().outputSchema()).isNotNull();
+	}
+
+	@Test
+	void testToolReturningMcpAppResultSplitsTextAndStructuredContent() {
+		class AppResultTool {
+
+			@McpTool(name = "app-result-tool", description = "Tool returning McpAppResult",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public Mono<McpAppResult> appResultTool(String input) {
+				return Mono.just(McpAppResult.of("text for the LLM", Map.of("key", "value")));
+			}
+
+		}
+
+		AppResultTool toolObject = new AppResultTool();
+		AsyncStatelessMcpToolProvider provider = new AsyncStatelessMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		// McpAppResult is a wire-format container: no output schema must be generated
+		assertThat(toolSpecs.get(0).tool().outputSchema()).isNull();
+
+		McpTransportContext context = mock(McpTransportContext.class);
+		CallToolRequest request = new CallToolRequest("app-result-tool", Map.of("input", "hello"));
+
+		StepVerifier.create(toolSpecs.get(0).callHandler().apply(context, request)).assertNext(result -> {
+			assertThat(result.content()).hasSize(1);
+			assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+			assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
+		}).verifyComplete();
+	}
+
+	@Test
+	void testToolWithResourceUriAddsUiMeta() {
+		class ResourceUriTool {
+
+			@McpTool(name = "uri-tool", description = "Tool with resourceUri",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP)
+			public Mono<String> uriTool(String input) {
+				return Mono.just("result: " + input);
+			}
+
+		}
+
+		ResourceUriTool toolObject = new ResourceUriTool();
+		AsyncStatelessMcpToolProvider provider = new AsyncStatelessMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		var tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui");
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui.get("visibility")).isEqualTo(List.of("app"));
 	}
 
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
@@ -30,7 +30,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.Visibility;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1001,6 +1003,67 @@ public class AsyncStatelessMcpToolProviderTests {
 		assertThat(toolSpec.tool().inputSchema()).isNotNull();
 		// Output schema should be generated for complex return types
 		assertThat(toolSpec.tool().outputSchema()).isNotNull();
+	}
+
+	@Test
+	void testToolReturningMcpAppResultSplitsTextAndStructuredContent() {
+		class AppResultTool {
+
+			@McpTool(name = "app-result-tool", description = "Tool returning McpAppResult",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public Mono<McpAppResult> appResultTool(String input) {
+				return Mono.just(McpAppResult.of("text for the LLM", Map.of("key", "value")));
+			}
+
+		}
+
+		AppResultTool toolObject = new AppResultTool();
+		AsyncStatelessMcpToolProvider provider = new AsyncStatelessMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		// McpAppResult is a wire-format container: no output schema must be generated
+		assertThat(toolSpecs.get(0).tool().outputSchema()).isNull();
+
+		McpTransportContext context = mock(McpTransportContext.class);
+		CallToolRequest request = new CallToolRequest("app-result-tool", Map.of("input", "hello"));
+
+		StepVerifier.create(toolSpecs.get(0).callHandler().apply(context, request)).assertNext(result -> {
+			assertThat(result.content()).hasSize(1);
+			assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+			assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
+		}).verifyComplete();
+	}
+
+	@Test
+	void testToolWithResourceUriAddsUiMeta() {
+		class ResourceUriTool {
+
+			@McpTool(name = "uri-tool", description = "Tool with resourceUri",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP)
+			public Mono<String> uriTool(String input) {
+				return Mono.just("result: " + input);
+			}
+
+		}
+
+		ResourceUriTool toolObject = new ResourceUriTool();
+		AsyncStatelessMcpToolProvider provider = new AsyncStatelessMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		var tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui");
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui.get("visibility")).isEqualTo(List.of("app"));
 	}
 
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
@@ -34,6 +34,7 @@ import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpCsp;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.Visibility;
@@ -985,7 +986,8 @@ public class SyncMcpToolProviderTests {
 		class ResourceUriCspTool {
 
 			@McpTool(name = "csp-tool", description = "Tool with resourceUri and CSP",
-					resourceUri = "ui://test-server/app.html", csp = @McpCsp(connectDomains = "api.example.com"))
+					resourceUri = "ui://test-server/app.html",
+					csp = @McpCsp(connectDomains = "https://api.example.com"))
 			public String cspTool(String input) {
 				return "result: " + input;
 			}
@@ -1011,7 +1013,7 @@ public class SyncMcpToolProviderTests {
 		assertThat(csp.get("connectDomains")).isInstanceOf(List.class);
 		@SuppressWarnings("unchecked")
 		List<String> connectDomains = (List<String>) csp.get("connectDomains");
-		assertThat(connectDomains).containsExactly("api.example.com");
+		assertThat(connectDomains).containsExactly("https://api.example.com");
 	}
 
 	@Test
@@ -1038,13 +1040,10 @@ public class SyncMcpToolProviderTests {
 
 		@SuppressWarnings("unchecked")
 		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
-		// Annotation-derived fields should be present
-		assertThat(ui.get("resourceUri")).isEqualTo("ui://test/view.html"); // provider
-																			// wins
-		assertThat(ui).containsKey("visibility");
-		// Provider's extra key should also be present (deep-merged)
-		assertThat(ui.get("visibility")).isInstanceOf(List.class);
-		// Provider wins on conflict — provider has ["model", "app"], annotation has
+		// Provider wins on conflict: UiMetaProvider overrides the annotation's
+		// resourceUri ("ui://test-server/app.html" -> "ui://test/view.html")
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test/view.html");
+		// Provider wins on conflict: provider sets ["model", "app"], annotation set
 		// ["app"]
 		@SuppressWarnings("unchecked")
 		List<String> mergedVisibility = (List<String>) ui.get("visibility");
@@ -1069,6 +1068,69 @@ public class SyncMcpToolProviderTests {
 
 		assertThat(toolSpecs).hasSize(1);
 		assertThat(toolSpecs.get(0).tool().meta()).isNull();
+	}
+
+	@Test
+	void testToolReturningMcpAppResultSplitsTextAndStructuredContent() {
+		class AppResultTool {
+
+			@McpTool(name = "app-result-tool", description = "Tool returning McpAppResult",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public McpAppResult appResultTool(String input) {
+				return McpAppResult.of("text for the LLM", Map.of("key", "value"));
+			}
+
+		}
+
+		AppResultTool toolObject = new AppResultTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		// McpAppResult is a wire-format container: no output schema must be generated
+		assertThat(tool.outputSchema()).isNull();
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("app-result-tool", Map.of("input", "hello"));
+		CallToolResult result = toolSpecs.get(0).callHandler().apply(exchange, request);
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+		assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
+	}
+
+	@Test
+	void testToolReturningMcpAppResultWithExplicitOutputSchemaGenerationDisabled() {
+		class AppResultSchemaDisabledTool {
+
+			@McpTool(name = "app-result-schema-tool", description = "McpAppResult with generateOutputSchema true",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public McpAppResult appResultTool(String input) {
+				return McpAppResult.of("text for the LLM", Map.of("key", "value"));
+			}
+
+		}
+
+		AppResultSchemaDisabledTool toolObject = new AppResultSchemaDisabledTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		// Even with generateOutputSchema=true, McpAppResult must be excluded from schema
+		// generation — it's a wire-format container, not a structured data output.
+		assertThat(tool.outputSchema()).isNull();
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("app-result-schema-tool", Map.of("input", "hello"));
+		CallToolResult result = toolSpecs.get(0).callHandler().apply(exchange, request);
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+		assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
 	}
 
 	public static class UiMetaProvider implements MetaProvider {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
@@ -34,7 +34,9 @@ import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpCsp;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.Visibility;
 import org.springframework.ai.mcp.annotation.context.MetaProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -915,6 +917,158 @@ public class SyncMcpToolProviderTests {
 
 		// The input schema should be minimal when only CallToolRequest is present
 		assertThat(toolSpec.tool().inputSchema()).isNotNull();
+	}
+
+	@Test
+	void testToolWithResourceUri() {
+		class ResourceUriTool {
+
+			@McpTool(name = "uri-tool", description = "Tool with resourceUri",
+					resourceUri = "ui://test-server/app.html")
+			public String uriTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		ResourceUriTool toolObject = new ResourceUriTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui");
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+	}
+
+	@Test
+	void testToolWithResourceUriAndVisibility() {
+		class ResourceUriVisibilityTool {
+
+			@McpTool(name = "vis-tool", description = "Tool with resourceUri and visibility",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP)
+			public String visTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		ResourceUriVisibilityTool toolObject = new ResourceUriVisibilityTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui.get("visibility")).isInstanceOf(List.class);
+		@SuppressWarnings("unchecked")
+		List<String> visibility = (List<String>) ui.get("visibility");
+		assertThat(visibility).containsExactly("app");
+	}
+
+	@Test
+	void testToolWithResourceUriAndCsp() {
+		class ResourceUriCspTool {
+
+			@McpTool(name = "csp-tool", description = "Tool with resourceUri and CSP",
+					resourceUri = "ui://test-server/app.html", csp = @McpCsp(connectDomains = "api.example.com"))
+			public String cspTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		ResourceUriCspTool toolObject = new ResourceUriCspTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui).containsKey("csp");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> csp = (Map<String, Object>) ui.get("csp");
+		assertThat(csp.get("connectDomains")).isInstanceOf(List.class);
+		@SuppressWarnings("unchecked")
+		List<String> connectDomains = (List<String>) csp.get("connectDomains");
+		assertThat(connectDomains).containsExactly("api.example.com");
+	}
+
+	@Test
+	void testToolWithResourceUriAndMetaProviderMerge() {
+		class MergeTool {
+
+			@McpTool(name = "merge-tool", description = "Tool with merged meta",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP,
+					metaProvider = UiMetaProvider.class)
+			public String mergeTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		MergeTool toolObject = new MergeTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		// Annotation-derived fields should be present
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test/view.html"); // provider
+																			// wins
+		assertThat(ui).containsKey("visibility");
+		// Provider's extra key should also be present (deep-merged)
+		assertThat(ui.get("visibility")).isInstanceOf(List.class);
+		// Provider wins on conflict — provider has ["model", "app"], annotation has
+		// ["app"]
+		@SuppressWarnings("unchecked")
+		List<String> mergedVisibility = (List<String>) ui.get("visibility");
+		assertThat(mergedVisibility).containsExactly("model", "app");
+	}
+
+	@Test
+	void testToolWithNoResourceUriKeepsBehavior() {
+		class PlainTool {
+
+			@McpTool(name = "plain-tool", description = "Plain tool, no resourceUri")
+			public String plainTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		PlainTool toolObject = new PlainTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		assertThat(toolSpecs.get(0).tool().meta()).isNull();
 	}
 
 	public static class UiMetaProvider implements MetaProvider {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
@@ -34,6 +34,7 @@ import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpCsp;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.Visibility;
@@ -986,7 +987,8 @@ public class SyncMcpToolProviderTests {
 		class ResourceUriCspTool {
 
 			@McpTool(name = "csp-tool", description = "Tool with resourceUri and CSP",
-					resourceUri = "ui://test-server/app.html", csp = @McpCsp(connectDomains = "api.example.com"))
+					resourceUri = "ui://test-server/app.html",
+					csp = @McpCsp(connectDomains = "https://api.example.com"))
 			public String cspTool(String input) {
 				return "result: " + input;
 			}
@@ -1012,7 +1014,7 @@ public class SyncMcpToolProviderTests {
 		assertThat(csp.get("connectDomains")).isInstanceOf(List.class);
 		@SuppressWarnings("unchecked")
 		List<String> connectDomains = (List<String>) csp.get("connectDomains");
-		assertThat(connectDomains).containsExactly("api.example.com");
+		assertThat(connectDomains).containsExactly("https://api.example.com");
 	}
 
 	@Test
@@ -1039,13 +1041,10 @@ public class SyncMcpToolProviderTests {
 
 		@SuppressWarnings("unchecked")
 		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
-		// Annotation-derived fields should be present
-		assertThat(ui.get("resourceUri")).isEqualTo("ui://test/view.html"); // provider
-																			// wins
-		assertThat(ui).containsKey("visibility");
-		// Provider's extra key should also be present (deep-merged)
-		assertThat(ui.get("visibility")).isInstanceOf(List.class);
-		// Provider wins on conflict — provider has ["model", "app"], annotation has
+		// Provider wins on conflict: UiMetaProvider overrides the annotation's
+		// resourceUri ("ui://test-server/app.html" -> "ui://test/view.html")
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test/view.html");
+		// Provider wins on conflict: provider sets ["model", "app"], annotation set
 		// ["app"]
 		@SuppressWarnings("unchecked")
 		List<String> mergedVisibility = (List<String>) ui.get("visibility");
@@ -1070,6 +1069,69 @@ public class SyncMcpToolProviderTests {
 
 		assertThat(toolSpecs).hasSize(1);
 		assertThat(toolSpecs.get(0).tool().meta()).isNull();
+	}
+
+	@Test
+	void testToolReturningMcpAppResultSplitsTextAndStructuredContent() {
+		class AppResultTool {
+
+			@McpTool(name = "app-result-tool", description = "Tool returning McpAppResult",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public McpAppResult appResultTool(String input) {
+				return McpAppResult.of("text for the LLM", Map.of("key", "value"));
+			}
+
+		}
+
+		AppResultTool toolObject = new AppResultTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		// McpAppResult is a wire-format container: no output schema must be generated
+		assertThat(tool.outputSchema()).isNull();
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("app-result-tool", Map.of("input", "hello"));
+		CallToolResult result = toolSpecs.get(0).callHandler().apply(exchange, request);
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+		assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
+	}
+
+	@Test
+	void testToolReturningMcpAppResultWithExplicitOutputSchemaGenerationDisabled() {
+		class AppResultSchemaDisabledTool {
+
+			@McpTool(name = "app-result-schema-tool", description = "McpAppResult with generateOutputSchema true",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public McpAppResult appResultTool(String input) {
+				return McpAppResult.of("text for the LLM", Map.of("key", "value"));
+			}
+
+		}
+
+		AppResultSchemaDisabledTool toolObject = new AppResultSchemaDisabledTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		// Even with generateOutputSchema=true, McpAppResult must be excluded from schema
+		// generation — it's a wire-format container, not a structured data output.
+		assertThat(tool.outputSchema()).isNull();
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("app-result-schema-tool", Map.of("input", "hello"));
+		CallToolResult result = toolSpecs.get(0).callHandler().apply(exchange, request);
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+		assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
 	}
 
 	public static class UiMetaProvider implements MetaProvider {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
@@ -34,7 +34,9 @@ import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpCsp;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.Visibility;
 import org.springframework.ai.mcp.annotation.context.MetaProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -916,6 +918,158 @@ public class SyncMcpToolProviderTests {
 
 		// The input schema should be minimal when only CallToolRequest is present
 		assertThat(toolSpec.tool().inputSchema()).isNotNull();
+	}
+
+	@Test
+	void testToolWithResourceUri() {
+		class ResourceUriTool {
+
+			@McpTool(name = "uri-tool", description = "Tool with resourceUri",
+					resourceUri = "ui://test-server/app.html")
+			public String uriTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		ResourceUriTool toolObject = new ResourceUriTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui");
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+	}
+
+	@Test
+	void testToolWithResourceUriAndVisibility() {
+		class ResourceUriVisibilityTool {
+
+			@McpTool(name = "vis-tool", description = "Tool with resourceUri and visibility",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP)
+			public String visTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		ResourceUriVisibilityTool toolObject = new ResourceUriVisibilityTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui.get("visibility")).isInstanceOf(List.class);
+		@SuppressWarnings("unchecked")
+		List<String> visibility = (List<String>) ui.get("visibility");
+		assertThat(visibility).containsExactly("app");
+	}
+
+	@Test
+	void testToolWithResourceUriAndCsp() {
+		class ResourceUriCspTool {
+
+			@McpTool(name = "csp-tool", description = "Tool with resourceUri and CSP",
+					resourceUri = "ui://test-server/app.html", csp = @McpCsp(connectDomains = "api.example.com"))
+			public String cspTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		ResourceUriCspTool toolObject = new ResourceUriCspTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui).containsKey("csp");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> csp = (Map<String, Object>) ui.get("csp");
+		assertThat(csp.get("connectDomains")).isInstanceOf(List.class);
+		@SuppressWarnings("unchecked")
+		List<String> connectDomains = (List<String>) csp.get("connectDomains");
+		assertThat(connectDomains).containsExactly("api.example.com");
+	}
+
+	@Test
+	void testToolWithResourceUriAndMetaProviderMerge() {
+		class MergeTool {
+
+			@McpTool(name = "merge-tool", description = "Tool with merged meta",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP,
+					metaProvider = UiMetaProvider.class)
+			public String mergeTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		MergeTool toolObject = new MergeTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		McpSchema.Tool tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		// Annotation-derived fields should be present
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test/view.html"); // provider
+																			// wins
+		assertThat(ui).containsKey("visibility");
+		// Provider's extra key should also be present (deep-merged)
+		assertThat(ui.get("visibility")).isInstanceOf(List.class);
+		// Provider wins on conflict — provider has ["model", "app"], annotation has
+		// ["app"]
+		@SuppressWarnings("unchecked")
+		List<String> mergedVisibility = (List<String>) ui.get("visibility");
+		assertThat(mergedVisibility).containsExactly("model", "app");
+	}
+
+	@Test
+	void testToolWithNoResourceUriKeepsBehavior() {
+		class PlainTool {
+
+			@McpTool(name = "plain-tool", description = "Plain tool, no resourceUri")
+			public String plainTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		PlainTool toolObject = new PlainTool();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		assertThat(toolSpecs.get(0).tool().meta()).isNull();
 	}
 
 	public static class UiMetaProvider implements MetaProvider {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProviderTests.java
@@ -32,7 +32,9 @@ import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.Visibility;
 import org.springframework.ai.util.JsonHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -961,6 +963,67 @@ public class SyncStatelessMcpToolProviderTests {
 		assertThat(result.content()).hasSize(1);
 		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
 		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Only context tool executed");
+	}
+
+	@Test
+	void testToolReturningMcpAppResultSplitsTextAndStructuredContent() {
+		class AppResultTool {
+
+			@McpTool(name = "app-result-tool", description = "Tool returning McpAppResult",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public McpAppResult appResultTool(String input) {
+				return McpAppResult.of("text for the LLM", Map.of("key", "value"));
+			}
+
+		}
+
+		AppResultTool toolObject = new AppResultTool();
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		// McpAppResult is a wire-format container: no output schema must be generated
+		assertThat(toolSpecs.get(0).tool().outputSchema()).isNull();
+
+		McpTransportContext context = mock(McpTransportContext.class);
+		CallToolRequest request = new CallToolRequest("app-result-tool", Map.of("input", "hello"));
+
+		CallToolResult result = toolSpecs.get(0).callHandler().apply(context, request);
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+		assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
+	}
+
+	@Test
+	void testToolWithResourceUriAddsUiMeta() {
+		class ResourceUriTool {
+
+			@McpTool(name = "uri-tool", description = "Tool with resourceUri",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP)
+			public String uriTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		ResourceUriTool toolObject = new ResourceUriTool();
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		var tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui");
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui.get("visibility")).isEqualTo(List.of("app"));
 	}
 
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProviderTests.java
@@ -32,7 +32,9 @@ import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.McpAppResult;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.Visibility;
 import org.springframework.ai.util.JsonHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -958,6 +960,67 @@ public class SyncStatelessMcpToolProviderTests {
 		assertThat(result.content()).hasSize(1);
 		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
 		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Only context tool executed");
+	}
+
+	@Test
+	void testToolReturningMcpAppResultSplitsTextAndStructuredContent() {
+		class AppResultTool {
+
+			@McpTool(name = "app-result-tool", description = "Tool returning McpAppResult",
+					resourceUri = "ui://test-server/app.html", generateOutputSchema = true)
+			public McpAppResult appResultTool(String input) {
+				return McpAppResult.of("text for the LLM", Map.of("key", "value"));
+			}
+
+		}
+
+		AppResultTool toolObject = new AppResultTool();
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		// McpAppResult is a wire-format container: no output schema must be generated
+		assertThat(toolSpecs.get(0).tool().outputSchema()).isNull();
+
+		McpTransportContext context = mock(McpTransportContext.class);
+		CallToolRequest request = new CallToolRequest("app-result-tool", Map.of("input", "hello"));
+
+		CallToolResult result = toolSpecs.get(0).callHandler().apply(context, request);
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("text for the LLM");
+		assertThat(result.structuredContent()).isEqualTo(Map.of("key", "value"));
+	}
+
+	@Test
+	void testToolWithResourceUriAddsUiMeta() {
+		class ResourceUriTool {
+
+			@McpTool(name = "uri-tool", description = "Tool with resourceUri",
+					resourceUri = "ui://test-server/app.html", visibility = Visibility.APP)
+			public String uriTool(String input) {
+				return "result: " + input;
+			}
+
+		}
+
+		ResourceUriTool toolObject = new ResourceUriTool();
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(toolObject));
+
+		var toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		var tool = toolSpecs.get(0).tool();
+		assertThat(tool.meta()).isNotNull();
+		assertThat(tool.meta()).containsKey("ui");
+		assertThat(tool.meta()).containsKey("ui/resourceUri");
+		assertThat(tool.meta().get("ui/resourceUri")).isEqualTo("ui://test-server/app.html");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> ui = (Map<String, Object>) tool.meta().get("ui");
+		assertThat(ui.get("resourceUri")).isEqualTo("ui://test-server/app.html");
+		assertThat(ui.get("visibility")).isEqualTo(List.of("app"));
 	}
 
 }


### PR DESCRIPTION
## Summary

Add SEP-1865 (MCP Apps) support to the `mcp-annotations` module, enabling Spring AI MCP servers to expose interactive UI widgets alongside their tools.

### What's included

- **`@McpTool` extensions** — `resourceUri`, `visibility`, and `csp` fields to link tools to UI resources and control visibility (model-only, app-only, or both)
- **`Visibility` enum** — `MODEL` and `APP` visibility scopes
- **`@McpCsp` annotation** — declare Content Security Policy domains (`connectDomains`, `resourceDomains`, `redirectDomains`) for widget sandboxing
- **`McpAppResult`** — convenience return type that splits `text` → `content[]` (for the LLM) and `structuredContent` (for the widget UI)
- **`MetaUtils`** — `buildUiMeta()` and `mergeMeta()` helpers to construct `_meta.ui` blocks per the SEP-1865 spec
- **Tool provider updates** — all 4 providers (sync/async × stateful/stateless) now merge UI metadata into tool definitions
- **`ResourceAdapter`** — validates `ui://` URIs and `text/html;profile=mcp-app` MIME type for MCP App resources
- **Comprehensive tests** — `McpAppResultTests`, `ResourceAdapterTests`, `MetaUtilsTest`, `SyncMcpToolProviderTests`

### Example usage

```java
@McpTool(
    name = "my_tool",
    description = "...",
    resourceUri = "ui://my-server/widget.html",
    visibility = { Visibility.MODEL, Visibility.APP }
)
public McpAppResult myTool(@McpToolParam(description = "...") String input) {
    return McpAppResult.of(
        "Text for the LLM",
        Map.of("key", "structured data for the widget")
    );
}
```

### Context

[SEP-1865](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/seps/1865-mcp-apps-interactive-user-interfaces-for-mcp.md) defines how MCP servers expose interactive UIs (widgets) that render inside AI chat clients (ChatGPT, Claude, etc.). This PR adds first-class annotation support so Spring AI developers can build MCP Apps with the same `@McpTool` / `@McpResource` patterns they already use.

## Test plan

- [x] `McpAppResultTests` — verifies text/structuredContent split
- [x] `ResourceAdapterTests` — validates ui:// URI and MIME type handling
- [x] `MetaUtilsTest` — tests meta construction and merging
- [x] `SyncMcpToolProviderTests` — verifies tool providers inject UI metadata
- [x] Manual end-to-end testing with MCPJam Inspector and ChatGPT