### PR TITLE
Add native structured output support to MiniMax

### DIFF
--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
@@ -30,8 +30,10 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.minimax.api.MiniMaxApi;
 import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.model.tool.StructuredOutputChatOptions;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.util.json.JsonParser;
 
 /**
  * MiniMaxChatOptions represents the options for performing chat completion using the
@@ -46,7 +48,7 @@ import org.springframework.ai.tool.ToolCallback;
  * @author Sebastien Deleuze
  * @since 1.0.0 M1
  */
-public class MiniMaxChatOptions implements ToolCallingChatOptions {
+public class MiniMaxChatOptions implements ToolCallingChatOptions, StructuredOutputChatOptions {
 
 	// @formatter:off
 	/**
@@ -77,6 +79,8 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	/**
 	 * An object specifying the format that the model must output. Setting to { "type":
 	 * "json_object" } enables JSON mode, which guarantees the message the model generates is valid JSON.
+	 * Setting to { "type": "json_schema" } with a supplied schema enables native structured output,
+	 * which guarantees the model output matches the schema (only supported by MiniMax-Text-01).
 	 */
 	private MiniMaxApi.ChatCompletionRequest.@Nullable ResponseFormat responseFormat;
 	/**
@@ -216,6 +220,18 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 		return this.responseFormat;
 	}
 
+	@Override
+	public @Nullable String getOutputSchema() {
+		if (this.responseFormat == null) {
+			return null;
+		}
+		MiniMaxApi.ChatCompletionRequest.ResponseFormat.JsonSchema jsonSchema = this.responseFormat.jsonSchema();
+		if (jsonSchema == null) {
+			return null;
+		}
+		return JsonParser.toJson(jsonSchema.schema());
+	}
+
 	public @Nullable Integer getSeed() {
 		return this.seed;
 	}
@@ -344,7 +360,7 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	}
 
 	protected abstract static class AbstractBuilder<B extends AbstractBuilder<B>>
-			extends DefaultToolCallingChatOptions.Builder<B> {
+			extends DefaultToolCallingChatOptions.Builder<B> implements StructuredOutputChatOptions.Builder<B> {
 
 		@Override
 		public B clone() {
@@ -372,6 +388,21 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 
 		public B responseFormat(MiniMaxApi.ChatCompletionRequest.@Nullable ResponseFormat responseFormat) {
 			this.responseFormat = responseFormat;
+			return self();
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public B outputSchema(@Nullable String outputSchema) {
+			if (outputSchema == null) {
+				this.responseFormat = null;
+				return self();
+			}
+			Map<String, Object> schema = Objects.requireNonNull(
+					(Map<String, Object>) JsonParser.fromJson(outputSchema, Map.class),
+					"outputSchema must be a valid JSON object");
+			this.responseFormat = new MiniMaxApi.ChatCompletionRequest.ResponseFormat("json_schema",
+					new MiniMaxApi.ChatCompletionRequest.ResponseFormat.JsonSchema("custom_schema", schema));
 			return self();
 		}
 

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
@@ -640,11 +640,43 @@ public class MiniMaxApi {
 
 		/**
 		 * An object specifying the format that the model must output.
-		 * @param type Must be one of 'text' or 'json_object'.
+		 *
+		 * @param type Must be one of 'text', 'json_object' or 'json_schema'. Setting to
+		 * 'json_object' enables JSON mode, which guarantees the message the model
+		 * generates is valid JSON. Setting to 'json_schema' enables Structured Outputs
+		 * which ensures the model output matches the supplied {@link JsonSchema}.
+		 * @param jsonSchema The JSON schema the model output must conform to. Only
+		 * applicable when {@code type} is 'json_schema', which is currently only supported
+		 * by the {@code MiniMax-Text-01} model.
 		 */
 		@JsonInclude(Include.NON_NULL)
 		public record ResponseFormat(
-				@JsonProperty("type") String type) {
+				@JsonProperty("type") String type,
+				@JsonProperty("json_schema") @Nullable JsonSchema jsonSchema) {
+
+			/**
+			 * Shortcut constructor for a response format with only a type, e.g.
+			 * {@code { "type": "json_object" }} to enable JSON mode.
+			 * @param type Must be one of 'text', 'json_object' or 'json_schema'.
+			 */
+			public ResponseFormat(String type) {
+				this(type, null);
+			}
+
+			/**
+			 * The JSON schema definition that constrains the model output when the
+			 * response format type is 'json_schema'.
+			 *
+			 * @param name A name for the response schema. Must contain only alphanumeric
+			 * characters or underscores, with a maximum length of 64 characters.
+			 * @param schema The JSON Schema object describing the structure the model
+			 * output must match.
+			 */
+			@JsonInclude(Include.NON_NULL)
+			public record JsonSchema(
+					@JsonProperty("name") String name,
+					@JsonProperty("schema") Map<String, Object> schema) {
+			}
 		}
 	}
 

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/ChatCompletionRequestTests.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/ChatCompletionRequestTests.java
@@ -107,4 +107,22 @@ public class ChatCompletionRequestTests {
 		assertThat(request.model()).isEqualTo("DEFAULT_MODEL");
 	}
 
+	@Test
+	public void createRequestWithStructuredOutput() {
+
+		var client = new MiniMaxChatModel(new MiniMaxApi("TEST"),
+				MiniMaxChatOptions.builder().model("MiniMax-Text-01").build());
+
+		String schema = "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"]}";
+
+		var request = client.createRequest(new Prompt("Test message content",
+				MiniMaxChatOptions.builder().model("MiniMax-Text-01").outputSchema(schema).build()), false);
+
+		assertThat(request.responseFormat()).isNotNull();
+		assertThat(request.responseFormat().type()).isEqualTo("json_schema");
+		assertThat(request.responseFormat().jsonSchema()).isNotNull();
+		assertThat(request.responseFormat().jsonSchema().name()).isEqualTo("custom_schema");
+		assertThat(request.responseFormat().jsonSchema().schema()).containsEntry("type", "object");
+	}
+
 }

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/MiniMaxChatOptionsTests.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/MiniMaxChatOptionsTests.java
@@ -24,7 +24,9 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.minimax.MiniMaxChatOptions.Builder;
 import org.springframework.ai.minimax.api.MiniMaxApi;
