### PR TITLE
GH-6206: Update tool callback guidance

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-examples.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-examples.adoc
@@ -680,7 +680,7 @@ public class McpClientApplication {
         return args -> {
 
             ChatClient chatClient = ChatClient.builder(openAiChatModel)
-                    .defaultToolCallbacks(mcpToolProvider)
+                    .defaultTools(t -> t.callbacks(mcpToolProvider))
                     .build();
 
             String userQuestion = """

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-security.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-security.adoc
@@ -505,7 +505,8 @@ Then add the client to your chat client:
 [source,java]
 ----
 var chatResponse = chatClient.prompt("Prompt the LLM to do the thing")
-        .toolCallbacks(new SyncMcpToolCallbackProvider(mcpClient1, mcpClient2, mcpClient3))
+        .tools(t -> t.callbacks(new SyncMcpToolCallbackProvider(
+                mcpClient1, mcpClient2, mcpClient3)))
         .call()
         .content();
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools-migration.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools-migration.adoc
@@ -63,10 +63,10 @@ After:
 String response = ChatClient.create(chatModel)
     .prompt()
     .user("What's the weather like in San Francisco?")
-    .tools(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
-        .description("Get the weather in location")
-        .inputType(MockWeatherService.Request.class)
-        .build())
+    .tools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+            .description("Get the weather in location")
+            .inputType(MockWeatherService.Request.class)
+            .build()))
     .call()
     .content();
 ----
@@ -116,12 +116,12 @@ And you can use the same `ChatClient#tools()` API to register method-based tool 
 String response = ChatClient.create(chatModel)
     .prompt()
     .user("What's the weather like in San Francisco?")
-    .tools(MethodToolCallback.builder()
-        .toolDefinition(ToolDefinition.builder(toolMethod)
-            .description("Get the weather in location")
-            .build())
-        .toolMethod(toolMethod)
-        .build())
+    .tools(t -> t.callbacks(MethodToolCallback.builder()
+            .toolDefinition(ToolDefinition.builder(toolMethod)
+                .description("Get the weather in location")
+                .build())
+            .toolMethod(toolMethod)
+            .build()))
     .call()
     .content();
 ----
@@ -176,10 +176,10 @@ After:
 [source,java]
 ----
 ChatClient.builder(chatModel)
-    .defaultTools(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
-        .description("Get the weather in location")
-        .inputType(MockWeatherService.Request.class)
-        .build())
+    .defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+            .description("Get the weather in location")
+            .inputType(MockWeatherService.Request.class)
+            .build()))
     .build()
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1197,7 +1197,7 @@ ChatModel chatModel = ...
 ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
 
 ChatOptions chatOptions = ToolCallingChatOptions.builder()
-    .toolCallbacks(new CustomerTools())
+    .toolCallbacks(ToolCallbacks.from(new CustomerTools()))
     .internalToolExecutionEnabled(false)
     .build();
 Prompt prompt = new Prompt("Tell me more about the customer with ID 42", chatOptions);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/guides/getting-started-mcp.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/guides/getting-started-mcp.adoc
@@ -63,7 +63,7 @@ public CommandLineRunner demo(ChatClient chatClient, ToolCallbackProvider mcpToo
     return args -> {
         String response = chatClient
             .prompt("What's the weather like in Paris?")
-            .toolCallbacks(mcpTools)
+            .tools(t -> t.callbacks(mcpTools))
             .call()
             .content();
         System.out.println(response);

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
@@ -75,8 +75,9 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 				.toList();
 
 			if (toolMethods.isEmpty()) {
-				throw new IllegalStateException("No @Tool annotated methods found in " + toolObject + "."
-						+ "Did you mean to pass a ToolCallback or ToolCallbackProvider? If so, you have to use .toolCallbacks() instead of .tool()");
+				throw new IllegalStateException("No @Tool annotated methods found in " + toolObject + ". "
+						+ "Did you mean to pass a ToolCallback or ToolCallbackProvider? If so, you have to use"
+						+ " .tools(toolSpec -> toolSpec.callbacks(...)) instead of .tools(...)");
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

I'm not sure whether the maintainers want to add `tools(ToolCallback...)` and `tools(ToolCallbackProvider...)` overloads. This PR does not add those APIs. Instead, it updates the exception message and documentation examples that currently point users toward deprecated or incorrect usage.

## Changes

- Update the `MethodToolCallbackProvider` exception message to suggest using `tools(toolSpec -> toolSpec.callbacks(...))` instead of passing callbacks/providers directly to `tools(...)`.
- Update MCP and tool migration documentation examples to pass `ToolCallback` and `ToolCallbackProvider` instances through `callbacks(...)`.
- Fix a `ToolCallingChatOptions` example that passed an `@Tool` object directly to `toolCallbacks(...)` by converting it with `ToolCallbacks.from(...)`.

## Tests

- `./mvnw -pl spring-ai-model -Dtest=MethodToolCallbackProviderTests test`

Related #6206