### PR TITLE
Remove internal tool execution from GoogleGenAiChatModel

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfiguration.java
@@ -30,9 +30,7 @@ import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.cache.GoogleGenAiCachedContentService;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
-import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -136,15 +134,12 @@ public class GoogleGenAiChatAutoConfiguration {
 	public GoogleGenAiChatModel googleGenAiChatModel(Client googleGenAiClient, GoogleGenAiChatProperties chatProperties,
 			ToolCallingManager toolCallingManager, ApplicationContext context,
 			ObjectProvider<RetryTemplate> retryTemplate, ObjectProvider<ObservationRegistry> observationRegistry,
-			ObjectProvider<ChatModelObservationConvention> observationConvention,
-			ObjectProvider<ToolExecutionEligibilityPredicate> toolExecutionEligibilityPredicate) {
+			ObjectProvider<ChatModelObservationConvention> observationConvention) {
 
 		GoogleGenAiChatModel chatModel = GoogleGenAiChatModel.builder()
 			.genAiClient(googleGenAiClient)
 			.options(chatProperties.toOptions())
 			.toolCallingManager(toolCallingManager)
-			.toolExecutionEligibilityPredicate(
-					toolExecutionEligibilityPredicate.getIfUnique(() -> new DefaultToolExecutionEligibilityPredicate()))
 			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.build();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithFunctionBeanIT.java
@@ -18,16 +18,20 @@ package org.springframework.ai.model.google.genai.autoconfigure.chat.tool;
 
 import java.util.function.Function;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.ai.tool.ToolCallback;
@@ -52,7 +56,8 @@ public class FunctionCallWithFunctionBeanIT {
 	@EnabledIfEnvironmentVariable(named = "GOOGLE_API_KEY", matches = ".+")
 	void functionCallWithApiKey() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withPropertyValues("spring.ai.google.genai.api-key=" + System.getenv("GOOGLE_API_KEY"))
+			.withPropertyValues("spring.ai.google.genai.api-key=" + System.getenv("GOOGLE_API_KEY"),
+					"spring.ai.google.genai.chat.model=" + GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
 			.withConfiguration(AutoConfigurations.of(GoogleGenAiChatAutoConfiguration.class,
 					SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class))
 			.withUserConfiguration(FunctionConfiguration.class);
@@ -60,6 +65,12 @@ public class FunctionCallWithFunctionBeanIT {
 		contextRunner.run(context -> {
 
 			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
+
+			var chatClient = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build();
 
 			var options = GoogleGenAiChatOptions.builder()
 				.model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
@@ -69,7 +80,7 @@ public class FunctionCallWithFunctionBeanIT {
 			Prompt prompt = new Prompt("What's the weather like in San Francisco, Paris and in Tokyo?"
 					+ "Return the temperature in Celsius.", options);
 
-			ChatResponse response = chatModel.call(prompt);
+			ChatResponse response = chatClient.prompt(prompt).call().chatResponse();
 
 			logger.info("Response: {}", response);
 
@@ -83,7 +94,8 @@ public class FunctionCallWithFunctionBeanIT {
 	void functionCallWithVertexAi() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.google.genai.project-id=" + System.getenv("GOOGLE_CLOUD_PROJECT"),
-					"spring.ai.google.genai.location=" + System.getenv("GOOGLE_CLOUD_LOCATION"))
+					"spring.ai.google.genai.location=" + System.getenv("GOOGLE_CLOUD_LOCATION"),
+					"spring.ai.google.genai.chat.model=" + GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
 			.withConfiguration(AutoConfigurations.of(GoogleGenAiChatAutoConfiguration.class,
 					SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class))
 			.withUserConfiguration(FunctionConfiguration.class);
@@ -91,6 +103,12 @@ public class FunctionCallWithFunctionBeanIT {
 		contextRunner.run(context -> {
 
 			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
+
+			var chatClient = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build();
 
 			var options = GoogleGenAiChatOptions.builder()
 				.model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
@@ -100,7 +118,7 @@ public class FunctionCallWithFunctionBeanIT {
 			Prompt prompt = new Prompt("What's the weather like in San Francisco, Paris and in Tokyo?"
 					+ "Return the temperature in Celsius.", options);
 
-			ChatResponse response = chatModel.call(prompt);
+			ChatResponse response = chatClient.prompt(prompt).call().chatResponse();
 
 			logger.info("Response: {}", response);
 
@@ -126,32 +144,5 @@ public class FunctionCallWithFunctionBeanIT {
 		}
 
 	}
-	//
-	// public static class MockWeatherService implements
-	// Function<MockWeatherService.Request, MockWeatherService.Response> {
-	//
-	// public record Request(String location, String unit) {
-	// }
-	//
-	// public record Response(double temperature, String unit, String description) {
-	// }
-	//
-	// @Override
-	// public Response apply(Request request) {
-	// double temperature = 0;
-	// if (request.location.contains("Paris")) {
-	// temperature = 15.5;
-	// }
-	// else if (request.location.contains("Tokyo")) {
-	// temperature = 10.5;
-	// }
-	// else if (request.location.contains("San Francisco")) {
-	// temperature = 30.5;
-	// }
-	// return new Response(temperature, request.unit != null ? request.unit : "°C",
-	// "sunny");
-	// }
-	//
-	// }
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithFunctionWrapperIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithFunctionWrapperIT.java
@@ -20,16 +20,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.ai.tool.ToolCallback;
@@ -51,13 +55,20 @@ public class FunctionCallWithFunctionWrapperIT {
 	@EnabledIfEnvironmentVariable(named = "GOOGLE_API_KEY", matches = ".+")
 	void functionCallWithApiKey() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withPropertyValues("spring.ai.google.genai.api-key=" + System.getenv("GOOGLE_API_KEY"))
+			.withPropertyValues("spring.ai.google.genai.api-key=" + System.getenv("GOOGLE_API_KEY"),
+					"spring.ai.google.genai.chat.model=" + GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
 			.withConfiguration(AutoConfigurations.of(GoogleGenAiChatAutoConfiguration.class,
 					SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class));
 
 		contextRunner.run(context -> {
 
 			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
+
+			var chatClient = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build();
 
 			Function<MockWeatherService.Request, MockWeatherService.Response> weatherFunction = new MockWeatherService();
 
@@ -75,7 +86,7 @@ public class FunctionCallWithFunctionWrapperIT {
 			Prompt prompt = new Prompt("What's the weather like in San Francisco, Paris and in Tokyo?"
 					+ "Return the temperature in Celsius.", options);
 
-			ChatResponse response = chatModel.call(prompt);
+			ChatResponse response = chatClient.prompt(prompt).call().chatResponse();
 
 			logger.info("Response: {}", response);
 
@@ -89,13 +100,20 @@ public class FunctionCallWithFunctionWrapperIT {
 	void functionCallWithVertexAi() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.google.genai.project-id=" + System.getenv("GOOGLE_CLOUD_PROJECT"),
-					"spring.ai.google.genai.location=" + System.getenv("GOOGLE_CLOUD_LOCATION"))
+					"spring.ai.google.genai.location=" + System.getenv("GOOGLE_CLOUD_LOCATION"),
+					"spring.ai.google.genai.chat.model=" + GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
 			.withConfiguration(AutoConfigurations.of(GoogleGenAiChatAutoConfiguration.class,
 					SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class));
 
 		contextRunner.run(context -> {
 
 			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
+
+			var chatClient = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build();
 
 			Function<MockWeatherService.Request, MockWeatherService.Response> weatherFunction = new MockWeatherService();
 
@@ -113,39 +131,12 @@ public class FunctionCallWithFunctionWrapperIT {
 			Prompt prompt = new Prompt("What's the weather like in San Francisco, Paris and in Tokyo?"
 					+ "Return the temperature in Celsius.", options);
 
-			ChatResponse response = chatModel.call(prompt);
+			ChatResponse response = chatClient.prompt(prompt).call().chatResponse();
 
 			logger.info("Response: {}", response);
 
 			assertThat(response.getResult().getOutput().getText()).contains("30.789", "10.456", "15.123");
 		});
 	}
-
-	// public static class MockWeatherService implements
-	// Function<MockWeatherService.Request, MockWeatherService.Response> {
-	//
-	// public record Request(String location, String unit) {
-	// }
-	//
-	// public record Response(double temperature, String unit, String description) {
-	// }
-	//
-	// @Override
-	// public Response apply(Request request) {
-	// double temperature = 0;
-	// if (request.location.contains("Paris")) {
-	// temperature = 15.5;
-	// }
-	// else if (request.location.contains("Tokyo")) {
-	// temperature = 10.5;
-	// }
-	// else if (request.location.contains("San Francisco")) {
-	// temperature = 30.5;
-	// }
-	// return new Response(temperature, request.unit != null ? request.unit : "°C",
-	// "sunny");
-	// }
-	//
-	// }
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithPromptFunctionIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithPromptFunctionIT.java
@@ -18,17 +18,21 @@ package org.springframework.ai.model.google.genai.autoconfigure.chat.tool;
 
 import java.util.List;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.ai.tool.function.FunctionToolCallback;
@@ -45,48 +49,58 @@ public class FunctionCallWithPromptFunctionIT {
 
 	private final Logger logger = LoggerFactory.getLogger(FunctionCallWithPromptFunctionIT.class);
 
+	private final String modelName = GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue();
+
 	@Test
 	@EnabledIfEnvironmentVariable(named = "GOOGLE_API_KEY", matches = ".+")
 	void functionCallTestWithApiKey() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withPropertyValues("spring.ai.google.genai.api-key=" + System.getenv("GOOGLE_API_KEY"))
+			.withPropertyValues("spring.ai.google.genai.api-key=" + System.getenv("GOOGLE_API_KEY"),
+					"spring.ai.google.genai.chat.model=" + this.modelName)
 			.withConfiguration(AutoConfigurations.of(GoogleGenAiChatAutoConfiguration.class,
 					SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class));
 
-		contextRunner
-			.withPropertyValues(
-					"spring.ai.google.genai.chat.model=" + GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
-			.run(context -> {
+		contextRunner.run(context -> {
 
-				GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
 
-				var userMessage = new UserMessage("""
-						What's the weather like in San Francisco, Paris and in Tokyo?
-						Return the temperature in Celsius.
-						""");
+			var userMessage = new UserMessage("""
+					What's the weather like in San Francisco, Paris and in Tokyo?
+					Return the temperature in Celsius.
+					""");
 
-				var promptOptions = GoogleGenAiChatOptions.builder()
-					.toolCallbacks(
-							List.of(FunctionToolCallback.builder("CurrentWeatherService", new MockWeatherService())
-								.description("Get the weather in location")
-								.inputType(MockWeatherService.Request.class)
-								.build()))
-					.build();
+			var promptOptions = GoogleGenAiChatOptions.builder()
+				.model(this.modelName)
+				.toolCallbacks(List.of(FunctionToolCallback.builder("CurrentWeatherService", new MockWeatherService())
+					.description("Get the weather in location")
+					.inputType(MockWeatherService.Request.class)
+					.build()))
+				.build();
 
-				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), promptOptions));
+			var chatClient = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build();
 
-				logger.info("Response: {}", response);
+			ChatResponse response = chatClient.prompt(new Prompt(List.of(userMessage), promptOptions))
+				.call()
+				.chatResponse();
 
-				assertThat(response.getResult().getOutput().getText()).contains("30.789", "10.456", "15.123");
+			logger.info("Response: {}", response);
 
-				// Verify that no function call is made.
-				response = chatModel.call(new Prompt(List.of(userMessage), GoogleGenAiChatOptions.builder().build()));
+			assertThat(response.getResult().getOutput().getText()).contains("30.789", "10.456", "15.123");
 
-				logger.info("Response: {}", response);
+			// Verify that no function call is made.
+			response = chatClient.prompt(new Prompt(List.of(userMessage), GoogleGenAiChatOptions.builder().build()))
+				.call()
+				.chatResponse();
 
-				assertThat(response.getResult().getOutput().getText()).doesNotContain("30.789", "10.456", "15.123");
+			logger.info("Response: {}", response);
 
-			});
+			assertThat(response.getResult().getOutput().getText()).doesNotContain("30.789", "10.456", "15.123");
+
+		});
 	}
 
 	@Test
@@ -95,44 +109,50 @@ public class FunctionCallWithPromptFunctionIT {
 	void functionCallTestWithVertexAi() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.google.genai.project-id=" + System.getenv("GOOGLE_CLOUD_PROJECT"),
-					"spring.ai.google.genai.location=" + System.getenv("GOOGLE_CLOUD_LOCATION"))
+					"spring.ai.google.genai.location=" + System.getenv("GOOGLE_CLOUD_LOCATION"),
+					"spring.ai.google.genai.chat.model=" + this.modelName)
 			.withConfiguration(AutoConfigurations.of(GoogleGenAiChatAutoConfiguration.class,
 					SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class));
 
-		contextRunner
-			.withPropertyValues(
-					"spring.ai.google.genai.chat.model=" + GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue())
-			.run(context -> {
+		contextRunner.run(context -> {
 
-				GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
+			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
 
-				var userMessage = new UserMessage("""
-						What's the weather like in San Francisco, Paris and in Tokyo?
-						Return the temperature in Celsius.
-						""");
+			var chatClient = ChatClient
+				.builder(chatModel, ObservationRegistry.NOOP, null, null,
+						ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+				.build();
 
-				var promptOptions = GoogleGenAiChatOptions.builder()
-					.toolCallbacks(
-							List.of(FunctionToolCallback.builder("CurrentWeatherService", new MockWeatherService())
-								.description("Get the weather in location")
-								.inputType(MockWeatherService.Request.class)
-								.build()))
-					.build();
+			var userMessage = new UserMessage("""
+					What's the weather like in San Francisco, Paris and in Tokyo?
+					Return the temperature in Celsius.
+					""");
 
-				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), promptOptions));
+			var promptOptions = GoogleGenAiChatOptions.builder()
+				.model(this.modelName)
+				.toolCallbacks(List.of(FunctionToolCallback.builder("CurrentWeatherService", new MockWeatherService())
+					.description("Get the weather in location")
+					.inputType(MockWeatherService.Request.class)
+					.build()))
+				.build();
 
-				logger.info("Response: {}", response);
+			ChatResponse response = chatClient.prompt(new Prompt(List.of(userMessage), promptOptions))
+				.call()
+				.chatResponse();
 
-				assertThat(response.getResult().getOutput().getText()).contains("30.789", "10.456", "15.123");
+			logger.info("Response: {}", response);
 
-				// Verify that no function call is made.
-				response = chatModel.call(new Prompt(List.of(userMessage), GoogleGenAiChatOptions.builder().build()));
+			assertThat(response.getResult().getOutput().getText()).contains("30.789", "10.456", "15.123");
 
-				logger.info("Response: {}", response);
+			// Verify that no function call is made.
+			response = chatModel.call(new Prompt(List.of(userMessage), GoogleGenAiChatOptions.builder().build()));
 
-				assertThat(response.getResult().getOutput().getText()).doesNotContain("30.789", "10.456", "15.123");
+			logger.info("Response: {}", response);
 
-			});
+			assertThat(response.getResult().getOutput().getText()).doesNotContain("30.789", "10.456", "15.123");
+
+		});
 	}
 
 }

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -52,7 +51,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.scheduler.Schedulers;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -74,7 +72,6 @@ import org.springframework.ai.chat.observation.ChatModelObservationContext;
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.chat.observation.ChatModelObservationDocumentation;
 import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
-import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.google.genai.cache.GoogleGenAiCachedContentService;
@@ -85,10 +82,6 @@ import org.springframework.ai.google.genai.metadata.GoogleGenAiUsage;
 import org.springframework.ai.google.genai.schema.GoogleGenAiToolCallingManager;
 import org.springframework.ai.model.ChatModelDescription;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolExecutionResult;
-import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
@@ -153,8 +146,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 
 	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();
 
-	private static final ToolCallingManager DEFAULT_TOOL_CALLING_MANAGER = ToolCallingManager.builder().build();
-
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	private final Client genAiClient;
@@ -183,14 +174,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	 */
 	private final ToolCallingManager toolCallingManager;
 
-	/**
-	 * The tool execution eligibility predicate used to determine if a tool can be
-	 * executed.
-	 */
-	private final ToolExecutionEligibilityChecker toolExecutionEligibilityChecker;
-
-	private final AtomicBoolean internalToolExecutionWarned = new AtomicBoolean(false);
-
 	private final JsonMapper jsonMapper = JacksonUtils.getDefaultJsonMapper()
 		.rebuild()
 		.addMixIn(Schema.class, SchemaMixin.class)
@@ -214,37 +197,17 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	public GoogleGenAiChatModel(Client genAiClient, GoogleGenAiChatOptions options,
 			ToolCallingManager toolCallingManager, RetryTemplate retryTemplate,
 			ObservationRegistry observationRegistry) {
-		this(genAiClient, options, toolCallingManager, retryTemplate, observationRegistry,
-				chatResponse -> chatResponse != null && chatResponse.hasToolCalls());
-	}
-
-	/**
-	 * Creates a new instance of GoogleGenAiChatModel.
-	 * @param genAiClient the GenAI Client instance to use
-	 * @param options the default options to use
-	 * @param toolCallingManager the tool calling manager to use. It is wrapped in a
-	 * {@link GoogleGenAiToolCallingManager} to ensure compatibility with Vertex AI's
-	 * OpenAPI schema format.
-	 * @param retryTemplate the retry template to use
-	 * @param observationRegistry the observation registry to use
-	 * @param toolExecutionEligibilityChecker the tool execution eligibility checker
-	 */
-	public GoogleGenAiChatModel(Client genAiClient, GoogleGenAiChatOptions options,
-			ToolCallingManager toolCallingManager, RetryTemplate retryTemplate, ObservationRegistry observationRegistry,
-			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker) {
 
 		Assert.notNull(genAiClient, "GenAI Client must not be null");
 		Assert.notNull(options, "GoogleGenAiChatOptions must not be null");
 		Assert.notNull(options.getModel(), "GoogleGenAiChatOptions.modelName must not be null");
 		Assert.notNull(retryTemplate, "RetryTemplate must not be null");
 		Assert.notNull(toolCallingManager, "ToolCallingManager must not be null");
-		Assert.notNull(toolExecutionEligibilityChecker, "ToolExecutionEligibilityChecker must not be null");
 
 		this.genAiClient = genAiClient;
 		this.options = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
-		this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
 		this.cachedContentService = (genAiClient != null && genAiClient.caches != null && genAiClient.async != null
 				&& genAiClient.async.caches != null) ? new GoogleGenAiCachedContentService(genAiClient) : null;
 
@@ -254,29 +217,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		else {
 			this.toolCallingManager = new GoogleGenAiToolCallingManager(toolCallingManager);
 		}
-	}
-
-	/**
-	 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-	 * {@link #GoogleGenAiChatModel(Client, GoogleGenAiChatOptions, ToolCallingManager, RetryTemplate, ObservationRegistry, ToolExecutionEligibilityChecker)}.
-	 */
-	@Deprecated(since = "2.0.0", forRemoval = true)
-	@SuppressWarnings({ "deprecation", "removal" })
-	public GoogleGenAiChatModel(Client genAiClient, GoogleGenAiChatOptions defaultOptions,
-			ToolCallingManager toolCallingManager, RetryTemplate retryTemplate, ObservationRegistry observationRegistry,
-			ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate) {
-		this(genAiClient, defaultOptions, toolCallingManager, retryTemplate, observationRegistry,
-				new ToolExecutionEligibilityChecker() {
-					@Override
-					public Boolean apply(ChatResponse chatResponse) {
-						return chatResponse != null && chatResponse.hasToolCalls();
-					}
-
-					@Override
-					public boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse) {
-						return toolExecutionEligibilityPredicate.test(promptOptions, chatResponse);
-					}
-				});
 	}
 
 	private static GeminiMessageType toGeminiMessageType(MessageType type) {
@@ -494,27 +434,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 				});
 			});
 
-		if (this.toolExecutionEligibilityChecker.isToolExecutionRequired(options, response)) {
-			if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-				logger.warn(
-						"Internal tool execution in GoogleGenAiChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-								+ "Use ChatClient with ToolCallAdvisor instead.");
-			}
-			var toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
-			if (toolExecutionResult.returnDirect()) {
-				// Return tool execution result directly to the client.
-				return ChatResponse.builder()
-					.from(response)
-					.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-					.build();
-			}
-			else {
-				// Send the tool execution result back to the model.
-				return this.internalCall(new Prompt(toolExecutionResult.conversationHistory(), prompt.getOptions()),
-						response);
-			}
-		}
-
 		return response;
 
 	}
@@ -574,43 +493,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 							observationContext.setResponse(aggregatedResponse);
 						});
 
-				Flux<ChatResponse> resultFlux = aggregatedFlux.concatWith(Flux.deferContextual(ctx -> {
-					ChatResponse aggregatedResponse = aggregatedResponseRef.get();
-					if (aggregatedResponse != null && this.toolExecutionEligibilityChecker
-						.isToolExecutionRequired(options, aggregatedResponse)) {
-						// FIXME: bounded elastic needs to be used since tool calling
-						// is currently only synchronous
-						ToolExecutionResult toolExecutionResult;
-						try {
-							if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-								logger.warn(
-										"Internal tool execution in GoogleGenAiChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-												+ "Use ChatClient with ToolCallAdvisor instead.");
-							}
-							ToolCallReactiveContextHolder.setContext(ctx);
-							toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, aggregatedResponse);
-						}
-						finally {
-							ToolCallReactiveContextHolder.clearContext();
-						}
-						if (toolExecutionResult.returnDirect()) {
-							// Return tool execution result directly to the client.
-							return Flux.just(ChatResponse.builder()
-								.from(aggregatedResponse)
-								.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-								.build());
-						}
-						else {
-							// Send the tool execution result back to the model.
-							return this.internalStream(
-									new Prompt(toolExecutionResult.conversationHistory(), prompt.getOptions()),
-									aggregatedResponse);
-						}
-					}
-					return Flux.empty();
-				}).subscribeOn(Schedulers.boundedElastic()));
-
-				return resultFlux.doOnError(observation::error)
+				return aggregatedFlux.doOnError(observation::error)
 					.doFinally(s -> observation.stop())
 					.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 
@@ -1066,9 +949,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 
 		@Nullable private ToolCallingManager toolCallingManager;
 
-		private ToolExecutionEligibilityChecker toolExecutionEligibilityChecker = chatResponse -> chatResponse != null
-				&& chatResponse.hasToolCalls();
-
 		private RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
 
 		private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
@@ -1100,45 +980,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			return this;
 		}
 