+import org.springframework.ai.model.tool.StructuredOutputChatOptions;
 import org.springframework.ai.test.options.AbstractChatOptionsTests;
+import org.springframework.ai.util.json.JsonParser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -197,6 +199,47 @@ class MiniMaxChatOptionsTests extends AbstractChatOptionsTests<MiniMaxChatOption
 		assertThat(options.getToolChoice()).isEqualTo("test");
 		assertThat(options.getInternalToolExecutionEnabled()).isEqualTo(true);
 		assertThat(options.getToolContext()).isEqualTo(Map.of("key1", "value1"));
+	}
+
+	@Test
+	void testImplementsStructuredOutputChatOptions() {
+		assertThat(MiniMaxChatOptions.builder().build()).isInstanceOf(StructuredOutputChatOptions.class);
+	}
+
+	@Test
+	void testOutputSchema() {
+		String schema = """
+				{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}""";
+
+		MiniMaxChatOptions options = MiniMaxChatOptions.builder().outputSchema(schema).build();
+
+		MiniMaxApi.ChatCompletionRequest.ResponseFormat responseFormat = options.getResponseFormat();
+		assertThat(responseFormat).isNotNull();
+		assertThat(responseFormat.type()).isEqualTo("json_schema");
+		assertThat(responseFormat.jsonSchema()).isNotNull();
+		assertThat(responseFormat.jsonSchema().name()).isEqualTo("custom_schema");
+		assertThat(responseFormat.jsonSchema().schema()).containsEntry("type", "object");
+
+		// getOutputSchema() round-trips the supplied schema back to JSON.
+		assertThat(JsonParser.fromJson(options.getOutputSchema(), Map.class))
+			.isEqualTo(JsonParser.fromJson(schema, Map.class));
+	}
+
+	@Test
+	void testOutputSchemaWithNull() {
+		MiniMaxChatOptions options = MiniMaxChatOptions.builder().outputSchema(null).build();
+
+		assertThat(options.getResponseFormat()).isNull();
+		assertThat(options.getOutputSchema()).isNull();
+	}
+
+	@Test
+	void testGetOutputSchemaReturnsNullForJsonMode() {
+		MiniMaxChatOptions options = MiniMaxChatOptions.builder()
+			.responseFormat(new MiniMaxApi.ChatCompletionRequest.ResponseFormat("json_object"))
+			.build();
+
+		assertThat(options.getOutputSchema()).isNull();
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/structured-output-converter.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/structured-output-converter.adoc
@@ -295,6 +295,7 @@ The following models currently support native structured output:
 * **Anthropic**: Claude 3.5 Sonnet and later models
 * **Google GenAI**: Gemini 1.5 Pro and later models
 * **Mistral AI**: Mistral Small and later models with JSON Schema support
+* **MiniMax**: MiniMax-Text-01 with JSON Schema support
 
 NOTE: Some AI models, such as OpenAI, don't support arrays of objects natively at the top level. In such cases, you can use the Spring AI default structured output conversion (without the native structured output advisor).
 


### PR DESCRIPTION
Fixes gh-6226

Implements native structured output for MiniMax, bringing it in line with the other chat model integrations (OpenAI, Anthropic, Google GenAI, Mistral, Ollama, Bedrock Converse).

### What
- `MiniMaxChatOptions` now implements `StructuredOutputChatOptions` (`getOutputSchema()` + builder `outputSchema(String)`), so MiniMax can take part in Spring AI's native structured output path (`AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT` / `ChatClient#entity`) instead of relying solely on prompt-based `BeanOutputConverter`.
- `MiniMaxApi.ChatCompletionRequest.ResponseFormat` gains a nested `JsonSchema(name, schema)` and a backward-compatible single-arg constructor, so existing `text` / `json_object` usage is unchanged.
- Reference docs list MiniMax (`MiniMax-Text-01`) under "Supported Models for Native Structured Output".

### Notes
- Native `json_schema` output is currently only supported by the `MiniMax-Text-01` model, per the [MiniMax API docs](https://platform.minimax.io/docs/api-reference/text-post).
- The change is additive; the existing `responseFormat(...)` builder option keeps working.

### Testing
- New unit tests for the options round-trip (`MiniMaxChatOptionsTests`) and the request wiring (`ChatCompletionRequestTests`).
- `./mvnw -pl models/spring-ai-minimax test` → 27 tests pass (3 IT skipped without API keys).
- `spring-javaformat:validate` and checkstyle (`-Pcheckstyle-check`) both clean.
