### PR TITLE
fix: prevent IllegalStateException when ToolResponseMessage has no responses (GH-6197)

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -815,20 +815,16 @@ public final class OpenAiChatModel implements ChatModel {
 				else if (message.getMessageType() == MessageType.TOOL) {
 					ToolResponseMessage toolMessage = (ToolResponseMessage) message;
 
-					ChatCompletionToolMessageParam.Builder builder = ChatCompletionToolMessageParam.builder();
-					builder.content(toolMessage.getText() != null ? toolMessage.getText() : "");
-					builder.role(JsonValue.from(MessageType.TOOL.getValue()));
-
-					if (toolMessage.getResponses().isEmpty()) {
-						return List.of(ChatCompletionMessageParam.ofTool(builder.build()));
-					}
-					return toolMessage.getResponses().stream().map(response -> {
-						String callId = response.id();
-						String callResponse = response.responseData();
-
-						return ChatCompletionMessageParam
-							.ofTool(builder.toolCallId(callId).content(callResponse).build());
-					}).toList();
+					return toolMessage.getResponses()
+						.stream()
+						.filter(response -> StringUtils.hasText(response.id()))
+						.map(response -> {
+							ChatCompletionToolMessageParam.Builder builder = ChatCompletionToolMessageParam.builder();
+							builder.role(JsonValue.from(MessageType.TOOL.getValue()));
+							return ChatCompletionMessageParam
+								.ofTool(builder.toolCallId(response.id()).content(response.responseData()).build());
+						})
+						.toList();
 				}
 				else {
 					throw new IllegalArgumentException("Unsupported message type: " + message.getMessageType());

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
@@ -36,6 +37,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.PromptMetadata;
 import org.springframework.ai.chat.metadata.RateLimit;
@@ -191,6 +194,73 @@ class OpenAiChatModelTests {
 		assertThatThrownBy(() -> chatModel.createRequest(new Prompt("test", options), false))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Failed to parse toolChoice JSON");
+	}
+
+	@Test
+	void toolResponseMessageWithPopulatedResponses_mapsToOneParamPerResponse() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ToolResponseMessage toolMsg = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "myTool", "result1"),
+					new ToolResponseMessage.ToolResponse("call_2", "myTool", "result2")))
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt(List.of(toolMsg), options), false);
+
+		List<String> toolCallIds = request.messages()
+			.stream()
+			.filter(msg -> msg.isTool())
+			.map(msg -> msg.asTool().toolCallId())
+			.collect(Collectors.toList());
+
+		assertThat(toolCallIds).containsExactly("call_1", "call_2");
+	}
+
+	@Test
+	void toolResponseMessageWithEmptyResponses_producesNoMessages() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ToolResponseMessage emptyToolMsg = ToolResponseMessage.builder().build();
+
+		ChatCompletionCreateParams request = chatModel
+			.createRequest(new Prompt(List.of(new UserMessage("hello"), emptyToolMsg), options), false);
+
+		assertThat(request.messages().stream().filter(msg -> msg.isTool()).toList()).isEmpty();
+	}
+
+	@Test
+	void toolResponseMessageWithNullId_skipsResponse() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ToolResponseMessage toolMsg = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "myTool", "result1"),
+					new ToolResponseMessage.ToolResponse(null, "badTool", "result2")))
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt(List.of(toolMsg), options), false);
+
+		List<String> toolCallIds = request.messages()
+			.stream()
+			.filter(msg -> msg.isTool())
+			.map(msg -> msg.asTool().toolCallId())
+			.collect(Collectors.toList());
+
+		assertThat(toolCallIds).containsExactly("call_1");
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

With the new OpenAI Java SDK, `ChatCompletionToolMessageParam.builder().build()` now throws `IllegalStateException: toolCallId is required` at build time if `toolCallId` is not set. The previous code had two bugs that trigger this:

1. **Empty responses path**: when `ToolResponseMessage.getResponses()` is empty, the old code called `builder.build()` without ever setting `toolCallId`.
2. **Builder reuse**: a single `builder` instance was shared across all responses in the stream, meaning state from a previous response (e.g. a null ID) could bleed into the next.

The `ToolCallAdvisor` introduced in M7 auto-registers when tools are configured, changing the tool call flow and exposing both of these latent bugs.

## Fix

- Stream through `toolMessage.getResponses()`, skipping entries where `id` is null/empty.
- Create a fresh `ChatCompletionToolMessageParam.Builder` per response to eliminate builder-reuse state leakage.
- Remove the separate empty-responses early-return branch (now handled naturally by the filtered stream returning an empty list).

## Tests

Three new unit tests added to `OpenAiChatModelTests`:

- `toolResponseMessageWithPopulatedResponses_mapsToOneParamPerResponse` — verifies each response maps to one tool message param.
- `toolResponseMessageWithEmptyResponses_producesNoMessages` — verifies an empty `ToolResponseMessage` produces zero tool-typed params.
- `toolResponseMessageWithNullId_skipsResponse` — verifies responses with null IDs are filtered out.

Fixes #6197