### PR TITLE
Remove internal tool execution from AnthropicChatModel

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfiguration.java
@@ -25,9 +25,7 @@ import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
-import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -55,8 +53,7 @@ public class AnthropicChatAutoConfiguration {
 	public AnthropicChatModel anthropicChatModel(AnthropicConnectionProperties connectionProperties,
 			AnthropicChatProperties chatProperties, ToolCallingManager toolCallingManager,
 			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
-			ObjectProvider<ChatModelObservationConvention> observationConvention,
-			ObjectProvider<ToolExecutionEligibilityPredicate> anthropicToolExecutionEligibilityPredicate) {
+			ObjectProvider<ChatModelObservationConvention> observationConvention) {
 
 		AnthropicChatOptions.Builder builder = chatProperties.toOptions().mutate();
 		if (connectionProperties.getApiKey() != null) {
@@ -84,8 +81,6 @@ public class AnthropicChatAutoConfiguration {
 			.toolCallingManager(toolCallingManager)
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.meterRegistry(chatProperties.isConnectionPoolMetricsEnabled() ? meterRegistry.getIfAvailable() : null)
-			.toolExecutionEligibilityPredicate(anthropicToolExecutionEligibilityPredicate
-				.getIfUnique(DefaultToolExecutionEligibilityPredicate::new))
 			.build();
 
 		observationConvention.ifAvailable(chatModel::setObservationConvention);

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
@@ -16,24 +16,25 @@
 
 package org.springframework.ai.model.anthropic.autoconfigure.tool;
 
-import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.anthropic.models.messages.Model;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
 
 import org.springframework.ai.anthropic.AnthropicChatModel;
-import org.springframework.ai.anthropic.AnthropicChatOptions;
-import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.model.ChatResponse;
-import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration;
 import org.springframework.ai.model.anthropic.autoconfigure.tool.MockWeatherService.Request;
 import org.springframework.ai.model.anthropic.autoconfigure.tool.MockWeatherService.Response;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -43,13 +44,17 @@ import org.springframework.context.annotation.Description;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration test for tool calling via Spring bean-registered function callbacks.
+ * Integration test for tool calling via Spring bean-registered function callbacks using
+ * user-controlled tool execution with {@link ToolCallAdvisor}.
  *
  * @author Soby Chacko
  * @author Sebastien Deleuze
+ * @author Christian Tzolov
  */
 @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
 class FunctionCallWithFunctionBeanIT {
+
+	private static final String WEATHER_TOOL_DESCRIPTION = "Get the weather in location. Return temperature in 36°F or 36°C format.";
 
 	private final Logger logger = LoggerFactory.getLogger(FunctionCallWithFunctionBeanIT.class);
 
@@ -66,24 +71,85 @@ class FunctionCallWithFunctionBeanIT {
 
 				AnthropicChatModel chatModel = context.getBean(AnthropicChatModel.class);
 
-				var userMessage = new UserMessage(
-						"What's the weather like in San Francisco, in Paris, France and in Tokyo, Japan?"
-								+ " Return the temperature in Celsius.");
+				ToolCallback weatherToolCallback = buildToolCallback("weatherFunction",
+						context.getBean("weatherFunction", Function.class));
 
-				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-						AnthropicChatOptions.builder().toolNames("weatherFunction").build()));
+				String content = ChatClient.create(chatModel)
+					.prompt()
+					.advisors(ToolCallAdvisor.builder().build())
+					.user("What's the weather like in San Francisco, in Paris, France and in Tokyo, Japan?"
+							+ " Return the temperature in Celsius.")
+					.tools(t -> t.callbacks(weatherToolCallback))
+					.call()
+					.content();
 
-				logger.info("Response: {}", response);
+				logger.info("Response: {}", content);
+				assertThat(content).contains("30", "10", "15");
 
-				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
+				ToolCallback weatherToolCallback3 = buildToolCallback("weatherFunction3",
+						context.getBean("weatherFunction3", Function.class));
 
-				response = chatModel.call(new Prompt(List.of(userMessage),
-						AnthropicChatOptions.builder().toolNames("weatherFunction3").build()));
+				content = ChatClient.create(chatModel)
+					.prompt()
+					.advisors(ToolCallAdvisor.builder().build())
+					.user("What's the weather like in San Francisco, in Paris, France and in Tokyo, Japan?"
+							+ " Return the temperature in Celsius.")
+					.tools(t -> t.callbacks(weatherToolCallback3))
+					.call()
+					.content();
 
-				logger.info("Response: {}", response);
-
-				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
+				logger.info("Response: {}", content);
+				assertThat(content).contains("30", "10", "15");
 			});
+	}
+
+	@Test
+	void streamFunctionCallTest() {
+		this.contextRunner.withPropertyValues("spring.ai.anthropic.chat.model=" + Model.CLAUDE_HAIKU_4_5.asString())
+			.run(context -> {
+
+				AnthropicChatModel chatModel = context.getBean(AnthropicChatModel.class);
+
+				ToolCallback weatherToolCallback = buildToolCallback("weatherFunction",
+						context.getBean("weatherFunction", Function.class));
+
+				Flux<String> response = ChatClient.create(chatModel)
+					.prompt()
+					.advisors(ToolCallAdvisor.builder().build())
+					.user("What's the weather like in San Francisco, in Paris, France and in Tokyo, Japan?"
+							+ " Return the temperature in Celsius.")
+					.tools(t -> t.callbacks(weatherToolCallback))
+					.stream()
+					.content();
+
+				String content = response.collectList().block().stream().collect(Collectors.joining());
+				logger.info("Response: {}", content);
+				assertThat(content).contains("30", "10", "15");
+
+				ToolCallback weatherToolCallback3 = buildToolCallback("weatherFunction3",
+						context.getBean("weatherFunction3", Function.class));
+
+				response = ChatClient.create(chatModel)
+					.prompt()
+					.advisors(ToolCallAdvisor.builder().build())
+					.user("What's the weather like in San Francisco, in Paris, France and in Tokyo, Japan?"
+							+ " Return the temperature in Celsius.")
+					.tools(t -> t.callbacks(weatherToolCallback3))
+					.stream()
+					.content();
+
+				content = response.collectList().block().stream().collect(Collectors.joining());
+				logger.info("Response: {}", content);
+				assertThat(content).contains("30", "10", "15");
+			});
+	}
+
+	@SuppressWarnings("unchecked")
+	private static ToolCallback buildToolCallback(String name, Function<?, ?> fn) {
+		return FunctionToolCallback.builder(name, (Function<Request, Response>) fn)
+			.description(WEATHER_TOOL_DESCRIPTION)
+			.inputType(MockWeatherService.Request.class)
+			.build();
 	}
 
 	@Configuration

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
@@ -29,6 +29,9 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -37,9 +40,11 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration test for tool calling via prompt-level function callbacks.
+ * Integration test for tool calling via prompt-level function callbacks using
+ * user-controlled tool execution.
  *
  * @author Soby Chacko
+ * @author Christian Tzolov
  */
 @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
 class FunctionCallWithPromptFunctionIT {
@@ -56,18 +61,28 @@ class FunctionCallWithPromptFunctionIT {
 		this.contextRunner.run(context -> {
 
 			AnthropicChatModel chatModel = context.getBean(AnthropicChatModel.class);
+			ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
-			UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, in Paris and in Tokyo?"
-					+ " Return the temperature in Celsius.");
-
-			var promptOptions = AnthropicChatOptions.builder()
+			AnthropicChatOptions options = AnthropicChatOptions.builder()
+				.internalToolExecutionEnabled(false)
 				.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 					.description("Get the weather in location. Return temperature in 36°F or 36°C format.")
 					.inputType(MockWeatherService.Request.class)
 					.build()))
 				.build();
 
-			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), promptOptions));
+			Prompt prompt = new Prompt(
+					List.of(new UserMessage("What's the weather like in San Francisco, in Paris and in Tokyo?"
+							+ " Return the temperature in Celsius.")),
+					options);
+
+			ChatResponse response = chatModel.call(prompt);
+
+			while (response.hasToolCalls()) {
+				ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+				prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+				response = chatModel.call(prompt);
+			}
 
 			logger.info("Response: {}", response);
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.anthropic.client.AnthropicClient;
@@ -99,9 +98,6 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
@@ -175,10 +171,6 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 	private final ToolCallingManager toolCallingManager;
 
