### PR TITLE
fix(core): allow tool callbacks and providers directly in ChatClient tools()

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1166,7 +1167,43 @@ public class DefaultChatClient implements ChatClient {
 		public ChatClientRequestSpec tools(Object... toolObjects) {
 			Assert.notNull(toolObjects, "toolObjects cannot be null");
 			Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
-			this.toolCallbacks.addAll(Arrays.asList(ToolCallbacks.from(toolObjects)));
+
+			List<Object> pojos = new ArrayList<>();
+			for (Object toolObject : toolObjects) {
+				if (toolObject instanceof ToolCallback toolCallback) {
+					this.toolCallbacks.add(toolCallback);
+				}
+				else if (toolObject instanceof ToolCallbackProvider toolCallbackProvider) {
+					this.toolCallbackProviders.add(toolCallbackProvider);
+				}
+				else if (toolObject instanceof ToolCallback[] callbacks) {
+					this.toolCallbacks.addAll(Arrays.asList(callbacks));
+				}
+				else if (toolObject instanceof ToolCallbackProvider[] providers) {
+					this.toolCallbackProviders.addAll(Arrays.asList(providers));
+				}
+				else if (toolObject instanceof Collection<?> collection) {
+					for (Object element : collection) {
+						if (element instanceof ToolCallback toolCallback) {
+							this.toolCallbacks.add(toolCallback);
+						}
+						else if (element instanceof ToolCallbackProvider toolCallbackProvider) {
+							this.toolCallbackProviders.add(toolCallbackProvider);
+						}
+						else {
+							pojos.add(element);
+						}
+					}
+				}
+				else {
+					pojos.add(toolObject);
+				}
+			}
+
+			if (!pojos.isEmpty()) {
+				this.toolCallbacks.addAll(Arrays.asList(ToolCallbacks.from(pojos.toArray())));
+			}
+
 			return this;
 		}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1788,6 +1788,30 @@ class DefaultChatClientTests {
 	}
 
 	@Test
+	void whenToolsObjectsContainCallbackAndProviderThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+		ToolCallback toolCallback = mock(ToolCallback.class);
+		ToolCallbackProvider toolCallbackProvider = mock(ToolCallbackProvider.class);
+		spec = spec.tools(toolCallback, toolCallbackProvider);
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getToolCallbacks()).contains(toolCallback);
+		assertThat(defaultSpec.getToolCallbackProviders()).contains(toolCallbackProvider);
+	}
+
+	@Test
+	void whenToolsObjectsContainCollectionThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+		ToolCallback toolCallback = mock(ToolCallback.class);
+		ToolCallbackProvider toolCallbackProvider = mock(ToolCallbackProvider.class);
+		spec = spec.tools(List.of(toolCallback, toolCallbackProvider));
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getToolCallbacks()).contains(toolCallback);
+		assertThat(defaultSpec.getToolCallbackProviders()).contains(toolCallbackProvider);
+	}
+
+	@Test
 	void whenFunctionNameIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();


### PR DESCRIPTION
Resolves spring-projects/spring-ai#6206. Permitting ChatClient.prompt().tools(...) to accept ToolCallback, ToolCallbackProvider, collections, and arrays of them directly, matching user expectations after deprecation of toolCallbacks(...).