### PR TITLE
Resolve null parent observation for tool calls in streaming mode

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAIToolCallObservation2IT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAIToolCallObservation2IT.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.chat.client;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Hooks;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.DefaultChatClientBuilder;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationContext;
+import org.springframework.ai.chat.client.observation.ChatClientObservationContext;
+import org.springframework.ai.chat.observation.ChatModelObservationContext;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.test.chat.client.advisor.MockWeatherService;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.observation.ToolCallingObservationContext;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = OpenAIToolCallObservation2IT.Config.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+@ActiveProfiles("logging-test")
+class OpenAIToolCallObservation2IT {
+
+	private static final Logger logger = LoggerFactory.getLogger(OpenAIToolCallObservation2IT.class);
+
+	/**
+	 * The name returned by {@code ToolCallAdvisor.getName()}.
+	 */
+	static final String TOOL_CALLING_ADVISOR_NAME = "Tool Calling Advisor";
+
+	static final String CHAT_MODEL_STREAM_ADVISOR_NAME = "stream";
+
+	// =========================================================================
+	// Shared assertion helpers (must appear before inner types per InnerTypeLast)
+	// =========================================================================
+
+	private static void assertChatClientIsRoot(ObservationCapture capture) {
+		var chatClientNode = capture.findChatClient();
+		assertThat(chatClientNode).as("ChatClientObservationContext must be present").isPresent();
+		assertThat(chatClientNode.get().parentCtx()).as("spring.ai.chat.client must be the root span (no parent)")
+			.isNull();
+	}
+
+	// =========================================================================
+	// Per-test helper methods
+	// =========================================================================
+
+	private ChatClient buildChatClient(ObservationRegistry registry) {
+		var model = OpenAiChatModel.builder()
+			.observationRegistry(registry)
+			.options(OpenAiChatOptions.builder()
+				.apiKey(System.getenv("OPENAI_API_KEY"))
+				.model(OpenAiChatOptions.DEFAULT_CHAT_MODEL)
+				.build())
+			.build();
+
+		ToolCallAdvisor.Builder<?> toolCallAdvisorBuilder = ToolCallAdvisor.builder()
+			.toolCallingManager(ToolCallingManager.builder().observationRegistry(registry).build());
+
+		// Pass the same registry so ChatClientObservationContext,
+		// AdvisorObservationContext,
+		// and ChatModelObservationContext all share one registry and form a single tree.
+		return new DefaultChatClientBuilder(model, registry, null, null, toolCallAdvisorBuilder).build();
+	}
+
+	private void logCapture(ObservationCapture capture) {
+		logger.info("=== Observation timeline ({} events) ===", capture.fullTimeline().size());
+		capture.fullTimeline().forEach(event -> {
+			String kind = switch (event.kind()) {
+				case START -> "START      ";
+				case SCOPE_OPEN -> "SCOPE_OPEN ";
+				case SCOPE_CLOSE -> "SCOPE_CLOSE";
+			};
+			String ctxLabel = ctxLabel(event.ctx());
+			String parentLabel = event.parentCtx() != null ? " parent=" + ctxLabel(event.parentCtx()) : "";
+			String thread = " [" + event.thread() + "]";
+			logger.info("  {} {}{}{}", kind, ctxLabel, parentLabel, thread);
+		});
+	}
+
+	private static String ctxLabel(Observation.Context ctx) {
+		String type = ctx.getClass().getSimpleName();
+		if (ctx instanceof AdvisorObservationContext a) {
+			return type + "(" + a.getAdvisorName() + ")";
+		}
+		return type;
+	}
+
+	@Test
+	void withToolCallsObservationTreeWithEnabledContextPropagation() {
+		Hooks.enableAutomaticContextPropagation();
+		withToolCallsObservationTree();
+	}
+
+	@Test
+	void withToolCallsObservationTreeWithDisabledContextPropagation() {
+		Hooks.disableAutomaticContextPropagation();
+		withToolCallsObservationTree();
+	}
+
+	private void withToolCallsObservationTree() {
+
+		// Hooks.disableAutomaticContextPropagation();
+
+		var reg = TestObservationRegistry.create();
+		var capture = new ObservationCapture();
+		reg.observationConfig().observationHandler(capture.handler());
+
+		buildChatClient(reg).prompt()
+			.user("What is the weather in Tokyo?")
+			.tools(new Tools())
+			.stream()
+			.content()
+			.collectList()
+			.block();
+
+		logCapture(capture);
+
+		assertChatClientIsRoot(capture);
+
+		// context=ChatClientObservationContext parent=null
+		assertThat(capture.nodes.get(0).ctx()).as("ChatClientObservationContext must be the root span")
+			.isInstanceOf(ChatClientObservationContext.class);
+		assertThat(capture.nodes.get(0).parentCtx())
+			.as("ChatClientObservationContext must be the root span (no parent)")
+			.isNull();
+
+		// context=AdvisorObservationContext advisorName=Tool Calling Advisor
+		// parent=ChatClientObservationContext
+		assertThat(capture.nodes.get(1).ctx()).as("Second observation must be the Tool Calling Advisor span")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(TOOL_CALLING_ADVISOR_NAME));
+		assertThat(capture.nodes.get(1).parentCtx())
+			.as("Tool Calling Advisor parent must be ChatClientObservationContext")
+			.isInstanceOf(ChatClientObservationContext.class);
+
+		// context=AdvisorObservationContext advisorName=stream
+		// parent=AdvisorObservationContext
+		assertThat(capture.nodes.get(2).ctx()).as("Third observation must be the 'stream' advisor span")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(CHAT_MODEL_STREAM_ADVISOR_NAME));
+		assertThat(capture.nodes.get(2).parentCtx()).as("'stream' advisor parent must be Tool Calling Advisor")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(TOOL_CALLING_ADVISOR_NAME));
+
+		// context=ChatModelObservationContext parent=AdvisorObservationContext
+		assertThat(capture.nodes.get(3).ctx()).as("Fourth observation must be the ChatModel span")
+			.isInstanceOf(ChatModelObservationContext.class);
+		assertThat(capture.nodes.get(3).parentCtx()).as("ChatModel span parent must be the 'stream' advisor")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(CHAT_MODEL_STREAM_ADVISOR_NAME));
+
+		// context=ToolCallingObservationContext parent=AdvisorObservationContext
+		assertThat(capture.nodes.get(4).ctx()).as("Fourth observation must be the ToolCalling span")
+			.isInstanceOf(ToolCallingObservationContext.class);
+		assertThat(capture.nodes.get(4).parentCtx()).as("ToolCalling span parent must be an AdvisorObservationContext")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(TOOL_CALLING_ADVISOR_NAME));
+
+		// context=AdvisorObservationContext advisorName=stream
+		// parent=AdvisorObservationContext
+		assertThat(capture.nodes.get(5).ctx()).as("Fifth observation must be the second 'stream' advisor span")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(CHAT_MODEL_STREAM_ADVISOR_NAME));
+		assertThat(capture.nodes.get(5).parentCtx()).as("Second 'stream' advisor parent must be Tool Calling Advisor")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(TOOL_CALLING_ADVISOR_NAME));
+
+		// context=ChatModelObservationContext parent=AdvisorObservationContext
+		assertThat(capture.nodes.get(6).ctx()).as("Sixth observation must be the second ChatModel span")
+			.isInstanceOf(ChatModelObservationContext.class);
+		assertThat(capture.nodes.get(6).parentCtx())
+			.as("Second ChatModel span parent must be the second 'stream' advisor")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(CHAT_MODEL_STREAM_ADVISOR_NAME));
+
+		var toolAdvisorNode = capture.findAdvisor(TOOL_CALLING_ADVISOR_NAME);
+		assertThat(toolAdvisorNode).as("ToolCallAdvisor observation must be present in stream path").isPresent();
+		assertThat(toolAdvisorNode.get().parentCtx())
+			.as("Stream: ToolCallAdvisor parent must be ChatClientObservationContext")
+			.isInstanceOf(ChatClientObservationContext.class);
+
+		var chatModelNodes = capture.findAllByType(ChatModelObservationContext.class);
+		assertThat(chatModelNodes).as("Expected at least 2 LLM calls in stream tool-calling path")
+			.hasSizeGreaterThanOrEqualTo(2);
+	}
+
+	/**
+	 * Captures the full observation lifecycle — starts, scope opens, and scope closes —
+	 * in a single ordered timeline. Each event records the context, optional parent (for
+	 * START events), and the thread name, making it straightforward to see which
+	 * observations were active as thread-local current at each moment and on which
+	 * thread.
+	 *
+	 * <p>
+	 * The {@link #nodes} list is a filtered view of the timeline containing only START
+	 * events; it preserves backward-compatible indexed access used by the existing tests.
+	 */
+	static final class ObservationCapture {
+
+		final List<Node> nodes = new CopyOnWriteArrayList<>();
+
+		private final List<TimelineEvent> timeline = new CopyOnWriteArrayList<>();
+
+		ObservationHandler<Observation.Context> handler() {
+			return new ObservationHandler<>() {
+				@Override
+				public void onStart(Observation.Context ctx) {
+					Observation.Context parentCtx = null;
+					var parentObs = ctx.getParentObservation();
+					if (parentObs != null) {
+						parentCtx = (Observation.Context) parentObs.getContextView();
+					}
+					nodes.add(new Node(ctx, parentCtx));
+					timeline.add(new TimelineEvent(Kind.START, ctx, parentCtx, thread()));
+				}
+
+				@Override
+				public void onScopeOpened(Observation.Context ctx) {
+					timeline.add(new TimelineEvent(Kind.SCOPE_OPEN, ctx, null, thread()));
+				}
+
+				@Override
+				public void onScopeClosed(Observation.Context ctx) {
+					timeline.add(new TimelineEvent(Kind.SCOPE_CLOSE, ctx, null, thread()));
+				}
+
+				@Override
+				public boolean supportsContext(Observation.Context ctx) {
+					return true;
+				}
+
+				private String thread() {
+					return Thread.currentThread().getName();
+				}
+			};
+		}
+
+		List<Node> all() {
+			return Collections.unmodifiableList(this.nodes);
+		}
+
+		List<TimelineEvent> fullTimeline() {
+			return Collections.unmodifiableList(this.timeline);
+		}
+
+		Optional<Node> findChatClient() {
+			return this.nodes.stream().filter(n -> n.ctx() instanceof ChatClientObservationContext).findFirst();
+		}
+
+		Optional<Node> findAdvisor(String name) {
+			return this.nodes.stream()
+				.filter(n -> n.ctx() instanceof AdvisorObservationContext a && a.getAdvisorName().equals(name))
+				.findFirst();
+		}
+
+		List<Node> findAllAdvisors(String name) {
+			return this.nodes.stream()
+				.filter(n -> n.ctx() instanceof AdvisorObservationContext a && a.getAdvisorName().equals(name))
+				.toList();
+		}
+
+		List<Node> findAllByType(Class<? extends Observation.Context> type) {
+			return this.nodes.stream().filter(n -> type.isInstance(n.ctx())).toList();
+		}
+
+		// Inner types declared last to satisfy the InnerTypeLast checkstyle rule.
+
+		enum Kind {
+
+			START, SCOPE_OPEN, SCOPE_CLOSE
+
+		}
+
+		record TimelineEvent(Kind kind, Observation.Context ctx, Observation.@Nullable Context parentCtx,
+				String thread) {
+		}
+
+		record Node(Observation.Context ctx, Observation.@Nullable Context parentCtx) {
+		}
+
+	}
+
+	@SpringBootConfiguration
+	static class Config {
+
+		// Intentionally empty: each test creates its own ObservationRegistry so that
+		// handlers do not accumulate across methods. The Spring context is needed only
+		// to satisfy @SpringBootTest and load the logging-test profile.
+
+	}
+
+	class Tools {
+
+		private static final Logger logger = LoggerFactory.getLogger(Tools.class);
+
+		private final MockWeatherService weatherService = new MockWeatherService();
+
+		@Tool(description = "Get the current weather in a given location")
+		public MockWeatherService.Response getCurrentWeather(MockWeatherService.Request request) {
+			logger.info("Calling function to get weather by location");
+			return this.weatherService.apply(request);
+		}
+
+	}
+
+}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAIToolCallObservation3IT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAIToolCallObservation3IT.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.chat.client;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Hooks;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.DefaultChatClientBuilder;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationContext;
+import org.springframework.ai.chat.client.observation.ChatClientObservationContext;
+import org.springframework.ai.chat.observation.ChatModelObservationContext;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = OpenAIToolCallObservation3IT.Config.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+@ActiveProfiles("logging-test")
+class OpenAIToolCallObservation3IT {
+
+	private static final Logger logger = LoggerFactory.getLogger(OpenAIToolCallObservation3IT.class);
+
+	static final String CHAT_MODEL_STREAM_ADVISOR_NAME = "stream";
+
+	// =========================================================================
+	// Shared assertion helpers (must appear before inner types per InnerTypeLast)
+	// =========================================================================
+
+	private static void assertChatClientIsRoot(ObservationCapture capture) {
+		var chatClientNode = capture.findChatClient();
+		assertThat(chatClientNode).as("ChatClientObservationContext must be present").isPresent();
+		assertThat(chatClientNode.get().parentCtx()).as("spring.ai.chat.client must be the root span (no parent)")
+			.isNull();
+	}
+
+	// =========================================================================
+	// Per-test helper methods
+	// =========================================================================
+
+	private ChatClient buildChatClient(ObservationRegistry registry) {
+		var model = OpenAiChatModel.builder()
+			.observationRegistry(registry)
+			.options(OpenAiChatOptions.builder()
+				.apiKey(System.getenv("OPENAI_API_KEY"))
+				.model(OpenAiChatOptions.DEFAULT_CHAT_MODEL)
+				.build())
+			.build();
+
+		ToolCallAdvisor.Builder<?> toolCallAdvisorBuilder = ToolCallAdvisor.builder()
+			.toolCallingManager(ToolCallingManager.builder().observationRegistry(registry).build());
+
+		// Pass the same registry so ChatClientObservationContext,
+		// AdvisorObservationContext,
+		// and ChatModelObservationContext all share one registry and form a single tree.
+		return new DefaultChatClientBuilder(model, registry, null, null, toolCallAdvisorBuilder).build();
+	}
+
+	private void logCapture(ObservationCapture capture) {
+		logger.info("=== Observation timeline ({} events) ===", capture.fullTimeline().size());
+		capture.fullTimeline().forEach(event -> {
+			String kind = switch (event.kind()) {
+				case START -> "START      ";
+				case SCOPE_OPEN -> "SCOPE_OPEN ";
+				case SCOPE_CLOSE -> "SCOPE_CLOSE";
+			};
+			String ctxLabel = ctxLabel(event.ctx());
+			String parentLabel = event.parentCtx() != null ? " parent=" + ctxLabel(event.parentCtx()) : "";
+			String thread = " [" + event.thread() + "]";
+			logger.info("  {} {}{}{}", kind, ctxLabel, parentLabel, thread);
+		});
+	}
+
+	private static String ctxLabel(Observation.Context ctx) {
+		String type = ctx.getClass().getSimpleName();
+		if (ctx instanceof AdvisorObservationContext a) {
+			return type + "(" + a.getAdvisorName() + ")";
+		}
+		return type;
+	}
+
+	@Test
+	void streamObservationTreeEnabledContextPropagation() {
+		Hooks.enableAutomaticContextPropagation();
+		streamObservationTree();
+	}
+
+	@Test
+	void streamObservationTreeDisabledContextPropagation() {
+		// Hooks.disableAutomaticContextPropagation();
+		streamObservationTree();
+	}
+
+	private void streamObservationTree() {
+
+		// Hooks.disableAutomaticContextPropagation();
+
+		var reg = TestObservationRegistry.create();
+		var capture = new ObservationCapture();
+		reg.observationConfig().observationHandler(capture.handler());
+
+		String response = buildChatClient(reg).prompt()
+			.user("Say `Hello`")
+			.stream()
+			.content()
+			.collectList()
+			.block()
+			.stream()
+			.collect(Collectors.joining());
+
+		System.out.println(response);
+
+		logCapture(capture);
+
+		assertChatClientIsRoot(capture);
+
+		// context=ChatClientObservationContext parent=null
+		assertThat(capture.nodes.get(0).ctx()).as("ChatClientObservationContext must be the root span")
+			.isInstanceOf(ChatClientObservationContext.class);
+		assertThat(capture.nodes.get(0).parentCtx())
+			.as("ChatClientObservationContext must be the root span (no parent)")
+			.isNull();
+
+		// context=AdvisorObservationContext advisorName=stream
+		// parent=ChatClientObservationContext
+		assertThat(capture.nodes.get(1).ctx()).as("Second observation must be the 'stream' advisor span")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(CHAT_MODEL_STREAM_ADVISOR_NAME));
+		assertThat(capture.nodes.get(1).parentCtx()).as("'stream' advisor  parent must be ChatClientObservationContex")
+			.isInstanceOf(ChatClientObservationContext.class);
+
+		// context=ChatModelObservationContext parent=AdvisorObservationContext
+		assertThat(capture.nodes.get(2).ctx()).as("Third observation must be the ChatModel span")
+			.isInstanceOf(ChatModelObservationContext.class);
+		assertThat(capture.nodes.get(2).parentCtx()).as("ChatModel span parent must be the 'stream' advisor")
+			.isInstanceOf(AdvisorObservationContext.class)
+			.satisfies(ctx -> assertThat(((AdvisorObservationContext) ctx).getAdvisorName())
+				.isEqualTo(CHAT_MODEL_STREAM_ADVISOR_NAME));
+
+		var chatModelNodes = capture.findAllByType(ChatModelObservationContext.class);
+		assertThat(chatModelNodes).as("Expected at least 1 LLM calls").hasSizeGreaterThanOrEqualTo(1);
+	}
+
+	/**
+	 * Captures the full observation lifecycle — starts, scope opens, and scope closes —
+	 * in a single ordered timeline. Each event records the context, optional parent (for
+	 * START events), and the thread name, making it straightforward to see which
+	 * observations were active as thread-local current at each moment and on which
+	 * thread.
+	 *
+	 * <p>
+	 * The {@link #nodes} list is a filtered view of the timeline containing only START
+	 * events; it preserves backward-compatible indexed access used by the existing tests.
+	 */
+	static final class ObservationCapture {
+
+		final List<Node> nodes = new CopyOnWriteArrayList<>();
+
+		private final List<TimelineEvent> timeline = new CopyOnWriteArrayList<>();
+
+		ObservationHandler<Observation.Context> handler() {
+			return new ObservationHandler<>() {
+				@Override
+				public void onStart(Observation.Context ctx) {
+					Observation.Context parentCtx = null;
+					var parentObs = ctx.getParentObservation();
+					if (parentObs != null) {
+						parentCtx = (Observation.Context) parentObs.getContextView();
+					}
+					nodes.add(new Node(ctx, parentCtx));
+					timeline.add(new TimelineEvent(Kind.START, ctx, parentCtx, thread()));
+				}
+
+				@Override
+				public void onScopeOpened(Observation.Context ctx) {
+					timeline.add(new TimelineEvent(Kind.SCOPE_OPEN, ctx, null, thread()));
+				}
+
+				@Override
+				public void onScopeClosed(Observation.Context ctx) {
+					timeline.add(new TimelineEvent(Kind.SCOPE_CLOSE, ctx, null, thread()));
+				}
+
+				@Override
+				public boolean supportsContext(Observation.Context ctx) {
+					return true;
+				}
+
+				private String thread() {
+					return Thread.currentThread().getName();
+				}
+			};
+		}
+
+		List<Node> all() {
+			return Collections.unmodifiableList(this.nodes);
+		}
+
+		List<TimelineEvent> fullTimeline() {
+			return Collections.unmodifiableList(this.timeline);
+		}
+
+		Optional<Node> findChatClient() {
+			return this.nodes.stream().filter(n -> n.ctx() instanceof ChatClientObservationContext).findFirst();
+		}
+
+		Optional<Node> findAdvisor(String name) {
+			return this.nodes.stream()
+				.filter(n -> n.ctx() instanceof AdvisorObservationContext a && a.getAdvisorName().equals(name))
+				.findFirst();
+		}
+
+		List<Node> findAllAdvisors(String name) {
+			return this.nodes.stream()
+				.filter(n -> n.ctx() instanceof AdvisorObservationContext a && a.getAdvisorName().equals(name))
+				.toList();
+		}
+
+		List<Node> findAllByType(Class<? extends Observation.Context> type) {
+			return this.nodes.stream().filter(n -> type.isInstance(n.ctx())).toList();
+		}
+
+		// Inner types declared last to satisfy the InnerTypeLast checkstyle rule.
+
+		enum Kind {
+
+			START, SCOPE_OPEN, SCOPE_CLOSE
+
+		}
+
+		record TimelineEvent(Kind kind, Observation.Context ctx, Observation.@Nullable Context parentCtx,
+				String thread) {
+		}
+
+		record Node(Observation.Context ctx, Observation.@Nullable Context parentCtx) {
+		}
+
+	}
+
+	@SpringBootConfiguration
+	static class Config {
+
+		// Intentionally empty: each test creates its own ObservationRegistry so that
+		// handlers do not accumulate across methods. The Spring context is needed only
+		// to satisfy @SpringBootTest and load the logging-test profile.
+
+	}
+
+}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -912,24 +911,7 @@ public class DefaultChatClient implements ChatClient {
 					ccr.advisorObservationConvention, ccr.toolCallAdvisorBuilder);
 		}
 
