### PR TITLE
Add Mistral AI prompt mode

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiChatProperties.java
@@ -21,10 +21,11 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.mistralai.MistralAiChatOptions;
-import org.springframework.ai.mistralai.api.MistralAiApi;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.PromptMode;
 import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.ReasoningEffort;
 import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.ResponseFormat;
 import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.ToolChoice;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatModel;
 import org.springframework.ai.mistralai.api.MistralAiApi.FunctionTool;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
@@ -37,6 +38,7 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
  * @author Thomas Vitale
  * @author Alexandros Pappas
  * @author Sebastien Deleuze
+ * @author Nicolas Krier
  * @since 0.8.1
  */
 @ConfigurationProperties(MistralAiChatProperties.CONFIG_PREFIX)
@@ -44,7 +46,7 @@ public class MistralAiChatProperties extends MistralAiParentProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.mistralai.chat";
 
-	public static final String DEFAULT_CHAT_MODEL = MistralAiApi.ChatModel.MISTRAL_SMALL.getValue();
+	public static final String DEFAULT_CHAT_MODEL = ChatModel.MISTRAL_SMALL.getValue();
 
 	private static final Double DEFAULT_TOP_P = 1.0;
 
@@ -75,6 +77,8 @@ public class MistralAiChatProperties extends MistralAiParentProperties {
 	private @Nullable List<FunctionTool> tools;
 
 	private @Nullable ToolChoice toolChoice;
+
+	private @Nullable PromptMode promptMode;
 
 	private @Nullable ReasoningEffort reasoningEffort;
 
@@ -184,6 +188,14 @@ public class MistralAiChatProperties extends MistralAiParentProperties {
 		this.toolChoice = toolChoice;
 	}
 
+	public @Nullable PromptMode getPromptMode() {
+		return this.promptMode;
+	}
+
+	public void setPromptMode(@Nullable PromptMode promptMode) {
+		this.promptMode = promptMode;
+	}
+
 	public @Nullable ReasoningEffort getReasoningEffort() {
 		return this.reasoningEffort;
 	}
@@ -230,6 +242,9 @@ public class MistralAiChatProperties extends MistralAiParentProperties {
 		}
 		if (this.toolChoice != null) {
 			builder.toolChoice(this.toolChoice);
+		}
+		if (this.promptMode != null) {
+			builder.promptMode(this.promptMode);
 		}
 		if (this.reasoningEffort != null) {
 			builder.reasoningEffort(this.reasoningEffort);

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -486,6 +486,7 @@ public class MistralAiChatModel implements ChatModel {
 				request.stream(),
 				ModelOptionsUtils.mergeOption(options.getSafePrompt(), request.safePrompt()),
 				ModelOptionsUtils.mergeOption(options.getStop(), request.stop()),
+				ModelOptionsUtils.mergeOption(options.getPromptMode(), request.promptMode()),
 				ModelOptionsUtils.mergeOption(options.getReasoningEffort(), request.reasoningEffort()),
 				ModelOptionsUtils.mergeOption(options.getRandomSeed(), request.randomSeed()),
 				ModelOptionsUtils.mergeOption(options.getResponseFormat(), request.responseFormat())

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
@@ -27,10 +27,11 @@ import java.util.Set;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.chat.prompt.ChatOptions;
-import org.springframework.ai.mistralai.api.MistralAiApi;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.PromptMode;
 import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.ReasoningEffort;
 import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.ResponseFormat;
 import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.ToolChoice;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatModel;
 import org.springframework.ai.mistralai.api.MistralAiApi.FunctionTool;
 import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
 import org.springframework.ai.model.tool.StructuredOutputChatOptions;
@@ -106,9 +107,22 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 	private @Nullable List<String> stop;
 
 	/**
+	 * Controls the system prompt behavior. Assignment to actual system prompts is handled
+	 * internally. A system prompt may include knowledge, cutoff date, model capabilities,
+	 * tone to use, safety guidelines...
+	 * <p>
+	 * {@link PromptMode#REASONING} Explicitly uses the default reasoning system prompt.
+	 * Applicable for native reasoning models only.
+	 * </p>
+	 */
+	private @Nullable PromptMode promptMode;
+
+	/**
 	 * Controls the reasoning effort level for adjustable reasoning models.
-	 * {@link ReasoningEffort#HIGH} enables comprehensive reasoning traces,
-	 * {@link ReasoningEffort#NONE} disables reasoning effort.
+	 * <p>
+	 * {@link ReasoningEffort#HIGH} Enables comprehensive reasoning traces,
+	 * {@link ReasoningEffort#NONE} Disables reasoning effort.
+	 * </p>
 	 */
 	private @Nullable ReasoningEffort reasoningEffort;
 
@@ -173,7 +187,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 
 	protected MistralAiChatOptions(String model, @Nullable Double temperature, @Nullable Double topP,
 			@Nullable Integer maxTokens, @Nullable Boolean safePrompt, @Nullable Integer randomSeed,
-			@Nullable ResponseFormat responseFormat, @Nullable List<String> stop,
+			@Nullable ResponseFormat responseFormat, @Nullable List<String> stop, @Nullable PromptMode promptMode,
 			@Nullable ReasoningEffort reasoningEffort, @Nullable Double frequencyPenalty,
 			@Nullable Double presencePenalty, @Nullable Integer n, @Nullable List<FunctionTool> tools,
 			@Nullable ToolChoice toolChoice, @Nullable List<ToolCallback> toolCallbacks,
@@ -192,6 +206,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 		this.randomSeed = randomSeed;
 		this.responseFormat = responseFormat;
 		this.stop = stop;
+		this.promptMode = promptMode;
 		this.reasoningEffort = reasoningEffort;
 		if (frequencyPenalty != null) {
 			this.frequencyPenalty = frequencyPenalty;
@@ -251,6 +266,10 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 
 	public @Nullable List<String> getStop() {
 		return this.stop;
+	}
+
+	public @Nullable PromptMode getPromptMode() {
+		return this.promptMode;
 	}
 
 	public @Nullable ReasoningEffort getReasoningEffort() {
@@ -348,6 +367,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 			// Mistral AI specific
 			.safePrompt(this.safePrompt)
 			.randomSeed(this.randomSeed)
+			.promptMode(this.promptMode)
 			.reasoningEffort(this.reasoningEffort)
 			.responseFormat(this.responseFormat)
 			.n(this.n)
@@ -358,9 +378,9 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.model, this.temperature, this.topP, this.maxTokens, this.safePrompt, this.randomSeed,
-				this.responseFormat, this.stop, this.reasoningEffort, this.frequencyPenalty, this.presencePenalty,
-				this.n, this.tools, this.toolChoice, this.toolCallbacks, this.tools, this.internalToolExecutionEnabled,
-				this.toolContext);
+				this.responseFormat, this.stop, this.promptMode, this.reasoningEffort, this.frequencyPenalty,
+				this.presencePenalty, this.n, this.tools, this.toolChoice, this.toolCallbacks, this.tools,
+				this.internalToolExecutionEnabled, this.toolContext);
 	}
 
 	@Override
@@ -384,6 +404,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 				&& Objects.equals(this.randomSeed, other.randomSeed)
 				&& Objects.equals(this.responseFormat, other.responseFormat)
 				&& Objects.equals(this.stop, other.stop)
+				&& Objects.equals(this.promptMode, other.promptMode)
 				&& Objects.equals(this.reasoningEffort, other.reasoningEffort)
 				&& Objects.equals(this.frequencyPenalty, other.frequencyPenalty)
 				&& Objects.equals(this.presencePenalty, other.presencePenalty)
@@ -425,9 +446,11 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 
 		private @Nullable ToolChoice toolChoice;
 
+		private @Nullable PromptMode promptMode;
+
 		private @Nullable ReasoningEffort reasoningEffort;
 
-		public B model(MistralAiApi.@Nullable ChatModel chatModel) {
+		public B model(@Nullable ChatModel chatModel) {
 			if (chatModel != null) {
 				this.model(chatModel.getName());
 			}
@@ -449,6 +472,11 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 
 		public B stop(@Nullable List<String> stop) {
 			super.stopSequences(stop);
+			return self();
+		}
+
+		public B promptMode(@Nullable PromptMode promptMode) {
+			this.promptMode = promptMode;
 			return self();
 		}
 
@@ -513,6 +541,9 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 				if (that.toolChoice != null) {
 					this.toolChoice = that.toolChoice;
 				}
+				if (that.promptMode != null) {
+					this.promptMode = that.promptMode;
+				}
 				if (that.reasoningEffort != null) {
 					this.reasoningEffort = that.reasoningEffort;
 				}
@@ -526,7 +557,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 			// TODO: add assertions, remove SuppressWarnings
 			// Assert.state(this.model != null, "model must be set");
 			return new MistralAiChatOptions(this.model, this.temperature, this.topP, this.maxTokens, this.safePrompt,
-					this.randomSeed, this.responseFormat, this.stopSequences, this.reasoningEffort,
+					this.randomSeed, this.responseFormat, this.stopSequences, this.promptMode, this.reasoningEffort,
 					this.frequencyPenalty, this.presencePenalty, this.n, this.tools, this.toolChoice,
 					this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled, this.toolContext);
 		}

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -291,7 +291,8 @@ public class MistralAiApi {
 		MINISTRAL_3B("ministral-3b-latest"),
 		MINISTRAL_8B("ministral-8b-latest"),
 		MINISTRAL_14B("ministral-14b-latest"),
-		@Deprecated(forRemoval = true) // Retirement planed the 31st of July 2026
+		@Deprecated(forRemoval = true) // Retirement planned the 31st of July 2026
+		// It is an alias for mistral-small-latest and behaves accordingly.
 		MAGISTRAL_SMALL("magistral-small-latest"),
 		DEVSTRAL_SMALL("devstral-small-latest"),
 		MISTRAL_SMALL("mistral-small-latest"),
@@ -676,7 +677,9 @@ public class MistralAiApi {
 	 * result as JSON.
 	 * @param safePrompt Whether to inject a safety prompt before all conversations.
 	 * @param stop A list of tokens that the model should stop generating after.
-	 * @param reasoningEffort Controls the reasoning effort level for reasoning models.
+	 * @param promptMode Controls the system prompt behavior.
+	 * @param reasoningEffort Controls the reasoning effort level for adjustable reasoning
+	 * models.
 	 * @param randomSeed The seed to use for random sampling. If set, different calls will
 	 * generate deterministic results.
 	 * @param responseFormat An object specifying the format or schema that the model must
@@ -701,6 +704,7 @@ public class MistralAiApi {
 			@JsonProperty("stream") @Nullable Boolean stream,
 			@JsonProperty("safe_prompt") @Nullable Boolean safePrompt,
 			@JsonProperty("stop") @Nullable List<String> stop,
+			@JsonProperty("prompt_mode") @Nullable PromptMode promptMode,
 			@JsonProperty("reasoning_effort") @Nullable ReasoningEffort reasoningEffort,
 			@JsonProperty("random_seed") @Nullable Integer randomSeed,
 			@JsonProperty("response_format") @Nullable ResponseFormat responseFormat) {
@@ -714,7 +718,8 @@ public class MistralAiApi {
 		 * @param model ID of the model to use.
 		 */
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model) {
-			this(model, messages, null, null, 0.7, 1.0, null, null, null, null, false, false, null, null, null, null);
+			this(model, messages, null, null, 0.7, 1.0, null, null, null, null, false, false, null, null, null, null,
+					null);
 		}
 
 		/**
@@ -730,7 +735,7 @@ public class MistralAiApi {
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, Double temperature,
 				boolean stream) {
 			this(model, messages, null, null, temperature, 1.0, null, null, null, null, stream, false, null, null, null,
-					null);
+					null, null);
 		}
 
 		/**
@@ -744,7 +749,7 @@ public class MistralAiApi {
 		 */
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, Double temperature) {
 			this(model, messages, null, null, temperature, 1.0, null, null, null, null, false, false, null, null, null,
-					null);
+					null, null);
 		}
 
 		/**
@@ -760,7 +765,7 @@ public class MistralAiApi {
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, List<FunctionTool> tools,
 				ToolChoice toolChoice) {
 			this(model, messages, tools, toolChoice, null, 1.0, null, null, null, null, false, false, null, null, null,
-					null);
+					null, null);
 		}
 
 		/**
@@ -768,7 +773,8 @@ public class MistralAiApi {
 		 * stream.
 		 */
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, Boolean stream) {
-			this(null, messages, null, null, 0.7, 1.0, null, null, null, null, stream, false, null, null, null, null);
+			this(null, messages, null, null, 0.7, 1.0, null, null, null, null, stream, false, null, null, null, null,
+					null);
 		}
 
 		/**
@@ -789,10 +795,28 @@ public class MistralAiApi {
 		}
 
 		/**
+		 * Controls the system prompt behavior. Assignment to actual system prompts is
+		 * handled internally. A system prompt may include knowledge, cutoff date, model
+		 * capabilities, tone to use, safety guidelines...
 		 * <p>
+		 * {@link PromptMode#REASONING} Explicitly uses the default reasoning system
+		 * prompt. Applicable for native reasoning models only.
+		 * </p>
+		 */
+		public enum PromptMode {
+
+			// @formatter:off
+			@JsonProperty("reasoning")
+			REASONING
+			// @formatter:on
+
+		}
+
+		/**
 		 * Controls the reasoning effort level for adjustable reasoning models.
-		 * {@link ReasoningEffort#HIGH} enables comprehensive reasoning traces,
-		 * {@link ReasoningEffort#NONE} disables reasoning effort.
+		 * <p>
+		 * {@link ReasoningEffort#HIGH} Enables comprehensive reasoning traces,
+		 * {@link ReasoningEffort#NONE} Disables reasoning effort.
 		 * </p>
 		 */
 		public enum ReasoningEffort {

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
@@ -654,9 +654,14 @@ class MistralAiChatModelIT {
 	}
 
 	private static Prompt createThinkingPrompt(MistralAiApi.ChatModel chatModel) {
+		var promptMode = ThinkingModelUtils.providePromptMode(chatModel);
 		var reasoningEffort = ThinkingModelUtils.provideReasoningEffort(chatModel);
 		var model = ThinkingModelUtils.provideChatModelValue(chatModel);
-		var chatOptions = MistralAiChatOptions.builder().model(model).reasoningEffort(reasoningEffort).build();
+		var chatOptions = MistralAiChatOptions.builder()
+			.model(model)
+			.promptMode(promptMode)
+			.reasoningEffort(reasoningEffort)
+			.build();
 		var systemMessage = new SystemMessage("You are a helpful assistant providing accurate short answers.");
 		var userMessage = new UserMessage(
 				"What is the first planet of the solar system based on the mass in descending order?");

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ThinkingModelUtils.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ThinkingModelUtils.java
@@ -18,6 +18,7 @@ package org.springframework.ai.mistralai;
 
 import java.util.Set;
 
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.PromptMode;
 import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest.ReasoningEffort;
 import org.springframework.ai.mistralai.api.MistralAiApi.ChatModel;
 import org.springframework.util.Assert;
@@ -41,6 +42,13 @@ public interface ThinkingModelUtils {
 		// Mistral Medium Latest does not yet target model version 3.5, so this temporary
 		// workaround is used.
 		return ChatModel.MISTRAL_MEDIUM == chatModel ? "mistral-medium-3.5" : chatModel.getValue();
+	}
+
+	static PromptMode providePromptMode(ChatModel chatModel) {
+		verifyChatModelIsReasoning(chatModel);
+
+		// Reasoning prompt mode is only supported by Magistral Medium model.
+		return ChatModel.MAGISTRAL_MEDIUM == chatModel ? PromptMode.REASONING : null;
 	}
 
 	static ReasoningEffort provideReasoningEffort(ChatModel chatModel) {

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/api/MistralAiApiIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/api/MistralAiApiIT.java
@@ -262,6 +262,7 @@ class MistralAiApiIT {
 	}
 
 	private static ChatCompletionRequest createChatCompletionRequest(MistralAiApi.ChatModel chatModel, boolean stream) {
+		var promptMode = ThinkingModelUtils.providePromptMode(chatModel);
 		var reasoningEffort = ThinkingModelUtils.provideReasoningEffort(chatModel);
 		var model = ThinkingModelUtils.provideChatModelValue(chatModel);
 		var systemChatCompletionMessage = new ChatCompletionMessage(
@@ -271,7 +272,7 @@ class MistralAiApiIT {
 		var chatCompletionMessages = List.of(systemChatCompletionMessage, userChatCompletionMessage);
 
 		return new ChatCompletionRequest(model, chatCompletionMessages, null, null, 0.7, 1.0, null, null, null, null,
-				stream, false, null, reasoningEffort, null, null);
+				stream, false, null, promptMode, reasoningEffort, null, null);
 	}
 
 	private static boolean hasContent(List<ChatCompletionChunk> chatCompletionChunks,

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -144,6 +144,7 @@ The prefix `spring.ai.mistralai.chat` is the property prefix that lets you confi
 | spring.ai.mistralai.chat.stop | Stop generation if this token is detected. Or if one of these tokens is detected when providing an array. | -
 | spring.ai.mistralai.chat.top-p | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or `temperature` but not both. | -
 | spring.ai.mistralai.chat.response-format | An object specifying the format that the model must output. Setting to `{ "type": "json_object" }` enables JSON mode, which guarantees the message the model generates is valid JSON. Setting to `{ "type": "json_schema" }` with a supplied schema enables native structured outputs, which guarantees the model will match your supplied JSON schema. See the <<structured-output>> section for more details.| -
+| spring.ai.mistralai.chat.prompt-mode | Controls the system prompt behavior. `reasoning` value explicitly uses the default reasoning system prompt. | -
 | spring.ai.mistralai.chat.reasoning-effort | Controls the reasoning effort level for adjustable reasoning models. Valid values include `high` or `none`. | -
 | spring.ai.mistralai.chat.tools | A list of tools the model may call. Currently, only functions are supported as a tool. Use this to provide a list of functions the model may generate JSON inputs for. | -
 | spring.ai.mistralai.chat.tool-choice | Controls which (if any) function is called by the model. `none` means the model will not call a function and instead generates a message. `auto` means the model can pick between generating a message or calling a function. Specifying a particular function via `{"type: "function", "function": {"name": "my_function"}}` forces the model to call that function. `none` is the default when no functions are present. `auto` is the default if functions are present. | -
@@ -265,6 +266,22 @@ Mistral offers two approaches to reasoning:
 
 * Adjustable: Available on Mistral Small 4 and Mistral Medium 3.5 via the `reasoning_effort` parameter. Enables the model to think to varying degrees.
 * Native: Available for the Magistral model family. These models always generate reasoning traces and are purpose-built for deep reasoning tasks.
+
+=== Reasoning Prompt Mode
+
+You can configure the reasoning prompt mode using the `REASONING` value for `promptMode` property in `MistralAiChatOptions`.
+This allows you to apply the default reasoning system prompt while using native reasoning models.
+
+[source,java]
+----
+var options = MistralAiChatOptions.builder()
+    .model(MistralAiApi.ChatModel.MAGISTRAL_MEDIUM.getValue())
+    .promptMode(MistralAiApi.ChatCompletionRequest.PromptMode.REASONING)
+    .build();
+
+ChatResponse response = chatModel.call(
+    new Prompt("Solve this complex math problem...", options));
+----
 
 === Reasoning Effort
 


### PR DESCRIPTION
## Description

The reasoning prompt mode can be applied by using the `REASONING` value for `promptMode` property in `MistralAiChatOptions`. It is applicable only for the native reasoning models.

## Explanations

- I tried this request parameter while working on #5585 but I was confused because it behaves differently between `magistral-medium-latest` and `magistral-small-latest`: I got a 400 error (_Reasoning prompt mode is not enabled for this model_) when using it with `magistral-small-latest`, whereas it worked with `magistral-medium-latest`.
- I figured out that `magistral-small-latest` has its retirement planned the 31st of July 2026 and is now an alias for `mistral-small-latest` and behaves accordingly.
```shell
curl -s https://api.mistral.ai/v1/models/magistral-small-latest \
  -H "Authorization: Bearer $MISTRAL_AI_API_KEY"
{"id":"magistral-small-latest","object":"model","created":1780073669,"owned_by":"mistralai","capabilities":{"completion_chat":true,"function_calling":true,"reasoning":true,"completion_fim":false,"fine_tuning":false,"vision":true,"ocr":false,"classification":false,"moderation":false,"audio":false,"audio_transcription":false,"audio_transcription_realtime":false,"audio_speech":false},"name":"mistral-small-2603","description":"Mistral Small 4.","max_context_length":262144,"aliases":["mistral-small-2603","mistral-small-latest","mistral-vibe-cli-fast"],"deprecation":null,"deprecation_replacement_model":null,"default_model_temperature":0.3,"type":"base"}
```

## Proposed milestone

**2.0.0-RC1**

## Related work

#5585