### PR TITLE
Remove internal tool execution from OllamaChatModel

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatAutoConfiguration.java
@@ -21,9 +21,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
-import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.ollama.OllamaChatModel;
 import org.springframework.ai.ollama.api.OllamaApi;
 import org.springframework.ai.ollama.management.ModelManagementOptions;
@@ -63,7 +61,6 @@ public class OllamaChatAutoConfiguration {
 			OllamaInitializationProperties initProperties, ToolCallingManager toolCallingManager,
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<ChatModelObservationConvention> observationConvention,
-			ObjectProvider<ToolExecutionEligibilityPredicate> ollamaToolExecutionEligibilityPredicate,
 			ObjectProvider<RetryTemplate> retryTemplate) {
 		var chatModelPullStrategy = initProperties.getChat().isInclude() ? initProperties.getPullModelStrategy()
 				: PullModelStrategy.NEVER;
@@ -72,8 +69,6 @@ public class OllamaChatAutoConfiguration {
 			.ollamaApi(ollamaApi)
 			.options(properties.toOptions())
 			.toolCallingManager(toolCallingManager)
-			.toolExecutionEligibilityPredicate(
-					ollamaToolExecutionEligibilityPredicate.getIfUnique(DefaultToolExecutionEligibilityPredicate::new))
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.modelManagementOptions(
 					new ModelManagementOptions(chatModelPullStrategy, initProperties.getChat().getAdditionalModels(),

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/BaseOllamaIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/BaseOllamaIT.java
@@ -30,7 +30,6 @@ import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfigurat
 import org.springframework.ai.ollama.OllamaChatModel;
 import org.springframework.ai.ollama.api.OllamaApi;
 import org.springframework.ai.ollama.api.OllamaChatOptions;
-import org.springframework.ai.ollama.api.OllamaChatOptions.Builder;
 import org.springframework.ai.ollama.management.ModelManagementOptions;
 import org.springframework.ai.ollama.management.OllamaModelManager;
 import org.springframework.ai.ollama.management.PullModelStrategy;
@@ -112,7 +111,7 @@ public abstract class BaseOllamaIT {
 	/**
 	 * Merge options customizer {@code other} with the options coming from the model.
 	 */
-	protected static OllamaChatOptions mergeOptions(OllamaChatModel chatModel, Builder other) {
+	protected static OllamaChatOptions mergeOptions(OllamaChatModel chatModel, OllamaChatOptions.Builder other) {
 		return (OllamaChatOptions) chatModel.getOptions().mutate().combineWith(other).build();
 	}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/tool/FunctionCallbackInPromptIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/tool/FunctionCallbackInPromptIT.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
+import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -81,7 +82,10 @@ class FunctionCallbackInPromptIT extends BaseOllamaIT {
 							.inputType(MockWeatherService.Request.class)
 							.build())));
 
-			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), promptOptions));
+			ChatResponse response = ChatClient.create(chatModel)
+				.prompt(new Prompt(List.of(userMessage), promptOptions))
+				.call()
+				.chatResponse();
 
 			logger.info("Response: {}", response);
 
@@ -106,7 +110,10 @@ class FunctionCallbackInPromptIT extends BaseOllamaIT {
 							.inputType(MockWeatherService.Request.class)
 							.build())));
 
-			Flux<ChatResponse> response = chatModel.stream(new Prompt(List.of(userMessage), promptOptions));
+			Flux<ChatResponse> response = ChatClient.create(chatModel)
+				.prompt(new Prompt(List.of(userMessage), promptOptions))
+				.stream()
+				.chatResponse();
 
 			String content = response.collectList()
 				.blockOptional()

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/tool/OllamaFunctionCallbackIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/tool/OllamaFunctionCallbackIT.java
@@ -19,6 +19,7 @@ package org.springframework.ai.model.ollama.autoconfigure.tool;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -26,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -33,6 +35,7 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.ollama.autoconfigure.BaseOllamaIT;
 import org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.ollama.OllamaChatModel;
 import org.springframework.ai.ollama.api.OllamaChatOptions;
 import org.springframework.ai.ollama.api.OllamaChatOptions.Builder;
