### PR TITLE
Filter blank system messages in Bedrock Converse requests

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -456,6 +456,7 @@ public class BedrockProxyChatModel implements ChatModel {
 		List<org.springframework.ai.chat.messages.Message> systemMessageList = prompt.getInstructions()
 			.stream()
 			.filter(m -> m.getMessageType() == MessageType.SYSTEM)
+			.filter(m -> StringUtils.hasText(m.getText()))
 			.toList();
 
 		List<SystemContentBlock> systemMessages = new ArrayList<>();

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.bedrock.converse;
 
 import java.net.URL;
+import java.util.List;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,9 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 import org.springframework.ai.bedrock.converse.api.MediaFetcher;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
@@ -86,6 +90,17 @@ class BedrockProxyChatModelTest {
 	void sanitizeDocumentNameShouldPreserveAllowedSpecialCharacters() {
 		String name = "my document (1) [draft]";
 		assertThat(BedrockProxyChatModel.sanitizeDocumentName(name)).isEqualTo(name);
+	}
+
+	@Test
+	void createRequestShouldIgnoreBlankSystemMessages() {
+		BedrockProxyChatModel model = newModel();
+		Prompt prompt = new Prompt(List.of(new SystemMessage(""), new UserMessage("Hello")),
+				BedrockChatOptions.builder().build());
+
+		var request = model.createRequest(prompt);
+
+		assertThat(request.system()).isEmpty();
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Filter blank system messages before creating Bedrock Converse `SystemContentBlock` entries
- Add a regression test to ensure `SystemMessage("")` is not sent as an empty Bedrock system text block

## Motivation

Bedrock rejects empty system text blocks with a validation error because `system.*.member.text` must have length greater than or equal to 1. Spring AI can produce an empty `SystemMessage` in some flows, so the Bedrock Converse adapter should not serialize blank system text into the request.

Fixes gh-6205.

## Testing

```bash
./mvnw -pl models/spring-ai-bedrock-converse \
  -Dtest=BedrockProxyChatModelTest#createRequestShouldIgnoreBlankSystemMessages \
  -Dmaven.build.cache.enabled=false test
```
