### PR TITLE
Guard JSON schema generation

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -123,6 +123,12 @@ public final class JsonSchemaGenerator {
 	private JsonSchemaGenerator() {
 	}
 
+	private static ObjectNode generateSchema(SchemaGenerator generator, Type type) {
+		synchronized (generator) {
+			return generator.generateSchema(type);
+		}
+	}
+
 	/**
 	 * Generate a JSON Schema for a method's input parameters.
 	 */
@@ -149,7 +155,7 @@ public final class JsonSchemaGenerator {
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);
 			}
-			ObjectNode parameterNode = SUBTYPE_SCHEMA_GENERATOR.generateSchema(parameterType);
+			ObjectNode parameterNode = generateSchema(SUBTYPE_SCHEMA_GENERATOR, parameterType);
 			// victools generates self-contained schemas where $defs and the $ref
 			// pointers into them are rooted at the sub-schema. Inlining the
 			// sub-schema under properties.<paramName> re-parents existing
@@ -182,7 +188,7 @@ public final class JsonSchemaGenerator {
 	 */
 	public static String generateForType(Type type, SchemaOption... schemaOptions) {
 		Assert.notNull(type, "type cannot be null");
-		ObjectNode schema = TYPE_SCHEMA_GENERATOR.generateSchema(type);
+		ObjectNode schema = generateSchema(TYPE_SCHEMA_GENERATOR, type);
 		if ((type == Void.class) && !schema.has("properties")) {
 			schema.putObject("properties");
 		}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaUtils.java
@@ -60,6 +60,12 @@ public final class JsonSchemaUtils {
 	private JsonSchemaUtils() {
 	}
 
+	private static ObjectNode generateSchema(SchemaGenerator generator, Type inputType) {
+		synchronized (generator) {
+			return generator.generateSchema(inputType);
+		}
+	}
+
 	/**
 	 * Moves any {@code $defs} block found on {@code subSchema} into the {@code $defs}
 	 * block of {@code rootSchema}, creating one on the root if needed. On key collisions
@@ -220,8 +226,11 @@ public final class JsonSchemaUtils {
 			SCHEMA_GENERATOR_CACHE.compareAndSet(null, generator);
 		}
 
-		@SuppressWarnings("NullAway")
-		ObjectNode node = SCHEMA_GENERATOR_CACHE.get().generateSchema(inputType);
+		SchemaGenerator schemaGenerator = SCHEMA_GENERATOR_CACHE.get();
+		if (schemaGenerator == null) {
+			throw new IllegalStateException("JSON Schema generator has not been initialized");
+		}
+		ObjectNode node = generateSchema(schemaGenerator, inputType);
 
 		if ((inputType == Void.class) && !node.has("properties")) {
 			node.putObject("properties");

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -21,8 +21,15 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -885,9 +892,52 @@ class JsonSchemaGeneratorTests {
 	}
 
 	@Test
+	void generateSchemaForTypeCanRunConcurrently() throws Exception {
+		List<String> schemas = generateConcurrently(() -> JsonSchemaGenerator.generateForType(SearchRequest.class));
+
+		assertThat(schemas).hasSize(240);
+		assertThat(schemas).allSatisfy(schema -> assertThat(schema).contains("\"properties\""));
+	}
+
+	@Test
+	void generateSchemaForMethodInputCanRunConcurrently() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("searchBooksMethod", SearchRequest.class);
+
+		List<String> schemas = generateConcurrently(() -> JsonSchemaGenerator.generateForMethodInput(method));
+
+		assertThat(schemas).hasSize(240);
+		assertThat(schemas).allSatisfy(schema -> assertThat(schema).contains("\"$defs\""));
+	}
+
+	@Test
 	void throwExceptionWhenTypeIsNull() {
 		assertThatThrownBy(() -> JsonSchemaGenerator.generateForType(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("type cannot be null");
+	}
+
+	private static List<String> generateConcurrently(Callable<String> generator) throws Exception {
+		int threadCount = 12;
+		int callCount = 240;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		try {
+			List<Future<String>> futures = new ArrayList<>();
+			for (int i = 0; i < callCount; i++) {
+				futures.add(executor.submit(() -> {
+					start.await();
+					return generator.call();
+				}));
+			}
+			start.countDown();
+			List<String> schemas = new ArrayList<>();
+			for (Future<String> future : futures) {
+				schemas.add(future.get(30, TimeUnit.SECONDS));
+			}
+			return schemas;
+		}
+		finally {
+			executor.shutdownNow();
+		}
 	}
 
 	static class TestMethods {

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/schema/JsonSchemaUtilsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/schema/JsonSchemaUtilsTests.java
@@ -16,9 +16,18 @@
 
 package org.springframework.ai.util.json.schema;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ObjectNode;
 
 import org.springframework.ai.util.JsonHelper;
 
@@ -157,6 +166,43 @@ class JsonSchemaUtilsTests {
 		String normalizedSchema = JsonSchemaUtils.ensureValidInputSchema("");
 
 		assertThat(normalizedSchema).isEmpty();
+	}
+
+	@Test
+	void getJsonSchemaCanRunConcurrently() throws Exception {
+		List<ObjectNode> schemas = generateConcurrently(() -> JsonSchemaUtils.getJsonSchema(Person.class));
+
+		assertThat(schemas).hasSize(240);
+		assertThat(schemas)
+			.allSatisfy(schema -> assertThat(schema.at("/properties/name/type").asString()).isEqualTo("string"));
+	}
+
+	private static <T> List<T> generateConcurrently(Callable<T> generator) throws Exception {
+		int threadCount = 12;
+		int callCount = 240;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		try {
+			List<Future<T>> futures = new ArrayList<>();
+			for (int i = 0; i < callCount; i++) {
+				futures.add(executor.submit(() -> {
+					start.await();
+					return generator.call();
+				}));
+			}
+			start.countDown();
+			List<T> schemas = new ArrayList<>();
+			for (Future<T> future : futures) {
+				schemas.add(future.get(30, TimeUnit.SECONDS));
+			}
+			return schemas;
+		}
+		finally {
+			executor.shutdownNow();
+		}
+	}
+
+	record Person(String name, int age) {
 	}
 
 }


### PR DESCRIPTION
Fixes GH-6207.

Victools' SchemaGenerator instances are shared by the schema utilities, but schema generation can be reached concurrently through structured output and tool schema paths.

This guards calls into the shared generators and adds concurrent coverage for the type, method input, and utility code paths.

Tests:
- `.\mvnw.cmd -pl spring-ai-model -Dtest=JsonSchemaGeneratorTests,JsonSchemaUtilsTests test`