### PR TITLE
fix: correct starter and autoconfigure dependency declarations

### DIFF
--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
@@ -28,7 +28,6 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-client-chat</artifactId>
 			<version>${project.parent.version}</version>
-			<optional>true</optional>
 		</dependency>
 
 		<dependency>

--- a/starters/spring-ai-starter-model-google-genai/pom.xml
+++ b/starters/spring-ai-starter-model-google-genai/pom.xml
@@ -71,15 +71,6 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-google-genai-embedding</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-
-
-
-
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This Pull Request addresses and resolves two key Maven dependency issues:

1. **Issue #6171**: Removes the unnecessary \spring-ai-google-genai-embedding\ dependency from \spring-ai-starter-model-google-genai\ (chat starter) to prevent incorrect loading of embedding auto-configurations when only chat is needed.
2. **Issue #6170**: Removes the \<optional>true</optional>\ marker from \spring-ai-client-chat\ in \spring-ai-autoconfigure-model-chat-client\ to ensure core types are cleanly resolved for downstream libraries and extensions during compilation.

These adjustments ensure clean runtime initialization and robust classpath resolution across Spring AI starters.