### PR TITLE
Deprecate and rename ChatClient customizer

### DIFF
--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientBuilderCustomizer;
 import org.springframework.ai.chat.client.ChatClientCustomizer;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
@@ -82,9 +83,12 @@ public class ChatClientAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	ChatClientBuilderConfigurer chatClientBuilderConfigurer(ObjectProvider<ChatClientCustomizer> customizerProvider) {
+	@SuppressWarnings("removal")
+	ChatClientBuilderConfigurer chatClientBuilderConfigurer(ObjectProvider<ChatClientCustomizer> customizerProvider,
+			ObjectProvider<ChatClientBuilderCustomizer> builderCustomizerProvider) {
 		ChatClientBuilderConfigurer configurer = new ChatClientBuilderConfigurer();
 		configurer.setChatClientCustomizers(customizerProvider.orderedStream().toList());
+		configurer.setChatClientBuilderCustomizers(builderCustomizerProvider.orderedStream().toList());
 		return configurer;
 	}
 

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientBuilderConfigurer.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientBuilderConfigurer.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientBuilderCustomizer;
 import org.springframework.ai.chat.client.ChatClientCustomizer;
 
 /**
@@ -36,8 +37,15 @@ public class ChatClientBuilderConfigurer {
 
 	private @Nullable List<ChatClientCustomizer> customizers;
 
+	private @Nullable List<ChatClientBuilderCustomizer> builderCustomizers;
+
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	void setChatClientCustomizers(List<ChatClientCustomizer> customizers) {
 		this.customizers = customizers;
+	}
+
+	void setChatClientBuilderCustomizers(List<ChatClientBuilderCustomizer> builderCustomizers) {
+		this.builderCustomizers = builderCustomizers;
 	}
 
 	/**
@@ -51,9 +59,15 @@ public class ChatClientBuilderConfigurer {
 		return builder;
 	}
 
+	@SuppressWarnings("removal")
 	private void applyCustomizers(ChatClient.Builder builder) {
 		if (this.customizers != null) {
 			for (ChatClientCustomizer customizer : this.customizers) {
+				customizer.customize(builder);
+			}
+		}
+		if (this.builderCustomizers != null) {
+			for (ChatClientBuilderCustomizer customizer : this.builderCustomizers) {
 				customizer.customize(builder);
 			}
 		}

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientCreationPatternsTests.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientCreationPatternsTests.java
@@ -20,7 +20,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.ChatClientCustomizer;
+import org.springframework.ai.chat.client.ChatClientBuilderCustomizer;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
 import org.springframework.ai.chat.client.observation.ChatClientObservationConvention;
@@ -45,8 +45,8 @@ import static org.mockito.Mockito.mock;
  * same model type</li>
  * <li>Using {@link ChatClientBuilderConfigurer} for multiple clients of different model
  * types</li>
- * <li>Ensuring observability and {@link ChatClientCustomizer} beans are applied in both
- * patterns</li>
+ * <li>Ensuring observability and {@link ChatClientBuilderCustomizer} beans are applied in
+ * both patterns</li>
  * </ul>
  *
  */
@@ -96,7 +96,7 @@ class ChatClientCreationPatternsTests {
 	}
 
 	@Test
-	void prototypeBuilderAppliesChatClientCustomizers() {
+	void prototypeBuilderAppliesChatClientBuilderCustomizers() {
 		this.contextRunner
 			.withUserConfiguration(SingleModelMultipleClientsConfig.class, SystemPromptCustomizerConfig.class)
 			.run(context -> {
@@ -125,7 +125,7 @@ class ChatClientCreationPatternsTests {
 	}
 
 	@Test
-	void configurerPatternAppliesChatClientCustomizers() {
+	void configurerPatternAppliesChatClientBuilderCustomizers() {
 		this.contextRunner.withUserConfiguration(MultipleModelTypesConfig.class, SystemPromptCustomizerConfig.class)
 			.run(context -> {
 				assertThat(context).hasNotFailed();
@@ -139,8 +139,8 @@ class ChatClientCreationPatternsTests {
 				String primarySystemText = (String) ReflectionTestUtils.getField(primaryRequest, "systemText");
 				String secondarySystemText = (String) ReflectionTestUtils.getField(secondaryRequest, "systemText");
 
-				assertThat(primarySystemText).isEqualTo("Customized by ChatClientCustomizer.");
-				assertThat(secondarySystemText).isEqualTo("Customized by ChatClientCustomizer.");
+				assertThat(primarySystemText).isEqualTo("Customized by ChatClientBuilderCustomizer.");
+				assertThat(secondarySystemText).isEqualTo("Customized by ChatClientBuilderCustomizer.");
 			});
 	}
 
@@ -272,15 +272,15 @@ class ChatClientCreationPatternsTests {
 	}
 
 	/**
-	 * A {@link ChatClientCustomizer} that sets a fixed system prompt, used to verify that
-	 * customizers are applied in both ChatClient creation patterns.
+	 * A {@link ChatClientBuilderCustomizer} that sets a fixed system prompt, used to
+	 * verify that customizers are applied in both ChatClient creation patterns.
 	 */
 	@Configuration(proxyBeanMethods = false)
 	static class SystemPromptCustomizerConfig {
 
 		@Bean
-		ChatClientCustomizer systemPromptCustomizer() {
-			return builder -> builder.defaultSystem("Customized by ChatClientCustomizer.");
+		ChatClientBuilderCustomizer systemPromptCustomizer() {
+			return builder -> builder.defaultSystem("Customized by ChatClientBuilderCustomizer.");
 		}
 
 	}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/ChatClientAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/ChatClientAutoConfigurationIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.ChatClientCustomizer;
+import org.springframework.ai.chat.client.ChatClientBuilderCustomizer;
 import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -83,7 +83,7 @@ public class ChatClientAutoConfigurationIT {
 	}
 
 	@Test
-	void testChatClientCustomizers() {
+	void testChatClientBuilderCustomizers() {
 		this.contextRunner.withUserConfiguration(Config.class).run(context -> {
 
 			ChatClient.Builder builder = context.getBean(ChatClient.Builder.class);
@@ -111,7 +111,7 @@ public class ChatClientAutoConfigurationIT {
 	static class Config {
 
 		@Bean
-		public ChatClientCustomizer chatClientCustomizer() {
+		public ChatClientBuilderCustomizer chatClientCustomizer() {
 			return b -> b.defaultSystem("You are a movie expert.")
 				.defaultUser("Generate the filmography of 5 movies for {actor}.");
 		}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientBuilderCustomizer.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientBuilderCustomizer.java
@@ -24,12 +24,10 @@ package org.springframework.ai.chat.client;
  * @author Mark Pollack
  * @author Josh Long
  * @author Arjen Poutsma
- * @since 1.0.0 M1
- * @deprecated in favor of {@link ChatClientBuilderCustomizer}
+ * @since 2.0.0
  */
 @FunctionalInterface
-@Deprecated(since = "2.0.0", forRemoval = true)
-public interface ChatClientCustomizer {
+public interface ChatClientBuilderCustomizer {
 
 	/**
 	 * Callback to customize a {@link ChatClient.Builder ChatClient.Builder} instance.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -91,10 +91,10 @@ class ChatClientConfig {
 ==== ChatClients for Different Model Types
 
 When working with multiple AI models, you might be tempted to define separate `ChatClient` beans by using `ChatClient.create(chatModel)` or `ChatClient.builder(chatModel)`.
-However, doing so bypasses the auto-configured `ChatClient.Builder`, which means observability and `ChatClientCustomizer` beans are ignored.
+However, doing so bypasses the auto-configured `ChatClient.Builder`, which means observability and `ChatClientBuilderCustomizer` beans are ignored.
 
 To retain observability and customizers, you should inject `ChatClientBuilderConfigurer` to create custom builders.
-The `ChatClientBuilderConfigurer` applies all registered `ChatClientCustomizer` beans and wires up observability, mirroring what the auto-configuration does internally.
+The `ChatClientBuilderConfigurer` applies all registered `ChatClientBuilderCustomizer` beans and wires up observability, mirroring what the auto-configuration does internally.
 
 When multiple `ChatModel` beans are present in the application context, Spring cannot resolve the `ChatModel` dependency of the auto-configured `ChatClient.Builder` bean without ambiguity.
 To resolve this, you can mark one of your `ChatClient` beans as `@Primary`. You may also need to mark one of your `ChatModel` beans as `@Primary` if you are defining them manually, or alternatively, define your own `ChatClient.Builder` bean to override the auto-configured one.


### PR DESCRIPTION
 - Deprecate the existing ChatClientCustomizer and add a new ChatClientBuilderCustomizer
 - Update the ChatClientBuilderConfigurer to use the new ChatClientBuilderCustomizer
 - Update docs and tests