### PR TITLE
Trim whitespace from evaluation response check

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/RelevancyEvaluator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/RelevancyEvaluator.java
@@ -80,7 +80,7 @@ public class RelevancyEvaluator implements Evaluator {
 
 		boolean passing = false;
 		float score = 0;
-		if ("yes".equalsIgnoreCase(evaluationResponse)) {
+		if ("yes".equalsIgnoreCase(evaluationResponse.strip())) {
 			passing = true;
 			score = 1;
 		}


### PR DESCRIPTION
<img width="701" height="506" alt="image" src="https://github.com/user-attachments/assets/90889ed3-98b8-4c36-9c7b-e3015b69eca3" />

if condition is failing due to whitespace in the evaluationResponse 