-		@Deprecated(since = "2.0.0", forRemoval = true)
-		public DefaultChatClientRequestSpec(ChatModel chatModel, @Nullable String userText,
-				Map<String, Object> userParams, Map<String, Object> userMetadata, @Nullable String systemText,
-				Map<String, Object> systemParams, Map<String, Object> systemMetadata, List<ToolCallback> toolCallbacks,
-				List<ToolCallbackProvider> toolCallbackProviders, List<Message> messages, List<String> toolNames,
-				List<Media> media, ChatOptions.@Nullable Builder<?> customizer, List<Advisor> advisors,
-				Map<String, Object> advisorParams, ObservationRegistry observationRegistry,
-				@Nullable ChatClientObservationConvention chatClientObservationConvention,
-				Map<String, Object> toolContext, @Nullable TemplateRenderer templateRenderer,
-				@Nullable AdvisorObservationConvention advisorObservationConvention) {
-
-			this(chatModel, userText, userParams, userMetadata, systemText, systemParams, systemMetadata, toolCallbacks,
-					toolCallbackProviders, messages, toolNames, media, customizer, advisors, advisorParams,
-					observationRegistry, chatClientObservationConvention, toolContext, templateRenderer,
-					advisorObservationConvention, null);
-		}
-
-		public DefaultChatClientRequestSpec(ChatModel chatModel, @Nullable String userText,
+		protected DefaultChatClientRequestSpec(ChatModel chatModel, @Nullable String userText,
 				Map<String, Object> userParams, Map<String, Object> userMetadata, @Nullable String systemText,
 				Map<String, Object> systemParams, Map<String, Object> systemMetadata, List<ToolCallback> toolCallbacks,
 				List<ToolCallbackProvider> toolCallbackProviders, List<Message> messages, List<String> toolNames,
@@ -938,7 +920,7 @@ public class DefaultChatClient implements ChatClient {
 				@Nullable ChatClientObservationConvention chatClientObservationConvention,
 				Map<String, Object> toolContext, @Nullable TemplateRenderer templateRenderer,
 				@Nullable AdvisorObservationConvention advisorObservationConvention,
-				ToolCallAdvisor.@Nullable Builder<?> toolCallAdvisorBuilder) {
+				ToolCallAdvisor.Builder<?> toolCallAdvisorBuilder) {
 
 			Assert.notNull(chatModel, "chatModel cannot be null");
 			Assert.notNull(userParams, "userParams cannot be null");
@@ -956,7 +938,7 @@ public class DefaultChatClient implements ChatClient {
 			Assert.notNull(toolContext, "toolContext cannot be null");
 
 			this.chatModel = chatModel;
-			this.toolCallAdvisorBuilder = Objects.requireNonNullElse(toolCallAdvisorBuilder, ToolCallAdvisor.builder());
+			this.toolCallAdvisorBuilder = toolCallAdvisorBuilder;
 			this.optionsCustomizer = customizer != null ? customizer.clone() : null;
 
 			this.userText = userText;

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import io.micrometer.observation.ObservationRegistry;
@@ -37,6 +38,7 @@ import org.springframework.ai.chat.client.observation.ChatClientObservationConve
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.template.TemplateRenderer;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -60,14 +62,7 @@ public class DefaultChatClientBuilder implements Builder {
 	protected final DefaultChatClientRequestSpec defaultRequest;
 
 	DefaultChatClientBuilder(ChatModel chatModel) {
-		this(chatModel, ObservationRegistry.NOOP, null, null);
-	}
-
-	@Deprecated(since = "2.0.0", forRemoval = true)
-	public DefaultChatClientBuilder(ChatModel chatModel, ObservationRegistry observationRegistry,
-			@Nullable ChatClientObservationConvention chatClientObservationConvention,
-			@Nullable AdvisorObservationConvention advisorObservationConvention) {
-		this(chatModel, observationRegistry, chatClientObservationConvention, advisorObservationConvention, null);
+		this(chatModel, ObservationRegistry.NOOP, null, null, null);
 	}
 
 	public DefaultChatClientBuilder(ChatModel chatModel, ObservationRegistry observationRegistry,
@@ -76,6 +71,9 @@ public class DefaultChatClientBuilder implements Builder {
 			ToolCallAdvisor.@Nullable Builder<?> toolCallAdvisorBuilder) {
 		Assert.notNull(chatModel, "the " + ChatModel.class.getName() + " must be non-null");
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
+
+		toolCallAdvisorBuilder = Objects.requireNonNullElse(toolCallAdvisorBuilder, ToolCallAdvisor.builder()
+			.toolCallingManager(ToolCallingManager.builder().observationRegistry(observationRegistry).build()));
 
 		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), Map.of(), null, Map.of(),
 				Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -902,7 +902,7 @@ class DefaultChatClientTests {
 		given(chatModel.call(promptCaptor.capture()))
 			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("response")))));
 
-		ChatClient chatClient = new DefaultChatClientBuilder(chatModel, observationRegistry, null, null).build();
+		ChatClient chatClient = new DefaultChatClientBuilder(chatModel, observationRegistry, null, null, null).build();
 		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
 			.prompt("my question");
 		DefaultChatClient.DefaultCallResponseSpec spec = (DefaultChatClient.DefaultCallResponseSpec) chatClientRequestSpec
@@ -1448,7 +1448,7 @@ class DefaultChatClientTests {
 		given(chatModel.stream(promptCaptor.capture()))
 			.willReturn(Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage("response"))))));
 