-	private final ToolExecutionEligibilityChecker toolExecutionEligibilityChecker;
-
-	private final AtomicBoolean internalToolExecutionWarned = new AtomicBoolean(false);
-
 	private ChatModelObservationConvention observationConvention = DEFAULT_OBSERVATION_CONVENTION;
 
 	/**
@@ -195,8 +187,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	private AnthropicChatModel(@Nullable AnthropicClient anthropicClient,
 			@Nullable AnthropicClientAsync anthropicClientAsync, @Nullable AnthropicChatOptions options,
 			@Nullable ToolCallingManager toolCallingManager, @Nullable ObservationRegistry observationRegistry,
-			@Nullable MeterRegistry meterRegistry, @Nullable ExecutorService dispatcherExecutor,
-			@Nullable ToolExecutionEligibilityChecker toolExecutionEligibilityChecker) {
+			@Nullable MeterRegistry meterRegistry, @Nullable ExecutorService dispatcherExecutor) {
 
 		if (options == null) {
 			this.options = AnthropicChatOptions.builder().build();
@@ -224,8 +215,6 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 						this.dispatcherExecutor));
 
 		this.toolCallingManager = Objects.requireNonNullElse(toolCallingManager, DEFAULT_TOOL_CALLING_MANAGER);
-		this.toolExecutionEligibilityChecker = Objects.requireNonNullElse(toolExecutionEligibilityChecker,
-				chatResponse -> chatResponse != null && chatResponse.hasToolCalls());
 	}
 
 	/**
@@ -354,77 +343,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			// @formatter:on
 
 			// Aggregate streaming responses and handle tool execution on final response
-			return new MessageAggregator().aggregate(flux, observationContext::setResponse)
-				.flatMap(chatResponse -> handleStreamingToolExecution(prompt, chatResponse));
+			return new MessageAggregator().aggregate(flux, observationContext::setResponse);
 		});
-	}
-
-	/**
-	 * Handles the pivot from receiving a tool-call request to executing the tools and
-	 * starting the recursive streaming call with the results. This method is triggered
-	 * via {@code .flatMap()} after the initial stream from the model is fully consumed by
-	 * the {@link MessageAggregator}.
-	 * @param prompt The original prompt containing tool definitions.
-	 * @param chatResponse The aggregated response from the first API call, which contains
-	 * the tool call requests.
-	 * @return A new {@link Flux} of {@link ChatResponse} events. If tools were executed,
-	 * this Flux is the stream of the model's final answer. Otherwise, it's the original
-	 * response.
-	 */
-	private Flux<ChatResponse> handleStreamingToolExecution(Prompt prompt, ChatResponse chatResponse) {
-		ChatOptions promptOptions = prompt.getOptions();
-		if (promptOptions != null
-				&& this.toolExecutionEligibilityChecker.isToolExecutionRequired(promptOptions, chatResponse)) {
-			// Only execute tools when the model's turn is complete and its stated reason
-			// for stopping is that it wants to use a tool.
-			if (chatResponse.hasFinishReasons(java.util.Set.of("tool_use"))) {
-				return Flux.deferContextual(ctx -> {
-					ToolExecutionResult toolExecutionResult;
-					try {
-						if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-							logger.warn(
-									"Internal tool execution in AnthropicChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-											+ "Use ChatClient with ToolCallAdvisor instead.");
-						}
-						org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder.setContext(ctx);
-						toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, chatResponse);
-					}
-					finally {
-						org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder.clearContext();
-					}
-					if (toolExecutionResult.returnDirect()) {
-						// Return tool execution result directly to the client
-						return Flux.just(ChatResponse.builder()
-							.from(chatResponse)
-							.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-							.build());
-					}
-					else {
-						// RECURSIVE CALL: Return a *new stream* by calling internalStream
-						// again.
-						// The new prompt contains the full history, including the tool
-						// results.
-						return this.internalStream(
-								new Prompt(toolExecutionResult.conversationHistory(), prompt.getOptions()),
-								chatResponse); // Pass previous response for usage
-												// accumulation
-					}
-				}).subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic()); // Run
-																					// blocking
-																					// tool
-																					// execution
-																					// on
-																					// a
-																					// different
-																					// thread
-			}
-			else {
-				// Tool execution required but not at tool_use finish - skip this response
-				return Flux.empty();
-			}
-		}
-		// No tool execution needed - pass through the response
-		return Flux.just(chatResponse);
 	}
 
 	/**
@@ -644,29 +564,6 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 				return chatResponse;
 			});
-
-		ChatOptions promptOptions = prompt.getOptions();
-		if (promptOptions != null
-				&& this.toolExecutionEligibilityChecker.isToolExecutionRequired(promptOptions, response)) {
-			if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-				logger.warn(
-						"Internal tool execution in AnthropicChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-								+ "Use ChatClient with ToolCallAdvisor instead.");
-			}
-			var toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
-			if (toolExecutionResult.returnDirect()) {
-				// Return tool execution result directly to the client.
-				return ChatResponse.builder()
-					.from(response)
-					.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-					.build();
-			}
-			else {
-				// Send the tool execution result back to the model.
-				return this.internalCall(new Prompt(toolExecutionResult.conversationHistory(), prompt.getOptions()),
-						response);
-			}
-		}
 
 		return response;
 	}
@@ -1634,8 +1531,6 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 		private @Nullable ExecutorService dispatcherExecutor;
 
-		private @Nullable ToolExecutionEligibilityChecker toolExecutionEligibilityChecker;
-
 		private Builder() {
 		}
 
@@ -1724,52 +1619,12 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		}
 
 		/**
-		 * Sets the predicate to determine tool execution eligibility.
-		 * @param toolExecutionEligibilityPredicate the predicate
-		 * @return this builder
-		 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-		 * {@link #toolExecutionEligibilityChecker(ToolExecutionEligibilityChecker)}. For
-		 * the recommended long-term approach, internal tool execution in
-		 * {@link AnthropicChatModel} is superseded by {@code ToolCallAdvisor} used via
-		 * {@code ChatClient}.
-		 */
-		@Deprecated(since = "2.0.0", forRemoval = true)
-		@SuppressWarnings({ "deprecation", "removal" })
-		public Builder toolExecutionEligibilityPredicate(
-				ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate) {
-			this.toolExecutionEligibilityChecker = new ToolExecutionEligibilityChecker() {
-				@Override
-				public Boolean apply(ChatResponse chatResponse) {
-					return chatResponse != null && chatResponse.hasToolCalls();
-				}
-
-				@Override
-				public boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse) {
-					return toolExecutionEligibilityPredicate.test(promptOptions, chatResponse);
-				}
-			};
-			return this;
-		}
-
-		/**
-		 * Sets the checker to determine tool execution eligibility.
-		 * @param toolExecutionEligibilityChecker the checker
-		 * @return this builder
-		 */
-		public Builder toolExecutionEligibilityChecker(
-				ToolExecutionEligibilityChecker toolExecutionEligibilityChecker) {
-			this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
-			return this;
-		}
-
-		/**
 		 * Builds a new {@link AnthropicChatModel} instance.
 		 * @return the configured chat model
 		 */
 		public AnthropicChatModel build() {
 			return new AnthropicChatModel(this.anthropicClient, this.anthropicClientAsync, this.options,
-					this.toolCallingManager, this.observationRegistry, this.meterRegistry, this.dispatcherExecutor,
-					this.toolExecutionEligibilityChecker);
+					this.toolCallingManager, this.observationRegistry, this.meterRegistry, this.dispatcherExecutor);
 		}
 
 	}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelIT.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import com.anthropic.models.messages.Model;
