### PR TITLE
fix: use list position instead of API index when looking up chunk choice in OpenAI streaming

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
@@ -318,7 +319,9 @@ public final class OpenAiChatModel implements ChatModel {
 					try {
 						ChatCompletion chatCompletion = chunkToChatCompletion(chunk);
 						String id = chatCompletion.id();
-						List<Generation> generations = chatCompletion.choices().stream().map(choice -> {
+						List<ChatCompletion.Choice> choiceList = chatCompletion.choices();
+						List<Generation> generations = IntStream.range(0, choiceList.size()).mapToObj(i -> {
+							ChatCompletion.Choice choice = choiceList.get(i);
 							roleMap.putIfAbsent(id, choice.message()._role().asString().isPresent()
 									? choice.message()._role().asStringOrThrow() : "");
 
@@ -327,7 +330,7 @@ public final class OpenAiChatModel implements ChatModel {
 									choice.message().refusal().isPresent() ? choice.message().refusal() : "",
 									"annotations", choice.message().annotations().isPresent()
 											? choice.message().annotations() : List.of(),
-									"chunkChoice", chunk.choices().get((int) choice.index()));
+									"chunkChoice", chunk.choices().get(i));
 
 							return buildGeneration(choice, metadata, request);
 						}).toList();

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -17,18 +17,24 @@
 package org.springframework.ai.openai;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
+import com.openai.core.http.AsyncStreamResponse;
 import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessage;
 import com.openai.models.completions.CompletionUsage;
+import com.openai.services.async.ChatServiceAsync;
+import com.openai.services.async.chat.ChatCompletionServiceAsync;
 import com.openai.services.blocking.ChatService;
 import com.openai.services.blocking.chat.ChatCompletionService;
 import org.junit.jupiter.api.Test;
@@ -224,6 +230,53 @@ class OpenAiChatModelTests {
 		assertThat(aggregatedMetadata.getRateLimit()).isSameAs(rateLimit);
 		assertThat(aggregatedMetadata.getPromptMetadata()).isSameAs(promptMetadata);
 		assertThat((String) aggregatedMetadata.get("custom-key")).isEqualTo("custom-value");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void streamingDoesNotThrowWhenChoiceApiIndexExceedsListSize() {
+		ChatCompletionChunk chunk = ChatCompletionChunk.builder()
+			.id("stream-id")
+			.created(1234567890L)
+			.model("test-model")
+			.addChoice(ChatCompletionChunk.Choice.builder()
+				.index(1L)
+				.delta(ChatCompletionChunk.Choice.Delta.builder().content("hello").build())
+				.finishReason(ChatCompletionChunk.Choice.FinishReason.STOP)
+				.build())
+			.build();
+
+		ChatServiceAsync chatServiceAsync = mock(ChatServiceAsync.class);
+		ChatCompletionServiceAsync chatCompletionServiceAsync = mock(ChatCompletionServiceAsync.class);
+		AsyncStreamResponse<ChatCompletionChunk> streamResponse = mock(AsyncStreamResponse.class);
+
+		when(this.openAiClientAsync.chat()).thenReturn(chatServiceAsync);
+		when(chatServiceAsync.completions()).thenReturn(chatCompletionServiceAsync);
+		when(chatCompletionServiceAsync.createStreaming(any(ChatCompletionCreateParams.class)))
+			.thenReturn(streamResponse);
+
+		CompletableFuture<Void> completeFuture = new CompletableFuture<>();
+		when(streamResponse.subscribe(any())).thenAnswer(invocation -> {
+			AsyncStreamResponse.Handler<ChatCompletionChunk> handler = invocation.getArgument(0);
+			handler.onNext(chunk);
+			handler.onComplete(Optional.empty());
+			completeFuture.complete(null);
+			return streamResponse;
+		});
+		when(streamResponse.onCompleteFuture()).thenReturn(completeFuture);
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		org.springframework.ai.chat.model.ChatResponse response = chatModel
+			.stream(new org.springframework.ai.chat.prompt.Prompt("hi", options))
+			.blockLast(Duration.ofSeconds(5));
+		assertThat(response).isNotNull();
+		assertThat(response.getResult().getOutput().getText()).isEqualTo("hello");
 	}
 
 }


### PR DESCRIPTION
## Summary

Fixes an `IndexOutOfBoundsException` in `OpenAiChatModel.internalStream` that occurs when a streaming chunk contains a choice whose `index` API field value does not match its position in the `choices` list.

Closes #6023

## Root cause

In the streaming path, each `Generation`'s metadata included a `chunkChoice` entry populated by:

```java
"chunkChoice", chunk.choices().get((int) choice.index())
```

`choice.index()` is the **semantic** index from the OpenAI API response (e.g., `0` or `1`), not the **positional** index within the `choices` array. When a gateway sends a single chunk choice with `index: 1`, `chunk.choices()` has length 1 (position 0 only), so `get(1)` throws `IndexOutOfBoundsException`.

This breaks with:
- OpenAI-compatible gateways that use non-zero-based choice indices
- Usage-only final chunks with fewer choices than expected
- Responses where choices arrive in non-sequential order

## Fix

Switch from `Stream.map` to `IntStream.range` so the **list position** `i` is used for the chunk choice lookup, while `choice.index()` (the API field) continues to be stored in metadata:

```java
// Before (broken):
List<Generation> generations = chatCompletion.choices().stream().map(choice -> {
    ...
    "chunkChoice", chunk.choices().get((int) choice.index())  // uses API index as list pos
    ...
}).toList();

// After (fixed):
List<ChatCompletion.Choice> choiceList = chatCompletion.choices();
List<Generation> generations = IntStream.range(0, choiceList.size()).mapToObj(i -> {
    ChatCompletion.Choice choice = choiceList.get(i);
    ...
    "chunkChoice", chunk.choices().get(i)  // uses list position
    ...
}).toList();
```

This is safe because `chunkToChatCompletion()` converts `chunk.choices()` in order, so position `i` in `chatCompletion.choices()` always corresponds to position `i` in `chunk.choices()`.

## Test

Added `streamingDoesNotThrowWhenChoiceApiIndexExceedsListSize` in `OpenAiChatModelTests` that mocks the async streaming path with a chunk containing a single choice having `index=1` (API index != list position 0) and asserts the response completes successfully.

## Test plan

- [x] New test `streamingDoesNotThrowWhenChoiceApiIndexExceedsListSize` passes
- [x] All 8 tests in `OpenAiChatModelTests` pass