### PR TITLE
GH-6211: Avoid duplicate chat memory in tool prompts

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -78,8 +78,12 @@ public final class MessageChatMemoryAdvisor implements BaseChatMemoryAdvisor {
 		List<Message> memoryMessages = this.chatMemory.get(conversationId);
 
 		// 2. Advise the request messages list.
-		List<Message> processedMessages = new ArrayList<>(memoryMessages);
-		processedMessages.addAll(chatClientRequest.prompt().getInstructions());
+		List<Message> promptMessages = chatClientRequest.prompt().getInstructions();
+		List<Message> processedMessages = new ArrayList<>();
+		if (!isMemoryAlreadyInPrompt(promptMessages, memoryMessages)) {
+			processedMessages.addAll(memoryMessages);
+		}
+		processedMessages.addAll(promptMessages);
 
 		// 2.1. Ensure system message, if present, appears first in the list.
 		for (int i = 0; i < processedMessages.size(); i++) {
@@ -100,6 +104,33 @@ public final class MessageChatMemoryAdvisor implements BaseChatMemoryAdvisor {
 		this.chatMemory.add(conversationId, userMessage);
 
 		return processedChatClientRequest;
+	}
+
+	private static boolean isMemoryAlreadyInPrompt(List<Message> promptMessages, List<Message> memoryMessages) {
+		if (memoryMessages.isEmpty()) {
+			return true;
+		}
+		if (promptMessages.size() < memoryMessages.size()) {
+			return false;
+		}
+		for (int offset = 0; offset <= promptMessages.size() - memoryMessages.size(); offset++) {
+			if (startsWith(promptMessages, memoryMessages, offset)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean startsWith(List<Message> messages, List<Message> prefix, int offset) {
+		if (messages.size() - offset < prefix.size()) {
+			return false;
+		}
+		for (int i = 0; i < prefix.size(); i++) {
+			if (!messages.get(i + offset).equals(prefix.get(i))) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisorTests.java
@@ -159,6 +159,82 @@ public class MessageChatMemoryAdvisorTests {
 	}
 
 	@Test
+	void whenBeforeWithMemoryAlreadyInPromptThenDoesNotDuplicateMemory() {
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+		UserMessage userMessage = new UserMessage("When can I pick up dog 45?");
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("")
+			.toolCalls(
+					List.of(new AssistantMessage.ToolCall("call-45", "function", "schedulePickup", "{\"dogId\":45}")))
+			.build();
+		chatMemory.add("test-conversation", List.of(userMessage, assistantMessage));
+		MessageChatMemoryAdvisor advisor = MessageChatMemoryAdvisor.builder(chatMemory).build();
+		ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call-45", "schedulePickup",
+					"Pickup scheduled for Tuesday morning")))
+			.build();
+		Prompt prompt = Prompt.builder().messages(userMessage, assistantMessage, toolResponse).build();
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.context(ChatMemory.CONVERSATION_ID, "test-conversation")
+			.build();
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		ChatClientRequest processedRequest = advisor.before(request, chain);
+
+		assertThat(processedRequest.prompt().getInstructions()).containsExactly(userMessage, assistantMessage,
+				toolResponse);
+		assertThat(chatMemory.get("test-conversation")).containsExactly(userMessage, assistantMessage, toolResponse);
+	}
+
+	@Test
+	void whenBeforeWithWindowedMemoryAlreadyInPromptThenDoesNotDuplicateMemory() {
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.maxMessages(3)
+			.build();
+		UserMessage userMessage = new UserMessage("When can I pick up dog 45?");
+		AssistantMessage firstAssistantMessage = AssistantMessage.builder()
+			.content("")
+			.toolCalls(
+					List.of(new AssistantMessage.ToolCall("call-45", "function", "schedulePickup", "{\"dogId\":45}")))
+			.build();
+		ToolResponseMessage firstToolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call-45", "schedulePickup",
+					"Pickup scheduled for Tuesday morning")))
+			.build();
+		AssistantMessage secondAssistantMessage = AssistantMessage.builder()
+			.content("")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-46", "function", "confirmPickup",
+					"{\"dogId\":45,\"location\":\"Lisbon\"}")))
+			.build();
+		chatMemory.add("test-conversation",
+				List.of(userMessage, firstAssistantMessage, firstToolResponse, secondAssistantMessage));
+		MessageChatMemoryAdvisor advisor = MessageChatMemoryAdvisor.builder(chatMemory).build();
+		ToolResponseMessage secondToolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call-46", "confirmPickup",
+					"Pickup confirmed for the Lisbon location")))
+			.build();
+		Prompt prompt = Prompt.builder()
+			.messages(userMessage, firstAssistantMessage, firstToolResponse, secondAssistantMessage, secondToolResponse)
+			.build();
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.context(ChatMemory.CONVERSATION_ID, "test-conversation")
+			.build();
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		ChatClientRequest processedRequest = advisor.before(request, chain);
+
+		assertThat(processedRequest.prompt().getInstructions()).containsExactly(userMessage, firstAssistantMessage,
+				firstToolResponse, secondAssistantMessage, secondToolResponse);
+		assertThat(chatMemory.get("test-conversation")).containsExactly(firstToolResponse, secondAssistantMessage,
+				secondToolResponse);
+	}
+
+	@Test
 	void whenBeforeMovesSystemMessageToFirstPosition() {
 		ChatMemory chatMemory = MessageWindowChatMemory.builder()
 			.chatMemoryRepository(new InMemoryChatMemoryRepository())


### PR DESCRIPTION
Fixes #6211

## Summary

- Avoid prepending chat memory when the current prompt already contains the stored memory messages.
- Keep tool-call continuation prompts from repeating prior user, assistant, and tool messages while still storing the latest tool response in memory.
- Cover both full-history and windowed-memory cases.

## Tests

- `./mvnw -pl spring-ai-client-chat -Dtest=MessageChatMemoryAdvisorTests -Dmaven.build.cache.enabled=false test`
- `./mvnw -pl spring-ai-client-chat -Dmaven.build.cache.enabled=false test`
