### PR TITLE
Eliminate calls to deprecated `HttpHeaders.asMultiValueMap()`

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/HeaderUtils.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/HeaderUtils.java
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.mcp.server.webmvc.transport;
+package org.springframework.ai.mcp.server.webflux.transport;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerRequest;
 
 /**
  * Utility class for working with HTTP headers. Internal use only.
+ *
+ * <p>
+ * * This is the reactive version of
+ * {@link org.springframework.ai.mcp.server.webmvc.transport.HeaderUtils}
  *
  * @author Daniel Garnier-Moiroux
  * @author Yanming Zhou

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server.webflux.transport;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -333,7 +332,7 @@ public final class WebFluxSseServerTransportProvider implements McpServerTranspo
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {
@@ -405,7 +404,7 @@ public final class WebFluxSseServerTransportProvider implements McpServerTranspo
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
@@ -18,7 +18,6 @@ package org.springframework.ai.mcp.server.webflux.transport;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import io.modelcontextprotocol.common.McpTransportContext;
@@ -124,7 +123,7 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server.webflux.transport;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.modelcontextprotocol.common.McpTransportContext;
@@ -205,7 +204,7 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {
@@ -269,7 +268,7 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {
@@ -384,7 +383,7 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/utils/McpTestRequestRecordingExchangeFilterFunction.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/utils/McpTestRequestRecordingExchangeFilterFunction.java
@@ -33,6 +33,7 @@ import org.springframework.web.reactive.function.server.ServerResponse;
  * Simple {@link HandlerFilterFunction} which records calls made to an MCP server.
  *
  * @author Daniel Garnier-Moiroux
+ * @author Yanming Zhou
  */
 public class McpTestRequestRecordingExchangeFilterFunction implements HandlerFilterFunction {
 
@@ -42,10 +43,9 @@ public class McpTestRequestRecordingExchangeFilterFunction implements HandlerFil
 	public Mono<ServerResponse> filter(ServerRequest request, HandlerFunction next) {
 		Map<String, String> headers = request.headers()
 			.asHttpHeaders()
-			.asMultiValueMap()
-			.keySet()
+			.headerSet()
 			.stream()
-			.collect(Collectors.toMap(String::toLowerCase, k -> String.join(",", request.headers().header(k))));
+			.collect(Collectors.toMap(e -> e.getKey().toLowerCase(), e -> String.join(",", e.getValue())));
 
 		var cr = request.bodyToMono(String.class).defaultIfEmpty("").map(body -> {
 			this.calls.add(new Call(request.method(), headers, body));

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server.webmvc.transport;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -272,7 +271,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/HeaderUtilsTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/HeaderUtilsTests.java
@@ -18,7 +18,6 @@ package org.springframework.ai.mcp.server.webmvc.transport;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -73,17 +72,12 @@ class HeaderUtilsTests {
 	void collectHeadersMixedCase() {
 		ServerRequest request = mock(ServerRequest.class);
 		ServerRequest.Headers headers = mock(ServerRequest.Headers.class);
-		HttpHeaders httpHeaders = mock(HttpHeaders.class);
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.addAll("X-Custom", List.of("one", "two"));
+		httpHeaders.add("x-custom", "three");
 
 		when(request.headers()).thenReturn(headers);
 		when(headers.asHttpHeaders()).thenReturn(httpHeaders);
-
-		// Mock headerNames to return mixed case keys
-		when(httpHeaders.headerNames()).thenReturn(Set.of("X-Custom", "x-custom"));
-
-		// Mock header values for each key
-		when(headers.header("X-Custom")).thenReturn(List.of("one", "two"));
-		when(headers.header("x-custom")).thenReturn(List.of("three"));
 
 		Map<String, List<String>> result = HeaderUtils.collectHeaders(request);
 


### PR DESCRIPTION
And refactor `HeaderUtils::collectHeaders` to use `headerSet` instead.