### PR TITLE
Fix rate-limit drop in MessageAggregator for streamed responses

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -134,9 +134,9 @@ public class MessageAggregator {
 						&& chatResponse.getMetadata().getPromptMetadata().iterator().hasNext()) {
 					metadataPromptMetadataRef.set(chatResponse.getMetadata().getPromptMetadata());
 				}
-				if (chatResponse.getMetadata().getRateLimit() != null
-						&& !(metadataRateLimitRef.get() instanceof EmptyRateLimit)) {
-					metadataRateLimitRef.set(chatResponse.getMetadata().getRateLimit());
+				RateLimit incomingRateLimit = chatResponse.getMetadata().getRateLimit();
+				if (incomingRateLimit != null && !(incomingRateLimit instanceof EmptyRateLimit)) {
+					metadataRateLimitRef.set(incomingRateLimit);
 				}
 				if (StringUtils.hasText(chatResponse.getMetadata().getId())) {
 					metadataIdRef.set(chatResponse.getMetadata().getId());

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.model;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.EmptyRateLimit;
+import org.springframework.ai.chat.metadata.RateLimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MessageAggregator}.
+ *
+ * @author Soby Chacko
+ */
+class MessageAggregatorTests {
+
+	@Test
+	void rateLimitFromStreamedChunkSurvivesAggregation() {
+		RateLimit rateLimit = new TestRateLimit();
+
+		Flux<ChatResponse> responses = Flux.just(chunk("Hello", new EmptyRateLimit()), chunk(" world", rateLimit));
+
+		AtomicReference<ChatResponse> aggregated = new AtomicReference<>();
+		new MessageAggregator().aggregate(responses, aggregated::set).blockLast();
+
+		assertThat(aggregated.get().getMetadata().getRateLimit()).isSameAs(rateLimit);
+	}
+
+	@Test
+	void rateLimitStaysEmptyWhenNoChunkCarriesOne() {
+		Flux<ChatResponse> responses = Flux.just(chunk("Hello", new EmptyRateLimit()),
+				chunk(" world", new EmptyRateLimit()));
+
+		AtomicReference<ChatResponse> aggregated = new AtomicReference<>();
+		new MessageAggregator().aggregate(responses, aggregated::set).blockLast();
+
+		assertThat(aggregated.get().getMetadata().getRateLimit()).isInstanceOf(EmptyRateLimit.class);
+	}
+
+	private static ChatResponse chunk(String text, RateLimit rateLimit) {
+		ChatResponseMetadata metadata = ChatResponseMetadata.builder().rateLimit(rateLimit).build();
+		return new ChatResponse(List.of(new Generation(new AssistantMessage(text))), metadata);
+	}
+
+	private static final class TestRateLimit implements RateLimit {
+
+		@Override
+		public Long getRequestsLimit() {
+			return 100L;
+		}
+
+		@Override
+		public Long getRequestsRemaining() {
+			return 99L;
+		}
+
+		@Override
+		public Duration getRequestsReset() {
+			return Duration.ofSeconds(1);
+		}
+
+		@Override
+		public Long getTokensLimit() {
+			return 1000L;
+		}
+
+		@Override
+		public Long getTokensRemaining() {
+			return 999L;
+		}
+
+		@Override
+		public Duration getTokensReset() {
+			return Duration.ofSeconds(2);
+		}
+
+	}
+
+}


### PR DESCRIPTION
The rate-limit accumulation guard tested the stored accumulator (seeded with EmptyRateLimit) instead of the incoming chunk's rate limit, so the condition was never true and the value was never stored. Every streamed chunk's rate limit was silently dropped, leaving getRateLimit() on the aggregated response always EmptyRateLimit.

Guard the incoming value instead, so the last real rate limit seen on a chunk carries through to the aggregated response.

Adding tests to verify.

