### PR TITLE
Update Mistral AI chat models

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -282,20 +282,22 @@ public class MistralAiApi {
 
 		// @formatter:off
 		// Premier Models
+		@Deprecated(forRemoval = true) // Retirement planned the 31st of July 2026
 		MAGISTRAL_MEDIUM("magistral-medium-latest"),
-		MISTRAL_MEDIUM("mistral-medium-latest"),
 		CODESTRAL("codestral-latest"),
-		DEVSTRAL_MEDIUM("devstral-medium-latest"),
-		MISTRAL_LARGE("mistral-large-latest"),
 		// Free Models
 		MINISTRAL_3B("ministral-3b-latest"),
 		MINISTRAL_8B("ministral-8b-latest"),
 		MINISTRAL_14B("ministral-14b-latest"),
-		@Deprecated(forRemoval = true) // Retirement planed the 31st of July 2026
-		MAGISTRAL_SMALL("magistral-small-latest"),
-		DEVSTRAL_SMALL("devstral-small-latest"),
 		MISTRAL_SMALL("mistral-small-latest"),
+		MISTRAL_MEDIUM("mistral-medium-latest"),
+		MISTRAL_LARGE("mistral-large-latest"),
+		@Deprecated(forRemoval = true) // Retirement planned the 31st of July 2026
+		DEVSTRAL("devstral-latest"),
+		@Deprecated(forRemoval = true) // Retirement planned the 31st of July 2026
+		MAGISTRAL_SMALL("magistral-small-latest"),
 		// Free Models - Research
+		@Deprecated(forRemoval = true) // Retirement planned the 31st of July 2026
 		OPEN_MISTRAL_NEMO("open-mistral-nemo");
 		// @formatter:on
 


### PR DESCRIPTION
## Description

- Remove devstral-medium-latest planned for retirement the 31st of May 2026,
- Replace devstral-small-latest retired the 31st of March 2026 by devstral-latest,
- Deprecate magistral-medium-latest, devstral-latest and open-mistral-nemo,
- Reorganize premier and free models.

## Explanations

See Mistral AI Models documentation, especially [Legacy Models section](https://docs.mistral.ai/models/overview#legacy-models).

## Proposed milestone

**2.0.0-RC1**