### PR TITLE
Polish ServerTransportProvider

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
@@ -53,6 +53,8 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 
 	private static final Logger logger = LoggerFactory.getLogger(WebFluxStatelessServerTransport.class);
 
+	public static final String DEFAULT_MCP_ENDPOINT = "/mcp";
+
 	private final McpJsonMapper jsonMapper;
 
 	private final String mcpEndpoint;
@@ -61,7 +63,7 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 
 	private @Nullable McpStatelessServerHandler mcpHandler;
 
-	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+	private final McpTransportContextExtractor<ServerRequest> contextExtractor;
 
 	private volatile boolean isClosing = false;
 
@@ -201,7 +203,7 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 
 		private @Nullable McpJsonMapper jsonMapper;
 
-		private String mcpEndpoint = "/mcp";
+		private String mcpEndpoint = DEFAULT_MCP_ENDPOINT;
 
 		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
 

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
@@ -65,6 +65,8 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 
 	private static final Logger logger = LoggerFactory.getLogger(WebFluxStreamableServerTransportProvider.class);
 
+	public static final String DEFAULT_MCP_ENDPOINT = "/mcp";
+
 	public static final String MESSAGE_EVENT_TYPE = "message";
 
 	private final McpJsonMapper jsonMapper;
@@ -79,7 +81,7 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 
 	private final ConcurrentHashMap<String, McpStreamableServerSession> sessions = new ConcurrentHashMap<>();
 
-	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+	private final McpTransportContextExtractor<ServerRequest> contextExtractor;
 
 	private volatile boolean isClosing = false;
 
@@ -483,7 +485,7 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 
 		private McpJsonMapper jsonMapper = McpJsonDefaults.getMapper();
 
-		private String mcpEndpoint = "/mcp";
+		private String mcpEndpoint = DEFAULT_MCP_ENDPOINT;
 
 		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
 

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
@@ -47,13 +47,15 @@ import org.springframework.web.servlet.function.ServerResponse;
  *
  * <p>
  * This is the non-reactive version of
- * {@link io.modelcontextprotocol.server.transport.WebFluxStatelessServerTransport}
+ * {@link org.springframework.ai.mcp.server.webflux.transport.WebFluxStatelessServerTransport}
  *
  * @author Christian Tzolov
  */
 public final class WebMvcStatelessServerTransport implements McpStatelessServerTransport {
 
 	private static final Logger logger = LoggerFactory.getLogger(WebMvcStatelessServerTransport.class);
+
+	public static final String DEFAULT_MCP_ENDPOINT = "/mcp";
 
 	private final McpJsonMapper jsonMapper;
 
@@ -63,7 +65,7 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 
 	private @Nullable McpStatelessServerHandler mcpHandler;
 
-	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+	private final McpTransportContextExtractor<ServerRequest> contextExtractor;
 
 	private volatile boolean isClosing = false;
 
@@ -224,7 +226,7 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 
 		private @Nullable McpJsonMapper jsonMapper;
 
-		private String mcpEndpoint = "/mcp";
+		private String mcpEndpoint = DEFAULT_MCP_ENDPOINT;
 
 		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
 

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -61,7 +61,7 @@ import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
  *
  * <p>
  * This is the non-reactive version of
- * {@link io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider}
+ * {@link org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider}
  *
  * @author Christian Tzolov
  * @author Dariusz Jędrzejczyk
@@ -72,20 +72,12 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 
 	private static final Logger logger = LoggerFactory.getLogger(WebMvcStreamableServerTransportProvider.class);
 
+	public static final String DEFAULT_MCP_ENDPOINT = "/mcp";
+
 	/**
 	 * Event type for JSON-RPC messages sent through the SSE connection.
 	 */
 	public static final String MESSAGE_EVENT_TYPE = "message";
-
-	/**
-	 * Event type for sending the message endpoint URI to clients.
-	 */
-	public static final String ENDPOINT_EVENT_TYPE = "endpoint";
-
-	/**
-	 * Default base URL for the message endpoint.
-	 */
-	public static final String DEFAULT_BASE_URL = "";
 
 	/**
 	 * The endpoint URI where clients should send their JSON-RPC messages. Defaults to
@@ -109,7 +101,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 	 */
 	private final ConcurrentHashMap<String, McpStreamableServerSession> sessions = new ConcurrentHashMap<>();
 
-	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+	private final McpTransportContextExtractor<ServerRequest> contextExtractor;
 
 	/**
 	 * Flag indicating if the transport is shutting down.
@@ -678,7 +670,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 
 		private @Nullable McpJsonMapper jsonMapper;
 
-		private String mcpEndpoint = "/mcp";
+		private String mcpEndpoint = DEFAULT_MCP_ENDPOINT;
 
 		private boolean disallowDelete = false;
 


### PR DESCRIPTION
1. fix stale `{@link}`
2. remove unused fields
3. extract constant `DEFAULT_MCP_ENDPOINT` for Streamable-HTTP to align with SSE
4. mark `contextExtractor` as final