### PR TITLE
Improve Mistral AI Chat documentation for reasoning models and `ReasoningEffort` Javadoc

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
@@ -106,7 +106,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 	private @Nullable List<String> stop;
 
 	/**
-	 * Controls the reasoning effort level for reasoning models.
+	 * Controls the reasoning effort level for adjustable reasoning models.
 	 * {@link ReasoningEffort#HIGH} enables comprehensive reasoning traces,
 	 * {@link ReasoningEffort#NONE} disables reasoning effort.
 	 */

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -792,7 +792,7 @@ public class MistralAiApi {
 
 		/**
 		 * <p>
-		 * Controls the reasoning effort level for reasoning models.
+		 * Controls the reasoning effort level for adjustable reasoning models.
 		 * {@link ReasoningEffort#HIGH} enables comprehensive reasoning traces,
 		 * {@link ReasoningEffort#NONE} disables reasoning effort.
 		 * </p>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -144,7 +144,7 @@ The prefix `spring.ai.mistralai.chat` is the property prefix that lets you confi
 | spring.ai.mistralai.chat.stop | Stop generation if this token is detected. Or if one of these tokens is detected when providing an array. | -
 | spring.ai.mistralai.chat.top-p | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or `temperature` but not both. | -
 | spring.ai.mistralai.chat.response-format | An object specifying the format that the model must output. Setting to `{ "type": "json_object" }` enables JSON mode, which guarantees the message the model generates is valid JSON. Setting to `{ "type": "json_schema" }` with a supplied schema enables native structured outputs, which guarantees the model will match your supplied JSON schema. See the <<structured-output>> section for more details.| -
-| spring.ai.mistralai.chat.reasoning-effort | Controls the reasoning effort level for reasoning models. Valid values include `high` or `none`. | -
+| spring.ai.mistralai.chat.reasoning-effort | Controls the reasoning effort level for adjustable reasoning models. Valid values include `high` or `none`. | -
 | spring.ai.mistralai.chat.tools | A list of tools the model may call. Currently, only functions are supported as a tool. Use this to provide a list of functions the model may generate JSON inputs for. | -
 | spring.ai.mistralai.chat.tool-choice | Controls which (if any) function is called by the model. `none` means the model will not call a function and instead generates a message. `auto` means the model can pick between generating a message or calling a function. Specifying a particular function via `{"type: "function", "function": {"name": "my_function"}}` forces the model to call that function. `none` is the default when no functions are present. `auto` is the default if functions are present. | -
 | spring.ai.mistralai.chat.tool-names | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
@@ -261,8 +261,10 @@ For more information about structured outputs, see the xref:api/structured-outpu
 
 == Reasoning Models
 
-Mistral AI provides reasoning models that can perform complex reasoning tasks before returning a response.
-When using these models, you can control the level of reasoning effort and access the model's internal reasoning process.
+Mistral offers two approaches to reasoning:
+
+* Adjustable: Available on Mistral Small 4 and Mistral Medium 3.5 via the `reasoning_effort` parameter. Enables the model to think to varying degrees.
+* Native: Available for the Magistral model family. These models always generate reasoning traces and are purpose-built for deep reasoning tasks.
 
 === Reasoning Effort
 
@@ -272,7 +274,7 @@ This allows you to adjust the amount of computational effort the model spends on
 [source,java]
 ----
 var options = MistralAiChatOptions.builder()
-    .model(MistralAiApi.ChatModel.MISTRAL_SMALL.getValue()) // Or any reasoning model
+    .model(MistralAiApi.ChatModel.MISTRAL_SMALL.getValue()) // Or any adjustable reasoning model
     .reasoningEffort(MistralAiApi.ChatCompletionRequest.ReasoningEffort.HIGH)
     .build();
 
@@ -285,11 +287,11 @@ ChatResponse response = chatModel.call(
 Mistral reasoning models expose their internal chain of thought and references.
 Spring AI maps these from the API responses to the message metadata.
 
-You can access the following metadata keys from the `AssistantMessage` when using a reasoning model:
+You can access the following metadata keys from the `AssistantMessage`:
 
-* `thinking_content`: The step-by-step reasoning process the model used to arrive at its final answer.
-* `reference_thinking_content`: The reference thinking content.
-* `reference_content`: The reference content.
+* `reference_content`: The unique keys linking model responses to their source documents for traceability and citations.
+* `thinking_content`: The step-by-step reasoning process the model used to arrive at its final answer (accessible only for reasoning models).
+* `reference_thinking_content`: The unique keys linking the model's reasoning steps to their source documents for traceability and citations (possibly accessible only for reasoning models).
 
 [source,java]
 ----
@@ -298,7 +300,7 @@ ChatResponse response = chatModel.call(new Prompt("Solve this complex math probl
 AssistantMessage message = response.getResult().getOutput();
 
 // Access the thinking content from metadata
-String thinking = (String) message.getMetadata().get("thinking_content");
+String thinking = (String) message.getMetadata().get(MistralAiChatModel.THINKING_CONTENT_METADATA);
 if (thinking != null && !thinking.isEmpty()) {
     System.out.println("Model's thinking process:");
     System.out.println(thinking);
@@ -377,7 +379,7 @@ Add a `application.properties` file under the `src/main/resources` directory to 
 [source,application.properties]
 ----
 spring.ai.mistralai.api-key=YOUR_API_KEY
-spring.ai.mistralai.chat.model=mistral-small
+spring.ai.mistralai.chat.model=mistral-small-latest
 spring.ai.mistralai.chat.temperature=0.7
 ----
 


### PR DESCRIPTION
## Description

- Clarify adjustable versus native reasoning model types,
- Expand on metadata use,
- Use constant instead of string for thinking content metadata,
- Complement `ReasoningEffort` Javadoc,
- Add latest tag to Mistral Small model within an `application.properties` snippet.

## Explanations

- I have discovered that Mistral AI's reasoning models are well explained within [Mistral AI Studio API](https://docs.mistral.ai/studio-api/conversations/reasoning) documentation.
- `reference_content` metadata is not relative to reasoning models (cf `MistralAiChatModelIT.referenceCall`).
- `mistral-small` seems to be the old version of Mistral Small. I have updated it to the latest tag due to this error:
```shell
curl -s https://api.mistral.ai/v1/models/mistral-small \       
  -H "Authorization: Bearer $MISTRAL_AI_API_KEY"  
{"object":"error","message":"Model mistral-small is deprecated.","type":"invalid_model","param":null,"code":"1500","raw_status_code":404}
```

## Proposed milestone

**2.0.0-RC1**

## Related work

- #5585
- [Add reasoning effort configuration property](https://github.com/spring-projects/spring-ai/commit/187ec3307e101b18e647d1497ad8c9c0370793df)