### PR TITLE
Add observability metrics to StabilityAiImageModel

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageAutoConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.model.stabilityai.autoconfigure;
 
+import io.micrometer.observation.ObservationRegistry;
+
+import org.springframework.ai.image.observation.ImageModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.stabilityai.StabilityAiImageModel;
@@ -68,8 +71,13 @@ public class StabilityAiImageAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public StabilityAiImageModel stabilityAiImageModel(StabilityAiApi stabilityAiApi,
-			StabilityAiImageProperties stabilityAiImageProperties) {
-		return new StabilityAiImageModel(stabilityAiApi, stabilityAiImageProperties.toOptions());
+			StabilityAiImageProperties stabilityAiImageProperties,
+			ObjectProvider<ObservationRegistry> observationRegistry,
+			ObjectProvider<ImageModelObservationConvention> observationConvention) {
+		var imageModel = new StabilityAiImageModel(stabilityAiApi, stabilityAiImageProperties.toOptions(),
+				observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP));
+		observationConvention.ifAvailable(imageModel::setObservationConvention);
+		return imageModel;
 	}
 
 }

--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.stabilityai;
 
 import java.util.List;
+import java.util.Objects;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.image.Image;
@@ -27,7 +29,12 @@ import org.springframework.ai.image.ImageOptions;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 import org.springframework.ai.image.ImageResponseMetadata;
+import org.springframework.ai.image.observation.DefaultImageModelObservationConvention;
+import org.springframework.ai.image.observation.ImageModelObservationContext;
+import org.springframework.ai.image.observation.ImageModelObservationConvention;
+import org.springframework.ai.image.observation.ImageModelObservationDocumentation;
 import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.stabilityai.api.StabilityAiApi;
 import org.springframework.ai.stabilityai.api.StabilityAiImageOptions;
 import org.springframework.util.Assert;
