### PR TITLE
Simplify ToolCallAdvisor stream aggregation by removing publish() multicast

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -55,6 +55,8 @@ import org.springframework.util.Assert;
  */
 public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor {
 
+	private static final ChatClientMessageAggregator CHAT_CLIENT_MESSAGE_AGGREGATOR = new ChatClientMessageAggregator();
+
 	/**
 	 * Default advisor order. Placed early in the chain so that all downstream advisors
 	 * (e.g. {@link org.springframework.ai.chat.client.advisor.api.BaseChatMemoryAdvisor})
@@ -255,40 +257,24 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 
 			final ChatClientRequest finalRequest = processedRequest;
 
-			// Get the streaming response
+			// Propagate this round's observation as the parent for inner-chain advisors
+			// (e.g. ChatModelStreamAdvisor) so their spans are correctly nested.
 			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
 
-			// Holder for aggregated response (set when aggregation completes)
-			AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
-
-			return streamWithToolCallResponses(responseFlux, aggregatedResponseRef, finalRequest, streamAdvisorChain,
-					originalRequest, optionsCopy);
+			return streamWithToolCallResponses(responseFlux, finalRequest, streamAdvisorChain, originalRequest,
+					optionsCopy);
 		});
 	}
 
-	/**
-	 * Streams all chunks immediately including intermediate tool call responses. Uses
-	 * publish() to multicast the stream for parallel streaming and aggregation.
-	 */
 	private Flux<ChatClientResponse> streamWithToolCallResponses(Flux<ChatClientResponse> responseFlux,
-			AtomicReference<ChatClientResponse> aggregatedResponseRef, ChatClientRequest finalRequest,
-			StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
+			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
 			ToolCallingChatOptions optionsCopy) {
 
-		return responseFlux.publish(shared -> {
-			// Branch 1: Stream chunks immediately for real-time streaming UX
-			Flux<ChatClientResponse> streamingBranch = new ChatClientMessageAggregator()
-				.aggregateChatClientResponse(shared, aggregatedResponseRef::set);
+		AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
 
-			// Branch 2: After streaming completes, check for tool calls and
-			// potentially recurse.
-			Flux<ChatClientResponse> recursionBranch = Flux
-				.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest, streamAdvisorChain,
-						originalRequest, optionsCopy));
-
-			// Emit all streaming chunks first, then append any recursive results
-			return streamingBranch.concatWith(recursionBranch);
-		})
+		return CHAT_CLIENT_MESSAGE_AGGREGATOR.aggregateChatClientResponse(responseFlux, aggregatedResponseRef::set)
+			.concatWith(Flux.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest,
+					streamAdvisorChain, originalRequest, optionsCopy)))
 			.filter(ccr -> this.streamToolCallResponses
 					|| !(ccr.chatResponse() != null && ccr.chatResponse().hasToolCalls()));
 	}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -257,8 +257,6 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor 
 
 			final ChatClientRequest finalRequest = processedRequest;
 
-			// Propagate this round's observation as the parent for inner-chain advisors
-			// (e.g. ChatModelStreamAdvisor) so their spans are correctly nested.
 			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
 
 			return streamWithToolCallResponses(responseFlux, finalRequest, streamAdvisorChain, originalRequest,


### PR DESCRIPTION

Replace the publish()-based dual-branch pattern with a straightforward sequential aggregation: aggregate the response first, then defer the tool-call recursion. 
Also extract ChatClientMessageAggregator as a static field to avoid repeated instantiation per stream invocation.

Closes #6017