-		/**
-		 * Sets the predicate to determine tool execution eligibility.
-		 * @param toolExecutionEligibilityPredicate the predicate
-		 * @return this builder
-		 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-		 * {@link #toolExecutionEligibilityChecker(ToolExecutionEligibilityChecker)}. For
-		 * the recommended long-term approach, internal tool execution in
-		 * {@link GoogleGenAiChatModel} is superseded by {@code ToolCallAdvisor} used via
-		 * {@code ChatClient}.
-		 */
-		@Deprecated(since = "2.0.0", forRemoval = true)
-		@SuppressWarnings({ "deprecation", "removal" })
-		public Builder toolExecutionEligibilityPredicate(
-				ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate) {
-			this.toolExecutionEligibilityChecker = new ToolExecutionEligibilityChecker() {
-				@Override
-				public Boolean apply(ChatResponse chatResponse) {
-					return chatResponse != null && chatResponse.hasToolCalls();
-				}
-
-				@Override
-				public boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse) {
-					return toolExecutionEligibilityPredicate.test(promptOptions, chatResponse);
-				}
-			};
-			return this;
-		}
-
-		/**
-		 * Sets the checker to determine tool execution eligibility.
-		 * @param toolExecutionEligibilityChecker the checker
-		 * @return this builder
-		 */
-		public Builder toolExecutionEligibilityChecker(
-				ToolExecutionEligibilityChecker toolExecutionEligibilityChecker) {
-			this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
-			return this;
-		}
-
 		public Builder retryTemplate(RetryTemplate retryTemplate) {
 			this.retryTemplate = retryTemplate;
 			return this;
@@ -1153,10 +994,12 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			Assert.notNull(this.genAiClient, "GenAI Client must not be null");
 			if (this.toolCallingManager != null) {
 				return new GoogleGenAiChatModel(this.genAiClient, this.options, this.toolCallingManager,
-						this.retryTemplate, this.observationRegistry, this.toolExecutionEligibilityChecker);
+						this.retryTemplate, this.observationRegistry);
 			}
