### PR TITLE
GH-1184-guardrails Add guardrails to Amazon Bedrock Converse API

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
@@ -64,12 +64,16 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 
 	private final @Nullable String outputSchema;
 
+	private @Nullable String guardrailId;
+
+	private @Nullable String guardrailVersion;
+
 	protected BedrockChatOptions(@Nullable String model, @Nullable Double frequencyPenalty, @Nullable Integer maxTokens,
 			@Nullable Double presencePenalty, @Nullable Map<String, String> requestParameters,
 			@Nullable List<String> stopSequences, @Nullable Double temperature, @Nullable Integer topK,
 			@Nullable Double topP, @Nullable List<ToolCallback> toolCallbacks,
 			@Nullable Map<String, Object> toolContext, @Nullable BedrockCacheOptions cacheOptions,
-			@Nullable String outputSchema) {
+			@Nullable String outputSchema, @Nullable String guardrailId, @Nullable String guardrailVersion) {
 		this.model = model;
 		this.frequencyPenalty = frequencyPenalty;
 		this.maxTokens = maxTokens;
@@ -83,6 +87,8 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		this.toolContext = toolContext != null ? Map.copyOf(toolContext) : null;
 		this.cacheOptions = cacheOptions;
 		this.outputSchema = outputSchema;
+		this.guardrailId = guardrailId;
+		this.guardrailVersion = guardrailVersion;
 	}
 
 	public static Builder builder() {
@@ -152,6 +158,14 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		return this.outputSchema;
 	}
 
+	public @Nullable String getGuardrailId() {
+		return this.guardrailId;
+	}
+
+	public @Nullable String getGuardrailVersion() {
+		return this.guardrailVersion;
+	}
+
 	@Override
 	public Builder mutate() {
 		return BedrockChatOptions.builder()
@@ -170,7 +184,9 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 			// Bedrock Specific
 			.requestParameters(this.requestParameters)
 			.cacheOptions(this.cacheOptions)
-			.outputSchema(this.outputSchema);
+			.outputSchema(this.outputSchema)
+			.guardrailId(this.guardrailId)
+			.guardrailVersion(this.guardrailVersion);
 	}
 
 	@Override
@@ -190,14 +206,16 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 				&& Objects.equals(this.topP, that.topP) && Objects.equals(this.toolCallbacks, that.toolCallbacks)
 				&& Objects.equals(this.toolContext, that.toolContext)
 				&& Objects.equals(this.cacheOptions, that.cacheOptions)
-				&& Objects.equals(this.outputSchema, that.outputSchema);
+				&& Objects.equals(this.outputSchema, that.outputSchema)
+				&& Objects.equals(this.guardrailId, that.guardrailId)
+				&& Objects.equals(this.guardrailVersion, that.guardrailVersion);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.model, this.frequencyPenalty, this.maxTokens, this.presencePenalty,
 				this.requestParameters, this.stopSequences, this.temperature, this.topK, this.topP, this.toolCallbacks,
-				this.toolContext, this.cacheOptions, this.outputSchema);
+				this.toolContext, this.cacheOptions, this.outputSchema, this.guardrailId, this.guardrailVersion);
 	}
 
 	// public Builder class exposed to users. Avoids having to deal with noisy generic
@@ -222,6 +240,10 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 
 		private @Nullable String outputSchema;
 
+		private @Nullable String guardrailId;
+
+		private @Nullable String guardrailVersion;
+
 		public B requestParameters(@Nullable Map<String, String> requestParameters) {
 			this.requestParameters = requestParameters;
 			return self();
@@ -229,6 +251,16 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 
 		public B cacheOptions(@Nullable BedrockCacheOptions cacheOptions) {
 			this.cacheOptions = cacheOptions;
+			return self();
+		}
+
+		public B guardrailId(@Nullable String guardrailId) {
+			this.guardrailId = guardrailId;
+			return self();
+		}
+
+		public B guardrailVersion(@Nullable String guardrailVersion) {
+			this.guardrailVersion = guardrailVersion;
 			return self();
 		}
 
@@ -251,6 +283,12 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 				if (that.outputSchema != null) {
 					this.outputSchema = that.outputSchema;
 				}
+				if (that.guardrailId != null) {
+					this.guardrailId = that.guardrailId;
+				}
+				if (that.guardrailVersion != null) {
+					this.guardrailVersion = that.guardrailVersion;
+				}
 			}
 			return self();
 		}