-		ChatClient chatClient = new DefaultChatClientBuilder(chatModel, observationRegistry, null, null).build();
+		ChatClient chatClient = new DefaultChatClientBuilder(chatModel, observationRegistry, null, null, null).build();
 		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
 			.prompt("my question");
 		DefaultChatClient.DefaultStreamResponseSpec spec = (DefaultChatClient.DefaultStreamResponseSpec) chatClientRequestSpec
@@ -1598,7 +1598,8 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mockChatModel();
 		DefaultChatClient.DefaultChatClientRequestSpec spec = new DefaultChatClient.DefaultChatClientRequestSpec(
 				chatModel, null, Map.of(), Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(),
-				List.of(), List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null);
+				List.of(), List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null,
+				ToolCallAdvisor.builder());
 		assertThat(spec).isNotNull();
 	}
 
@@ -1606,7 +1607,7 @@ class DefaultChatClientTests {
 	void whenChatModelIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(null, null, Map.of(), Map.of(),
 				null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(),
-				Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null))
+				Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null, ToolCallAdvisor.builder()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("chatModel cannot be null");
 	}
@@ -1615,7 +1616,7 @@ class DefaultChatClientTests {
 	void whenObservationRegistryIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(mockChatModel(), null, Map.of(),
 				Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null,
-				List.of(), Map.of(), null, null, Map.of(), null, null))
+				List.of(), Map.of(), null, null, Map.of(), null, null, ToolCallAdvisor.builder()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("observationRegistry cannot be null");
 	}
