### PR TITLE
GH-6117: Support multi-block system message caching for Bedrock

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -455,29 +455,30 @@ public class BedrockProxyChatModel implements ChatModel {
 			logger.debug("Cache strategy: {}, shouldCacheSystem: {}", cacheOptions.getStrategy(), shouldCacheSystem);
 		}
 
-		// Build system messages with optional caching on last message
 		List<org.springframework.ai.chat.messages.Message> systemMessageList = prompt.getInstructions()
 			.stream()
 			.filter(m -> m.getMessageType() == MessageType.SYSTEM)
 			.toList();
 
+		// With multi-block system caching, place the cache point after the
+		// second-to-last block so a trailing dynamic block can vary without
+		// invalidating the cached prefix.
+		boolean multiBlockSystemCaching = cacheOptions != null && cacheOptions.isMultiBlockSystemCaching()
+				&& systemMessageList.size() > 1;
+		int cacheBoundaryIndex = multiBlockSystemCaching ? systemMessageList.size() - 2 : systemMessageList.size() - 1;
+
 		List<SystemContentBlock> systemMessages = new ArrayList<>();
 		for (int i = 0; i < systemMessageList.size(); i++) {
 			org.springframework.ai.chat.messages.Message sysMessage = systemMessageList.get(i);
 
-			// Add the text content block
 			SystemContentBlock textBlock = SystemContentBlock.builder().text(sysMessage.getText()).build();
 			systemMessages.add(textBlock);
 
-			// Apply cache point marker after last system message if caching is enabled
-			// SystemContentBlock is a UNION type - text and cachePoint must be separate
-			// blocks
-			boolean isLastSystem = (i == systemMessageList.size() - 1);
-			if (isLastSystem && shouldCacheSystem) {
+			// SystemContentBlock is a union: text and cachePoint must be separate blocks.
+			if (i == cacheBoundaryIndex && shouldCacheSystem) {
 				CachePointBlock cachePoint = CachePointBlock.builder().type("default").build();
 				SystemContentBlock cachePointBlock = SystemContentBlock.builder().cachePoint(cachePoint).build();
 				systemMessages.add(cachePointBlock);
-				logger.debug("Applied cache point after system message");
 			}
 		}
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptions.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptions.java
@@ -54,8 +54,11 @@ public class BedrockCacheOptions {
 
 	private final BedrockCacheStrategy strategy;
 
-	protected BedrockCacheOptions(@Nullable BedrockCacheStrategy strategy) {
+	private final boolean multiBlockSystemCaching;
+
+	protected BedrockCacheOptions(@Nullable BedrockCacheStrategy strategy, boolean multiBlockSystemCaching) {
 		this.strategy = (strategy != null ? strategy : BedrockCacheStrategy.NONE);
+		this.multiBlockSystemCaching = multiBlockSystemCaching;
 	}
 
 	/**
@@ -75,11 +78,29 @@ public class BedrockCacheOptions {
 	}
 
 	/**
+	 * Returns whether multi-block system message caching is enabled. When enabled, each
+	 * {@link org.springframework.ai.chat.messages.SystemMessage} is emitted as a separate
+	 * {@code SystemContentBlock} in the Bedrock Converse request, with a
+	 * {@code CachePoint} placed after the second-to-last text block. This allows a static
+	 * system prompt prefix to be cached while dynamic content (e.g., advisor-injected RAG
+	 * context) in the last block can change freely without invalidating the cache. When
+	 * disabled (default), the cache point is placed after the last system block, so any
+	 * change to the last block invalidates the cache.
+	 * @return {@code true} if each system message is emitted as a separate content block
+	 * with the cache point placed before the last block; {@code false} otherwise
+	 */
+	public boolean isMultiBlockSystemCaching() {
+		return this.multiBlockSystemCaching;
+	}
+
+	/**
 	 * Builder for constructing BedrockCacheOptions instances.
 	 */
 	public static class Builder {
 
 		private BedrockCacheStrategy strategy = BedrockCacheStrategy.NONE;
+
+		private boolean multiBlockSystemCaching = false;
 
 		/**
 		 * Sets the caching strategy.
@@ -92,11 +113,26 @@ public class BedrockCacheOptions {
 		}
 
 		/**
+		 * Sets whether multi-block system message caching is enabled. When enabled, each
+		 * {@link org.springframework.ai.chat.messages.SystemMessage} is emitted as a
+		 * separate {@code SystemContentBlock} and the cache point is placed after the
+		 * second-to-last block, allowing a static prefix to be cached while the last
+		 * (dynamic) block can change freely.
+		 * @param multiBlockSystemCaching {@code true} to enable multi-block system
+		 * caching; defaults to {@code false}
+		 * @return this Builder instance
+		 */
+		public Builder multiBlockSystemCaching(boolean multiBlockSystemCaching) {
+			this.multiBlockSystemCaching = multiBlockSystemCaching;
+			return this;
+		}
+
+		/**
 		 * Builds the BedrockCacheOptions instance.
 		 * @return the configured BedrockCacheOptions
 		 */
 		public BedrockCacheOptions build() {
-			return new BedrockCacheOptions(this.strategy);
+			return new BedrockCacheOptions(this.strategy, this.multiBlockSystemCaching);
 		}
 
 	}

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
@@ -471,6 +471,70 @@ class BedrockProxyChatModelIT {
 	}
 
 	@Test
+	void testMultiBlockSystemPromptCaching() {
+		String model = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+		String basePrompt = """
+				You are an expert software architect with deep knowledge of distributed systems,
+				microservices, cloud computing, and software design patterns. Your role is to provide
+				detailed technical guidance on system architecture, design decisions, and best practices.
+
+				Key areas of expertise:
+				- Distributed systems design and architecture
+				- Microservices patterns and anti-patterns
+				- Cloud-native application development
+				- Event-driven architectures
+				- Database design and scaling strategies
+				- API design and RESTful services
+				- Security best practices
+				- Performance optimization and scalability
+
+				""";
+
+		// Repeat to exceed 4096 token minimum for Claude Haiku 4.5.
+		String staticSystemPrompt = basePrompt.repeat(40)
+				+ "When answering questions, provide clear, structured responses with examples.";
+
+		BedrockCacheOptions cacheOptions = BedrockCacheOptions.builder()
+			.strategy(BedrockCacheStrategy.SYSTEM_ONLY)
+			.multiBlockSystemCaching(true)
+			.build();
+
+		BedrockChatOptions chatOptions = BedrockChatOptions.builder()
+			.model(model)
+			.cacheOptions(cacheOptions)
+			.maxTokens(500)
+			.build();
+
+		// Each call mutates the trailing dynamic system block. With
+		// multiBlockSystemCaching, the static prefix should still get a cache read
+		// despite the dynamic block changing each request.
+		List<String> questions = List.of("What is a monolith?", "What is a microservice?",
+				"What is event-driven architecture?", "What is a service mesh?", "What is CQRS?");
+		AtomicInteger questionIndex = new AtomicInteger(0);
+		Awaitility.await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(3)).untilAsserted(() -> {
+			int idx = questionIndex.getAndIncrement();
+			String question = questions.get(idx % questions.size());
+			String dynamicContext = "Dynamic context for turn " + idx + ": timestamp=" + System.nanoTime();
+
+			ChatResponse response = this.chatModel.call(new Prompt(List.of(new SystemMessage(staticSystemPrompt),
+					new SystemMessage(dynamicContext), new UserMessage(question)), chatOptions));
+			assertThat(response.getResults()).hasSize(1);
+			assertThat(response.getResult().getOutput().getText()).isNotEmpty();
+
+			Integer cacheRead = response.getMetadata().get("cacheReadInputTokens");
+			Integer cacheWrite = response.getMetadata().get("cacheWriteInputTokens");
+			logger.info("[multiBlockSystem] attempt={}, cacheWrite={}, cacheRead={}", idx, cacheWrite, cacheRead);
+
+			assertThat(cacheRead).as("Static prefix should eventually be read from cache despite dynamic block changes")
+				.isNotNull()
+				.isPositive();
+			assertThat(cacheRead).as("Cache read should meet the 4096 token minimum for Claude Haiku 4.5")
+				.isGreaterThan(4096);
+		});
+	}
+
+	@Test
 	void testToolsOnlyPromptCaching() {
 		// IMPORTANT: This test requires a Claude model - Amazon Nova models do NOT
 		// support tool caching and will return ValidationException.

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.bedrock.converse;
 
 import java.net.URL;
+import java.util.List;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
@@ -29,8 +30,15 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
 
+import org.springframework.ai.bedrock.converse.api.BedrockCacheOptions;
+import org.springframework.ai.bedrock.converse.api.BedrockCacheStrategy;
 import org.springframework.ai.bedrock.converse.api.MediaFetcher;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
@@ -199,6 +207,128 @@ class BedrockProxyChatModelTest {
 			.cause()
 			.isInstanceOf(SecurityException.class)
 			.hasMessageContaining("evil.com");
+	}
+
+	@Test
+	void multiBlockSystemCachingPlacesCachePointBeforeLastSystemBlock() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(BedrockCacheOptions.builder()
+				.strategy(BedrockCacheStrategy.SYSTEM_ONLY)
+				.multiBlockSystemCaching(true)
+				.build())
+			.build();
+
+		Prompt prompt = new Prompt(List.of(new SystemMessage("Static system instructions."),
+				new SystemMessage("Dynamic RAG context."), new UserMessage("Question?")), options);
+
+		ConverseRequest request = model.createRequest(prompt);
+		List<SystemContentBlock> system = request.system();
+
+		// Expect: [text(static), cachePoint, text(dynamic)]
+		assertThat(system).hasSize(3);
+		assertThat(system.get(0).text()).isEqualTo("Static system instructions.");
+		assertThat(system.get(0).cachePoint()).isNull();
+		assertThat(system.get(1).text()).isNull();
+		assertThat(system.get(1).cachePoint()).isNotNull();
+		assertThat(system.get(1).cachePoint().typeAsString()).isEqualTo("default");
+		assertThat(system.get(2).text()).isEqualTo("Dynamic RAG context.");
+		assertThat(system.get(2).cachePoint()).isNull();
+	}
+
+	@Test
+	void multiBlockSystemCachingWithSingleMessageFallsBackToLastBlockPlacement() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(BedrockCacheOptions.builder()
+				.strategy(BedrockCacheStrategy.SYSTEM_ONLY)
+				.multiBlockSystemCaching(true)
+				.build())
+			.build();
+
+		Prompt prompt = new Prompt(List.of(new SystemMessage("Only system message."), new UserMessage("Question?")),
+				options);
+
+		ConverseRequest request = model.createRequest(prompt);
+		List<SystemContentBlock> system = request.system();
+
+		// Single message: cache point goes after the only text block.
+		assertThat(system).hasSize(2);
+		assertThat(system.get(0).text()).isEqualTo("Only system message.");
+		assertThat(system.get(1).cachePoint()).isNotNull();
+	}
+
+	@Test
+	void multiBlockSystemCachingDisabledByDefaultPlacesCachePointAfterLastBlock() {
+		BedrockProxyChatModel model = newModel();
+
+		// multiBlockSystemCaching not set: defaults to false.
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(BedrockCacheOptions.builder().strategy(BedrockCacheStrategy.SYSTEM_ONLY).build())
+			.build();
+
+		Prompt prompt = new Prompt(List.of(new SystemMessage("Static system instructions."),
+				new SystemMessage("Dynamic RAG context."), new UserMessage("Question?")), options);
+
+		ConverseRequest request = model.createRequest(prompt);
+		List<SystemContentBlock> system = request.system();
+
+		// Expect: [text(static), text(dynamic), cachePoint] - backward compatible.
+		assertThat(system).hasSize(3);
+		assertThat(system.get(0).text()).isEqualTo("Static system instructions.");
+		assertThat(system.get(1).text()).isEqualTo("Dynamic RAG context.");
+		assertThat(system.get(2).cachePoint()).isNotNull();
+	}
+
+	@Test
+	void multiBlockSystemCachingHonorsSystemAndToolsStrategy() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(BedrockCacheOptions.builder()
+				.strategy(BedrockCacheStrategy.SYSTEM_AND_TOOLS)
+				.multiBlockSystemCaching(true)
+				.build())
+			.build();
+
+		Prompt prompt = new Prompt(
+				List.of(new SystemMessage("Static."), new SystemMessage("Dynamic."), new UserMessage("Question?")),
+				options);
+
+		ConverseRequest request = model.createRequest(prompt);
+		List<SystemContentBlock> system = request.system();
+
+		// SYSTEM_AND_TOOLS still places the system cache point between blocks.
+		assertThat(system).hasSize(3);
+		assertThat(system.get(0).text()).isEqualTo("Static.");
+		assertThat(system.get(1).cachePoint()).isNotNull();
+		assertThat(system.get(2).text()).isEqualTo("Dynamic.");
+	}
+
+	@Test
+	void multiBlockSystemCachingHasNoEffectWhenStrategyIsNone() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(BedrockCacheOptions.builder()
+				.strategy(BedrockCacheStrategy.NONE)
+				.multiBlockSystemCaching(true)
+				.build())
+			.build();
+
+		Prompt prompt = new Prompt(
+				List.of(new SystemMessage("Static."), new SystemMessage("Dynamic."), new UserMessage("Question?")),
+				options);
+
+		ConverseRequest request = model.createRequest(prompt);
+		List<SystemContentBlock> system = request.system();
+
+		// No cache point added when caching is off.
+		assertThat(system).hasSize(2);
+		assertThat(system.get(0).cachePoint()).isNull();
+		assertThat(system.get(1).cachePoint()).isNull();
 	}
 
 }

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptionsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptionsTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link BedrockCacheOptions}.
+ *
+ * @author Soby Chacko
+ */
+class BedrockCacheOptionsTests {
+
+	@Test
+	void defaultsAreSane() {
+		BedrockCacheOptions options = BedrockCacheOptions.builder().build();
+		assertThat(options.getStrategy()).isEqualTo(BedrockCacheStrategy.NONE);
+		assertThat(options.isMultiBlockSystemCaching()).isFalse();
+	}
+
+	@Test
+	void builderSetsStrategy() {
+		BedrockCacheOptions options = BedrockCacheOptions.builder().strategy(BedrockCacheStrategy.SYSTEM_ONLY).build();
+		assertThat(options.getStrategy()).isEqualTo(BedrockCacheStrategy.SYSTEM_ONLY);
+	}
+
+	@Test
+	void multiBlockSystemCachingDefaultsToFalse() {
+		BedrockCacheOptions options = BedrockCacheOptions.builder().build();
+		assertThat(options.isMultiBlockSystemCaching()).isFalse();
+	}
+
+	@Test
+	void builderEnablesMultiBlockSystemCaching() {
+		BedrockCacheOptions options = BedrockCacheOptions.builder()
+			.strategy(BedrockCacheStrategy.SYSTEM_ONLY)
+			.multiBlockSystemCaching(true)
+			.build();
+		assertThat(options.isMultiBlockSystemCaching()).isTrue();
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -288,6 +288,42 @@ String response = chatClient.prompt()
     .content();
 ----
 
+==== Multi-Block System Message Caching
+
+When using advisors (e.g., RAG context injection), your system prompt may consist of multiple `SystemMessage` instances: a static prefix (your base instructions) and a dynamic suffix (advisor-injected context that changes each request).
+
+By default, when `SYSTEM_ONLY` or `SYSTEM_AND_TOOLS` caching is enabled, each `SystemMessage` is emitted as a separate `SystemContentBlock` and the cache point is placed *after the last block*.
+If any part of that content changes between requests, the entire system cache is invalidated — resulting in a 1.25x cache write cost on every request instead of the much cheaper cache read.
+
+The `multiBlockSystemCaching` option solves this by placing the cache point *after the second-to-last* system block (i.e., at the boundary between the static prefix and the dynamic suffix), so the static portion remains cached even as the last block changes freely.
+
+[source,java]
+----
+BedrockCacheOptions cacheOptions = BedrockCacheOptions.builder()
+    .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
+    .multiBlockSystemCaching(true)
+    .build();
+
+BedrockChatOptions chatOptions = BedrockChatOptions.builder()
+    .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
+    .cacheOptions(cacheOptions)
+    .build();
+
+// Static system prompt (will be cached)
+SystemMessage staticPrompt = new SystemMessage("You are an expert assistant...");
+// Dynamic RAG context (injected by advisor, changes each request)
+SystemMessage dynamicContext = new SystemMessage("Relevant context: " + ragResults);
+
+Prompt prompt = new Prompt(List.of(staticPrompt, dynamicContext, new UserMessage("...")), chatOptions);
+----
+
+This produces a Bedrock `system` array of the form `[text(static), cachePoint, text(dynamic)]` so only the static prefix participates in the cache key.
+
+NOTE: If only a single `SystemMessage` is present, the cache point is placed after that single block (same as the default behavior).
+The `multiBlockSystemCaching` option only changes placement when there are two or more system messages.
+
+IMPORTANT: Message ordering matters. The cache point is always placed after the second-to-last system block, so static content must come before dynamic content in the message list. If you register your base instructions as the first `SystemMessage` and let advisors append dynamic context after, this ordering is naturally satisfied.
+
 ==== Using ChatClient Fluent API
 
 [source,java]


### PR DESCRIPTION
Closes #6117

https://github.com/spring-projects/spring-ai/issues/6117

Add `multiBlockSystemCaching` flag to `BedrockCacheOptions`. When enabled and there are 2+ system messages, place the cache point after the second-to-last `SystemContentBlock` so a static system prefix stays cached while a trailing dynamic block can change freely. Defaults to false; single system message and existing behavior unchanged.
