### PR TITLE
GH-5994: Validate initialize params and handle null error messages in WebMvcStreamableServerTransportProvider

### DIFF
--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -390,6 +390,16 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 				McpSchema.InitializeRequest initializeRequest = this.jsonMapper.convertValue(jsonrpcRequest.params(),
 						new TypeRef<McpSchema.InitializeRequest>() {
 						});
+				if (initializeRequest == null || initializeRequest.protocolVersion() == null
+						|| initializeRequest.protocolVersion().isBlank() || initializeRequest.capabilities() == null
+						|| initializeRequest.clientInfo() == null) {
+					logger.debug("Rejecting malformed initialize request: missing required fields");
+					return ServerResponse.badRequest()
+						.body(McpError.builder(McpSchema.ErrorCodes.INVALID_PARAMS)
+							.message(
+									"Invalid initialize params: protocolVersion, capabilities, and clientInfo are required")
+							.build());
+				}
 				var sf = this.sessionFactory;
 				if (sf == null) {
 					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -410,9 +420,10 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 								null));
 				}
 				catch (Exception e) {
-					logger.error("Failed to initialize session: {}", e.getMessage());
+					String errorMessage = e.getMessage() != null ? e.getMessage() : "Session initialization failed";
+					logger.warn("Failed to initialize session: {}", errorMessage);
 					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-						.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR).message(e.getMessage()).build());