@@ -46,12 +47,14 @@ import org.springframework.ai.anthropic.AnthropicWebSearchTool;
 import org.springframework.ai.anthropic.Citation;
 import org.springframework.ai.anthropic.metadata.AnthropicRateLimit;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.chat.prompt.SystemPromptTemplate;
@@ -59,6 +62,10 @@ import org.springframework.ai.content.Media;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.converter.ListOutputConverter;
 import org.springframework.ai.converter.MapOutputConverter;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
+import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -281,13 +288,11 @@ class AnthropicChatModelIT {
 
 	@Test
 	void functionCallTest() {
-		UserMessage userMessage = new UserMessage(
-				"What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.");
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
-		List<Message> messages = new ArrayList<>(List.of(userMessage));
-
-		var promptOptions = AnthropicChatOptions.builder()
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
 			.model(Model.CLAUDE_HAIKU_4_5.asString())
+			.internalToolExecutionEnabled(false)
 			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
@@ -295,28 +300,32 @@ class AnthropicChatModelIT {
 				.build())
 			.build();
 
-		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
+		Prompt prompt = new Prompt(
+				List.of(new UserMessage(
+						"What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.")),
+				options);
+
+		ChatResponse response = this.chatModel.call(prompt);
+
+		while (response.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+			response = this.chatModel.call(prompt);
+		}
 
 		logger.info("Response: {}", response);
 
-		Generation generation = response.getResult();
-		assertThat(generation).isNotNull();
-		assertThat(generation.getOutput()).isNotNull();
-		assertThat(generation.getOutput().getText()).contains("30", "10", "15");
-		assertThat(response.getMetadata()).isNotNull();
-		assertThat(response.getMetadata().getUsage()).isNotNull();
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 		assertThat(response.getMetadata().getUsage().getTotalTokens()).isGreaterThan(100);
 	}
 
 	@Test
 	void streamFunctionCallTest() {
-		UserMessage userMessage = new UserMessage(
-				"What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.");
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
-		List<Message> messages = new ArrayList<>(List.of(userMessage));
-
-		var promptOptions = AnthropicChatOptions.builder()
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
 			.model(Model.CLAUDE_HAIKU_4_5.asString())
+			.internalToolExecutionEnabled(false)
 			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
@@ -324,39 +333,43 @@ class AnthropicChatModelIT {
 				.build())
 			.build();
 
-		Flux<ChatResponse> responseFlux = this.chatModel.stream(new Prompt(messages, promptOptions));
+		Prompt prompt = new Prompt(
+				List.of(new UserMessage(
+						"What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.")),
+				options);
 
-		String content = responseFlux.collectList()
-			.block()
-			.stream()
-			.filter(cr -> cr.getResult() != null)
-			.map(cr -> cr.getResult().getOutput().getText())
-			.filter(text -> text != null)
-			.collect(java.util.stream.Collectors.joining());
+		AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+		new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
 
+		while (aggregatedRef.get().hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, aggregatedRef.get());
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+			aggregatedRef.set(null);
+			new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+		}
+
+		String content = aggregatedRef.get().getResult().getOutput().getText();
 		logger.info("Streaming Response: {}", content);
 		assertThat(content).contains("30", "10", "15");
 	}
 
 	@Test
 	void streamFunctionCallUsageTest() {
-		UserMessage userMessage = new UserMessage(
-				"What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.");
-
-		List<Message> messages = new ArrayList<>(List.of(userMessage));
-
-		var promptOptions = AnthropicChatOptions.builder()
-			.model(Model.CLAUDE_HAIKU_4_5.asString())
-			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
-				.description(
-						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
-				.inputType(MockWeatherService.Request.class)
-				.build())
+		ToolCallback weatherToolCallback = FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+			.description(
+					"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
+			.inputType(MockWeatherService.Request.class)
 			.build();
 
-		Flux<ChatResponse> responseFlux = this.chatModel.stream(new Prompt(messages, promptOptions));
-
-		ChatResponse lastResponse = responseFlux.collectList()
+		ChatResponse lastResponse = ChatClient.create(this.chatModel)
+			.prompt()
+			.advisors(ToolCallAdvisor.builder().build())
+			.options(AnthropicChatOptions.builder().model(Model.CLAUDE_HAIKU_4_5.asString()))
+			.user("What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.")
+			.tools(t -> t.callbacks(weatherToolCallback))
+			.stream()
+			.chatResponse()
+			.collectList()
 			.block()
 			.stream()
 			.filter(cr -> cr.getMetadata() != null && cr.getMetadata().getUsage() != null

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicPromptCachingIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicPromptCachingIT.java
@@ -40,6 +40,9 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -134,25 +137,32 @@ class AnthropicPromptCachingIT {
 	void shouldCacheSystemAndTools() {
 		String systemPrompt = loadPrompt("system-and-tools-cache-prompt.txt");
 
-		MockWeatherService weatherService = new MockWeatherService();
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
 			.model(Model.CLAUDE_SONNET_4_20250514.asString())
 			.cacheOptions(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.SYSTEM_AND_TOOLS).build())
 			.maxTokens(200)
 			.temperature(0.3)
-			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", weatherService)
+			.internalToolExecutionEnabled(false)
+			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description("Get current weather for a location")
 				.inputType(MockWeatherService.Request.class)
 				.build())
 			.build();
 
-		ChatResponse response = this.chatModel.call(
-				new Prompt(
-						List.of(new SystemMessage(systemPrompt),
-								new UserMessage(
-										"What's the weather like in San Francisco and should I go for a walk?")),
-						options));
+		Prompt prompt = new Prompt(
+				List.of(new SystemMessage(systemPrompt),
+						new UserMessage("What's the weather like in San Francisco and should I go for a walk?")),
+				options);
+
+		ChatResponse response = this.chatModel.call(prompt);
+
+		while (response.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+			response = this.chatModel.call(prompt);
+		}
 
 		assertThat(response).isNotNull();
 		assertThat(response.getResult().getOutput().getText()).isNotEmpty();

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -209,7 +209,6 @@ ChatResponse response = chatModel.call(
 | toolChoice | Controls which tool (if any) is called by the model. Use `ToolChoiceAuto`, `ToolChoiceAny`, `ToolChoiceTool`, or `ToolChoiceNone`. | AUTO
 | toolCallbacks | List of tool callbacks to register with the model. | -
 | toolNames | Set of tool names to be resolved at runtime. | -
-| internalToolExecutionEnabled | If false, tool calls are proxied to the client for manual handling. If true, Spring AI handles tool calls internally. | true
 | disableParallelToolUse | When true, the model will use at most one tool per response. | false
 |====
 
@@ -264,12 +263,52 @@ You can register custom Java functions or methods with the `AnthropicChatModel` 
 This is a powerful technique to connect the LLM capabilities with external tools and APIs.
 Read more about xref:api/tools.adoc[Tool Calling].
 
-=== Basic Tool Calling
+`AnthropicChatModel` does not execute tool calls internally.
+Tool execution must be handled externally using one of two supported approaches:
+
+* **xref:api/tools.adoc#_chatclient_tool_execution[ChatClient with ToolCallAdvisor]** — the recommended approach for most use cases. `ToolCallAdvisor` is automatically registered and manages the tool-call loop transparently.
+* **xref:api/tools.adoc#_user_controlled_tool_execution[User-controlled tool execution]** — use `DefaultToolCallingManager` directly when you need full control over the loop (for example, when combining tool calling with prompt caching).
+
+=== Tool Calling via ChatClient (Recommended)
+
+Use `ChatClient` with `ToolCallAdvisor` for both synchronous and streaming tool execution.
+`ToolCallAdvisor` is auto-registered when tools are present, so no explicit advisor configuration is required.
 
 [source,java]
 ----
-var chatOptions = AnthropicChatOptions.builder()
-    .model("claude-sonnet-4-20250514")
+ToolCallback weatherCallback = FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
+    .description("Get the weather in location")
+    .inputType(WeatherService.Request.class)
+    .build();
+
+// Synchronous
+String response = ChatClient.create(chatModel)
+    .prompt()
+    .user("What's the weather in Paris, Tokyo, and New York?")
+    .tools(t -> t.callbacks(weatherCallback))
+    .call()
+    .content();
+
+// Streaming
+Flux<String> stream = ChatClient.create(chatModel)
+    .prompt()
+    .user("What's the weather in Paris, Tokyo, and New York?")
+    .tools(t -> t.callbacks(weatherCallback))
+    .stream()
+    .content();
+----
+
+=== User-Controlled Tool Execution
+
+Use this pattern when you need direct access to the `ChatModel` API — for example, when combining tool calling with xref:api/chat/anthropic-chat.adoc#_prompt_caching[prompt caching].
+Set `internalToolExecutionEnabled(false)` on the options and drive the tool-call loop yourself using `DefaultToolCallingManager`.
+
+[source,java]
+----
+ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
+AnthropicChatOptions options = AnthropicChatOptions.builder()
+    .internalToolExecutionEnabled(false)
     .toolCallbacks(List.of(
         FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
             .description("Get the weather in location")
@@ -277,15 +316,40 @@ var chatOptions = AnthropicChatOptions.builder()
             .build()))
     .build();
 
-var chatModel = new AnthropicChatModel(chatOptions);
+Prompt prompt = new Prompt("What's the weather in Paris, Tokyo, and New York?", options);
+ChatResponse response = chatModel.call(prompt);
 
-ChatResponse response = chatModel.call(
-    new Prompt("What's the weather like in San Francisco?", chatOptions));
+while (response.hasToolCalls()) {
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, response);
+    prompt = new Prompt(result.conversationHistory(), options);
+    response = chatModel.call(prompt);
+}
+----
+
+For streaming, aggregate each streaming response with `MessageAggregator` to detect tool calls across chunks:
+
+[source,java]
+----
+AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+new MessageAggregator()
+    .aggregate(chatModel.stream(prompt), aggregatedRef::set)
+    .collectList().block();
+
+while (aggregatedRef.get().hasToolCalls()) {
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, aggregatedRef.get());
+    prompt = new Prompt(result.conversationHistory(), options);
+    aggregatedRef.set(null);
+    new MessageAggregator()
+        .aggregate(chatModel.stream(prompt), aggregatedRef::set)
+        .collectList().block();
+}
+
+String content = aggregatedRef.get().getResult().getOutput().getText();
 ----
 
 === Tool Choice Options
 
-Control how Claude uses tools with the `toolChoice` option:
+Control which tool Claude selects with the `toolChoice` option:
 
 [source,java]
 ----
@@ -320,29 +384,6 @@ The Anthropic Java SDK provides convenient static factory methods for common too
 * `ToolChoice.any()` can be used instead of `ToolChoice.ofAny(...)`.
 * `ToolChoice.none()` can be used instead of `ToolChoice.ofNone(...)`.
 ====
-
-=== Streaming Tool Calling
-
-The Anthropic SDK module fully supports tool calling in streaming mode. When Claude decides to call a tool during streaming:
-
-1. Tool call arguments are accumulated from partial JSON deltas
-2. Tools are executed when the content block completes
-3. Results are sent back to Claude
-4. The conversation continues recursively until Claude provides a final response
-
-[source,java]
-----
-Flux<ChatResponse> stream = chatModel.stream(
-    new Prompt("What's the weather in Paris, Tokyo, and New York?", chatOptions));
-
-String response = stream
-    .collectList()
-    .block()
-    .stream()
-    .map(r -> r.getResult().getOutput().getContent())
-    .filter(Objects::nonNull)
-    .collect(Collectors.joining());
-----
 
 == Streaming
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1217,6 +1217,39 @@ System.out.println(chatResponse.getResult().getOutput().getText());
 
 NOTE: When choosing the user-controlled tool execution approach, we recommend using a `ToolCallingManager` to manage the tool calling operations. This way, you can benefit from the built-in support provided by Spring AI for tool execution. However, nothing prevents you from implementing your own tool execution logic.
 
+The same pattern works with the streaming API.
+Because tool calls span multiple stream chunks, each streaming call must be aggregated first using `MessageAggregator` before checking for tool calls:
+
+[source,java]
+----
+ChatModel chatModel = ...
+ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+
+ChatOptions chatOptions = ToolCallingChatOptions.builder()
+    .toolCallbacks(new CustomerTools())
+    .internalToolExecutionEnabled(false)
+    .build();
+Prompt prompt = new Prompt("Tell me more about the customer with ID 42", chatOptions);
+
+AtomicReference<ChatResponse> aggregatedResponseRef = new AtomicReference<>();
+new MessageAggregator()
+    .aggregate(chatModel.stream(prompt), aggregatedResponseRef::set)
+    .collectList().block();
+
+while (aggregatedResponseRef.get().hasToolCalls()) {
+    ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, aggregatedResponseRef.get());
+
+    prompt = new Prompt(toolExecutionResult.conversationHistory(), chatOptions);
+
+    aggregatedResponseRef.set(null);
+    new MessageAggregator()
+        .aggregate(chatModel.stream(prompt), aggregatedResponseRef::set)
+        .collectList().block();
+}
+
+System.out.println(aggregatedResponseRef.get().getResult().getOutput().getText());
+----
+
 The next examples shows a minimal implementation of the user-controlled tool execution approach combined with the usage of the `ChatMemory` API:
 
 [source,java]


### PR DESCRIPTION
- Drop the built-in call/stream tool-execution loop and the ToolExecutionEligibilityChecker wiring from AnthropicChatModel and its autoconfiguration. 
- Tool execution is now handled externally via ToolCallAdvisor (ChatClient) or the user-controlled DefaultToolCallingManager loop.
- Update all related tests and documentation accordingly.

Part of #6251
