### PR TITLE
Remove google gen ai internal tool execution

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfiguration.java
@@ -30,9 +30,7 @@ import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.cache.GoogleGenAiCachedContentService;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
-import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -136,15 +134,12 @@ public class GoogleGenAiChatAutoConfiguration {
 	public GoogleGenAiChatModel googleGenAiChatModel(Client googleGenAiClient, GoogleGenAiChatProperties chatProperties,
 			ToolCallingManager toolCallingManager, ApplicationContext context,
 			ObjectProvider<RetryTemplate> retryTemplate, ObjectProvider<ObservationRegistry> observationRegistry,
-			ObjectProvider<ChatModelObservationConvention> observationConvention,
-			ObjectProvider<ToolExecutionEligibilityPredicate> toolExecutionEligibilityPredicate) {
+			ObjectProvider<ChatModelObservationConvention> observationConvention) {
 
 		GoogleGenAiChatModel chatModel = GoogleGenAiChatModel.builder()
 			.genAiClient(googleGenAiClient)
 			.options(chatProperties.toOptions())
 			.toolCallingManager(toolCallingManager)
-			.toolExecutionEligibilityPredicate(
-					toolExecutionEligibilityPredicate.getIfUnique(() -> new DefaultToolExecutionEligibilityPredicate()))
 			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.build();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithFunctionBeanIT.java
@@ -28,6 +28,9 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.ai.tool.ToolCallback;
@@ -60,8 +63,10 @@ public class FunctionCallWithFunctionBeanIT {
 		contextRunner.run(context -> {
 
 			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
 			var options = GoogleGenAiChatOptions.builder()
+				.internalToolExecutionEnabled(false)
 				.model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
 				.toolNames("CurrentWeatherService")
 				.build();
@@ -70,6 +75,11 @@ public class FunctionCallWithFunctionBeanIT {
 					+ "Return the temperature in Celsius.", options);
 
 			ChatResponse response = chatModel.call(prompt);
+			while(response.hasToolCalls()){
+				ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt,response);
+				prompt= new Prompt(toolExecutionResult.conversationHistory(),options);
+				response = chatModel.call(prompt);
+			}
 
 			logger.info("Response: {}", response);
 
@@ -91,8 +101,10 @@ public class FunctionCallWithFunctionBeanIT {
 		contextRunner.run(context -> {
 
 			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
 			var options = GoogleGenAiChatOptions.builder()
+				.internalToolExecutionEnabled(false)
 				.model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
 				.toolNames("CurrentWeatherService")
 				.build();
@@ -101,6 +113,11 @@ public class FunctionCallWithFunctionBeanIT {
 					+ "Return the temperature in Celsius.", options);
 
 			ChatResponse response = chatModel.call(prompt);
+			while (response.hasToolCalls()) {
+				ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+				 prompt= new Prompt(toolExecutionResult.conversationHistory(),options);
+				 response = chatModel.call(prompt);
+			}
 
 			logger.info("Response: {}", response);
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithFunctionWrapperIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithFunctionWrapperIT.java
@@ -30,6 +30,9 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.ai.tool.ToolCallback;
@@ -58,6 +61,7 @@ public class FunctionCallWithFunctionWrapperIT {
 		contextRunner.run(context -> {
 
 			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
 			Function<MockWeatherService.Request, MockWeatherService.Response> weatherFunction = new MockWeatherService();
 
@@ -68,6 +72,7 @@ public class FunctionCallWithFunctionWrapperIT {
 				.build());
 
 			var options = GoogleGenAiChatOptions.builder()
+				.internalToolExecutionEnabled(false)
 				.model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
 				.toolCallbacks(toolCallbacks)
 				.build();
@@ -76,6 +81,11 @@ public class FunctionCallWithFunctionWrapperIT {
 					+ "Return the temperature in Celsius.", options);
 
 			ChatResponse response = chatModel.call(prompt);
+			while(response.hasToolCalls()){
+				ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt,response);
+				prompt= new Prompt(toolExecutionResult.conversationHistory(),options);
+				response = chatModel.call(prompt);
+			}
 
 			logger.info("Response: {}", response);
 
@@ -96,6 +106,7 @@ public class FunctionCallWithFunctionWrapperIT {
 		contextRunner.run(context -> {
 
 			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
 			Function<MockWeatherService.Request, MockWeatherService.Response> weatherFunction = new MockWeatherService();
 
@@ -106,6 +117,7 @@ public class FunctionCallWithFunctionWrapperIT {
 				.build());
 
 			var options = GoogleGenAiChatOptions.builder()
+				.internalToolExecutionEnabled(false)
 				.model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
 				.toolCallbacks(toolCallbacks)
 				.build();
@@ -114,6 +126,11 @@ public class FunctionCallWithFunctionWrapperIT {
 					+ "Return the temperature in Celsius.", options);
 
 			ChatResponse response = chatModel.call(prompt);
+			while(response.hasToolCalls()){
+				ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt,response);
+				 prompt= new Prompt(toolExecutionResult.conversationHistory(),options);
+				 response = chatModel.call(prompt);
+			}
 
 			logger.info("Response: {}", response);
 

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -86,9 +86,6 @@ import org.springframework.ai.google.genai.schema.GoogleGenAiToolCallingManager;
 import org.springframework.ai.model.ChatModelDescription;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolExecutionResult;
-import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
@@ -179,7 +176,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	private final ObservationRegistry observationRegistry;
 
 	/**
-	 * Tool calling manager used to call tools.
+	 * Tool calling manager used to resolve the tool definition sent to the model.
 	 */
 	private final ToolCallingManager toolCallingManager;
 
@@ -187,9 +184,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	 * The tool execution eligibility predicate used to determine if a tool can be
 	 * executed.
 	 */
-	private final ToolExecutionEligibilityChecker toolExecutionEligibilityChecker;
 
-	private final AtomicBoolean internalToolExecutionWarned = new AtomicBoolean(false);
 
 	private final JsonMapper jsonMapper = JacksonUtils.getDefaultJsonMapper()
 		.rebuild()
@@ -214,37 +209,18 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	public GoogleGenAiChatModel(Client genAiClient, GoogleGenAiChatOptions options,
 			ToolCallingManager toolCallingManager, RetryTemplate retryTemplate,
 			ObservationRegistry observationRegistry) {
-		this(genAiClient, options, toolCallingManager, retryTemplate, observationRegistry,
-				chatResponse -> chatResponse != null && chatResponse.hasToolCalls());
-	}
 
-	/**
-	 * Creates a new instance of GoogleGenAiChatModel.
-	 * @param genAiClient the GenAI Client instance to use
-	 * @param options the default options to use
-	 * @param toolCallingManager the tool calling manager to use. It is wrapped in a
-	 * {@link GoogleGenAiToolCallingManager} to ensure compatibility with Vertex AI's
-	 * OpenAPI schema format.
-	 * @param retryTemplate the retry template to use
-	 * @param observationRegistry the observation registry to use
-	 * @param toolExecutionEligibilityChecker the tool execution eligibility checker
-	 */
-	public GoogleGenAiChatModel(Client genAiClient, GoogleGenAiChatOptions options,
-			ToolCallingManager toolCallingManager, RetryTemplate retryTemplate, ObservationRegistry observationRegistry,
-			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker) {
 
 		Assert.notNull(genAiClient, "GenAI Client must not be null");
 		Assert.notNull(options, "GoogleGenAiChatOptions must not be null");
 		Assert.notNull(options.getModel(), "GoogleGenAiChatOptions.modelName must not be null");
 		Assert.notNull(retryTemplate, "RetryTemplate must not be null");
 		Assert.notNull(toolCallingManager, "ToolCallingManager must not be null");
-		Assert.notNull(toolExecutionEligibilityChecker, "ToolExecutionEligibilityChecker must not be null");
 
 		this.genAiClient = genAiClient;
 		this.options = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
-		this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
 		this.cachedContentService = (genAiClient != null && genAiClient.caches != null && genAiClient.async != null
 				&& genAiClient.async.caches != null) ? new GoogleGenAiCachedContentService(genAiClient) : null;
 
@@ -256,28 +232,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		}
 	}
 
-	/**
-	 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-	 * {@link #GoogleGenAiChatModel(Client, GoogleGenAiChatOptions, ToolCallingManager, RetryTemplate, ObservationRegistry, ToolExecutionEligibilityChecker)}.
-	 */
-	@Deprecated(since = "2.0.0", forRemoval = true)
-	@SuppressWarnings({ "deprecation", "removal" })
-	public GoogleGenAiChatModel(Client genAiClient, GoogleGenAiChatOptions defaultOptions,
-			ToolCallingManager toolCallingManager, RetryTemplate retryTemplate, ObservationRegistry observationRegistry,
-			ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate) {
-		this(genAiClient, defaultOptions, toolCallingManager, retryTemplate, observationRegistry,
-				new ToolExecutionEligibilityChecker() {
-					@Override
-					public Boolean apply(ChatResponse chatResponse) {
-						return chatResponse != null && chatResponse.hasToolCalls();
-					}
-
-					@Override
-					public boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse) {
-						return toolExecutionEligibilityPredicate.test(promptOptions, chatResponse);
-					}
-				});
-	}
 
 	private static GeminiMessageType toGeminiMessageType(MessageType type) {
 
@@ -494,26 +448,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 				});
 			});
 
-		if (this.toolExecutionEligibilityChecker.isToolExecutionRequired(options, response)) {
-			if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-				logger.warn(
-						"Internal tool execution in GoogleGenAiChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-								+ "Use ChatClient with ToolCallAdvisor instead.");
-			}
-			var toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
-			if (toolExecutionResult.returnDirect()) {
-				// Return tool execution result directly to the client.
-				return ChatResponse.builder()
-					.from(response)
-					.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-					.build();
-			}
-			else {
-				// Send the tool execution result back to the model.
-				return this.internalCall(new Prompt(toolExecutionResult.conversationHistory(), prompt.getOptions()),
-						response);
-			}
-		}
 
 		return response;
 
@@ -530,96 +464,67 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		Assert.notNull(options, "Options must not be null");
 
 		return Flux.deferContextual(contextView -> {
-
 			ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
-				.prompt(prompt)
-				.provider(GoogleGenAiConstants.PROVIDER_NAME)
-				.streaming(true)
-				.build();
+					.prompt(prompt)
+					.provider(GoogleGenAiConstants.PROVIDER_NAME)
+					.streaming(true)
+					.build();
 
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(
 					this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
 					this.observationRegistry);
-
 			observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
 
 			var request = createGeminiRequest(prompt);
 
+			ResponseStream<GenerateContentResponse> responseStream;
 			try {
-				ResponseStream<GenerateContentResponse> responseStream = this.genAiClient.models
-					.generateContentStream(request.modelName, request.contents, request.config);
+				responseStream = this.genAiClient.models
+						.generateContentStream(request.modelName, request.contents, request.config);
+			}
+			catch (Exception e) {
+				observation.error(e);
+				observation.stop();
+				return Flux.<ChatResponse>error(new RuntimeException("Failed to generate content", e));
+			}
 
-				Flux<ChatResponse> chatResponseFlux = Flux.fromIterable(responseStream).concatMap(response -> {
-					List<Generation> generations = response.candidates()
+			Flux<ChatResponse> chatResponseFlux = Flux.fromIterable(responseStream).concatMap(response -> {
+				List<Generation> generations = response.candidates()
 						.orElse(List.of())
 						.stream()
 						.map(this::responseCandidateToGeneration)
 						.flatMap(List::stream)
 						.toList();
 
-					var usage = response.usageMetadata();
-					Usage currentUsage = usage.isPresent() ? getDefaultUsage(usage.get(), options)
-							: getDefaultUsage(null, options);
-					Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
-					ChatResponse chatResponse = new ChatResponse(generations,
-							toChatResponseMetadata(cumulativeUsage, response.modelVersion().get()));
-					return Flux.just(chatResponse);
-				});
+				var usage = response.usageMetadata();
+				Usage currentUsage = usage.isPresent()
+						? getDefaultUsage(usage.get(), options)
+						: getDefaultUsage(null, options);
+				Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
 
-				AtomicReference<ChatResponse> aggregatedResponseRef = new AtomicReference<>();
+				ChatResponse chatResponse = new ChatResponse(generations,
+						toChatResponseMetadata(cumulativeUsage, response.modelVersion().get()));
+				return Flux.just(chatResponse);
+			});
 
-				Flux<ChatResponse> aggregatedFlux = new MessageAggregator().aggregate(chatResponseFlux,
-						aggregatedResponse -> {
-							aggregatedResponseRef.set(aggregatedResponse);
-							observationContext.setResponse(aggregatedResponse);
-						});
+			AtomicReference<ChatResponse> aggregatedResponseRef = new AtomicReference<>();
+			Flux<ChatResponse> aggregatedFlux = new MessageAggregator().aggregate(chatResponseFlux,
+					aggregatedResponse -> {
+						aggregatedResponseRef.set(aggregatedResponse);
+						observationContext.setResponse(aggregatedResponse);
+					});
 
-				Flux<ChatResponse> resultFlux = aggregatedFlux.concatWith(Flux.deferContextual(ctx -> {
-					ChatResponse aggregatedResponse = aggregatedResponseRef.get();
-					if (aggregatedResponse != null && this.toolExecutionEligibilityChecker
-						.isToolExecutionRequired(options, aggregatedResponse)) {
-						// FIXME: bounded elastic needs to be used since tool calling
-						// is currently only synchronous
-						ToolExecutionResult toolExecutionResult;
-						try {
-							if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-								logger.warn(
-										"Internal tool execution in GoogleGenAiChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-												+ "Use ChatClient with ToolCallAdvisor instead.");
-							}
-							ToolCallReactiveContextHolder.setContext(ctx);
-							toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, aggregatedResponse);
-						}
-						finally {
-							ToolCallReactiveContextHolder.clearContext();
-						}
-						if (toolExecutionResult.returnDirect()) {
-							// Return tool execution result directly to the client.
-							return Flux.just(ChatResponse.builder()
-								.from(aggregatedResponse)
-								.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-								.build());
-						}
-						else {
-							// Send the tool execution result back to the model.
-							return this.internalStream(
-									new Prompt(toolExecutionResult.conversationHistory(), prompt.getOptions()),
-									aggregatedResponse);
-						}
-					}
-					return Flux.empty();
-				}).subscribeOn(Schedulers.boundedElastic()));
-
-				return resultFlux.doOnError(observation::error)
+			return aggregatedFlux
+					.concatWith(Flux.defer(() -> {
+						ChatResponse aggregatedResponse = aggregatedResponseRef.get();
+						// guard against null if stream completed with no content
+						return aggregatedResponse != null ? Flux.just(aggregatedResponse) : Flux.empty();
+					}))
+					.doOnError(observation::error)
 					.doFinally(s -> observation.stop())
 					.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
-
-			}
-			catch (Exception e) {
-				throw new RuntimeException("Failed to generate content", e);
-			}
-
 		});
+
 	}
 
 	protected List<Generation> responseCandidateToGeneration(Candidate candidate) {
@@ -1101,34 +1006,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		}
 
 		/**
-		 * Sets the predicate to determine tool execution eligibility.
-		 * @param toolExecutionEligibilityPredicate the predicate
-		 * @return this builder
-		 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-		 * {@link #toolExecutionEligibilityChecker(ToolExecutionEligibilityChecker)}. For
-		 * the recommended long-term approach, internal tool execution in
-		 * {@link GoogleGenAiChatModel} is superseded by {@code ToolCallAdvisor} used via
-		 * {@code ChatClient}.
-		 */
-		@Deprecated(since = "2.0.0", forRemoval = true)
-		@SuppressWarnings({ "deprecation", "removal" })
-		public Builder toolExecutionEligibilityPredicate(
-				ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate) {
-			this.toolExecutionEligibilityChecker = new ToolExecutionEligibilityChecker() {
-				@Override
-				public Boolean apply(ChatResponse chatResponse) {
-					return chatResponse != null && chatResponse.hasToolCalls();
-				}
-
-				@Override
-				public boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse) {
-					return toolExecutionEligibilityPredicate.test(promptOptions, chatResponse);
-				}
-			};
-			return this;
-		}
-
-		/**
 		 * Sets the checker to determine tool execution eligibility.
 		 * @param toolExecutionEligibilityChecker the checker
 		 * @return this builder
@@ -1153,10 +1030,10 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			Assert.notNull(this.genAiClient, "GenAI Client must not be null");
 			if (this.toolCallingManager != null) {
 				return new GoogleGenAiChatModel(this.genAiClient, this.options, this.toolCallingManager,
-						this.retryTemplate, this.observationRegistry, this.toolExecutionEligibilityChecker);
+						this.retryTemplate, this.observationRegistry);
 			}
 			return new GoogleGenAiChatModel(this.genAiClient, this.options, DEFAULT_TOOL_CALLING_MANAGER,
-					this.retryTemplate, this.observationRegistry, this.toolExecutionEligibilityChecker);
+					this.retryTemplate, this.observationRegistry);
 		}
 
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
@@ -158,46 +158,92 @@ TIP: In addition to the model specific `GoogleGenAiChatOptions` you can use a po
 
 == Tool Calling
 
-The Google GenAI model supports tool calling (function calling) capabilities, allowing models to use tools during conversations.
-Here's an example of how to define and use `@Tool`-based tools:
+You can register custom Java functions with the `GoogleGenAiChatModel` and have the Google GenAI model intelligently choose to output a JSON object containing arguments to call one or many of the registered functions.
+This is a powerful technique to connect the LLM capabilities with external tools and APIs.
+Read more about xref:api/tools.adoc[Tool Calling].
+
+`GoogleGenAiChatModel` does not execute tool calls internally.
+Tool execution must be handled externally using one of two supported approaches:
+
+* **xref:api/tools.adoc#_advisor_controlled_tool_execution_with_toolcalladvisor[ChatClient with ToolCallAdvisor]** — the recommended approach for most use cases. `ToolCallAdvisor` is automatically registered when tools are present and manages the tool-call loop transparently.
+* **xref:api/tools.adoc#_user_controlled_tool_execution[User-controlled tool execution]** — use `DefaultToolCallingManager` directly when you need full control over the loop (for example, when combining tool calling with direct `ChatModel` access).
+
+=== Tool Calling via ChatClient (Recommended)
+
+Use `ChatClient` for both synchronous and streaming tool execution.
+`ToolCallAdvisor` is auto-registered when tools are present, so no explicit advisor configuration is required.
 
 [source,java]
 ----
+ToolCallback weatherCallback = FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
+    .description("Get the weather in location")
+    .inputType(WeatherService.Request.class)
+    .build();
 
-public class WeatherService {
+// Synchronous
+String response = ChatClient.create(chatModel)
+    .prompt()
+    .user("What's the weather in Paris, Tokyo, and New York?")
+    .tools(t -> t.callbacks(weatherCallback))
+    .call()
+    .content();
 
-    @Tool(description = "Get the weather in location")
-    public String weatherByLocation(@ToolParam(description= "City or state name") String location) {
-        ...
-    }
-}
-
-String response = ChatClient.create(this.chatModel)
-        .prompt("What's the weather like in Boston?")
-        .tools(new WeatherService())
-        .call()
-        .content();
+// Streaming
+Flux<String> stream = ChatClient.create(chatModel)
+    .prompt()
+    .user("What's the weather in Paris, Tokyo, and New York?")
+    .tools(t -> t.callbacks(weatherCallback))
+    .stream()
+    .content();
 ----
 
-You can use the java.util.function beans as tools as well:
+=== User-Controlled Tool Execution
+
+Use this pattern when you need direct access to the `ChatModel` API.
+Set `internalToolExecutionEnabled(false)` on the options and drive the tool-call loop yourself using `DefaultToolCallingManager`.
 
 [source,java]
 ----
-@Bean
-@Description("Get the weather in location. Return temperature in 36°F or 36°C format.")
-public Function<Request, Response> weatherFunction() {
-    return new MockWeatherService();
-}
+ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
-String response = ChatClient.create(this.chatModel)
-        .prompt("What's the weather like in Boston?")
-        .toolNames("weatherFunction")
-        .inputType(Request.class)
-        .call()
-        .content();
+GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+    .internalToolExecutionEnabled(false)
+    .toolCallbacks(List.of(
+        FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
+            .description("Get the weather in location")
+            .inputType(WeatherService.Request.class)
+            .build()))
+    .build();
+
+Prompt prompt = new Prompt("What's the weather in Paris, Tokyo, and New York?", options);
+ChatResponse response = chatModel.call(prompt);
+while (response.hasToolCalls()) {
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, response);
+    prompt = new Prompt(result.conversationHistory(), options);
+    response = chatModel.call(prompt);
+}
 ----
 
-Find more in xref:api/tools.adoc[Tools] documentation.
+For streaming, aggregate each streaming response with `MessageAggregator` to detect tool calls across chunks:
+
+[source,java]
+----
+AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+new MessageAggregator()
+    .aggregate(chatModel.stream(prompt), aggregatedRef::set)
+    .collectList().block();
+
+while (aggregatedRef.get().hasToolCalls()) {
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, aggregatedRef.get());
+    prompt = new Prompt(result.conversationHistory(), options);
+    aggregatedRef.set(null);
+    new MessageAggregator()
+        .aggregate(chatModel.stream(prompt), aggregatedRef::set)
+        .collectList().block();
+}
+
+String content = aggregatedRef.get().getResult().getOutput().getText();
+----
 
 == Server-Side Tool Invocations [[server-side-tool-invocations]]
 


### PR DESCRIPTION
Drop the built-in call/stream tool-execution loop and the ToolExecutionEligibilityChecker wiring from GoogleGenAIChatModel and its autoconfiguration. Tool execution is now handled externally via ToolCallAdvisor (ChatClient) or the user-controlled DefaultToolCallingManager loop. Updated related tests and documentation.

Part of https://github.com/spring-projects/spring-ai/issues/6251