@@ -2354,7 +2355,7 @@ class DefaultChatClientTests {
 		var advisorObservationConvention = mock(AdvisorObservationConvention.class);
 
 		var builder = new DefaultChatClientBuilder(chatModel, observationRegistry, observationConvention,
-				advisorObservationConvention);
+				advisorObservationConvention, null);
 
 		assertThat(builder).isNotNull();
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallObservationThreadLocalTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallObservationThreadLocalTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ToolCallObservationThreadLocalTests {
+
+	private TestObservationRegistry observationRegistry = TestObservationRegistry.create();
+
+	@Test
+	public void testSyncToolWithMockModel() {
+		AtomicReference<Observation> threadLocalObservation = new AtomicReference<>();
+
+		ToolCallback syncTool = FunctionToolCallback.<CityInput, String>builder("getWeather", in -> {
+			threadLocalObservation.set(this.observationRegistry.getCurrentObservation());
+
+			// Simulate a synchronous RestTemplate call that creates an observation
+			Observation restTemplateObs = Observation.createNotStarted("http.client.requests",
+					this.observationRegistry);
+			restTemplateObs.start().stop(); // parent will be whatever is in ThreadLocal
+
+			return in.city() + ": 25C";
+		}).description("Get weather").inputType(CityInput.class).build();
+
+		ChatModel mockModel = new ChatModel() {
+			private boolean first = true;
+
+			@Override
+			public ChatResponse call(Prompt prompt) {
+				return null;
+			}
+
+			@Override
+			public Flux<ChatResponse> stream(Prompt prompt) {
+				return Flux.deferContextual(ctx -> {
+					// Manually create chat.model observation as models do
+					Observation obs = Observation.createNotStarted("chat.model",
+							ToolCallObservationThreadLocalTests.this.observationRegistry);
+					obs.parentObservation(ctx.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
+
+					ChatResponse response;
+					if (this.first) {
+						this.first = false;
+						AssistantMessage.ToolCall tc = new AssistantMessage.ToolCall("1", "function", "getWeather",
+								"{\"city\":\"Paris\"}");
+						AssistantMessage msg = org.springframework.ai.chat.messages.AssistantMessage.builder()
+							.toolCalls(List.of(tc))
+							.build();
+						response = new ChatResponse(List.of(new Generation(msg)));
+					}
+					else {
+						response = new ChatResponse(List.of(new Generation(new AssistantMessage("Weather is 25C"))));
+					}
+
+					return Flux.just(response)
+						.publishOn(Schedulers.parallel()) // Simulate response on
+															// different thread!
+						.doFinally(st -> obs.stop());
+				});
+			}
+
+			@Override
+			public ChatOptions getDefaultOptions() {
+				return org.springframework.ai.model.tool.DefaultToolCallingChatOptions.builder().build();
+			}
+		};
+
+		ChatClient chatClient = ChatClient.builder(mockModel, this.observationRegistry, null, null, null).build();
+
+		chatClient.prompt("weather in Paris?").tools(t -> t.callbacks(syncTool)).stream().chatResponse().blockLast();
+
+		assertThat(threadLocalObservation.get()).isNotNull();
+		assertThat(threadLocalObservation.get().getContextView().getName()).isEqualTo("spring.ai.tool");
+	}
+
+	public record CityInput(String city) {
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -30,6 +30,7 @@ import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.util.context.ContextView;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -237,21 +238,32 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 				.toolCallArguments(finalToolInputArguments)
 				.build();
 
-			String toolCallResult = ToolCallingObservationDocumentation.TOOL_CALL
-				.observation(this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
-						this.observationRegistry)
-				.parentObservation(parent)
-				.observe(() -> {
-					String toolResult;
-					try {
-						toolResult = toolCallback.call(finalToolInputArguments, toolContext);
-					}
-					catch (ToolExecutionException ex) {
-						toolResult = this.toolExecutionExceptionProcessor.process(ex);
-					}
-					observationContext.setToolCallResult(toolResult);
-					return toolResult;
-				});
+			var toolObservation = ToolCallingObservationDocumentation.TOOL_CALL.observation(this.observationConvention,
+					DEFAULT_OBSERVATION_CONVENTION, () -> observationContext, this.observationRegistry);
+
+			// When tool execution runs on a boundedElastic thread (streaming path)
+			// without Hooks.enableAutomaticContextPropagation(), the Micrometer
+			// thread-local is empty and setParentFromCurrentObservation() cannot find the
+			// parent. ToolCallAdvisor stores the Reactor context in
+			// ToolCallReactiveContextHolder before dispatching, so we can read the parent
+			// observation from there and set it explicitly.
+			ContextView reactorCtx = ToolCallReactiveContextHolder.getContext();
+			if (reactorCtx.hasKey(ObservationThreadLocalAccessor.KEY)) {
+				Observation parentObs = reactorCtx.get(ObservationThreadLocalAccessor.KEY);
+				toolObservation.parentObservation(parentObs);
+			}
+
+			String toolCallResult = toolObservation.observe(() -> {
+				String toolResult;
+				try {
+					toolResult = toolCallback.call(finalToolInputArguments, toolContext);
+				}
+				catch (ToolExecutionException ex) {
+					toolResult = this.toolExecutionExceptionProcessor.process(ex);
+				}
+				observationContext.setToolCallResult(toolResult);
+				return toolResult;
+			});
 
 			toolResponses.add(new ToolResponseMessage.ToolResponse(toolCall.id(), toolName,
 					toolCallResult != null ? toolCallResult : ""));


### PR DESCRIPTION
- Document reactive streaming context propagation and observation tree
- Wire the ObservationRegistry into the default ToolCallingManager so that spring.ai.tool observations are recorded.
- Fix a parent-observation gap in DefaultToolCallingManager where tool execution on a boundedElastic thread could not find its parent span when automatic context propagation was disabled
- Clean up deprecated DefaultChatClientBuilder and DefaultChatClientRequestSpec constructors.
- Add streaming observation integration tests and document the reactive context propagation behaviour in the observability guide.