### PR TITLE
fix ToolCallAdvisor: correct per-round observations in streaming mode

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
@@ -36,6 +36,7 @@ import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationContext;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationDocumentation;
@@ -128,6 +129,13 @@ public class DefaultAroundAdvisorChain implements BaseAdvisorChain {
 			}
 
 			var advisor = this.streamAdvisors.pop();
+
+			// ToolAdvisor owns a multi-round stream and manages per-round observations
+			// internally. Skip the outer observation + aggregation wrapper so the chain
+			// does not produce a single span that incorrectly spans all rounds.
+			if (advisor instanceof ToolAdvisor) {
+				return advisor.adviseStream(chatClientRequest, this);
+			}
 
 			AdvisorObservationContext observationContext = AdvisorObservationContext.builder()
 				.advisorName(advisor.getName())

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -17,9 +17,14 @@
 package org.springframework.ai.chat.client.advisor;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.client.ChatClientMessageAggregator;
@@ -31,6 +36,10 @@ import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationContext;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationDocumentation;
+import org.springframework.ai.chat.client.advisor.observation.DefaultAdvisorObservationConvention;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.ChatOptions;
@@ -54,6 +63,10 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  */
 public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor {
+
+	private static final ChatClientMessageAggregator CHAT_CLIENT_MESSAGE_AGGREGATOR = new ChatClientMessageAggregator();
+
+	private static final AdvisorObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultAdvisorObservationConvention();
 
 	/**
 	 * Default advisor order. Placed early in the chain so that all downstream advisors
@@ -79,8 +92,11 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 
 	private final boolean streamToolCallResponses;
 
+	private final AdvisorObservationConvention observationConvention;
+
 	protected ToolCallAdvisor(ToolCallingManager toolCallingManager, int advisorOrder,
-			boolean conversationHistoryEnabled, boolean streamToolCallResponses) {
+			boolean conversationHistoryEnabled, boolean streamToolCallResponses,
+			@Nullable AdvisorObservationConvention observationConvention) {
 		Assert.notNull(toolCallingManager, "toolCallingManager must not be null");
 		Assert.isTrue(advisorOrder > BaseAdvisor.HIGHEST_PRECEDENCE && advisorOrder < BaseAdvisor.LOWEST_PRECEDENCE,
 				"advisorOrder must be between HIGHEST_PRECEDENCE and LOWEST_PRECEDENCE");
@@ -89,6 +105,8 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 		this.advisorOrder = advisorOrder;
 		this.conversationHistoryEnabled = conversationHistoryEnabled;
 		this.streamToolCallResponses = streamToolCallResponses;
+		this.observationConvention = observationConvention != null ? observationConvention
+				: DEFAULT_OBSERVATION_CONVENTION;
 	}
 
 	@Override
@@ -255,40 +273,58 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 
 			final ChatClientRequest finalRequest = processedRequest;
 
-			// Get the streaming response
-			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
+			// Create a per-round observation. The chain skips the outer observation for
+			// ToolAdvisor, so each internalStream() call is responsible for its own span.
+			AdvisorObservationContext obsCtx = AdvisorObservationContext.builder()
+				.advisorName(getName())
+				.chatClientRequest(processedRequest)
+				.order(getOrder())
+				.build();
 
-			// Holder for aggregated response (set when aggregation completes)
-			AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
+			Observation obs = AdvisorObservationDocumentation.AI_ADVISOR.observation(this.observationConvention,
+					DEFAULT_OBSERVATION_CONVENTION, () -> obsCtx, streamAdvisorChain.getObservationRegistry());
 
-			return streamWithToolCallResponses(responseFlux, aggregatedResponseRef, finalRequest, streamAdvisorChain,
-					originalRequest, optionsCopy);
+			obs.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
+
+			// Propagate this round's observation as the parent for inner-chain advisors
+			// (e.g. ChatModelStreamAdvisor) so their spans are correctly nested.
+			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest)
+				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, obs));
+
+			return streamWithToolCallResponses(responseFlux, finalRequest, streamAdvisorChain, originalRequest,
+					optionsCopy, obs, obsCtx);
 		});
 	}
 
-	/**
-	 * Streams all chunks immediately including intermediate tool call responses. Uses
-	 * publish() to multicast the stream for parallel streaming and aggregation.
-	 */
 	private Flux<ChatClientResponse> streamWithToolCallResponses(Flux<ChatClientResponse> responseFlux,
-			AtomicReference<ChatClientResponse> aggregatedResponseRef, ChatClientRequest finalRequest,
-			StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy) {
+			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
+			ToolCallingChatOptions optionsCopy, Observation observation, AdvisorObservationContext obsCtx) {
 
-		return responseFlux.publish(shared -> {
-			// Branch 1: Stream chunks immediately for real-time streaming UX
-			Flux<ChatClientResponse> streamingBranch = new ChatClientMessageAggregator()
-				.aggregateChatClientResponse(shared, aggregatedResponseRef::set);
+		AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
 
-			// Branch 2: After streaming completes, check for tool calls and
-			// potentially recurse.
-			Flux<ChatClientResponse> recursionBranch = Flux
-				.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest, streamAdvisorChain,
-						originalRequest, optionsCopy));
+		// Guard against double-stop: the success path stops the observation inside the
+		// aggregation callback (doOnComplete), which fires before concatWith starts the
+		// next round. doFinally handles the error/cancel paths.
+		AtomicBoolean observationStopped = new AtomicBoolean(false);
 
-			// Emit all streaming chunks first, then append any recursive results
-			return streamingBranch.concatWith(recursionBranch);
+		return CHAT_CLIENT_MESSAGE_AGGREGATOR.aggregateChatClientResponse(responseFlux, ccr -> {
+			aggregatedResponseRef.set(ccr);
+			obsCtx.setChatClientResponse(ccr);
+			// Stop NOW — inside doOnComplete, before concatWith subscribes to round N+1.
+			// This ensures the span covers only this round and carries the correct
+			// response (including tool calls that will be filtered from the output stream
+			// below).
+			if (observationStopped.compareAndSet(false, true)) {
+				observation.stop();
+			}
+		}).doOnError(observation::error).doFinally(signal -> {
+			// Covers error and cancel; success is already handled above.
+			if (signal != SignalType.ON_COMPLETE && observationStopped.compareAndSet(false, true)) {
+				observation.stop();
+			}
 		})
+			.concatWith(Flux.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest,
+					streamAdvisorChain, originalRequest, optionsCopy)))
 			.filter(ccr -> this.streamToolCallResponses
 					|| !(ccr.chatResponse() != null && ccr.chatResponse().hasToolCalls()));
 	}
