### PR TITLE
Remove duplicate builder overrides in OpenAiChatOptions

### DIFF
--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -144,19 +144,21 @@ class AnthropicChatOptionsTests extends AbstractChatOptionsTests<AnthropicChatOp
 			.toolContext(Map.of("base-key", "base-value"))
 			.build();
 
-		AnthropicChatOptions override = AnthropicChatOptions.builder()
-			.stopSequences(List.of("override-stop1", "override-stop2"))
-			.toolNames(Set.of("override-tool"))
-			// toolContext is empty, should not override
+		AnthropicChatOptions combine = AnthropicChatOptions.builder()
+			.stopSequences(List.of("combine-stop1", "combine-stop2"))
+			.toolNames(Set.of("combine-tool1", "combine-tool2"))
+			.toolContext(Map.of("combine-key1", "combine-value1", "combine-key2", "combine-value2"))
 			.build();
 
-		AnthropicChatOptions merged = base.mutate().combineWith(override.mutate()).build();
+		AnthropicChatOptions merged = base.mutate().combineWith(combine.mutate()).build();
 
-		// Non-empty collections from override take precedence
-		assertThat(merged.getStopSequences()).containsExactly("override-stop1", "override-stop2");
-		assertThat(merged.getToolNames()).containsExactly("base-tool", "override-tool");
-		// Empty collections don't override
+		// Non-empty collections from combine take precedence
+		assertThat(merged.getStopSequences()).containsExactly("base-stop", "combine-stop1", "combine-stop2");
+		assertThat(merged.getToolNames()).containsExactlyInAnyOrder("base-tool", "combine-tool1", "combine-tool2");
+		// Empty collections don't combine
 		assertThat(merged.getToolContext()).containsEntry("base-key", "base-value");
+		assertThat(merged.getToolContext()).containsEntry("combine-key1", "combine-value1");
+		assertThat(merged.getToolContext()).containsEntry("combine-key2", "combine-value2");
 	}
 
 	@Test

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -154,7 +154,7 @@ class AnthropicChatOptionsTests extends AbstractChatOptionsTests<AnthropicChatOp
 
 		// Non-empty collections from override take precedence
 		assertThat(merged.getStopSequences()).containsExactly("override-stop1", "override-stop2");
-		assertThat(merged.getToolNames()).containsExactly("override-tool");
+		assertThat(merged.getToolNames()).containsExactly("base-tool", "override-tool");
 		// Empty collections don't override
 		assertThat(merged.getToolContext()).containsEntry("base-key", "base-value");
 	}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -152,10 +152,11 @@ class AnthropicChatOptionsTests extends AbstractChatOptionsTests<AnthropicChatOp
 
 		AnthropicChatOptions merged = base.mutate().combineWith(combine.mutate()).build();
 
-		// Non-empty collections from combine take precedence
+		// Combine stopSequences
 		assertThat(merged.getStopSequences()).containsExactly("base-stop", "combine-stop1", "combine-stop2");
+		// Combine toolNames
 		assertThat(merged.getToolNames()).containsExactlyInAnyOrder("base-tool", "combine-tool1", "combine-tool2");
-		// Empty collections don't combine
+		// Combine toolContext
 		assertThat(merged.getToolContext()).containsEntry("base-key", "base-value");
 		assertThat(merged.getToolContext()).containsEntry("combine-key1", "combine-value1");
 		assertThat(merged.getToolContext()).containsEntry("combine-key2", "combine-value2");

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
@@ -17,7 +17,6 @@
 package org.springframework.ai.minimax;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -215,7 +214,7 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	}
 
 	public @Nullable List<String> getStop() {
-		return (this.stop != null) ? Collections.unmodifiableList(this.stop) : null;
+		return this.stop;
 	}
 
 	@Override