-			return new GoogleGenAiChatModel(this.genAiClient, this.options, DEFAULT_TOOL_CALLING_MANAGER,
-					this.retryTemplate, this.observationRegistry, this.toolExecutionEligibilityChecker);
+
+			return new GoogleGenAiChatModel(this.genAiClient, this.options,
+					ToolCallingManager.builder().observationRegistry(this.observationRegistry).build(),
+					this.retryTemplate, this.observationRegistry);
 		}
 
 	}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelIT.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.client.AdvisorParams;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -481,7 +482,10 @@ class GoogleGenAiChatModelIT {
 				.build())
 			.build();
 
-		ChatClient chatClient = ChatClient.builder(chatModelWithTools).build();
+		ChatClient chatClient = ChatClient
+			.builder(chatModelWithTools, ObservationRegistry.NOOP, null, null,
+					ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+			.build();
 
 		// Create a prompt that will trigger the tool call with a specific request that
 		// should invoke the tool

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiThoughtSignatureLifecycleIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiThoughtSignatureLifecycleIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.google.genai;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -34,8 +35,12 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.google.genai.tool.MockWeatherService;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
@@ -85,6 +90,8 @@ class GoogleGenAiThoughtSignatureLifecycleIT {
 	@Autowired
 	private GoogleGenAiChatModel chatModel;
 
+	private final ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
 	/**
 	 * Tests that thought signatures are properly handled when includeThoughts is
 	 * explicitly set to false. In this case, no thought signatures should be present in
@@ -106,7 +113,14 @@ class GoogleGenAiThoughtSignatureLifecycleIT {
 				.build()))
 			.build();
 
-		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
+		var prompt = new Prompt(messages, promptOptions);
+		ChatResponse response = this.chatModel.call(prompt);
+
+		while (response.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			response = this.chatModel.call(prompt);
+		}
 
 		assertThat(response).isNotNull();
 		logger.info("Response: {}", response.getResult().getOutput().getText());
@@ -147,7 +161,19 @@ class GoogleGenAiThoughtSignatureLifecycleIT {
 
 		// Execute streaming call
 		logger.info("=== Testing Thought Signatures with Streaming ===");
-		ChatResponse lastResponse = this.chatModel.stream(new Prompt(messages, promptOptions)).blockLast();
+		var prompt = new Prompt(messages, promptOptions);
+		AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+		new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+
+		while (aggregatedRef.get().hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt,
+					aggregatedRef.get());
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			aggregatedRef.set(null);
+			new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+		}
+
+		ChatResponse lastResponse = aggregatedRef.get();
 
 		assertThat(lastResponse).isNotNull();
 		logger.info("Final streaming response: {}", lastResponse.getResult().getOutput().getText());
@@ -218,7 +244,6 @@ class GoogleGenAiThoughtSignatureLifecycleIT {
 		var promptOptions = GoogleGenAiChatOptions.builder()
 			.model(model)
 			.includeThoughts(true) // Enable thought signatures
-			.internalToolExecutionEnabled(true) // Enable automatic tool execution
 			.toolCallbacks(List.of(
 					FunctionToolCallback.builder("check_flight", new MockFlightService())
 						.description("Gets the current status of a flight including departure time and delay status.")
@@ -233,10 +258,14 @@ class GoogleGenAiThoughtSignatureLifecycleIT {
 		logger.info("=== Scenario 1: Sequential Function Calling with {} ===", modelName);
 		logger.info("Prompt: {}", userMessage.getText());
 
-		// Single call that triggers multiple sequential function executions
-		// If thought signatures are not propagated properly in the internal loop,
-		// this would fail with HTTP 400 validation error
-		ChatResponse response = this.chatModel.call(new Prompt(userMessage, promptOptions));
+		var prompt = new Prompt(userMessage, promptOptions);
+		ChatResponse response = this.chatModel.call(prompt);
+
+		while (response.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			response = this.chatModel.call(prompt);
+		}
 
 		assertThat(response).isNotNull();
 		String responseText = response.getResult().getOutput().getText();

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tool/GoogleGenAiChatModelToolCallingIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tool/GoogleGenAiChatModelToolCallingIT.java
@@ -18,24 +18,25 @@ package org.springframework.ai.google.genai.tool;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import com.google.genai.Client;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
 
-import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
-import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
@@ -53,6 +54,8 @@ public class GoogleGenAiChatModelToolCallingIT {
 
 	@Autowired
 	private GoogleGenAiChatModel chatModel;
+
+	ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
 	@Test
 	public void functionCallExplicitOpenApiSchema() {
@@ -80,7 +83,7 @@ public class GoogleGenAiChatModelToolCallingIT {
 					}
 					""";
 
-		var promptOptions = GoogleGenAiChatOptions.builder()
+		var options = GoogleGenAiChatOptions.builder()
 			.toolCallbacks(List.of(FunctionToolCallback.builder("get_current_weather", new MockWeatherService())
 				.description("Get the current weather in a given location")
 				.inputSchema(openApiSchema)
@@ -88,8 +91,15 @@ public class GoogleGenAiChatModelToolCallingIT {
 				.build()))
 			.build();
 
-		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
+		var prompt = new Prompt(messages, options);
 
+		ChatResponse response = this.chatModel.call(prompt);
+
+		while (response.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+			response = this.chatModel.call(prompt);
+		}
 		logger.info("Response: {}", response);
 
 		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
@@ -116,7 +126,14 @@ public class GoogleGenAiChatModelToolCallingIT {
 						.build()))
 			.build();
 
-		ChatResponse chatResponse = this.chatModel.call(new Prompt(messages, promptOptions));
+		var prompt = new Prompt(messages, promptOptions);
+		ChatResponse chatResponse = this.chatModel.call(prompt);
+
+		while (chatResponse.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, chatResponse);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			chatResponse = this.chatModel.call(prompt);
+		}
 
 		assertThat(chatResponse).isNotNull();
 		logger.info("Response: {}", chatResponse);
@@ -126,8 +143,14 @@ public class GoogleGenAiChatModelToolCallingIT {
 		assertThat(chatResponse.getMetadata().getUsage()).isNotNull();
 		assertThat(chatResponse.getMetadata().getUsage().getTotalTokens()).isGreaterThan(150).isLessThan(500);
 
-		ChatResponse response2 = this.chatModel
-			.call(new Prompt("What is the payment status for transaction 696?", promptOptions));
+		var prompt2 = new Prompt("What is the payment status for transaction 696?", promptOptions);
+		ChatResponse response2 = this.chatModel.call(prompt2);
+
+		while (response2.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt2, response2);
+			prompt2 = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			response2 = this.chatModel.call(prompt2);
+		}
 
 		logger.info("Response: {}", response2);
 
@@ -150,16 +173,20 @@ public class GoogleGenAiChatModelToolCallingIT {
 				.build()))
 			.build();
 
-		Flux<ChatResponse> response = this.chatModel.stream(new Prompt(messages, promptOptions));
+		var prompt = new Prompt(messages, promptOptions);
 
-		String responseString = response.collectList()
-			.block()
-			.stream()
-			.map(ChatResponse::getResults)
-			.flatMap(List::stream)
-			.map(Generation::getOutput)
-			.map(AssistantMessage::getText)
-			.collect(Collectors.joining());
+		AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+		new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+
+		while (aggregatedRef.get().hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt,
+					aggregatedRef.get());
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			aggregatedRef.set(null);
+			new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+		}
+
+		String responseString = aggregatedRef.get().getResult().getOutput().getText();
 
 		logger.info("Response: {}", responseString);
 
@@ -188,17 +215,25 @@ public class GoogleGenAiChatModelToolCallingIT {
 						.build()))
 			.build();
 
-		Flux<ChatResponse> response = this.chatModel.stream(new Prompt(messages, promptOptions));
+		var prompt = new Prompt(messages, promptOptions);
 
-		ChatResponse chatResponse = response.blockLast();
+		AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+		new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
 
-		logger.info("Response: {}", chatResponse);
+		while (aggregatedRef.get().hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt,
+					aggregatedRef.get());
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			aggregatedRef.set(null);
+			new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+		}
+
+		ChatResponse chatResponse = aggregatedRef.get();
 
 		assertThat(chatResponse).isNotNull();
 		assertThat(chatResponse.getMetadata()).isNotNull();
 		assertThat(chatResponse.getMetadata().getUsage()).isNotNull();
 		assertThat(chatResponse.getMetadata().getUsage().getTotalTokens()).isGreaterThan(150).isLessThan(500);
-
 	}
 
 	@Test
@@ -223,9 +258,20 @@ public class GoogleGenAiChatModelToolCallingIT {
 						.build()))
 			.build();
 
-		Flux<ChatResponse> response = this.chatModel.stream(new Prompt(messages, promptOptions));
+		var prompt = new Prompt(messages, promptOptions);
 
-		ChatResponse chatResponse = response.blockLast();
+		AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+		new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+
+		while (aggregatedRef.get().hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt,
+					aggregatedRef.get());
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			aggregatedRef.set(null);
+			new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+		}
+
+		ChatResponse chatResponse = aggregatedRef.get();
 
 		logger.info("Response: {}", chatResponse);
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
@@ -118,10 +118,9 @@ The prefix `spring.ai.google.genai.chat` is the property prefix that lets you co
 | spring.ai.google.genai.chat.presence-penalty | Presence penalties for reducing repetition. | -
 | spring.ai.google.genai.chat.thinking-budget | Thinking budget for the thinking process. See <<thinking-config>>. | -
 | spring.ai.google.genai.chat.thinking-level | The level of thinking tokens the model should generate. Valid values: `LOW`, `HIGH`, `THINKING_LEVEL_UNSPECIFIED`. See <<thinking-config>>. | -
-| spring.ai.google.genai.chat.include-thoughts | Enable thought signatures for function calling. **Required** for Gemini 3 Pro to avoid validation errors during the internal tool execution loop. See <<thought-signatures>>. | false
+| spring.ai.google.genai.chat.include-thoughts | Enable thought signatures for function calling. **Required** for Gemini 3 Pro to avoid validation errors during the tool-call loop. See <<thought-signatures>>. | false
 | spring.ai.google.genai.chat.tool-names | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
 | spring.ai.google.genai.chat.tool-callbacks | Tool Callbacks to register with the ChatModel. | -
-| spring.ai.google.genai.chat.internal-tool-execution-enabled | If true, the tool execution should be performed, otherwise the response from the model is returned back to the user. Default is null, but if it's null, `ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_ENABLED` which is true will take into account | -
 | spring.ai.google.genai.chat.safety-settings | List of safety settings to control safety filters, as defined by https://ai.google.dev/gemini-api/docs/safety-settings[Google GenAI Safety Settings]. Each safety setting can have a method, threshold, and category. | -
 | spring.ai.google.genai.chat.cached-content-name | The name of cached content to use for this request. When set along with `use-cached-content=true`, the cached content will be used as context. See <<cached-content>>. | -
 | spring.ai.google.genai.chat.use-cached-content | Whether to use cached content if available. When true and `cached-content-name` is set, the system will use the cached content. | false
@@ -158,12 +157,15 @@ TIP: In addition to the model specific `GoogleGenAiChatOptions` you can use a po
 
 == Tool Calling
 
-The Google GenAI model supports tool calling (function calling) capabilities, allowing models to use tools during conversations.
-Here's an example of how to define and use `@Tool`-based tools:
+`GoogleGenAiChatModel` does not execute tool calls internally.
+Tool execution must be handled externally using one of the two supported approaches below.
+
+=== Tool Calling via ChatClient (Recommended)
+
+The recommended approach is to use `ChatClient` with the `ToolCallAdvisor`, which is automatically registered and manages the tool-call loop transparently for both synchronous and streaming scenarios.
 
 [source,java]
 ----
-
 public class WeatherService {
 
     @Tool(description = "Get the weather in location")
@@ -179,7 +181,7 @@ String response = ChatClient.create(this.chatModel)
         .content();
 ----
 
-You can use the java.util.function beans as tools as well:
+You can use `java.util.function` beans as tools as well:
 
 [source,java]
 ----
@@ -192,9 +194,35 @@ public Function<Request, Response> weatherFunction() {
 String response = ChatClient.create(this.chatModel)
         .prompt("What's the weather like in Boston?")
         .toolNames("weatherFunction")
-        .inputType(Request.class)
         .call()
         .content();
+----
+
+=== User-Controlled Tool Execution
+
+For advanced use cases where you need full control over the tool-call loop, use `DefaultToolCallingManager` directly and set `internalToolExecutionEnabled(false)` on the prompt options so the model returns tool calls without executing them:
+
+[source,java]
+----
+ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
+GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+        .internalToolExecutionEnabled(false)
+        .toolCallbacks(List.of(
+            FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
+                .description("Get the weather in a given location")
+                .inputType(WeatherRequest.class)
+                .build()))
+        .build();
+
+Prompt prompt = new Prompt("What's the weather like in Boston?", options);
+ChatResponse response = chatModel.call(prompt);
+
+while (response.hasToolCalls()) {
+    ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+    prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+    response = chatModel.call(prompt);
+}
 ----
 
 Find more in xref:api/tools.adoc[Tools] documentation.
@@ -448,11 +476,11 @@ NOTE: Enabling thinking features increases token usage and API costs. Use approp
 
 == Thought Signatures [[thought-signatures]]
 
-Gemini 3 Pro introduces thought signatures, which are opaque byte arrays that preserve the model's reasoning context during function calling. When `includeThoughts` is enabled, the model returns thought signatures that must be passed back within the **same turn** during the internal tool execution loop.
+Gemini 3 Pro introduces thought signatures, which are opaque byte arrays that preserve the model's reasoning context during function calling. When `includeThoughts` is enabled, the model returns thought signatures that must be passed back within the **same turn** during the tool-call loop.
 
 === When Thought Signatures Matter
 
-**IMPORTANT**: Thought signature validation only applies to the **current turn** - specifically during the internal tool execution loop when the model makes function calls (both parallel and sequential). The API does **not** validate thought signatures for previous turns in conversation history.
+**IMPORTANT**: Thought signature validation only applies to the **current turn** - specifically during the tool-call loop when the model makes function calls (both parallel and sequential). The API does **not** validate thought signatures for previous turns in conversation history.
 
 Per https://ai.google.dev/gemini-api/docs/thought-signatures[Google's documentation]:
 
@@ -488,17 +516,13 @@ ChatResponse response = chatModel.call(
     ));
 ----
 
-=== Automatic Handling
+=== Automatic Handling via ChatClient (Recommended)
 
-Spring AI automatically handles thought signatures during the internal tool execution loop. When `internalToolExecutionEnabled` is true (the default), Spring AI:
+When using `ChatClient` with `ToolCallAdvisor` (the recommended approach), Spring AI automatically handles thought signatures:
 
 1. **Extracts** thought signatures from model responses
 2. **Attaches** them to the correct `functionCall` parts when sending back function responses
 3. **Propagates** them correctly during function calls within a single turn (both parallel and sequential)
-
-You don't need to manually manage thought signatures - Spring AI ensures they are properly attached to `functionCall` parts as required by the API specification.
-
-=== Example with Function Calling
 
 [source,java]
 ----
@@ -520,9 +544,9 @@ String response = ChatClient.create(this.chatModel)
         .content();
 ----
 
-=== Manual Tool Execution Mode
+=== User-Controlled Tool Execution with Thought Signatures
 
-If you set `internalToolExecutionEnabled=false` to manually control the tool execution loop, you must handle thought signatures yourself when using Gemini 3 Pro with `includeThoughts=true`.
+When using a manual tool execution loop, you must preserve thought signatures by keeping the original `AssistantMessage` (with its metadata) in the conversation history. Spring AI automatically attaches the signatures to the correct `functionCall` parts when converting messages.
 
 **Requirements for manual tool execution with thought signatures:**
 


### PR DESCRIPTION
- Internal tool calling loop removed from GoogleGenAiChatModel and its auto-configuration. 
- Tool execution must now be handled via ChatClient with ToolCallAdvisor (recommended) or a manual DefaultToolCallingManager loop. 
- Documentation updated accordingly.

Part of #6251