@@ -38,19 +45,31 @@ import org.springframework.util.Assert;
  */
 public class StabilityAiImageModel implements ImageModel {
 
+	private static final ImageModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultImageModelObservationConvention();
+
 	private final StabilityAiImageOptions defaultOptions;
 
 	private final StabilityAiApi stabilityAiApi;
+
+	private final ObservationRegistry observationRegistry;
+
+	private ImageModelObservationConvention observationConvention = DEFAULT_OBSERVATION_CONVENTION;
 
 	public StabilityAiImageModel(StabilityAiApi stabilityAiApi) {
 		this(stabilityAiApi, StabilityAiImageOptions.builder().build());
 	}
 
 	public StabilityAiImageModel(StabilityAiApi stabilityAiApi, StabilityAiImageOptions defaultOptions) {
+		this(stabilityAiApi, defaultOptions, ObservationRegistry.NOOP);
+	}
+
+	public StabilityAiImageModel(StabilityAiApi stabilityAiApi, StabilityAiImageOptions defaultOptions,
+			ObservationRegistry observationRegistry) {
 		Assert.notNull(stabilityAiApi, "StabilityAiApi must not be null");
 		Assert.notNull(defaultOptions, "StabilityAiImageOptions must not be null");
 		this.stabilityAiApi = stabilityAiApi;
 		this.defaultOptions = defaultOptions;
+		this.observationRegistry = Objects.requireNonNullElse(observationRegistry, ObservationRegistry.NOOP);
 	}
 
 	private static StabilityAiApi.GenerateImageRequest getGenerateImageRequest(ImagePrompt stabilityAiImagePrompt,
@@ -96,12 +115,35 @@ public class StabilityAiImageModel implements ImageModel {
 		StabilityAiApi.GenerateImageRequest generateImageRequest = getGenerateImageRequest(imagePrompt,
 				requestImageOptions);
 
-		// Make the request
-		StabilityAiApi.GenerateImageResponse generateImageResponse = this.stabilityAiApi
-			.generateImage(generateImageRequest);
+		var observationContext = ImageModelObservationContext.builder()
+			.imagePrompt(imagePrompt)
+			.provider(AiProvider.STABILITY_AI.value())
+			.build();
 
-		// Convert to org.springframework.ai.model derived ImageResponse data type
-		return convertResponse(generateImageResponse);
+		return Objects.requireNonNull(
+				ImageModelObservationDocumentation.IMAGE_MODEL_OPERATION
+					.observation(this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
+							this.observationRegistry)
+					.observe(() -> {
+						// Make the request
+						StabilityAiApi.GenerateImageResponse generateImageResponse = this.stabilityAiApi
+							.generateImage(generateImageRequest);
+
+						// Convert to org.springframework.ai.model derived ImageResponse
+						// data type
+						ImageResponse imageResponse = convertResponse(generateImageResponse);
+						observationContext.setResponse(imageResponse);
+						return imageResponse;
+					}));
+	}
+
+	/**
+	 * Use the provided convention for reporting observation data
+	 * @param observationConvention The provided convention
+	 */
+	public void setObservationConvention(ImageModelObservationConvention observationConvention) {
+		Assert.notNull(observationConvention, "observationConvention cannot be null");
+		this.observationConvention = observationConvention;
 	}
 
 	private ImageResponse convertResponse(StabilityAiApi.GenerateImageResponse generateImageResponse) {

--- a/models/spring-ai-stability-ai/src/test/java/org/springframework/ai/stabilityai/StabilityAiImageModelObservationTests.java
+++ b/models/spring-ai-stability-ai/src/test/java/org/springframework/ai/stabilityai/StabilityAiImageModelObservationTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.stabilityai;
+
+import java.util.List;
+
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.image.observation.DefaultImageModelObservationConvention;
+import org.springframework.ai.image.observation.ImageModelObservationDocumentation;
+import org.springframework.ai.observation.conventions.AiOperationType;
+import org.springframework.ai.observation.conventions.AiProvider;
+import org.springframework.ai.stabilityai.api.StabilityAiApi;
+import org.springframework.ai.stabilityai.api.StabilityAiImageOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for observation instrumentation in {@link StabilityAiImageModel}.
+ */
+class StabilityAiImageModelObservationTests {
+
+	@Test
+	void observationForImageOperation() {
+		var observationRegistry = TestObservationRegistry.create();
+
+		StabilityAiApi stabilityAiApi = mock(StabilityAiApi.class);
+		when(stabilityAiApi.generateImage(any())).thenReturn(new StabilityAiApi.GenerateImageResponse("SUCCESS",
+				List.of(new StabilityAiApi.GenerateImageResponse.Artifacts(42L, "aGVsbG8=", "SUCCESS"))));
+
+		var imageModel = new StabilityAiImageModel(stabilityAiApi, StabilityAiImageOptions.builder().build(),
+				observationRegistry);
+
+		var promptOptions = StabilityAiImageOptions.builder()
+			.model("stable-diffusion-v1-6")
+			.width(512)
+			.height(512)
+			.build();
+
+		ImageResponse imageResponse = imageModel.call(new ImagePrompt("Lighthouse on a rocky coast", promptOptions));
+		assertThat(imageResponse.getResults()).hasSize(1);
+
+		TestObservationRegistryAssert.assertThat(observationRegistry)
+			.doesNotHaveAnyRemainingCurrentObservation()
+			.hasObservationWithNameEqualTo(DefaultImageModelObservationConvention.DEFAULT_NAME)
+			.that()
+			.hasContextualNameEqualTo("image stable-diffusion-v1-6")
+			.hasLowCardinalityKeyValue(
+					ImageModelObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
+					AiOperationType.IMAGE.value())
+			.hasLowCardinalityKeyValue(ImageModelObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(),
+					AiProvider.STABILITY_AI.value())
+			.hasLowCardinalityKeyValue(
+					ImageModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL.asString(),
+					"stable-diffusion-v1-6")
+			.hasHighCardinalityKeyValue(
+					ImageModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_IMAGE_SIZE.asString(), "512x512")
+			.hasBeenStarted()
+			.hasBeenStopped();
+	}
+
+}

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiProvider.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiProvider.java
@@ -80,6 +80,11 @@ public enum AiProvider {
 	SPRING_AI("spring_ai"),
 
 	/**
+	 * AI system provided by Stability AI.
+	 */
+	STABILITY_AI("stability_ai"),
+
+	/**
 	 * AI system provided by Vertex AI.
 	 */
 	VERTEX_AI("vertex_ai");


### PR DESCRIPTION
## Summary
Wires `StabilityAiImageModel` into the existing image-model observation
infrastructure so it emits `gen_ai.client.operation` metrics and traces,
consistent with `OpenAiImageModel`. Resolves #1608, where Stability AI
produced no observability.

## Changes
- Add `STABILITY_AI("stability_ai")` to `AiProvider`.
- Wrap `StabilityAiImageModel.call(...)` in an `ImageModelObservationContext`
  via `ImageModelObservationDocumentation.IMAGE_MODEL_OPERATION`. Adds an
  `ObservationRegistry`-aware constructor and `setObservationConvention(...)`;
- `StabilityAiImageAutoConfiguration` injects `ObjectProvider<ObservationRegistry>`
  and `ObjectProvider<ImageModelObservationConvention>`, mirroring
  `OpenAiImageAutoConfiguration`.

## Test Plan
- New `StabilityAiImageModelObservationTests` (unit test, no API key) mocks
  `StabilityAiApi` and asserts via `TestObservationRegistry` that the observation
  is recorded with the expected low-cardinality keys (operation `image`,
  provider `stability_ai`, request model) and image size, and is started/stopped.
- `./mvnw -pl
models/spring-ai-stability-ai,auto-configurations/models/spring-ai-autoconfigure-model-stability-ai -am
verify` passes (0 checkstyle violations).

Fixes GH-1608