### PR TITLE
GH-6007: Unwrap Optional values in Neo4jChatMemoryRepository metadata before saving

### DIFF
--- a/memory/repository/spring-ai-model-chat-memory-repository-neo4j/src/main/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-neo4j/src/main/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepository.java
@@ -262,7 +262,7 @@ public final class Neo4jChatMemoryRepository implements ChatMemoryRepository {
 					CREATE (msg)-[:HAS_METADATA]->(metadataNode)
 					SET metadataNode = $metadata
 					""");
-			Map<String, Object> metadataCopy = new HashMap<>(message.getMetadata());
+			Map<String, Object> metadataCopy = sanitizeMetadata(message.getMetadata());
 			metadataCopy.remove("messageType");
 			queryParameters.put("metadata", metadataCopy);
 			queryParameters.put("metadataLabel", this.config.getMetadataLabel());
@@ -318,6 +318,20 @@ public final class Neo4jChatMemoryRepository implements ChatMemoryRepository {
 			queryParameters.put("mediaLabel", this.config.getMediaLabel());
 		}
 		t.run(statementBuilder.toString(), queryParameters);
+	}
+
+	private static Map<String, Object> sanitizeMetadata(Map<String, Object> metadata) {
+		Map<String, Object> result = new HashMap<>();
+		for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+			Object value = entry.getValue();
+			if (value instanceof Optional<?> optional) {
+				value = optional.orElse(null);
+			}
+			if (value != null) {
+				result.put(entry.getKey(), value);
+			}
+		}
+		return result;
 	}
 
 	private List<Map<String, Object>> convertMediaToMap(List<Media> media) {


### PR DESCRIPTION
## Summary

- Fixes `Neo4jChatMemoryRepository.saveAll()` to unwrap `java.util.Optional` values from the `AssistantMessage` metadata map before passing them to the Neo4j driver
- When using chat models whose SDKs return `Optional`-typed fields in response objects (e.g. the OpenAI Java SDK's `refusal` and `toolCalls` fields on `ChatCompletionMessage`), those `Optional` instances end up in the `AssistantMessage` metadata map
- The Neo4j driver's `Values.value()` does not know how to convert `java.util.Optional` and throws `ClientException: Unable to convert java.util.Optional to Neo4j Value`
- Fix adds a private `sanitizeMetadata()` helper that copies the metadata map while unwrapping `Optional` values — present `Optional`s yield their wrapped value, empty `Optional`s are dropped (treated as absent)

## Test plan

- [x] Module compiles cleanly: `./mvnw -pl memory/repository/spring-ai-model-chat-memory-repository-neo4j test`
- Integration tests in `Neo4jChatMemoryRepositoryIT` require a live Neo4j instance; unit verification: the change is a straightforward `instanceof Optional<?>` pattern-match applied before handing off to the driver

Fixes: #6007