@@ -233,7 +232,7 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	}
 
 	public @Nullable List<MiniMaxApi.FunctionTool> getTools() {
-		return (this.tools != null) ? Collections.unmodifiableList(this.tools) : null;
+		return this.tools;
 	}
 
 	public @Nullable String getToolChoice() {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -20,7 +20,6 @@ import java.net.Proxy;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -36,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.model.ApiKey;
+import org.springframework.ai.model.NoopApiKey;
 import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
 import org.springframework.ai.model.tool.StructuredOutputChatOptions;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
@@ -592,6 +592,9 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 
 	@Override
 	public boolean equals(@Nullable Object o) {
+		if (this == o) {
+			return true;
+		}
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
@@ -805,71 +808,6 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 		protected @Nullable Map<String, Object> extraBody;
 
 		@Override
-		public B toolCallbacks(@Nullable List<ToolCallback> toolCallbacks) {
-			this.toolCallbacks = toolCallbacks;
-			return self();
-		}
-
-		@Override
-		public B toolCallbacks(ToolCallback... toolCallbacks) {
-			if (this.toolCallbacks == null) {
-				this.toolCallbacks = new ArrayList<>();
-			}
-			this.toolCallbacks.addAll(java.util.Arrays.asList(toolCallbacks));
-			return self();
-		}
-
-		@Override
-		public B toolNames(@Nullable Set<String> toolNames) {
-			this.toolNames = toolNames;
-			return self();
-		}
-
-		@Override
-		public B toolNames(String... toolNames) {
-			if (this.toolNames == null) {
-				this.toolNames = new HashSet<>();
-			}
-			this.toolNames.addAll(Set.of(toolNames));
-			return self();
-		}
-
-		@Override
-		public B toolContext(@Nullable Map<String, Object> context) {
-			if (context != null) {
-				if (this.toolContext == null) {
-					this.toolContext = new HashMap<>();
-				}
-				this.toolContext.putAll(context);
-			}
-			else {
-				this.toolContext = null;
-			}
-			return self();
-		}
-
-		@Override
-		public B toolContext(String key, Object value) {
-			if (this.toolContext == null) {
-				this.toolContext = new HashMap<>();
-			}
-			this.toolContext.put(key, value);
-			return self();
-		}
-
-		@Override
-		public B internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
-			this.internalToolExecutionEnabled = internalToolExecutionEnabled;
-			return self();
-		}
-
-		@Override
-		public B frequencyPenalty(@Nullable Double frequencyPenalty) {
-			this.frequencyPenalty = frequencyPenalty;
-			return self();
-		}
-
-		@Override
 		public B maxTokens(@Nullable Integer maxTokens) {
 			if (this.maxCompletionTokens != null) {
 				logger.warn(
@@ -880,36 +818,6 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 			else {
 				this.maxTokens = maxTokens;
 			}
-			return self();
-		}
-
-		@Override
-		public B presencePenalty(@Nullable Double presencePenalty) {
-			this.presencePenalty = presencePenalty;
-			return self();
-		}
-
-		@Override
-		public B stopSequences(@Nullable List<String> stopSequences) {
-			this.stopSequences = stopSequences;
-			return self();
-		}
-
-		@Override
-		public B temperature(@Nullable Double temperature) {
-			this.temperature = temperature;
-			return self();
-		}
-
-		@Override
-		public B topK(@Nullable Integer topK) {
-			this.topK = topK;
-			return self();
-		}
-
-		@Override
-		public B topP(@Nullable Double topP) {
-			this.topP = topP;
 			return self();
 		}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptions.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.chat.prompt;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -78,7 +77,7 @@ public class DefaultChatOptions implements ChatOptions {
 
 	@Override
 	public @Nullable List<String> getStopSequences() {
-		return this.stopSequences != null ? Collections.unmodifiableList(this.stopSequences) : null;
+		return this.stopSequences;
 	}
 
 	@Override

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
+import org.springframework.ai.tool.ToolCallback;
 
 /**
  * Implementation of {@link ChatOptions.Builder} to create {@link DefaultChatOptions}.
@@ -131,7 +132,14 @@ public class DefaultChatOptionsBuilder<B extends DefaultChatOptionsBuilder<B>> i
 				this.presencePenalty = that.presencePenalty;
 			}
 			if (that.stopSequences != null) {
-				this.stopSequences = new ArrayList<>(that.stopSequences);
+				if (this.stopSequences == null) {
+					this.stopSequences = new ArrayList<>(that.stopSequences);
+				}
+				else {
+					List<String> merged = new ArrayList<>(this.stopSequences);
+					merged.addAll(that.stopSequences);
+					this.stopSequences = merged;
+				}
 			}
 			if (that.temperature != null) {
 				this.temperature = that.temperature;

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
@@ -154,7 +154,6 @@ public class DefaultChatOptionsBuilder<B extends DefaultChatOptionsBuilder<B>> i
 	}
 
 	public ChatOptions build() {
-		// TODO: Assert.notNull() as required
 		return new DefaultChatOptions(this.model, this.frequencyPenalty, this.maxTokens, this.presencePenalty,
 				this.stopSequences, this.temperature, this.topK, this.topP);
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
-import org.springframework.ai.tool.ToolCallback;
 
 /**
  * Implementation of {@link ChatOptions.Builder} to create {@link DefaultChatOptions}.

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
@@ -17,7 +17,6 @@
 package org.springframework.ai.model.tool;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -166,7 +165,7 @@ public class DefaultToolCallingChatOptions extends DefaultChatOptions implements
 			if (this.toolCallbacks == null) {
 				this.toolCallbacks = new ArrayList<>();
 			}
-			this.toolCallbacks.addAll(Arrays.asList(toolCallbacks));
+			this.toolCallbacks.addAll(List.of(toolCallbacks));
 			return self();
 		}
 
@@ -234,10 +233,24 @@ public class DefaultToolCallingChatOptions extends DefaultChatOptions implements
 			super.combineWith(other);
 			if (other instanceof Builder<?> that) {
 				if (that.toolCallbacks != null) {
-					this.toolCallbacks = new ArrayList<>(that.toolCallbacks);
+					if (this.toolCallbacks == null) {
+						this.toolCallbacks = new ArrayList<>(that.toolCallbacks);
+					}
+					else {
+						List<ToolCallback> merged = new ArrayList<>(this.toolCallbacks);
+						merged.addAll(that.toolCallbacks);
+						this.toolCallbacks = merged;
+					}
 				}
 				if (that.toolNames != null) {
-					this.toolNames = new HashSet<>(that.toolNames);
+					if (this.toolNames == null) {
+						this.toolNames = new HashSet<>(that.toolNames);
+					}
+					else {
+						Set<String> merged = new HashSet<>(this.toolNames);
+						merged.addAll(that.toolNames);
+						this.toolNames = merged;
+					}
 				}
 				if (that.toolContext != null) {
 					if (this.toolContext == null) {


### PR DESCRIPTION
- Removed toolCallbacks, toolNames, toolContext, internalToolExecutionEnabled, frequencyPenalty, presencePenalty, stopSequences, temperature, topK, topP overrides from the OpenAiChatOptions.Builder class.
- Fixed combineWith() to properly merge toolCallbacks, toolNames and stopSequences instead of replacing them.