### PR TITLE
GH-6163: Omit null temperature/topP from BedrockProxyChatModel inferenceConfig

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -484,13 +484,16 @@ public class BedrockProxyChatModel implements ChatModel {
 			toolConfiguration = ToolConfiguration.builder().tools(bedrockTools).build();
 		}
 
-		InferenceConfiguration inferenceConfiguration = InferenceConfiguration.builder()
+		InferenceConfiguration.Builder inferenceConfigBuilder = InferenceConfiguration.builder()
 			.maxTokens(updatedRuntimeOptions.getMaxTokens())
-			.stopSequences(updatedRuntimeOptions.getStopSequences())
-			.temperature(updatedRuntimeOptions.getTemperature() != null
-					? updatedRuntimeOptions.getTemperature().floatValue() : null)
-			.topP(updatedRuntimeOptions.getTopP() != null ? updatedRuntimeOptions.getTopP().floatValue() : null)
-			.build();
+			.stopSequences(updatedRuntimeOptions.getStopSequences());
+		if (updatedRuntimeOptions.getTemperature() != null) {
+			inferenceConfigBuilder.temperature(updatedRuntimeOptions.getTemperature().floatValue());
+		}
+		if (updatedRuntimeOptions.getTopP() != null) {
+			inferenceConfigBuilder.topP(updatedRuntimeOptions.getTopP().floatValue());
+		}
+		InferenceConfiguration inferenceConfiguration = inferenceConfigBuilder.build();
 
 		BedrockChatOptions bedrockOptions = (BedrockChatOptions) prompt.getOptions();
 		Assert.notNull(bedrockOptions, "options can't be null here");

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.bedrock.converse;
 
 import java.net.URL;
+import java.util.List;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
@@ -29,8 +30,11 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
 
 import org.springframework.ai.bedrock.converse.api.MediaFetcher;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
@@ -199,6 +203,36 @@ class BedrockProxyChatModelTest {
 			.cause()
 			.isInstanceOf(SecurityException.class)
 			.hasMessageContaining("evil.com");
+	}
+
+	@Test
+	void nullTemperatureAndTopPAreOmittedFromInferenceConfig() {
+		BedrockProxyChatModel model = new BedrockProxyChatModel(this.syncClient, this.asyncClient,
+				BedrockChatOptions.builder().model("anthropic.claude-opus-4-7").build(), ObservationRegistry.NOOP,
+				ToolCallingManager.builder().build(), new DefaultToolExecutionEligibilityPredicate());
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("hello")),
+				BedrockChatOptions.builder().model("anthropic.claude-opus-4-7").build());
+
+		ConverseRequest request = model.createRequest(prompt);
+
+		assertThat(request.inferenceConfig().temperature()).isNull();
+		assertThat(request.inferenceConfig().topP()).isNull();
+	}
+
+	@Test
+	void explicitTemperatureAndTopPAreIncludedInInferenceConfig() {
+		BedrockProxyChatModel model = new BedrockProxyChatModel(this.syncClient, this.asyncClient,
+				BedrockChatOptions.builder().model("anthropic.claude-3-sonnet").build(), ObservationRegistry.NOOP,
+				ToolCallingManager.builder().build(), new DefaultToolExecutionEligibilityPredicate());
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("hello")),
+				BedrockChatOptions.builder().model("anthropic.claude-3-sonnet").temperature(0.7).topP(0.9).build());
+
+		ConverseRequest request = model.createRequest(prompt);
+
+		assertThat(request.inferenceConfig().temperature()).isEqualTo(0.7f);
+		assertThat(request.inferenceConfig().topP()).isEqualTo(0.9f);
 	}
 
 }


### PR DESCRIPTION
## Summary

- Fixes `BedrockProxyChatModel.createRequest()` to **omit** `temperature` and `topP` from `InferenceConfiguration` when they are `null`, rather than passing `null` explicitly to the AWS SDK builder
- The previous code called `.temperature(null)` / `.topP(null)` on the `InferenceConfiguration.Builder`, which caused the field to be present (as null) in the serialized Bedrock Converse request payload
- Models like Claude Opus 4.7 reject the request with `"temperature is deprecated for this model"` even when no temperature was configured by the caller, because Bedrock forwards the null field to the Anthropic API which treats its presence as an explicit (invalid) setting
- Added two unit tests to `BedrockProxyChatModelTest` — one verifying that null temperature/topP are absent from the built request, and one verifying that explicit values are still forwarded correctly

## Test plan

- [x] `./mvnw -pl models/spring-ai-bedrock-converse test -Dtest="BedrockProxyChatModelTest"` — 13 tests pass (11 existing + 2 new)
- [ ] Manually test with `eu.anthropic.claude-opus-4-7` and no temperature configured → should no longer produce `ValidationException: temperature is deprecated`

Fixes: #6163