### PR TITLE
Allow custom JSON serialization for `@Tool` method results

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -768,7 +768,7 @@ public interface ToolCallResultConverter {
 
 The default `DefaultToolCallResultConverter` uses Jackson to serialize the result. Configure a custom converter on the `@Tool` annotation (`resultConverter`) or via `ToolMetadata`.
 
-When exposing multiple `@Tool` methods through a `MethodToolCallbackProvider`, you can apply a single default `ToolCallResultConverter` to every tool by setting it on the provider's builder via `MethodToolCallbackProvider.builder().toolCallResultConverter(...)`. An explicit `resultConverter` on the `@Tool` annotation overrides this default for that tool.
+When exposing multiple `@Tool` methods through a `MethodToolCallbackProvider`, you can apply a single default `ToolCallResultConverter` to every tool by setting it on the provider's builder via `MethodToolCallbackProvider.builder().toolCallResultConverter(...)`. A `resultConverter` other than `DefaultToolCallResultConverter` on the `@Tool` annotation overrides this default for that tool.
 
 [[method-tool-limitations]]
 === Method Tool Limitations

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -768,6 +768,8 @@ public interface ToolCallResultConverter {
 
 The default `DefaultToolCallResultConverter` uses Jackson to serialize the result. Configure a custom converter on the `@Tool` annotation (`resultConverter`) or via `ToolMetadata`.
 
+When exposing multiple `@Tool` methods through a `MethodToolCallbackProvider`, you can apply a single default `ToolCallResultConverter` to every tool by setting it on the provider's builder via `MethodToolCallbackProvider.builder().toolCallResultConverter(...)`. An explicit `resultConverter` on the `@Tool` annotation overrides this default for that tool.
+
 [[method-tool-limitations]]
 === Method Tool Limitations
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverter.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverter.java
@@ -28,26 +28,47 @@ import javax.imageio.ImageIO;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.util.JsonHelper;
+import org.springframework.util.Assert;
 
 /**
  * A default implementation of {@link ToolCallResultConverter}.
  *
  * @author Thomas Vitale
+ * @author Jewoo Shin
  * @since 1.0.0
  */
 public final class DefaultToolCallResultConverter implements ToolCallResultConverter {
 
-	private static final JsonHelper jsonHelper = new JsonHelper();
-
 	private static final Log logger = LogFactory.getLog(DefaultToolCallResultConverter.class);
+
+	private final JsonHelper jsonHelper;
+
+	public DefaultToolCallResultConverter() {
+		this.jsonHelper = new JsonHelper();
+	}
+
+	/**
+	 * Create a converter that serializes tool results using the given {@link JsonMapper}.
+	 * <p>
+	 * Use this constructor to apply a customized {@code JsonMapper} (e.g. one that
+	 * suppresses {@code null} properties) to the JSON produced for tool results, without
+	 * replacing the conversion logic of the default converter.
+	 * @param jsonMapper the {@link JsonMapper} to use for JSON serialization
+	 * @since 2.0.0
+	 */
+	public DefaultToolCallResultConverter(JsonMapper jsonMapper) {
+		Assert.notNull(jsonMapper, "jsonMapper cannot be null");
+		this.jsonHelper = new JsonHelper(jsonMapper);
+	}
 
 	@Override
 	public String convert(@Nullable Object result, @Nullable Type returnType) {
 		if (returnType == Void.TYPE) {
 			logger.debug("The tool has no return type. Converting to conventional response.");
-			return jsonHelper.toJson("Done");
+			return this.jsonHelper.toJson("Done");
 		}
 		if (result instanceof RenderedImage) {
 			final var buf = new ByteArrayOutputStream(1024 * 4);
@@ -58,11 +79,11 @@ public final class DefaultToolCallResultConverter implements ToolCallResultConve
 				return "Failed to convert tool result to a base64 image: " + e.getMessage();
 			}
 			final var imgB64 = Base64.getEncoder().encodeToString(buf.toByteArray());
-			return jsonHelper.toJson(Map.of("mimeType", "image/png", "data", imgB64));
+			return this.jsonHelper.toJson(Map.of("mimeType", "image/png", "data", imgB64));
 		}
 		else {
 			logger.debug("Converting tool result to JSON.");
-			return jsonHelper.toJson(result, true);
+			return this.jsonHelper.toJson(result, true);
 		}
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
@@ -29,10 +29,12 @@ import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.execution.ToolCallResultConverter;
 import org.springframework.ai.tool.metadata.ToolMetadata;
 import org.springframework.ai.tool.support.ToolDefinitions;
 import org.springframework.ai.tool.support.ToolUtils;
@@ -48,6 +50,7 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Thomas Vitale
  * @author Christian Tzolov
+ * @author Jewoo Shin
  * @since 1.0.0
  */
 public final class MethodToolCallbackProvider implements ToolCallbackProvider {
@@ -56,11 +59,15 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 
 	private final List<Object> toolObjects;
 
-	private MethodToolCallbackProvider(List<Object> toolObjects) {
+	private final @Nullable ToolCallResultConverter toolCallResultConverter;
+
+	private MethodToolCallbackProvider(List<Object> toolObjects,
+			@Nullable ToolCallResultConverter toolCallResultConverter) {
 		Assert.notNull(toolObjects, "toolObjects cannot be null");
 		Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
 		assertToolAnnotatedMethodsPresent(toolObjects);
 		this.toolObjects = toolObjects;
+		this.toolCallResultConverter = toolCallResultConverter;
 		validateToolCallbacks(getToolCallbacks());
 	}
 
@@ -96,7 +103,8 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 					.toolMetadata(ToolMetadata.from(toolMethod))
 					.toolMethod(toolMethod)
 					.toolObject(toolObject)
-					.toolCallResultConverter(ToolUtils.getToolCallResultConverter(toolMethod))
+					.toolCallResultConverter(
+							ToolUtils.getToolCallResultConverter(toolMethod, this.toolCallResultConverter))
 					.build())
 				.toArray(ToolCallback[]::new))
 			.flatMap(Stream::of)
@@ -144,6 +152,8 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 
 		private List<Object> toolObjects = new ArrayList<>();
 
+		private @Nullable ToolCallResultConverter toolCallResultConverter;
+
 		private Builder() {
 		}
 
@@ -153,8 +163,28 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 			return this;
 		}
 
+		/**
+		 * Set the default {@link ToolCallResultConverter} to apply when a tool method
+		 * leaves {@link Tool#resultConverter()} at its default value of
+		 * {@link org.springframework.ai.tool.execution.DefaultToolCallResultConverter}.
+		 * <p>
+		 * A {@link Tool} annotation that explicitly declares a {@code resultConverter}
+		 * other than {@code DefaultToolCallResultConverter} takes precedence over this
+		 * default. Because the annotation's default value is also
+		 * {@code DefaultToolCallResultConverter}, a tool that explicitly sets
+		 * {@code resultConverter = DefaultToolCallResultConverter.class} is
+		 * indistinguishable from the unset case and will therefore receive this default.
+		 * @param toolCallResultConverter the converter to use as the default
+		 * @return this builder
+		 * @since 2.0.0
+		 */
+		public Builder toolCallResultConverter(ToolCallResultConverter toolCallResultConverter) {
+			this.toolCallResultConverter = toolCallResultConverter;
+			return this;
+		}
+
 		public MethodToolCallbackProvider build() {
-			return new MethodToolCallbackProvider(this.toolObjects);
+			return new MethodToolCallbackProvider(this.toolObjects, this.toolCallResultConverter);
 		}
 
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/support/ToolUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/support/ToolUtils.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.annotation.Tool;
@@ -39,6 +40,7 @@ import org.springframework.util.StringUtils;
  * Miscellaneous tool utility methods. Mainly for internal use within the framework.
  *
  * @author Thomas Vitale
+ * @author Jewoo Shin
  */
 public final class ToolUtils {
 
@@ -89,12 +91,41 @@ public final class ToolUtils {
 	}
 
 	public static ToolCallResultConverter getToolCallResultConverter(Method method) {
+		return getToolCallResultConverter(method, null);
+	}
+
+	/**
+	 * Resolve the {@link ToolCallResultConverter} for the given method, falling back to
+	 * the supplied {@code defaultConverter} when the method does not explicitly opt into
+	 * a converter through {@link Tool#resultConverter()}.
+	 * <p>
+	 * Resolution order:
+	 * <ol>
+	 * <li>If the method has no {@link Tool} annotation, return {@code defaultConverter}
+	 * when non-null, otherwise a new {@link DefaultToolCallResultConverter}.</li>
+	 * <li>If the {@link Tool} annotation leaves {@code resultConverter} at its default
+	 * value ({@link DefaultToolCallResultConverter}), return {@code defaultConverter}
+	 * when non-null (so callers can inject a customized default); otherwise fall through
+	 * to the no-arg instantiation.</li>
+	 * <li>Otherwise instantiate the explicitly declared {@code resultConverter}
+	 * class.</li>
+	 * </ol>
+	 * @param method the tool method
+	 * @param defaultConverter the converter to use when the method does not declare an
+	 * explicit one, or {@code null} to preserve the legacy behaviour
+	 * @since 2.0.0
+	 */
+	public static ToolCallResultConverter getToolCallResultConverter(Method method,
+			@Nullable ToolCallResultConverter defaultConverter) {
 		Assert.notNull(method, "method cannot be null");
 		var tool = AnnotatedElementUtils.findMergedAnnotation(method, Tool.class);
 		if (tool == null) {
-			return new DefaultToolCallResultConverter();
+			return defaultConverter != null ? defaultConverter : new DefaultToolCallResultConverter();
 		}
 		var type = tool.resultConverter();
+		if (type == DefaultToolCallResultConverter.class && defaultConverter != null) {
+			return defaultConverter;
+		}
 		try {
 			return type.getDeclaredConstructor().newInstance();
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverterTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverterTests.java
@@ -26,7 +26,10 @@ import java.util.Map;
 
 import javax.imageio.ImageIO;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.util.JsonHelper;
 import org.springframework.util.MimeType;
@@ -38,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for {@link DefaultToolCallResultConverter}.
  *
  * @author Thomas Vitale
+ * @author Jewoo Shin
  */
 class DefaultToolCallResultConverterTests {
 
@@ -142,6 +146,20 @@ class DefaultToolCallResultConverterTests {
 	}
 
 	@Test
+	void convertWithCustomJsonMapperShouldOmitNullFields() {
+		JsonMapper nonNullMapper = JsonMapper.builder()
+			.changeDefaultPropertyInclusion(
+					incl -> JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+			.build();
+		DefaultToolCallResultConverter customConverter = new DefaultToolCallResultConverter(nonNullMapper);
+
+		String result = customConverter.convert(new NullablePair("present", null), NullablePair.class);
+
+		assertThat(result).contains("\"left\"").contains("\"present\"");
+		assertThat(result).doesNotContain("\"right\"");
+	}
+
+	@Test
 	void convertSpecialCharactersInStringsShouldEscapeJson() {
 		String specialChars = "Test with \"quotes\", newlines\n, tabs\t, and backslashes\\";
 		String result = this.converter.convert(specialChars, String.class);
@@ -157,6 +175,9 @@ class DefaultToolCallResultConverterTests {
 	}
 
 	record Base64Wrapper(MimeType mimeType, String data) {
+	}
+
+	record NullablePair(@Nullable String left, @Nullable String right) {
 	}
 
 	static class TestObject {

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
@@ -22,10 +22,12 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Type;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.tool.ToolCallback;
@@ -43,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
  * Unit tests for {@link MethodToolCallbackProvider}.
  *
  * @author Christian Tzolov
+ * @author Jewoo Shin
  */
 class MethodToolCallbackProviderTests {
 
@@ -118,6 +121,41 @@ class MethodToolCallbackProviderTests {
 
 		assertThat(provider.getToolCallbacks()).hasSize(1);
 		assertThat(provider.getToolCallbacks()[0].getToolDefinition().name()).isEqualTo("validTool");
+	}
+
+	@Test
+	void whenBuilderConverterNotSetAndToolUsesDefaultThenDefaultConverterApplied() {
+		MethodToolCallbackProvider provider = MethodToolCallbackProvider.builder()
+			.toolObjects(new ValidToolObject())
+			.build();
+
+		ToolCallback[] callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).hasSize(1);
+		assertThat(callbacks[0].call("{}")).isEqualTo("\"Valid tool result\"");
+	}
+
+	@Test
+	void whenBuilderConverterSetAndToolUsesDefaultThenBuilderConverterApplied() {
+		MethodToolCallbackProvider provider = MethodToolCallbackProvider.builder()
+			.toolObjects(new ValidToolObject())
+			.toolCallResultConverter(new MarkerConverter())
+			.build();
+
+		ToolCallback[] callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).hasSize(1);
+		assertThat(callbacks[0].call("{}")).isEqualTo("MARKER:Valid tool result");
+	}
+
+	@Test
+	void whenBuilderConverterSetAndToolHasExplicitConverterThenAnnotationWins() {
+		MethodToolCallbackProvider provider = MethodToolCallbackProvider.builder()
+			.toolObjects(new ExplicitConverterToolObject())
+			.toolCallResultConverter(new MarkerConverter())
+			.build();
+
+		ToolCallback[] callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).hasSize(1);
+		assertThat(callbacks[0].call("{}")).isEqualTo("EXPLICIT:Explicit tool result");
 	}
 
 	@Test
@@ -210,6 +248,33 @@ class MethodToolCallbackProviderTests {
 		@Tool
 		public Object objectTool() {
 			return "Object tool result";
+		}
+
+	}
+
+	static class ExplicitConverterToolObject {
+
+		@Tool(resultConverter = ExplicitConverter.class)
+		public String explicitTool() {
+			return "Explicit tool result";
+		}
+
+	}
+
+	public static class MarkerConverter implements ToolCallResultConverter {
+
+		@Override
+		public String convert(@Nullable Object result, @Nullable Type returnType) {
+			return "MARKER:" + result;
+		}
+
+	}
+
+	public static class ExplicitConverter implements ToolCallResultConverter {
+
+		@Override
+		public String convert(@Nullable Object result, @Nullable Type returnType) {
+			return "EXPLICIT:" + result;
 		}
 
 	}


### PR DESCRIPTION
Tool call result serialization could not use a customized `JsonMapper`, because `DefaultToolCallResultConverter` held a static `JsonHelper` and `MethodToolCallbackProvider` had no provider-level override.

This adds an explicit opt-in hook instead of automatically applying `spring.jackson` to all tool results: `DefaultToolCallResultConverter` now accepts a `JsonMapper`, and `MethodToolCallbackProvider.Builder` can set a default `ToolCallResultConverter` for emitted callbacks. A per-tool `@Tool` `resultConverter` other than `DefaultToolCallResultConverter` still takes precedence.

Tests cover custom `JsonMapper` serialization and provider builder precedence. The annotation-driven `@McpTool` path is a separate API path and remains out of scope.

Addresses #6097.