+						.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR).message(errorMessage).build());
 				}
 			}
 

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProviderIT.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProviderIT.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc.transport;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.mcp.server.TomcatTestUtil;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link WebMvcStreamableServerTransportProvider} covering
+ * edge-case request validation.
+ *
+ * @author Gorre Surya
+ */
+class WebMvcStreamableServerTransportProviderIT {
+
+	private static final String MCP_ENDPOINT = "/mcp/message";
+
+	private TomcatTestUtil.TomcatServer tomcatServer;
+
+	private int port;
+
+	private HttpClient httpClient;
+
+	@BeforeEach
+	void before() {
+		this.tomcatServer = TomcatTestUtil.createTomcatServer("", 0, TestConfig.class);
+		try {
+			this.tomcatServer.tomcat().start();
+			assertThat(this.tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+		this.port = this.tomcatServer.tomcat().getConnector().getLocalPort();
+		this.httpClient = HttpClient.newHttpClient();
+	}
+
+	@AfterEach
+	void after() {
+		if (this.tomcatServer.appContext() != null) {
+			this.tomcatServer.appContext().close();
+		}
+		if (this.tomcatServer.tomcat() != null) {
+			try {
+				this.tomcatServer.tomcat().stop();
+				this.tomcatServer.tomcat().destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Test
+	void malformedInitializeParamsReturns400WithInvalidParams() throws Exception {
+		String body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}";
+
+		HttpRequest request = HttpRequest.newBuilder()
+			.uri(URI.create("http://127.0.0.1:" + this.port + MCP_ENDPOINT))
+			.header("Content-Type", "application/json")
+			.header("Accept", "application/json, text/event-stream")
+			.POST(HttpRequest.BodyPublishers.ofString(body))
+			.build();
+
+		HttpResponse<String> response = this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+		assertThat(response.statusCode()).isEqualTo(400);
+		assertThat(response.body()).contains("protocolVersion");
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcStreamableServerTransportProvider webMvcStreamableServerTransportProvider() {
+			return WebMvcStreamableServerTransportProvider.builder().mcpEndpoint(MCP_ENDPOINT).build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(
+				WebMvcStreamableServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -20,7 +20,12 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -89,6 +94,18 @@ public final class JsonSchemaGenerator {
 
 	private static final SchemaGenerator SUBTYPE_SCHEMA_GENERATOR;
 
+	/**
+	 * Schema cache keyed by (Type, Set<SchemaOption>). Avoids repeated generation for the
+	 * same type and prevents ConcurrentModificationException in victools when many
+	 * threads concurrently request the schema for the same type.
+	 */
+	private static final Map<TypeAndOptions, String> TYPE_SCHEMA_CACHE = new ConcurrentHashMap<>();
+
+	/**
+	 * Schema cache for method input schemas, keyed by (Method, Set<SchemaOption>).
+	 */
+	private static final Map<MethodAndOptions, String> METHOD_SCHEMA_CACHE = new ConcurrentHashMap<>();
+
 	/*
 	 * Initialize JSON Schema generators.
 	 */
@@ -127,6 +144,12 @@ public final class JsonSchemaGenerator {
 	 * Generate a JSON Schema for a method's input parameters.
 	 */
 	public static String generateForMethodInput(Method method, SchemaOption... schemaOptions) {
+		MethodAndOptions key = new MethodAndOptions(method,
+				schemaOptions.length == 0 ? Set.of() : EnumSet.copyOf(Arrays.asList(schemaOptions)));
+		return METHOD_SCHEMA_CACHE.computeIfAbsent(key, k -> generateForMethodInputInternal(k.method(), schemaOptions));
+	}
+
+	private static String generateForMethodInputInternal(Method method, SchemaOption... schemaOptions) {
 		ObjectNode schema = JacksonUtils.getDefaultJsonMapper().createObjectNode();
 		schema.put("$schema", SchemaVersion.DRAFT_2020_12.getIdentifier());
 		schema.put("type", "object");
@@ -149,7 +172,10 @@ public final class JsonSchemaGenerator {
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);
 			}
-			ObjectNode parameterNode = SUBTYPE_SCHEMA_GENERATOR.generateSchema(parameterType);
+			ObjectNode parameterNode;
+			synchronized (SUBTYPE_SCHEMA_GENERATOR) {
+				parameterNode = SUBTYPE_SCHEMA_GENERATOR.generateSchema(parameterType);
+			}
 			// victools generates self-contained schemas where $defs and the $ref
 			// pointers into them are rooted at the sub-schema. Inlining the
 			// sub-schema under properties.<paramName> re-parents existing
@@ -182,7 +208,16 @@ public final class JsonSchemaGenerator {
 	 */
 	public static String generateForType(Type type, SchemaOption... schemaOptions) {
 		Assert.notNull(type, "type cannot be null");
-		ObjectNode schema = TYPE_SCHEMA_GENERATOR.generateSchema(type);
+		TypeAndOptions key = new TypeAndOptions(type,
+				schemaOptions.length == 0 ? Set.of() : EnumSet.copyOf(Arrays.asList(schemaOptions)));
+		return TYPE_SCHEMA_CACHE.computeIfAbsent(key, k -> generateForTypeInternal(k.type(), schemaOptions));
+	}
+
+	private static String generateForTypeInternal(Type type, SchemaOption... schemaOptions) {
+		ObjectNode schema;
+		synchronized (TYPE_SCHEMA_GENERATOR) {
+			schema = TYPE_SCHEMA_GENERATOR.generateSchema(type);
+		}
 		if ((type == Void.class) && !schema.has("properties")) {
 			schema.putObject("properties");
 		}
@@ -343,6 +378,14 @@ public final class JsonSchemaGenerator {
 		 * Convert all "type" values to upper case.
 		 */
 		UPPER_CASE_TYPE_VALUES
+
+	}
+
+	private record TypeAndOptions(Type type, Set<SchemaOption> options) {
+
+	}
+
+	private record MethodAndOptions(Method method, Set<SchemaOption> options) {
 
 	}
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -21,8 +21,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -888,6 +893,41 @@ class JsonSchemaGeneratorTests {
 	void throwExceptionWhenTypeIsNull() {
 		assertThatThrownBy(() -> JsonSchemaGenerator.generateForType(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("type cannot be null");
+	}
+
+	@Test
+	void generateForTypeConcurrently() throws Exception {
+		int threads = 20;
+		ExecutorService executor = Executors.newFixedThreadPool(threads);
+		List<CompletableFuture<String>> futures = new ArrayList<>();
+		for (int i = 0; i < threads; i++) {
+			futures.add(CompletableFuture.supplyAsync(() -> JsonSchemaGenerator.generateForType(OpenApiPerson.class),
+					executor));
+		}
+		executor.shutdown();
+		assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+		String expected = JsonSchemaGenerator.generateForType(OpenApiPerson.class);
+		for (CompletableFuture<String> future : futures) {
+			assertThat(future.get()).isEqualTo(expected);
+		}
+	}
+
+	@Test
+	void generateForMethodInputConcurrently() throws Exception {
+		Method method = TestMethods.class.getMethod("simpleMethod", String.class, int.class);
+		int threads = 20;
+		ExecutorService executor = Executors.newFixedThreadPool(threads);
+		List<CompletableFuture<String>> futures = new ArrayList<>();
+		for (int i = 0; i < threads; i++) {
+			futures
+				.add(CompletableFuture.supplyAsync(() -> JsonSchemaGenerator.generateForMethodInput(method), executor));
+		}
+		executor.shutdown();
+		assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+		String expected = JsonSchemaGenerator.generateForMethodInput(method);
+		for (CompletableFuture<String> future : futures) {
+			assertThat(future.get()).isEqualTo(expected);
+		}
 	}
 
 	static class TestMethods {


### PR DESCRIPTION
## Summary

Fixes two issues in `WebMvcStreamableServerTransportProvider.handlePost()` that occur when a client sends a malformed `initialize` request (e.g. `params: {}`):

- **Early param validation**: Checks required fields (`protocolVersion`, `capabilities`, `clientInfo`) before calling `startSession()`. Returns HTTP 400 / JSON-RPC `-32602 Invalid Params` with a descriptive message instead of propagating to `startSession()` which may throw a `NullPointerException` with no message.
- **Null-safe error message**: In the `catch` block, `e.getMessage()` can be `null` for `NullPointerException`. Passing `null` to `McpError.Builder.message()` threw a second exception ("message must not be empty"), which caused a misleading ERROR log ("Failed to deserialize message: message must not be empty") and masked the real problem. A fallback string is now used when `e.getMessage()` is `null`.
- **Log level**: Changed from `ERROR` to `WARN` for session initialization failures caused by client-supplied data — these are 4xx-class client mistakes, not 5xx server errors.

## Test plan

- [x] Added `WebMvcStreamableServerTransportProviderIT.malformedInitializeParamsReturns400WithInvalidParams` — starts a real Tomcat server, sends `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`, asserts HTTP 400 with error message containing `protocolVersion`
- [x] `./mvnw -pl mcp/transport/mcp-spring-webmvc test -Dtest="WebMvcStreamableServerTransportProviderIT"` — BUILD SUCCESS

Fixes: #5994