### PR TITLE
GH-6026: Pass reasoning_content back to DeepSeek API in multi-turn conversations

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -430,14 +430,17 @@ public class DeepSeekChatModel implements ChatModel {
 					}).toList();
 				}
 				Boolean isPrefixAssistantMessage = null;
-				if (message instanceof DeepSeekAssistantMessage
-						&& Boolean.TRUE.equals(((DeepSeekAssistantMessage) message).getPrefix())) {
-					isPrefixAssistantMessage = true;
+				String reasoningContent = null;
+				if (message instanceof DeepSeekAssistantMessage deepSeekMsg) {
+					if (Boolean.TRUE.equals(deepSeekMsg.getPrefix())) {
+						isPrefixAssistantMessage = true;
+					}
+					reasoningContent = deepSeekMsg.getReasoningContent();
 				}
 				String text = assistantMessage.getText();
 				Assert.state(text != null, "text must not be null");
 				return List.of(new ChatCompletionMessage(text, ChatCompletionMessage.Role.ASSISTANT, null, null,
-						toolCalls, isPrefixAssistantMessage, null));
+						toolCalls, isPrefixAssistantMessage, reasoningContent));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
@@ -16,8 +16,11 @@
 
 package org.springframework.ai.deepseek;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
 
@@ -52,6 +55,41 @@ public class DeepSeekChatCompletionRequestTests {
 
 		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
 		assertThat(request.temperature()).isEqualTo(99.9D);
+	}
+
+	@Test
+	public void reasoningContentIsPassedBackForDeepSeekAssistantMessage() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		DeepSeekAssistantMessage assistantMessage = new DeepSeekAssistantMessage.Builder().content("The answer is 42.")
+			.reasoningContent("I reasoned through the problem step by step.")
+			.build();
+
+		var prompt = new Prompt(
+				List.of(new UserMessage("What is the answer?"), assistantMessage, new UserMessage("Are you sure?")),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build());
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(3);
+		var assistantMsg = request.messages().get(1);
+		assertThat(assistantMsg.role()).isEqualTo(DeepSeekApi.ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(assistantMsg.reasoningContent()).isEqualTo("I reasoned through the problem step by step.");
+	}
+
+	@Test
+	public void nullReasoningContentIsOmittedForPlainAssistantMessage() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		var prompt = new Prompt(List.of(new UserMessage("Hello"),
+				new org.springframework.ai.chat.messages.AssistantMessage("Hi!"), new UserMessage("How are you?")),
+				DeepSeekChatOptions.builder().model("deepseek-chat").build());
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(3);
+		var assistantMsg = request.messages().get(1);
+		assertThat(assistantMsg.reasoningContent()).isNull();
 	}
 
 }


### PR DESCRIPTION
## Summary

- Fixes `DeepSeekChatModel.createRequest()` to forward `reasoning_content` from `DeepSeekAssistantMessage` when rebuilding conversation history for subsequent API calls
- DeepSeek reasoning models (`deepseek-reasoner`) require the `reasoning_content` field to be echoed back in ASSISTANT messages in the conversation history — without it, the API returns HTTP 400: `"The reasoning_content in the thinking mode must be passed back to the API."`
- Previously `createRequest()` always passed `null` as `reasoning_content` in `ChatCompletionMessage` for ASSISTANT turns, silently dropping the stored value
- The fix checks whether the incoming `AssistantMessage` is actually a `DeepSeekAssistantMessage` and, if so, reads `getReasoningContent()` and passes it forward
- Plain `AssistantMessage` (non-reasoning models like `deepseek-chat`) still emit `null` reasoning_content and are unaffected

## Test plan

- [x] `./mvnw -pl models/spring-ai-deepseek test -Dtest="DeepSeekChatCompletionRequestTests"` — 3 tests pass (1 existing + 2 new)
- New test `reasoningContentIsPassedBackForDeepSeekAssistantMessage` verifies the reasoning content is forwarded
- New test `nullReasoningContentIsOmittedForPlainAssistantMessage` verifies non-reasoning models are unaffected

Fixes: #6026