### PR TITLE
GH-6219: Refresh local transformer resource cache

### DIFF
--- a/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/ResourceCacheService.java
+++ b/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/ResourceCacheService.java
@@ -19,8 +19,11 @@ package org.springframework.ai.transformers;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.UUID;
 
 import org.apache.commons.logging.Log;
@@ -100,16 +103,18 @@ public class ResourceCacheService {
 	 */
 	public Resource getCachedResource(Resource originalResource) {
 		try {
-			if (this.excludedUriSchemas.contains(originalResource.getURI().getScheme())) {
+			URI originalResourceUri = originalResource.getURI();
+			if (this.excludedUriSchemas.contains(originalResourceUri.getScheme())) {
 				logger.info("The " + originalResource.toString() + " resource with URI schema ["
-						+ originalResource.getURI().getScheme() + "] is excluded from caching");
+						+ originalResourceUri.getScheme() + "] is excluded from caching");
 				return originalResource;
 			}
 
 			File cachedFile = getCachedFile(originalResource);
-			if (!cachedFile.exists()) {
+			if (shouldCacheResource(originalResource, originalResourceUri, cachedFile)) {
 				FileCopyUtils.copy(StreamUtils.copyToByteArray(originalResource.getInputStream()), cachedFile);
 				logger.info("Caching the " + originalResource.toString() + " resource to: " + cachedFile);
+				writeCacheMetadata(originalResource, originalResourceUri, cachedFile);
 			}
 			return new FileUrlResource(cachedFile.getAbsolutePath());
 		}
@@ -118,12 +123,87 @@ public class ResourceCacheService {
 		}
 	}
 
+	private boolean shouldCacheResource(Resource originalResource, URI originalResourceUri, File cachedFile) {
+		if (!cachedFile.exists()) {
+			return true;
+		}
+		if (isRemoteResource(originalResourceUri)) {
+			return false;
+		}
+
+		Path metadataFile = getMetadataFile(cachedFile);
+		if (!Files.exists(metadataFile)) {
+			return true;
+		}
+
+		try {
+			return !getCacheMetadata(originalResource, originalResourceUri).equals(readCacheMetadata(metadataFile));
+		}
+		catch (IOException e) {
+			throw new IllegalStateException("Failed to read cache metadata for: " + originalResource.getDescription(),
+					e);
+		}
+	}
+
+	private boolean isRemoteResource(URI originalResourceUri) {
+		String scheme = originalResourceUri.getScheme();
+		return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+	}
+
 	private File getCachedFile(Resource originalResource) throws IOException {
 		var resourceParentFolder = new File(this.cacheDirectory,
 				UUID.nameUUIDFromBytes(pathWithoutLastSegment(originalResource.getURI())).toString());
 		resourceParentFolder.mkdirs();
 		String newFileName = getCacheName(originalResource);
 		return new File(resourceParentFolder, newFileName);
+	}
+
+	private Path getMetadataFile(File cachedFile) {
+		return cachedFile.toPath().resolveSibling(cachedFile.getName() + ".metadata");
+	}
+
+	private Properties getCacheMetadata(Resource originalResource, URI originalResourceUri) {
+		Properties properties = new Properties();
+		properties.setProperty("uri", originalResourceUri.toASCIIString());
+		properties.setProperty("lastModified", Long.toString(getLastModified(originalResource)));
+		properties.setProperty("contentLength", Long.toString(getContentLength(originalResource)));
+		return properties;
+	}
+
+	private long getLastModified(Resource originalResource) {
+		try {
+			return originalResource.lastModified();
+		}
+		catch (IOException e) {
+			return -1;
+		}
+	}
+
+	private long getContentLength(Resource originalResource) {
+		try {
+			return originalResource.contentLength();
+		}
+		catch (IOException e) {
+			return -1;
+		}
+	}
+
+	private Properties readCacheMetadata(Path metadataFile) throws IOException {
+		Properties properties = new Properties();
+		try (var inputStream = Files.newInputStream(metadataFile)) {
+			properties.load(inputStream);
+		}
+		return properties;
+	}
+
+	private void writeCacheMetadata(Resource originalResource, URI originalResourceUri, File cachedFile)
+			throws IOException {
+		if (isRemoteResource(originalResourceUri)) {
+			return;
+		}
+		try (var outputStream = Files.newOutputStream(getMetadataFile(cachedFile))) {
+			getCacheMetadata(originalResource, originalResourceUri).store(outputStream, null);
+		}
 	}
 
 	private byte[] pathWithoutLastSegment(URI uri) {

--- a/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/ResourceCacheServiceTests.java
+++ b/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/ResourceCacheServiceTests.java
@@ -18,6 +18,8 @@ package org.springframework.ai.transformers;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -26,6 +28,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.DefaultResourceLoader;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,7 +66,7 @@ public class ResourceCacheServiceTests {
 
 		assertThat(cachedResource1).isNotEqualTo(new DefaultResourceLoader().getResource(originalResourceUri));
 		assertThat(this.tempDir.listFiles()).hasSize(1);
-		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(1);
+		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(2);
 
 		// Attempt to cache the same resource again should return the already cached
 		// resource.
@@ -73,7 +76,7 @@ public class ResourceCacheServiceTests {
 		assertThat(cachedResource2).isEqualTo(cachedResource1);
 
 		assertThat(this.tempDir.listFiles()).hasSize(1);
-		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(1);
+		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(2);
 
 	}
 
@@ -98,7 +101,7 @@ public class ResourceCacheServiceTests {
 		assertThat(this.tempDir.listFiles()).hasSize(1)
 			.describedAs(
 					"As both resources come from the same parent segments they should be cached in a single common parent.");
-		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(2);
+		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(4);
 	}
 
 	@Test
@@ -114,11 +117,63 @@ public class ResourceCacheServiceTests {
 	}
 
 	@Test
+	public void refreshesLocalCachedResourceWhenResourceMetadataChanges() throws IOException {
+		var cache = new ResourceCacheService(this.tempDir);
+
+		cache.setExcludedUriSchemas(List.of());
+
+		var originalResource = new TestResource("file:/models/model.onnx", "model.onnx", "old-model", 1);
+		var cachedResource = cache.getCachedResource(originalResource);
+
+		assertThat(cachedResource.getContentAsString(StandardCharsets.UTF_8)).isEqualTo("old-model");
+
+		var updatedResource = new TestResource("file:/models/model.onnx", "model.onnx", "new-model", 2);
+		var refreshedResource = cache.getCachedResource(updatedResource);
+
+		assertThat(refreshedResource).isEqualTo(cachedResource);
+		assertThat(refreshedResource.getContentAsString(StandardCharsets.UTF_8)).isEqualTo("new-model");
+		assertThat(this.tempDir.listFiles()).hasSize(1);
+		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(2);
+	}
+
+	@Test
 	public void shouldHandleNullUri() {
 		var cache = new ResourceCacheService(this.tempDir);
 
 		assertThatThrownBy(() -> cache.getCachedResource((String) null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Location must not be null");
+	}
+
+	private static final class TestResource extends ByteArrayResource {
+
+		private final URI uri;
+
+		private final String filename;
+
+		private final long lastModified;
+
+		TestResource(String uri, String filename, String content, long lastModified) {
+			super(content.getBytes(StandardCharsets.UTF_8));
+			this.uri = URI.create(uri);
+			this.filename = filename;
+			this.lastModified = lastModified;
+		}
+
+		@Override
+		public URI getURI() {
+			return this.uri;
+		}
+
+		@Override
+		public String getFilename() {
+			return this.filename;
+		}
+
+		@Override
+		public long lastModified() {
+			return this.lastModified;
+		}
+
 	}
 
 }


### PR DESCRIPTION
## Summary

Fixes GH-6219 (https://github.com/spring-projects/spring-ai/issues/6219) by refreshing cached local Transformer resources when the source resource changes.

`ResourceCacheService` previously reused an existing cached file solely because the resolved cache path already existed. For resources extracted from an executable jar, that meant a new application version could keep loading an old `model.onnx` or `tokenizer.json` from `${java.io.tmpdir}/spring-ai-onnx-generative` when the classpath resource path stayed the same.

This change stores lightweight metadata next to cached local resources and compares the current resource URI, last-modified timestamp, and content length before reusing the cached file. If the metadata differs, the cached resource is refreshed. Existing `http` and `https` cache behavior remains unchanged to avoid introducing extra remote checks.

## Validation

```bash
./mvnw -pl models/spring-ai-transformers -DskipITs -DskipNative -DskipTests=false -Dtest=ResourceCacheServiceTests test
```