@@ -97,12 +100,20 @@ class OllamaFunctionCallbackIT extends BaseOllamaIT {
 		this.contextRunner.run(context -> {
 
 			OllamaChatModel chatModel = context.getBean(OllamaChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
 
 			UserMessage userMessage = new UserMessage(USER_MESSAGE_TEXT);
 
 			Builder delta = OllamaChatOptions.builder().toolNames(TOOL_NAME);
 			OllamaChatOptions options = mergeOptions(chatModel, delta);
-			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), options));
+
+			ChatResponse response = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build()
+				.prompt(new Prompt(List.of(userMessage), options))
+				.call()
+				.chatResponse();
 
 			logger.info("Response: {}", response);
 
@@ -117,13 +128,20 @@ class OllamaFunctionCallbackIT extends BaseOllamaIT {
 		this.contextRunner.run(context -> {
 
 			OllamaChatModel chatModel = context.getBean(OllamaChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
 
 			UserMessage userMessage = new UserMessage(USER_MESSAGE_TEXT);
 
 			Builder delta = OllamaChatOptions.builder().toolNames(TOOL_NAME);
 			OllamaChatOptions options = mergeOptions(chatModel, delta);
 
-			Flux<ChatResponse> response = chatModel.stream(new Prompt(List.of(userMessage), options));
+			Flux<ChatResponse> response = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build()
+				.prompt(new Prompt(List.of(userMessage), options))
+				.stream()
+				.chatResponse();
 
 			String content = response.collectList()
 				.blockOptional()

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/tool/OllamaFunctionToolBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/tool/OllamaFunctionToolBeanIT.java
@@ -20,12 +20,15 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -33,6 +36,7 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.ollama.autoconfigure.BaseOllamaIT;
 import org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.ollama.OllamaChatModel;
 import org.springframework.ai.ollama.api.OllamaChatOptions;
 import org.springframework.ai.ollama.api.OllamaModel;
@@ -82,6 +86,7 @@ class OllamaFunctionToolBeanIT extends BaseOllamaIT {
 		this.contextRunner.run(context -> {
 
 			OllamaChatModel chatModel = context.getBean(OllamaChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
 
 			MyTools myTools = context.getBean(MyTools.class);
 
@@ -90,7 +95,13 @@ class OllamaFunctionToolBeanIT extends BaseOllamaIT {
 
 			OllamaChatOptions options = mergeOptions(chatModel,
 					OllamaChatOptions.builder().toolCallbacks(ToolCallbacks.from(myTools)));
-			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), options));
+
+			var chatClient = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build();
+
+			ChatResponse response = chatClient.prompt(new Prompt(List.of(userMessage), options)).call().chatResponse();
 
 			logger.info("Response: {}", response);
 
@@ -106,12 +117,17 @@ class OllamaFunctionToolBeanIT extends BaseOllamaIT {
 		this.contextRunner.run(context -> {
 
 			OllamaChatModel chatModel = context.getBean(OllamaChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
 
 			UserMessage userMessage = new UserMessage(USER_MESSAGE_TEXT);
 
 			OllamaChatOptions options = mergeOptions(chatModel,
 					OllamaChatOptions.builder().toolNames(WEATHER_INFO_TOOL_NAME));
-			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), options));
+			var chatClient = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build();
+			ChatResponse response = chatClient.prompt(new Prompt(List.of(userMessage), options)).call().chatResponse();
 
 			logger.info("Response: {}", response);
 
@@ -126,12 +142,19 @@ class OllamaFunctionToolBeanIT extends BaseOllamaIT {
 		this.contextRunner.run(context -> {
 
 			OllamaChatModel chatModel = context.getBean(OllamaChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
 
 			UserMessage userMessage = new UserMessage(USER_MESSAGE_TEXT);
 
 			OllamaChatOptions options = mergeOptions(chatModel,
 					OllamaChatOptions.builder().toolNames(WEATHER_INFO_TOOL_NAME));
-			Flux<ChatResponse> response = chatModel.stream(new Prompt(List.of(userMessage), options));
+			var chatClient = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build();
+			Flux<ChatResponse> response = chatClient.prompt(new Prompt(List.of(userMessage), options))
+				.stream()
+				.chatResponse();
 
 			String content = response.collectList()
 				.blockOptional()

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/kotlin/org/springframework/ai/model/ollama/autoconfigure/tool/FunctionCallbackContextKotlinIT.kt
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/kotlin/org/springframework/ai/model/ollama/autoconfigure/tool/FunctionCallbackContextKotlinIT.kt
@@ -24,7 +24,7 @@ import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.ai.model.ollama.autoconfigure.BaseOllamaIT
 import org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration
-import org.springframework.ai.model.tool.ToolCallingChatOptions
+import org.springframework.ai.model.tool.ToolCallingManager
 import org.springframework.ai.ollama.OllamaChatModel
 import org.springframework.ai.ollama.api.OllamaChatOptions
 import org.springframework.boot.autoconfigure.AutoConfigurations
@@ -60,15 +60,28 @@ class FunctionCallbackResolverKotlinIT : BaseOllamaIT() {
 
 	@Test
 	fun toolCallTest() {
-		this.contextRunner.run {context ->
+		this.contextRunner.run { context ->
 
 			val chatModel = context.getBean(OllamaChatModel::class.java)
+			val toolCallingManager = context.getBean(ToolCallingManager::class.java)
 
 			val userMessage = UserMessage(
 				"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations.")
 
-			val response = chatModel
-					.call(Prompt(listOf(userMessage), OllamaChatOptions.builder().model(MODEL_NAME).toolNames("weatherInfo").build()))
+			val options = OllamaChatOptions.builder()
+				.model(MODEL_NAME)
+				.toolNames("weatherInfo")
+				.internalToolExecutionEnabled(false)
+				.build()
+
+			var prompt = Prompt(listOf(userMessage), options)
+			var response = chatModel.call(prompt)
+
+			while (response.hasToolCalls()) {
+				val toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response)
+				prompt = Prompt(toolExecutionResult.conversationHistory(), options)
+				response = chatModel.call(prompt)
+			}
 
 			logger.info("Response: $response")
 
@@ -81,22 +94,29 @@ class FunctionCallbackResolverKotlinIT : BaseOllamaIT() {
 		this.contextRunner.run { context ->
 
 			val chatModel = context.getBean(OllamaChatModel::class.java)
+			val toolCallingManager = context.getBean(ToolCallingManager::class.java)
 
-			// Test weatherFunction
 			val userMessage = UserMessage(
 				"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations.")
 
-			val functionOptions = OllamaChatOptions.builder()
+			val options = OllamaChatOptions.builder()
 				.model(MODEL_NAME)
 				.toolNames("weatherInfo")
+				.internalToolExecutionEnabled(false)
 				.build()
 
-			val response = chatModel.call(Prompt(listOf(userMessage), functionOptions));
-			val output = response.getResult()!!.output.text
+			var prompt = Prompt(listOf(userMessage), options)
+			var response = chatModel.call(prompt)
 
-			logger.info("Response: $output");
+			while (response.hasToolCalls()) {
+				val toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response)
+				prompt = Prompt(toolExecutionResult.conversationHistory(), options)
+				response = chatModel.call(prompt)
+			}
 
-			assertThat(output).contains("30", "10", "15");
+			logger.info("Response: ${response.getResult()!!.output.text}")
+
+			assertThat(response.getResult()!!.output.text).contains("30", "10", "15")
 		}
 	}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/kotlin/org/springframework/ai/model/ollama/autoconfigure/tool/ToolCallbackKotlinIT.kt
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/kotlin/org/springframework/ai/model/ollama/autoconfigure/tool/ToolCallbackKotlinIT.kt
@@ -24,7 +24,7 @@ import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.ai.model.ollama.autoconfigure.BaseOllamaIT
 import org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration
-import org.springframework.ai.model.tool.ToolCallingChatOptions
+import org.springframework.ai.model.tool.ToolCallingManager
 import org.springframework.ai.ollama.OllamaChatModel
 import org.springframework.ai.ollama.api.OllamaChatOptions
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
@@ -63,15 +63,26 @@ class ToolCallbackKotlinIT : BaseOllamaIT() {
 		this.contextRunner.run { context ->
 
 			val chatModel = context.getBean(OllamaChatModel::class.java)
+			val toolCallingManager = context.getBean(ToolCallingManager::class.java)
 
 			val userMessage = UserMessage(
 				"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations."
 			)
 
-			val functionOptions = OllamaChatOptions.builder().model(MODEL_NAME).toolNames("weatherInfo").build()
+			val options = OllamaChatOptions.builder()
+				.model(MODEL_NAME)
+				.toolNames("weatherInfo")
+				.internalToolExecutionEnabled(false)
+				.build()
 
-			val response = chatModel
-				.call(Prompt(listOf(userMessage), functionOptions))
+			var prompt = Prompt(listOf(userMessage), options)
+			var response = chatModel.call(prompt)
+
+			while (response.hasToolCalls()) {
+				val toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response)
+				prompt = Prompt(toolExecutionResult.conversationHistory(), options)
+				response = chatModel.call(prompt)
+			}
 
 			logger.info("Response: $response")
 
@@ -84,19 +95,30 @@ class ToolCallbackKotlinIT : BaseOllamaIT() {
 		this.contextRunner.run { context ->
 
 			val chatModel = context.getBean(OllamaChatModel::class.java)
+			val toolCallingManager = context.getBean(ToolCallingManager::class.java)
 
-			// Test weatherFunction
 			val userMessage = UserMessage(
 				"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations."
 			)
 
-			val functionOptions = OllamaChatOptions.builder().model(MODEL_NAME).toolNames("weatherInfo").build()
+			val options = OllamaChatOptions.builder()
+				.model(MODEL_NAME)
+				.toolNames("weatherInfo")
+				.internalToolExecutionEnabled(false)
+				.build()
 
-			val response = chatModel.call(Prompt(listOf(userMessage), functionOptions));
-			val output = response.getResult()!!.output.text
-			logger.info("Response: $output");
+			var prompt = Prompt(listOf(userMessage), options)
+			var response = chatModel.call(prompt)
 
-			assertThat(output).contains("30", "10", "15");
+			while (response.hasToolCalls()) {
+				val toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response)
+				prompt = Prompt(toolExecutionResult.conversationHistory(), options)
+				response = chatModel.call(prompt)
+			}
+
+			logger.info("Response: ${response.getResult()!!.output.text}")
+
+			assertThat(response.getResult()!!.output.text).contains("30", "10", "15")
 		}
 	}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -31,7 +30,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
@@ -48,13 +46,8 @@ import org.springframework.ai.chat.observation.ChatModelObservationContext;
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.chat.observation.ChatModelObservationDocumentation;
 import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
-import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolExecutionResult;
-import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
 import org.springframework.ai.ollama.api.OllamaApi;
 import org.springframework.ai.ollama.api.OllamaApi.ChatRequest;
 import org.springframework.ai.ollama.api.OllamaApi.Message.Role;
@@ -128,13 +121,6 @@ public class OllamaChatModel implements ChatModel {
 
 	private final ToolCallingManager toolCallingManager;
 
-	/**
-	 * The tool execution eligibility checker used to determine if a tool can be executed.
-	 */
-	private final ToolExecutionEligibilityChecker toolExecutionEligibilityChecker;
-
-	private final AtomicBoolean internalToolExecutionWarned = new AtomicBoolean(false);
-
 	private ChatModelObservationConvention observationConvention = DEFAULT_OBSERVATION_CONVENTION;
 
 	private final RetryTemplate retryTemplate;
@@ -142,53 +128,28 @@ public class OllamaChatModel implements ChatModel {
 	public OllamaChatModel(OllamaApi ollamaApi, OllamaChatOptions options, ToolCallingManager toolCallingManager,
 			ObservationRegistry observationRegistry, ModelManagementOptions modelManagementOptions) {
 		this(ollamaApi, options, toolCallingManager, observationRegistry, modelManagementOptions,
-				chatResponse -> chatResponse != null && chatResponse.hasToolCalls(), RetryUtils.DEFAULT_RETRY_TEMPLATE);
+				RetryUtils.DEFAULT_RETRY_TEMPLATE);
 	}
 
 	public OllamaChatModel(OllamaApi ollamaApi, OllamaChatOptions options, ToolCallingManager toolCallingManager,
 			ObservationRegistry observationRegistry, ModelManagementOptions modelManagementOptions,
-			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, RetryTemplate retryTemplate) {
+			RetryTemplate retryTemplate) {
 
 		Assert.notNull(ollamaApi, "ollamaApi must not be null");
 		Assert.notNull(options, "options must not be null");
 		Assert.notNull(toolCallingManager, "toolCallingManager must not be null");
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
 		Assert.notNull(modelManagementOptions, "modelManagementOptions must not be null");
-		Assert.notNull(toolExecutionEligibilityChecker, "toolExecutionEligibilityChecker must not be null");
 		Assert.notNull(retryTemplate, "retryTemplate must not be null");
 		this.chatApi = ollamaApi;
 		this.options = options;
 		this.toolCallingManager = toolCallingManager;
 		this.observationRegistry = observationRegistry;
 		this.modelManager = new OllamaModelManager(this.chatApi, modelManagementOptions);
-		this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
 		this.retryTemplate = retryTemplate;
 		String model = options.getModel();
 		Assert.state(model != null, "model must not be null");
 		initializeModel(model, modelManagementOptions.pullModelStrategy());
-	}
-
-	/**
-	 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-	 * {@link #OllamaChatModel(OllamaApi, OllamaChatOptions, ToolCallingManager, ObservationRegistry, ModelManagementOptions, ToolExecutionEligibilityChecker, RetryTemplate)}.
-	 */
-	@Deprecated(since = "2.0.0", forRemoval = true)
-	@SuppressWarnings({ "deprecation", "removal" })
-	public OllamaChatModel(OllamaApi ollamaApi, OllamaChatOptions defaultOptions, ToolCallingManager toolCallingManager,
-			ObservationRegistry observationRegistry, ModelManagementOptions modelManagementOptions,
-			ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate, RetryTemplate retryTemplate) {
-		this(ollamaApi, defaultOptions, toolCallingManager, observationRegistry, modelManagementOptions,
-				new ToolExecutionEligibilityChecker() {
-					@Override
-					public Boolean apply(ChatResponse chatResponse) {
-						return chatResponse != null && chatResponse.hasToolCalls();
-					}
-
-					@Override
-					public boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse) {
-						return toolExecutionEligibilityPredicate.test(promptOptions, chatResponse);
-					}
-				}, retryTemplate);
 	}
 
 	public static Builder builder() {
@@ -313,29 +274,6 @@ public class OllamaChatModel implements ChatModel {
 				return chatResponse;
 
 			});
-
-		ChatOptions options = prompt.getOptions();
-		Assert.state(options != null, "ChatOptions must not be null");
-		if (this.toolExecutionEligibilityChecker.isToolExecutionRequired(options, response)) {
-			if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-				logger.warn(
-						"Internal tool execution in OllamaChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-								+ "Use ChatClient with ToolCallAdvisor instead.");
-			}
-			var toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
-			if (toolExecutionResult.returnDirect()) {
-				// Return tool execution result directly to the client.
-				return ChatResponse.builder()
-					.from(response)
-					.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-					.build();
-			}
-			else {
-				// Send the tool execution result back to the model.
-				return this.internalCall(new Prompt(toolExecutionResult.conversationHistory(), options), response);
-			}
-		}
-
 		return response;
 	}
 
@@ -406,50 +344,10 @@ public class OllamaChatModel implements ChatModel {
 				return new ChatResponse(List.of(generator), from(chunk, previousChatResponse));
 			});
 
-			// @formatter:off
-			Flux<ChatResponse> chatResponseFlux = chatResponse.flatMap(response -> {
-				ChatOptions options = prompt.getOptions();
-				Assert.state(options != null, "ChatOptions must not be null");
-				if (this.toolExecutionEligibilityChecker.isToolExecutionRequired(options, response)) {
-					// FIXME: bounded elastic needs to be used since tool calling
-					//  is currently only synchronous
-					return Flux.deferContextual(ctx -> {
-						ToolExecutionResult toolExecutionResult;
-						try {
-							if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-								logger.warn(
-										"Internal tool execution in OllamaChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-												+ "Use ChatClient with ToolCallAdvisor instead.");
-							}
-							ToolCallReactiveContextHolder.setContext(ctx);
-							toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
-						}
-						finally {
-							ToolCallReactiveContextHolder.clearContext();
-						}
-						if (toolExecutionResult.returnDirect()) {
-							// Return tool execution result directly to the client.
-							return Flux.just(ChatResponse.builder().from(response)
-									.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-									.build());
-						}
-						else {
-							// Send the tool execution result back to the model.
-							return this.internalStream(new Prompt(toolExecutionResult.conversationHistory(), options),
-									response);
-						}
-					}).subscribeOn(Schedulers.boundedElastic());
-				}
-				else {
-					return Flux.just(response);
-				}
-			})
-			.doOnError(observation::error)
-			.doFinally(s ->
-				observation.stop()
-			)
-			.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
-			// @formatter:on
+			Flux<ChatResponse> chatResponseFlux = chatResponse.flatMap(response -> Flux.just(response))
+				.doOnError(observation::error)
+				.doFinally(s -> observation.stop())
+				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 
 			return new MessageAggregator().aggregate(chatResponseFlux, observationContext::setResponse);
 		});
@@ -592,9 +490,6 @@ public class OllamaChatModel implements ChatModel {
 
 		private @Nullable ToolCallingManager toolCallingManager;
 
-		private ToolExecutionEligibilityChecker toolExecutionEligibilityChecker = chatResponse -> chatResponse != null
-				&& chatResponse.hasToolCalls();
-
 		private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
 		private ModelManagementOptions modelManagementOptions = ModelManagementOptions.defaults();
@@ -628,45 +523,6 @@ public class OllamaChatModel implements ChatModel {
 			return this;
 		}
 
-		/**
-		 * Sets the predicate to determine tool execution eligibility.
-		 * @param toolExecutionEligibilityPredicate the predicate
-		 * @return this builder
-		 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-		 * {@link #toolExecutionEligibilityChecker(ToolExecutionEligibilityChecker)}. For
-		 * the recommended long-term approach, internal tool execution in
-		 * {@link OllamaChatModel} is superseded by {@code ToolCallAdvisor} used via
-		 * {@code ChatClient}.
-		 */
-		@Deprecated(since = "2.0.0", forRemoval = true)
-		@SuppressWarnings({ "deprecation", "removal" })
-		public Builder toolExecutionEligibilityPredicate(
-				ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate) {
-			this.toolExecutionEligibilityChecker = new ToolExecutionEligibilityChecker() {
-				@Override
-				public Boolean apply(ChatResponse chatResponse) {
-					return chatResponse != null && chatResponse.hasToolCalls();
-				}
-
-				@Override
-				public boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse) {
-					return toolExecutionEligibilityPredicate.test(promptOptions, chatResponse);
-				}
-			};
-			return this;
-		}
-
-		/**
-		 * Sets the checker to determine tool execution eligibility.
-		 * @param toolExecutionEligibilityChecker the checker
-		 * @return this builder
-		 */
-		public Builder toolExecutionEligibilityChecker(
-				ToolExecutionEligibilityChecker toolExecutionEligibilityChecker) {
-			this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
-			return this;
-		}
-
 		public Builder observationRegistry(ObservationRegistry observationRegistry) {
 			this.observationRegistry = observationRegistry;
 			return this;
@@ -686,8 +542,7 @@ public class OllamaChatModel implements ChatModel {
 			Assert.state(this.ollamaApi != null, "OllamaApi must not be null");
 			return new OllamaChatModel(this.ollamaApi, this.options,
 					Objects.requireNonNullElse(this.toolCallingManager, DEFAULT_TOOL_CALLING_MANAGER),
-					this.observationRegistry, this.modelManagementOptions, this.toolExecutionEligibilityChecker,
-					this.retryTemplate);
+					this.observationRegistry, this.modelManagementOptions, this.retryTemplate);
 		}
 
 	}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
@@ -30,8 +30,9 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
-import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.ollama.api.OllamaApi;
 import org.springframework.ai.ollama.api.OllamaChatOptions;
 import org.springframework.ai.ollama.api.OllamaModel;
@@ -69,9 +70,18 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 						"Find the weather conditions, forecasts, and temperatures for a location, like a city or state.")
 				.inputType(MockWeatherService.Request.class)
 				.build()))
+			.internalToolExecutionEnabled(false)
 			.build();
 
-		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		Prompt prompt = new Prompt(messages, promptOptions);
+		ChatResponse response = this.chatModel.call(prompt);
+
+		while (response.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			response = this.chatModel.call(prompt);
+		}
 
 		logger.info("Response: {}", response);
 
@@ -113,18 +123,24 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 						"Find the weather conditions, forecasts, and temperatures for a location, like a city or state.")
 				.inputType(MockWeatherService.Request.class)
 				.build()))
+			.internalToolExecutionEnabled(false)
 			.build();
 
-		Flux<ChatResponse> response = this.chatModel.stream(new Prompt(messages, promptOptions));
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		Prompt prompt = new Prompt(messages, promptOptions);
 
-		String content = response.collectList()
-			.block()
-			.stream()
-			.map(ChatResponse::getResults)
-			.flatMap(List::stream)
-			.map(Generation::getOutput)
-			.map(AssistantMessage::getText)
-			.collect(Collectors.joining());
+		String content = this.chatModel.stream(prompt).flatMap(response -> {
+			if (response.hasToolCalls()) {
+				ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+				return this.chatModel.stream(new Prompt(toolExecutionResult.conversationHistory(), promptOptions));
+			}
+			return Flux.just(response);
+		})
+			.mapNotNull(r -> (r.getResult() == null || r.getResult().getOutput() == null) ? null
+					: r.getResult().getOutput().getText())
+			.collect(Collectors.joining())
+			.block();
+
 		logger.info("Response: {}", content);
 
 		assertThat(content).contains("30", "10", "15");

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -151,7 +151,6 @@ The remaining `options` properties are based on the link:https://github.com/olla
 | spring.ai.ollama.chat.stop              | Sets the stop sequences to use. When this pattern is encountered the LLM will stop generating text and return. Multiple stop patterns may be set by specifying multiple separate stop parameters in a modelfile. | -
 | spring.ai.ollama.chat.tool-names         | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
 | spring.ai.ollama.chat.tool-callbacks     | Tool Callbacks to register with the ChatModel. | -
-| spring.ai.ollama.chat.internal-tool-execution-enabled | If false, the Spring AI will not handle the tool calls internally, but will proxy them to the client. Then it is the client's responsibility to handle the tool calls, dispatch them to the appropriate function, and return the results. If true (the default), the Spring AI will handle the function calls internally. Applicable only for chat models with function calling support | true
 |====
 
 TIP: All properties prefixed with `spring.ai.ollama.chat` can be overridden at runtime by adding request-specific <<chat-options>> to the `Prompt` call.
@@ -250,6 +249,87 @@ This is a powerful technique to connect the LLM capabilities with external tools
 Read more about xref:api/tools.adoc[Tool Calling].
 
 TIP: You need Ollama 0.2.8 or newer to use the functional calling capabilities and Ollama 0.4.6 or newer to use them in streaming mode.
+
+`OllamaChatModel` does not execute tool calls internally.
+Tool execution must be handled externally using one of two supported approaches:
+
+* **xref:api/tools.adoc#_chatclient_tool_execution[ChatClient with ToolCallAdvisor]** — the recommended approach for most use cases. `ToolCallAdvisor` manages the tool-call loop transparently.
+* **xref:api/tools.adoc#_user_controlled_tool_execution[User-controlled tool execution]** — use `ToolCallingManager` directly when you need full control over the loop.
+
+=== Tool Calling via ChatClient (Recommended)
+
+Use `ChatClient` with `ToolCallAdvisor` for both synchronous and streaming tool execution.
+
+[source,java]
+----
+ToolCallback weatherCallback = FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
+    .description("Get the weather in location")
+    .inputType(WeatherService.Request.class)
+    .build();
+
+// Synchronous
+String response = ChatClient.create(chatModel)
+    .prompt()
+    .user("What's the weather in Paris, Tokyo, and New York?")
+    .tools(t -> t.callbacks(weatherCallback))
+    .call()
+    .content();
+
+// Streaming
+Flux<String> stream = ChatClient.create(chatModel)
+    .prompt()
+    .user("What's the weather in Paris, Tokyo, and New York?")
+    .tools(t -> t.callbacks(weatherCallback))
+    .stream()
+    .content();
+----
+
+=== User-Controlled Tool Execution
+
+Use this pattern when you need direct access to the `ChatModel` API.
+Set `internalToolExecutionEnabled(false)` on the options and drive the tool-call loop yourself using `ToolCallingManager`.
+
+[source,java]
+----
+ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+
+OllamaChatOptions options = OllamaChatOptions.builder()
+    .internalToolExecutionEnabled(false)
+    .toolCallbacks(List.of(
+        FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
+            .description("Get the weather in location")
+            .inputType(WeatherService.Request.class)
+            .build()))
+    .build();
+
+Prompt prompt = new Prompt("What's the weather in Paris, Tokyo, and New York?", options);
+ChatResponse response = chatModel.call(prompt);
+
+while (response.hasToolCalls()) {
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, response);
+    prompt = new Prompt(result.conversationHistory(), options);
+    response = chatModel.call(prompt);
+}
+----
+
+For streaming, use `flatMap` to detect tool calls and re-stream with the updated conversation history:
+
+[source,java]
+----
+ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+Prompt prompt = new Prompt("What's the weather in Paris, Tokyo, and New York?", options);
+
+String content = chatModel.stream(prompt).flatMap(response -> {
+    if (response.hasToolCalls()) {
+        ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, response);
+        return chatModel.stream(new Prompt(result.conversationHistory(), options));
+    }
+    return Flux.just(response);
+})
+.mapNotNull(r -> r.getResult() != null ? r.getResult().getOutput().getText() : null)
+.collect(Collectors.joining())
+.block();
+----
 
 == Thinking Mode (Reasoning)
 


### PR DESCRIPTION
Tool-call loop removed from OllamaChatModel. Tool execution must now be handled externally via ChatClient with ToolCallAdvisor (recommended) or user-controlled execution using ToolCallingManager directly.

- Remove tool-call loop and ToolExecutionEligibilityChecker from OllamaChatModel
- Migrate all tests to ChatClient/ToolCallAdvisor or user-controlled execution
- Update ollama-chat.adoc to document both approaches

Part of #6251