### PR TITLE
Add User-Agent tracking for Bedrock SDK calls

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockUserAgentInterceptor.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockUserAgentInterceptor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse;
+
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+
+/**
+ * Global interceptor auto-loaded by the AWS SDK via service loader. Configures the
+ * User-Agent app ID in its static initializer so every SDK client picks it up.
+ *
+ * @author Matt Meckes
+ */
+public final class BedrockUserAgentInterceptor implements ExecutionInterceptor {
+
+	static {
+		UserAgentProvider.configure();
+	}
+
+	@Override
+	public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
+		return context.request();
+	}
+
+}

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockUserAgentInterceptor.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockUserAgentInterceptor.java
@@ -16,9 +16,6 @@
 
 package org.springframework.ai.bedrock.converse;
 
-import software.amazon.awssdk.core.SdkRequest;
-import software.amazon.awssdk.core.interceptor.Context;
-import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 /**
@@ -26,16 +23,12 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
  * User-Agent app ID in its static initializer so every SDK client picks it up.
  *
  * @author Matt Meckes
+ * @since 2.0.0
  */
 public final class BedrockUserAgentInterceptor implements ExecutionInterceptor {
 
 	static {
 		UserAgentProvider.configure();
-	}
-
-	@Override
-	public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
-		return context.request();
 	}
 
 }

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/UserAgentProvider.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/UserAgentProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configures the AWS SDK {@code sdk.ua.appId} system property so that all SDK clients
+ * automatically include the spring-ai identifier in the User-Agent header. Preserves any
+ * user-provided value by appending rather than replacing.
+ *
+ * @author Matt Meckes
+ */
+final class UserAgentProvider {
+
+	private static final Logger logger = LoggerFactory.getLogger(UserAgentProvider.class);
+
+	private static final String SDK_USER_AGENT_APP_ID = "sdk.ua.appId";
+
+	private static final String APP_ID;
+
+	static {
+		String version = UserAgentProvider.class.getPackage().getImplementationVersion();
+		if (version == null) {
+			version = "unknown";
+		}
+		APP_ID = "spring-ai/" + version;
+	}
+
+	private UserAgentProvider() {
+	}
+
+	static void configure() {
+		try {
+			String existing = System.getProperty(SDK_USER_AGENT_APP_ID);
+			if (existing != null && existing.contains(APP_ID)) {
+				return;
+			}
+			String newValue = (existing == null || existing.isEmpty()) ? APP_ID : existing + "/" + APP_ID;
+			System.setProperty(SDK_USER_AGENT_APP_ID, newValue);
+			logger.debug("Set {} = {}", SDK_USER_AGENT_APP_ID, newValue);
+		}
+		catch (Exception ex) {
+			logger.warn("Unable to configure user agent system property", ex);
+		}
+	}
+
+	static String appId() {
+		return APP_ID;
+	}
+
+}

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/UserAgentProvider.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/UserAgentProvider.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.bedrock.converse;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +26,7 @@ import org.slf4j.LoggerFactory;
  * user-provided value by appending rather than replacing.
  *
  * @author Matt Meckes
+ * @since 2.0.0
  */
 final class UserAgentProvider {
 
@@ -35,7 +37,7 @@ final class UserAgentProvider {
 	private static final String APP_ID;
 
 	static {
-		String version = UserAgentProvider.class.getPackage().getImplementationVersion();
+		@Nullable String version = UserAgentProvider.class.getPackage().getImplementationVersion();
 		if (version == null) {
 			version = "unknown";
 		}

--- a/models/spring-ai-bedrock-converse/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
+++ b/models/spring-ai-bedrock-converse/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
@@ -1,0 +1,1 @@
+org.springframework.ai.bedrock.converse.BedrockUserAgentInterceptor

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/UserAgentProviderTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/UserAgentProviderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Matt Meckes
+ */
+class UserAgentProviderTest {
+
+	@AfterEach
+	void resetSystemProperty() {
+		System.clearProperty("sdk.ua.appId");
+	}
+
+	@Test
+	void configureSetsSystemProperty() {
+		UserAgentProvider.configure();
+		assertThat(System.getProperty("sdk.ua.appId")).startsWith("spring-ai/");
+	}
+
+	@Test
+	void configureAppendsToExistingValue() {
+		System.setProperty("sdk.ua.appId", "my-app");
+		UserAgentProvider.configure();
+		String value = System.getProperty("sdk.ua.appId");
+		assertThat(value).startsWith("my-app/");
+		assertThat(value).contains("spring-ai/");
+	}
+
+	@Test
+	void configureIsIdempotent() {
+		System.clearProperty("sdk.ua.appId");
+		UserAgentProvider.configure();
+		String first = System.getProperty("sdk.ua.appId");
+		UserAgentProvider.configure();
+		assertThat(System.getProperty("sdk.ua.appId")).isEqualTo(first);
+	}
+
+	@Test
+	void appIdStartsWithExpectedPrefix() {
+		assertThat(UserAgentProvider.appId()).startsWith("spring-ai/");
+	}
+
+}


### PR DESCRIPTION
Sets the `sdk.ua.appId` system property using an `ExecutionInterceptor` auto-loaded via the AWS SDK service loader, tagging all Bedrock API calls with a `spring-ai/<version>` identifier.

This approach:
- Works globally for all AWS SDK clients, including user-configured custom ones
- Appends to any existing user-provided app ID rather than overwriting
- Requires no per-module wiring — the service loader handles registration automatically

The global scope (all AWS SDK clients in the JVM, not just Bedrock) is intentional and follows the Powertools for AWS Lambda pattern. This was discussed with maintainers on Slack.

## Testing

Added `UserAgentProviderTest` covering property setting, appending to existing values, and idempotency.