@@ -441,6 +477,8 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 
 		private boolean streamToolCallResponses = false;
 
+		private @Nullable AdvisorObservationConvention observationConvention;
+
 		protected Builder() {
 		}
 
@@ -511,6 +549,19 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 		}
 
 		/**
+		 * Sets a custom {@link AdvisorObservationConvention} for the per-round
+		 * observations created by this advisor. When {@code null} (the default), the
+		 * {@link DefaultAdvisorObservationConvention} is used.
+		 * @param observationConvention the convention to use, or {@code null} for the
+		 * default
+		 * @return this Builder instance for method chaining
+		 */
+		public T observationConvention(@Nullable AdvisorObservationConvention observationConvention) {
+			this.observationConvention = observationConvention;
+			return self();
+		}
+
+		/**
 		 * Returns the configured ToolCallingManager.
 		 * @return the ToolCallingManager instance
 		 */
@@ -537,7 +588,8 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 			return new Builder<>().toolCallingManager(this.toolCallingManager)
 				.advisorOrder(this.advisorOrder)
 				.conversationHistoryEnabled(this.conversationHistoryEnabled)
-				.streamToolCallResponses(this.streamToolCallResponses);
+				.streamToolCallResponses(this.streamToolCallResponses)
+				.observationConvention(this.observationConvention);
 		}
 
 		/**
@@ -565,7 +617,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 		 */
 		public ToolCallAdvisor build() {
 			return new ToolCallAdvisor(this.toolCallingManager, this.advisorOrder, this.conversationHistoryEnabled,
-					this.streamToolCallResponses);
+					this.streamToolCallResponses, this.observationConvention);
 		}
 
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChainTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChainTests.java
@@ -31,6 +31,7 @@ import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationContext;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
 import org.springframework.ai.chat.client.advisor.observation.DefaultAdvisorObservationConvention;
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -135,6 +137,30 @@ class DefaultAroundAdvisorChainTests {
 
 		chain.nextStream(ChatClientRequest.builder().prompt(new Prompt("Hello")).build()).blockLast();
 		assertThat(chain.getStreamAdvisors()).containsExactlyInAnyOrder(advisors.toArray(new StreamAdvisor[0]));
+	}
+
+	@Test
+	void whenStreamAdvisorIsToolAdvisorThenOuterObservationIsSkipped() {
+		// A StreamAdvisor that also implements ToolAdvisor must bypass the outer
+		// observation + aggregation wrapper in nextStream() so it can manage per-round
+		// spans itself.
+		interface ToolStreamAdvisor extends StreamAdvisor, ToolAdvisor {
+
+		}
+		ToolStreamAdvisor toolAdvisor = mock(ToolStreamAdvisor.class);
+		ChatClientResponse expectedResponse = ChatClientResponse.builder().build();
+		when(toolAdvisor.adviseStream(any(), any())).thenReturn(Flux.just(expectedResponse));
+
+		StreamAdvisorChain chain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.push(toolAdvisor)
+			.build();
+
+		var responses = chain.nextStream(ChatClientRequest.builder().prompt(new Prompt("Hello")).build())
+			.collectList()
+			.block();
+
+		assertThat(responses).containsExactly(expectedResponse);
+		verify(toolAdvisor).adviseStream(any(), any());
 	}
 
 	@Test

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorObservationTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorObservationTests.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.DefaultChatClientBuilder;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationContext;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that reproduce the observation bugs reported in
+ * https://github.com/spring-projects/spring-ai/issues/5167.
+ *
+ * <p>
+ * In streaming mode with tool calling, the {@link DefaultAroundAdvisorChain} wraps the
+ * entire multi-round stream returned by {@link ToolCallAdvisor#adviseStream} with a
+ * single outer {@link org.springframework.ai.chat.client.ChatClientMessageAggregator}.
+ * This causes two bugs in the recorded {@link AdvisorObservationContext}:
+ *
+ * <ul>
+ * <li><b>Bug 1</b>: {@code toolCalls} is {@code null} — tool-call chunks are filtered out
+ * by {@link ToolCallAdvisor} before the outer aggregator sees them.</li>
+ * <li><b>Bug 2</b>: {@code textContent} is cumulative — text from both LLM rounds is
+ * concatenated into the single outer observation.</li>
+ * </ul>
+ *
+ * <p>
+ * Each test asserts the <em>correct</em> behavior. They currently <strong>fail</strong>
+ * with the buggy code and will pass once the fix is applied.
+ *
+ * @author Christian Tzolov
+ */
+@ExtendWith(MockitoExtension.class)
+class ToolCallAdvisorObservationTests {
+
+	static final String TOOL_NAME = "getCurrentWeather";
+
+	static final String ROUND1_TEXT = "Let me check the weather for you.";
+
+	static final String ROUND2_TEXT = "The weather in Tokyo is 10 degrees Celsius.";
+
+	@Mock
+	ChatModel chatModel;
+
+	// -------------------------------------------------------------------------
+	// Bug 1: toolCalls should not be null in the round-1 observation
+	// -------------------------------------------------------------------------
+
+	@Test
+	void roundOneObservationShouldRecordToolCalls() {
+		setupMockChatModel();
+
+		ObservationCapture capture = new ObservationCapture(1);
+		runStreamingRequest(buildChatClientWithObservation(capture));
+		capture.await();
+
+		AdvisorObservationContext firstRound = capture.contexts.get(0);
+		assertThat(firstRound.getChatClientResponse()).as("Observation context must have a ChatClientResponse")
+			.isNotNull();
+
+		assertThat(firstRound.getChatClientResponse().chatResponse().hasToolCalls())
+			.as("Bug 1: round-1 observation must record toolCalls — currently null because "
+					+ "DefaultAroundAdvisorChain's outer aggregator never sees the filtered tool-call chunks")
+			.isTrue();
+	}
+
+	// -------------------------------------------------------------------------
+	// Bug 2: textContent must not be cumulative across rounds
+	// -------------------------------------------------------------------------
+
+	@Test
+	void roundOneObservationShouldNotContainRoundTwoText() {
+		setupMockChatModel();
+
+		ObservationCapture capture = new ObservationCapture(1);
+		runStreamingRequest(buildChatClientWithObservation(capture));
+		capture.await();
+
+		AdvisorObservationContext firstRound = capture.contexts.get(0);
+		assertThat(firstRound.getChatClientResponse()).isNotNull();
+
+		String round1RecordedText = firstRound.getChatClientResponse().chatResponse().getResult().getOutput().getText();
+
+		assertThat(round1RecordedText)
+			.as("Bug 2: round-1 observation text must not include round-2 text — currently the outer "
+					+ "DefaultAroundAdvisorChain aggregator concatenates text from both LLM calls")
+			.doesNotContain(ROUND2_TEXT);
+	}
+
+	// -------------------------------------------------------------------------
+	// Combined: each round should produce an independent observation
+	// -------------------------------------------------------------------------
+
+	@Test
+	void eachRoundShouldProduceIndependentObservation() {
+		setupMockChatModel();
+
+		// Wait for 1 observation, then give a brief window for any concurrent second
+		// observation before asserting. With buggy code only 1 arrives; with the fix 2
+		// do.
+		ObservationCapture capture = new ObservationCapture(1);
+		String finalContent = runStreamingRequest(buildChatClientWithObservation(capture));
+		capture.await();
+
+		assertThat(finalContent).as("Final streamed content must contain the round-2 answer").contains("10");
+
+		try {
+			// Brief grace period: give the pipeline time to deliver the second
+			// observation if it is coming. With buggy code it never arrives; with the fix
+			// it does.
+			Thread.sleep(200);
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+		}
+
+		// With the bug: only 1 observation is captured (the single outer aggregation
+		// spanning the entire multi-round stream). After the fix: 2 observations — one
+		// per LLM call.
+		assertThat(capture.contexts)
+			.as("Bug: only one outer observation is produced, spanning both rounds; "
+					+ "expected one independent observation per LLM round")
+			.hasSize(2);
+
+		AdvisorObservationContext round1Ctx = capture.contexts.get(0);
+		AdvisorObservationContext round2Ctx = capture.contexts.get(1);
+
+		// Round 1: must have tool calls, text from round 1 only
+		assertThat(round1Ctx.getChatClientResponse().chatResponse().hasToolCalls())
+			.as("Round-1 observation must record tool calls")
+			.isTrue();
+		assertThat(round1Ctx.getChatClientResponse().chatResponse().getResult().getOutput().getText())
+			.as("Round-1 text must not include round-2 text")
+			.doesNotContain(ROUND2_TEXT);
+
+		// Round 2: must NOT have tool calls, text from round 2 only
+		assertThat(round2Ctx.getChatClientResponse().chatResponse().hasToolCalls())
+			.as("Round-2 observation must not have tool calls")
+			.isFalse();
+		assertThat(round2Ctx.getChatClientResponse().chatResponse().getResult().getOutput().getText())
+			.as("Round-2 text must contain the final answer")
+			.contains(ROUND2_TEXT);
+		assertThat(round2Ctx.getChatClientResponse().chatResponse().getResult().getOutput().getText())
+			.as("Round-2 text must not include round-1 text")
+			.doesNotContain(ROUND1_TEXT);
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private void setupMockChatModel() {
+		// Round 1: model responds with a preamble text chunk, then requests a tool call.
+		ChatResponse round1TextChunk = new ChatResponse(List.of(new Generation(new AssistantMessage(ROUND1_TEXT))));
+		ChatResponse round1ToolCallChunk = new ChatResponse(List.of(new Generation(AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call_001", "function", TOOL_NAME,
+					"{\"location\":\"Tokyo\",\"lat\":35.68,\"lon\":139.69,\"unit\":\"C\"}")))
+			.build())));
+
+		// Round 2: model provides the final answer after tool execution.
+		ChatResponse round2TextChunk = new ChatResponse(List.of(new Generation(new AssistantMessage(ROUND2_TEXT))));
+
+		when(this.chatModel.getDefaultOptions()).thenReturn(ToolCallingChatOptions.builder().build());
+		when(this.chatModel.stream(any(org.springframework.ai.chat.prompt.Prompt.class)))
+			.thenReturn(Flux.just(round1TextChunk, round1ToolCallChunk))
+			.thenReturn(Flux.just(round2TextChunk));
+	}
+
+	private ChatClient buildChatClientWithObservation(ObservationCapture capture) {
+		ObservationRegistry registry = ObservationRegistry.create();
+		registry.observationConfig().observationHandler(new ObservationHandler<Observation.Context>() {
+			@Override
+			public void onStop(Observation.Context context) {
+				if (context instanceof AdvisorObservationContext ctx
+						&& "Tool Calling Advisor".equals(ctx.getAdvisorName())) {
+					capture.add(ctx);
+				}
+			}
+
+			@Override
+			public boolean supportsContext(Observation.Context context) {
+				return true;
+			}
+		});
+
+		FunctionToolCallback<WeatherRequest, WeatherResponse> weatherTool = FunctionToolCallback
+			.builder(TOOL_NAME, new WeatherService())
+			.description("Get the current weather in a given location")
+			.inputType(WeatherRequest.class)
+			.build();
+
+		return new DefaultChatClientBuilder(this.chatModel, registry, null, null, null)
+			.defaultAdvisors(ToolCallAdvisor.builder().build())
+			// .defaultAdvisors(ToolCallAdvisor.builder().streamToolCallResponses(true).build())
+			.defaultTools(tool -> tool.callbacks(weatherTool))
+			.build();
+	}
+
+	private String runStreamingRequest(ChatClient chatClient) {
+		return chatClient.prompt()
+			.user("What is the weather in Tokyo?")
+			.stream()
+			.content()
+			.collectList()
+			.block()
+			.stream()
+			.collect(Collectors.joining());
+	}
+
+	// -------------------------------------------------------------------------
+	// Observation capture helper — provides synchronization so assertions
+	// do not race against doFinally firing on the boundedElastic thread.
+	// -------------------------------------------------------------------------
+
+	static final class ObservationCapture {
+
+		final List<AdvisorObservationContext> contexts = new CopyOnWriteArrayList<>();
+
+		private final CountDownLatch latch;
+
+		ObservationCapture(int awaitCount) {
+			this.latch = new CountDownLatch(awaitCount);
+		}
+
+		void add(AdvisorObservationContext ctx) {
+			this.contexts.add(ctx);
+			this.latch.countDown();
+		}
+
+		/** Blocks until {@code awaitCount} observations have been captured (or 5s). */
+		void await() {
+			try {
+				if (!this.latch.await(5, TimeUnit.SECONDS)) {
+					throw new AssertionError("Timed out waiting for ToolCallAdvisor observations (still missing "
+							+ this.latch.getCount() + ")");
+				}
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new AssertionError("Interrupted while waiting for observations", ex);
+			}
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// Minimal weather tool used in tests
+	// -------------------------------------------------------------------------
+
+	record WeatherRequest(@JsonProperty("location") String location, @JsonProperty("lat") double lat,
+			@JsonProperty("lon") double lon, @JsonProperty("unit") String unit) {
+	}
+
+	record WeatherResponse(double temp, String unit) {
+	}
+
+	static class WeatherService implements java.util.function.Function<WeatherRequest, WeatherResponse> {
+
+		@Override
+		public WeatherResponse apply(WeatherRequest request) {
+			return new WeatherResponse(10, "C");
+		}
+
+	}
+
+}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
@@ -37,6 +37,9 @@ import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationContext;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
+import org.springframework.ai.chat.client.advisor.observation.DefaultAdvisorObservationConvention;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -50,6 +53,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionResult;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -614,6 +618,52 @@ public class ToolCallAdvisorTests {
 	}
 
 	@Test
+	void testObservationConventionDefaultsToDefaultConvention() {
+		ToolCallAdvisor advisor = ToolCallAdvisor.builder().build();
+
+		assertThat(ReflectionTestUtils.getField(advisor, "observationConvention"))
+			.isInstanceOf(DefaultAdvisorObservationConvention.class);
+	}
+
+	@Test
+	void testObservationConventionBuilderMethod() {
+		AdvisorObservationConvention customConvention = new AdvisorObservationConvention() {
+			@Override
+			public String getName() {
+				return "custom.advisor";
+			}
+
+			@Override
+			public boolean supportsContext(io.micrometer.observation.Observation.Context context) {
+				return context instanceof AdvisorObservationContext;
+			}
+		};
+
+		ToolCallAdvisor advisor = ToolCallAdvisor.builder().observationConvention(customConvention).build();
+
+		assertThat(ReflectionTestUtils.getField(advisor, "observationConvention")).isSameAs(customConvention);
+	}
+
+	@Test
+	void testBuilderCopyPreservesObservationConvention() {
+		AdvisorObservationConvention customConvention = new AdvisorObservationConvention() {
+			@Override
+			public String getName() {
+				return "custom.advisor";
+			}
+
+			@Override
+			public boolean supportsContext(io.micrometer.observation.Observation.Context context) {
+				return context instanceof AdvisorObservationContext;
+			}
+		};
+
+		ToolCallAdvisor copy = ToolCallAdvisor.builder().observationConvention(customConvention).copy().build();
+
+		assertThat(ReflectionTestUtils.getField(copy, "observationConvention")).isSameAs(customConvention);
+	}
+
+	@Test
 	void testAdviseStreamWithToolCallResponsesEnabled() {
 		// Create advisor with tool call streaming explicitly enabled
 		ToolCallAdvisor advisor = ToolCallAdvisor.builder()
@@ -928,7 +978,7 @@ public class ToolCallAdvisorTests {
 		private final int[] hookCallCounts;
 
 		TestableToolCallAdvisor(ToolCallingManager toolCallingManager, int advisorOrder, int[] hookCallCounts) {
-			super(toolCallingManager, advisorOrder, true, true);
+			super(toolCallingManager, advisorOrder, true, true, null);
 			this.hookCallCounts = hookCallCounts;
 		}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -39,6 +39,7 @@ Key features:
 * Uses `callAdvisorChain.copy(this)` to create a sub-chain for recursive calls
 * Includes null safety checks to handle cases where the chat response might be null
 * Supports configurable conversation history management via `conversationHistoryEnabled`
+* Supports a custom `AdvisorObservationConvention` for per-round streaming observations via `observationConvention`
 
 Example usage:
 
@@ -107,6 +108,19 @@ spring.ai.chat.client.tool-calling.stream-tool-call-responses=true
 ----
 
 NOTE: Enabling this option increases the number of chunks the client receives but may interleave tool-call fragments with the final answer depending on how the client processes the stream.
+
+==== Custom Observation Convention
+
+Each LLM round in the streaming tool-call loop produces an independent Micrometer observation.
+By default, `DefaultAdvisorObservationConvention` is used.
+Set a custom `AdvisorObservationConvention` on the builder to control observation names, tags, or other attributes:
+
+[source,java]
+----
+var toolCallAdvisor = ToolCallAdvisor.builder()
+    .observationConvention(new MyAdvisorObservationConvention())
+    .build();
+----
 
 ==== Return Direct Functionality
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1153,6 +1153,7 @@ The `ToolCallAdvisor.Builder` supports the following configuration options:
 - `advisorOrder`: The order in which the advisor is applied in the chain. Must be between `BaseAdvisor.HIGHEST_PRECEDENCE` and `BaseAdvisor.LOWEST_PRECEDENCE`.
 - `conversationHistoryEnabled`: Controls whether the advisor maintains conversation history internally during tool call iterations. Default is `true`.
 - `streamToolCallResponses`: When `true`, each tool-call iteration streams its chunks in real time during a `.stream()` call. When `false` (default), only the final answer is streamed.
+- `observationConvention`: A custom `AdvisorObservationConvention` for the per-round observations created in streaming mode. When `null` (default), `DefaultAdvisorObservationConvention` is used.
 
 ==== Conversation History Management
 


### PR DESCRIPTION
- Refactor ToolCallAdvisor streaming to create individual observations per LLM round instead of spanning all rounds.
- Simplifies the streaming flow by replacing publish()-based multicast with aggregateChatClientResponse().concatWith() chain.
- Updates DefaultAroundAdvisorChain to skip outer observation for streaming ToolAdvisor instances.

Resolves #5167
Related to #6017