@@ -265,7 +303,8 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		public BedrockChatOptions build() {
 			return new BedrockChatOptions(this.model, this.frequencyPenalty, this.maxTokens, this.presencePenalty,
 					this.requestParameters, this.stopSequences, this.temperature, this.topK, this.topP,
-					this.toolCallbacks, this.toolContext, this.cacheOptions, this.outputSchema);
+					this.toolCallbacks, this.toolContext, this.cacheOptions, this.outputSchema, this.guardrailId,
+					this.guardrailVersion);
 		}
 
 	}

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -52,6 +52,8 @@ import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.DocumentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.DocumentSource;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConfiguration;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailStreamConfiguration;
 import software.amazon.awssdk.services.bedrockruntime.model.ImageBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.ImageSource;
 import software.amazon.awssdk.services.bedrockruntime.model.InferenceConfiguration;
@@ -446,7 +448,7 @@ public class BedrockProxyChatModel implements ChatModel {
 		Map<String, String> requestMetadata = ConverseApiUtils
 			.getRequestMetadata(prompt.getUserMessage().getMetadata());
 
-		return ConverseRequest.builder()
+		ConverseRequest.Builder converseRequestBuilder = ConverseRequest.builder()
 			.modelId(options.getModel())
 			.inferenceConfig(inferenceConfiguration)
 			.messages(instructionMessages)
@@ -454,8 +456,17 @@ public class BedrockProxyChatModel implements ChatModel {
 			.additionalModelRequestFields(additionalModelRequestFields)
 			.toolConfig(toolConfiguration)
 			.requestMetadata(requestMetadata)
-			.outputConfig(buildOutputConfig(options))
-			.build();
+			.outputConfig(buildOutputConfig(options));
+
+		if (StringUtils.hasText(bedrockOptions.getGuardrailId())
+				&& StringUtils.hasText(bedrockOptions.getGuardrailVersion())) {
+			converseRequestBuilder.guardrailConfig(GuardrailConfiguration.builder()
+				.guardrailIdentifier(bedrockOptions.getGuardrailId())
+				.guardrailVersion(bedrockOptions.getGuardrailVersion())
+				.build());
+		}
+
+		return converseRequestBuilder.build();
 	}
 
 	private @Nullable OutputConfig buildOutputConfig(BedrockChatOptions options) {
@@ -748,7 +759,7 @@ public class BedrockProxyChatModel implements ChatModel {
 				observation.start();
 			}
 
-			ConverseStreamRequest converseStreamRequest = ConverseStreamRequest.builder()
+			ConverseStreamRequest.Builder converseStreamRequestBuilder = ConverseStreamRequest.builder()
 				.modelId(converseRequest.modelId())
 				.inferenceConfig(converseRequest.inferenceConfig())
 				.messages(converseRequest.messages())
@@ -756,8 +767,16 @@ public class BedrockProxyChatModel implements ChatModel {
 				.additionalModelRequestFields(converseRequest.additionalModelRequestFields())
 				.toolConfig(converseRequest.toolConfig())
 				.requestMetadata(converseRequest.requestMetadata())
-				.outputConfig(converseRequest.outputConfig())
-				.build();
+				.outputConfig(converseRequest.outputConfig());
+
+			if (converseRequest.guardrailConfig() != null) {
+				converseStreamRequestBuilder.guardrailConfig(GuardrailStreamConfiguration.builder()
+					.guardrailIdentifier(converseRequest.guardrailConfig().guardrailIdentifier())
+					.guardrailVersion(converseRequest.guardrailConfig().guardrailVersion())
+					.build());
+			}
+
+			ConverseStreamRequest converseStreamRequest = converseStreamRequestBuilder.build();
 
 			Usage accumulatedUsage = null;
 			if (perviousChatResponse != null && perviousChatResponse.getMetadata() != null) {

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
@@ -80,6 +80,8 @@ class BedrockChatOptionsTests extends AbstractChatOptionsTests<BedrockChatOption
 		assertThat(options.getTopP()).isNull();
 		assertThat(options.getStopSequences()).isNull();
 		assertThat(options.getOutputSchema()).isNull();
+		assertThat(options.getGuardrailId()).isNull();
+		assertThat(options.getGuardrailVersion()).isNull();
 	}
 
 	@Test
@@ -103,6 +105,46 @@ class BedrockChatOptionsTests extends AbstractChatOptionsTests<BedrockChatOption
 
 		assertThat(merged.getRequestParameters()).containsEntry("base-key", "base-value");
 		assertThat(merged.getRequestParameters()).containsEntry("override-key", "override-value");
+	}
+
+	@Test
+	void testBuilderWithGuardrailFields() {
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.guardrailId("test-guardrail-123")
+			.guardrailVersion("Version 1")
+			.build();
+
+		assertThat(options.getGuardrailId()).isEqualTo("test-guardrail-123");
+		assertThat(options.getGuardrailVersion()).isEqualTo("Version 1");
+	}
+
+	@Test
+	void testCopyPreservesGuardrailFields() {
+		BedrockChatOptions original = BedrockChatOptions.builder()
+			.model("test-model")
+			.guardrailId("test-guardrail-123")
+			.guardrailVersion("DRAFT")
+			.build();
+
+		BedrockChatOptions copied = original.copy();
+
+		assertThat(copied.getGuardrailId()).isEqualTo("test-guardrail-123");
+		assertThat(copied.getGuardrailVersion()).isEqualTo("DRAFT");
+		assertThat(copied).isNotSameAs(original).isEqualTo(original);
+	}
+
+	@Test
+	void testMutatePreservesGuardrailFields() {
+		BedrockChatOptions original = BedrockChatOptions.builder()
+			.guardrailId("test-guardrail-123")
+			.guardrailVersion("Version 1")
+			.build();
+
+		BedrockChatOptions mutated = original.mutate().model("new-model").build();
+
+		assertThat(mutated.getGuardrailId()).isEqualTo("test-guardrail-123");
+		assertThat(mutated.getGuardrailVersion()).isEqualTo("Version 1");
+		assertThat(mutated.getModel()).isEqualTo("new-model");
 	}
 
 }

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -32,12 +32,14 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
 
 import org.springframework.ai.bedrock.converse.api.BedrockCacheOptions;
 import org.springframework.ai.bedrock.converse.api.BedrockCacheStrategy;
 import org.springframework.ai.bedrock.converse.api.MediaFetcher;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingManager;
@@ -188,6 +190,62 @@ class BedrockProxyChatModelTest {
 
 		assertThatThrownBy(() -> model.mapMediaToContentBlock(media)).isInstanceOf(RuntimeException.class)
 			.isInstanceOf(SecurityException.class);
+	}
+
+	// -------------------------------------------------------------------------
+	// Guardrail configuration tests
+	// -------------------------------------------------------------------------
+
+	@Test
+	void shouldIncludeGuardrailConfigWhenBothFieldsAreSet() {
+		BedrockProxyChatModel model = newModel();
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.model("test-model")
+			.guardrailId("test-guardrail-123")
+			.guardrailVersion("Version 1")
+			.build();
+
+		ConverseRequest request = model.createRequest(new Prompt("hello", options));
+
+		assertThat(request.guardrailConfig()).isNotNull();
+		assertThat(request.guardrailConfig().guardrailIdentifier()).isEqualTo("test-guardrail-123");
+		assertThat(request.guardrailConfig().guardrailVersion()).isEqualTo("Version 1");
+	}
+
+	@Test
+	void shouldNotIncludeGuardrailConfigWhenFieldsAreMissing() {
+		BedrockProxyChatModel model = newModel();
+		BedrockChatOptions options = BedrockChatOptions.builder().model("test-model").build();
+
+		ConverseRequest request = model.createRequest(new Prompt("hello", options));
+
+		assertThat(request.guardrailConfig()).isNull();
+	}
+
+	@Test
+	void shouldNotIncludeGuardrailConfigWhenOnlyGuardrailIdIsSet() {
+		BedrockProxyChatModel model = newModel();
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.model("test-model")
+			.guardrailId("test-guardrail-123")
+			.build();
+
+		ConverseRequest request = model.createRequest(new Prompt("hello", options));
+
+		assertThat(request.guardrailConfig()).isNull();
+	}
+
+	@Test
+	void shouldNotIncludeGuardrailConfigWhenOnlyGuardrailVersionIsSet() {
+		BedrockProxyChatModel model = newModel();
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.model("test-model")
+			.guardrailVersion("Version 1")
+			.build();
+
+		ConverseRequest request = model.createRequest(new Prompt("hello", options));
+
+		assertThat(request.guardrailConfig()).isNull();
 	}
 
 	// -------------------------------------------------------------------------

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/experiments/BedrockConverseGuardrailMain.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/experiments/BedrockConverseGuardrailMain.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse.experiments;
+
+import java.util.Objects;
+
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import org.springframework.ai.bedrock.converse.BedrockChatOptions;
+import org.springframework.ai.bedrock.converse.BedrockProxyChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+
+/**
+ * Used for reverse engineering the protocol.
+ *
+ * @author Venkatraman S
+ * @since 1.0.0
+ */
+
+public final class BedrockConverseGuardrailMain {
+
+	private BedrockConverseGuardrailMain() {
+	}
+
+	public static void main(String[] args) {
+
+		String guardrailId = System.getenv("GUARDRAIL_ID");
+		String guardrailVersion = System.getenv("GUARDRAIL_VERSION");
+
+		if (guardrailId == null || guardrailVersion == null) {
+			System.out.println("GUARDRAIL_ID and GUARDRAIL_VERSION environment variables must be set.");
+			System.exit(1);
+		}
+
+		BedrockProxyChatModel chatModel = BedrockProxyChatModel.builder()
+			.credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+			.region(Region.US_EAST_1)
+			.build();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.model("google.gemma-3-12b-it")
+			.guardrailId(guardrailId)
+			.guardrailVersion(guardrailVersion)
+			.build();
+
+		// Test 1: Prompt that should pass the guardrail
+		System.out.println("Test 1: Prompt that should pass the guardrail");
+		ChatResponse allowedResponse = chatModel.call(new Prompt("What is the capital of France?", options));
+		System.out.println(Objects.requireNonNull(allowedResponse.getResult()).getOutput().getText());
+
+		// Test 2: Prompt that should not pass the guardrail
+		System.out.println("Test 2: Prompt targeting the blocked topic");
+		ChatResponse blockedResponse = chatModel.call(new Prompt("This is my mobile number: 123456789, call me!", options));
+		System.out.println(Objects.requireNonNull(blockedResponse.getResult()).getOutput().getText());
+	}
+
+}


### PR DESCRIPTION
**Summary**
- Added `guardrailId` and `guardrailVersion` fields to `BedrockChatOptions` so users can configure Amazon Bedrock Guardrails per request.
- Wired `GuardrailConfiguration` into `ConverseRequest` (sync path) and `GuardrailStreamConfiguration` into `ConverseStreamRequest` (Streaming path) 
- Guardrails are only applied when both `guardrailId` and `guardrailVersion` are set, ensuring full backward compatibility with existing users.

**Changes**
- BedrockChatOptions.java - Added `guardrailId` and `guardrailVersion` fields with builder, getters, copy / mutate, equals / hashcode support
- BedrockProxyChatModel.java - Wired guardrail config into both sync and streaming paths.
- BedrockProxyChatModelTest.java - Added 4 unit tests covering both fields set, neither set and partial config cases
- BedrockChatOptionsTests.java - Added 4 unit tests covering builder, copy, mutate, and default values
- BedrockConverseGuardrailMain.java - Added manual experimental class for local end-to-end testing

**Test Plan**
- Unit tests pass - `./mvnw test -pl models/spring-ai-bedrock-converse`
- Manual end-to-end test run against real AWS Bedrock with a live guardrail
- Allowed prompt -> normal model response returned 
- Blocked prompt with guardrail ->guardrail intervention message returned

**Screenshots**
- Test 1: Denotes allowed prompt normal model response returned
<img width="1067" height="183" alt="Screenshot 2026-05-31 191959" src="https://github.com/user-attachments/assets/4481dfe7-40c1-4d05-99c3-35016b83597d" />

- Test 2: Denotes blocked prompt with guardrail response returned
<img width="897" height="82" alt="Screenshot 2026-05-31 192102" src="https://github.com/user-attachments/assets/e45cc091-f2ff-499c-8ae6-c3def2e9fc63" />

Signed-off-by: Venkatraman S adithyavenkat2002@gmail.com

Fixed: [GH-1184](https://github.com/spring-projects/spring-ai/issues/1184)