### PR TITLE
GH-6207: Make JSON schema generation thread-safe

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -89,6 +89,8 @@ public final class JsonSchemaGenerator {
 
 	private static final SchemaGenerator SUBTYPE_SCHEMA_GENERATOR;
 
+	private static final Object SCHEMA_GENERATION_LOCK = new Object();
+
 	/*
 	 * Initialize JSON Schema generators.
 	 */
@@ -149,7 +151,7 @@ public final class JsonSchemaGenerator {
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);
 			}
-			ObjectNode parameterNode = SUBTYPE_SCHEMA_GENERATOR.generateSchema(parameterType);
+			ObjectNode parameterNode = generateSchema(SUBTYPE_SCHEMA_GENERATOR, parameterType);
 			// victools generates self-contained schemas where $defs and the $ref
 			// pointers into them are rooted at the sub-schema. Inlining the
 			// sub-schema under properties.<paramName> re-parents existing
@@ -182,12 +184,18 @@ public final class JsonSchemaGenerator {
 	 */
 	public static String generateForType(Type type, SchemaOption... schemaOptions) {
 		Assert.notNull(type, "type cannot be null");
-		ObjectNode schema = TYPE_SCHEMA_GENERATOR.generateSchema(type);
+		ObjectNode schema = generateSchema(TYPE_SCHEMA_GENERATOR, type);
 		if ((type == Void.class) && !schema.has("properties")) {
 			schema.putObject("properties");
 		}
 		processSchemaOptions(schemaOptions, schema);
 		return schema.toPrettyString();
+	}
+
+	private static ObjectNode generateSchema(SchemaGenerator schemaGenerator, Type type) {
+		synchronized (SCHEMA_GENERATION_LOCK) {
+			return schemaGenerator.generateSchema(type);
+		}
 	}
 
 	private static void processSchemaOptions(SchemaOption[] schemaOptions, ObjectNode schema) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaUtils.java
@@ -57,6 +57,8 @@ public final class JsonSchemaUtils {
 
 	private static final AtomicReference<@Nullable SchemaGenerator> SCHEMA_GENERATOR_CACHE = new AtomicReference<>();
 
+	private static final Object SCHEMA_GENERATION_LOCK = new Object();
+
 	private JsonSchemaUtils() {
 	}
 
@@ -220,14 +222,24 @@ public final class JsonSchemaUtils {
 			SCHEMA_GENERATOR_CACHE.compareAndSet(null, generator);
 		}
 
-		@SuppressWarnings("NullAway")
-		ObjectNode node = SCHEMA_GENERATOR_CACHE.get().generateSchema(inputType);
+		SchemaGenerator generator = SCHEMA_GENERATOR_CACHE.get();
+		if (generator == null) {
+			throw new IllegalStateException("SchemaGenerator cache was not initialized");
+		}
+
+		ObjectNode node = generateSchema(generator, inputType);
 
 		if ((inputType == Void.class) && !node.has("properties")) {
 			node.putObject("properties");
 		}
 
 		return node;
+	}
+
+	private static ObjectNode generateSchema(SchemaGenerator schemaGenerator, Type inputType) {
+		synchronized (SCHEMA_GENERATION_LOCK) {
+			return schemaGenerator.generateSchema(inputType);
+		}
 	}
 
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -23,12 +23,22 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 
 import org.springframework.ai.chat.model.ToolContext;
@@ -890,6 +900,48 @@ class JsonSchemaGeneratorTests {
 			.hasMessage("type cannot be null");
 	}
 
+	// gh-6207: Victools' Jackson property sorter keeps mutable ordering state, so
+	// concurrent schema generation for structured outputs and tool inputs must be
+	// serialized by Spring AI.
+	@Test
+	void generateSchemasConcurrently() throws Exception {
+		Class<?>[] types = { OrderedStatement.class, Person.class, TestData.class, MoreTestData.class,
+				SearchRequest.class, OuterA.SearchRequest.class, OuterB.SearchRequest.class };
+		Method[] methods = {
+				TestMethods.class.getDeclaredMethod("complexMethod", List.class, TestData.class, MoreTestData.class),
+				TestMethods.class.getDeclaredMethod("searchBooksMethod", SearchRequest.class),
+				TestMethods.class.getDeclaredMethod("collidingSimpleNameMethod", OuterA.SearchRequest.class,
+						OuterB.SearchRequest.class) };
+		int threads = 24;
+		int iterations = 300;
+
+		ExecutorService executor = Executors.newFixedThreadPool(threads);
+		CountDownLatch start = new CountDownLatch(1);
+		List<Callable<Void>> tasks = IntStream.range(0, threads).<Callable<Void>>mapToObj(worker -> () -> {
+			start.await();
+			for (int i = 0; i < iterations; i++) {
+				JsonSchemaGenerator.generateForType(types[(worker + i) % types.length]);
+				JsonSchemaGenerator.generateForMethodInput(methods[(worker + i) % methods.length]);
+			}
+			return null;
+		}).toList();
+		List<Future<Void>> futures = tasks.stream().map(executor::submit).toList();
+		Logger schemaLogger = (Logger) LoggerFactory.getLogger("com.github.victools.jsonschema.generator");
+		Level schemaLoggerLevel = schemaLogger.getLevel();
+		schemaLogger.setLevel(Level.INFO);
+
+		try {
+			start.countDown();
+			for (Future<Void> future : futures) {
+				future.get();
+			}
+		}
+		finally {
+			schemaLogger.setLevel(schemaLoggerLevel);
+			executor.shutdownNow();
+		}
+	}
+
 	static class TestMethods {
 
 		public void simpleMethod(String name, int age) {
@@ -1027,6 +1079,12 @@ class JsonSchemaGeneratorTests {
 	}
 
 	record WithMapField(String name, Map<String, Integer> scores) {
+
+	}
+
+	@JsonPropertyOrder({ "accountId", "accountName", "currency", "totals" })
+	record OrderedStatement(@JsonProperty(required = true) String accountId,
+			@JsonProperty(required = true) String accountName, String currency, Map<String, Double> totals) {
 
 	}
 


### PR DESCRIPTION
Fixes GH-6207

JSON schema generation reuses Victools `SchemaGenerator` instances. With Jackson property ordering enabled, concurrent schema generation can race inside Victools' mutable property-ordering state and fail with `ConcurrentModificationException`.

This change serializes calls into the shared schema generators used by `JsonSchemaGenerator` and `JsonSchemaUtils`, while leaving the generated schema behavior unchanged. It also adds a concurrent regression test using ordered DTOs.

Tests:

- `./mvnw -pl spring-ai-model -Dmaven.build.cache.enabled=false -Dtest=JsonSchemaGeneratorTests#generateSchemasConcurrently test`
- `./mvnw -pl spring-ai-model -Dmaven.build.cache.enabled=false -Dtest=JsonSchemaGeneratorTests,JsonSchemaUtilsTests,BeanOutputConverterTest test`
- `./mvnw -pl spring-ai-model -Dmaven.build.cache.enabled=false clean test`

I also tried the root build, but latest `main` currently fails before completion in `spring-ai-advisors-vector-store` with existing NullAway errors in `QuestionAnswerAdvisor` and `VectorStoreChatMemoryAdvisor`. I verified the same failure from a clean latest `main` checkout.