### PR TITLE
GH-6261: Cache tool result messages during tool-calling rounds

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicCacheOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicCacheOptions.java
@@ -58,11 +58,13 @@ public class AnthropicCacheOptions {
 
 	private final boolean multiBlockSystemCaching;
 
+	private final boolean cacheToolResults;
+
 	protected AnthropicCacheOptions(@Nullable AnthropicCacheStrategy strategy,
 			@Nullable Function<@Nullable String, Integer> contentLengthFunction,
 			@Nullable Map<MessageType, AnthropicCacheTtl> messageTypeTtl,
-			@Nullable Map<MessageType, Integer> messageTypeMinContentLengths,
-			@Nullable Boolean multiBlockSystemCaching) {
+			@Nullable Map<MessageType, Integer> messageTypeMinContentLengths, @Nullable Boolean multiBlockSystemCaching,
+			@Nullable Boolean cacheToolResults) {
 		this.strategy = (strategy != null ? strategy : AnthropicCacheStrategy.NONE);
 		this.contentLengthFunction = (contentLengthFunction != null ? contentLengthFunction
 				: s -> s != null ? s.length() : 0);
@@ -75,6 +77,7 @@ public class AnthropicCacheOptions {
 					mt -> (messageTypeMinContentLengths != null && messageTypeMinContentLengths.containsKey(mt))
 							? messageTypeMinContentLengths.get(mt) : DEFAULT_MIN_CONTENT_LENGTH));
 		this.multiBlockSystemCaching = (multiBlockSystemCaching != null ? multiBlockSystemCaching : false);
+		this.cacheToolResults = (cacheToolResults != null ? cacheToolResults : false);
 	}
 
 	public static AnthropicCacheOptions.Builder builder() {
@@ -101,6 +104,20 @@ public class AnthropicCacheOptions {
 		return this.multiBlockSystemCaching;
 	}
 
+	/**
+	 * Whether a {@code cache_control} breakpoint is placed on the last tool result
+	 * message of a request, so that tool outputs are written to (and read from) the cache
+	 * across tool-calling rounds. Takes effect with strategies whose eligible message
+	 * types include tool results, i.e.
+	 * {@link AnthropicCacheStrategy#CONVERSATION_HISTORY}; it is a no-op for strategies
+	 * that only target tool definitions or system messages.
+	 * @return {@code true} if tool result caching is enabled
+	 * @since 2.0.0
+	 */
+	public boolean isCacheToolResults() {
+		return this.cacheToolResults;
+	}
+
 	@Override
 	public boolean equals(@Nullable Object o) {
 		if (this == o) {
@@ -109,7 +126,8 @@ public class AnthropicCacheOptions {
 		if (!(o instanceof AnthropicCacheOptions that)) {
 			return false;
 		}
-		return this.multiBlockSystemCaching == that.multiBlockSystemCaching && this.strategy == that.strategy
+		return this.multiBlockSystemCaching == that.multiBlockSystemCaching
+				&& this.cacheToolResults == that.cacheToolResults && this.strategy == that.strategy
 				&& Objects.equals(this.messageTypeTtl, that.messageTypeTtl)
 				&& Objects.equals(this.messageTypeMinContentLengths, that.messageTypeMinContentLengths);
 	}
@@ -117,7 +135,7 @@ public class AnthropicCacheOptions {
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.strategy, this.messageTypeTtl, this.messageTypeMinContentLengths,
-				this.multiBlockSystemCaching);
+				this.multiBlockSystemCaching, this.cacheToolResults);
 	}
 
 	public static final class Builder {
@@ -131,6 +149,8 @@ public class AnthropicCacheOptions {
 		private @Nullable Map<MessageType, Integer> messageTypeMinContentLengths;
 
 		private @Nullable Boolean multiBlockSystemCaching;
+
+		private @Nullable Boolean cacheToolResults;
 
 		public Builder strategy(@Nullable AnthropicCacheStrategy strategy) {
 			this.strategy = strategy;
@@ -173,9 +193,22 @@ public class AnthropicCacheOptions {
 			return this;
 		}
 
+		/**
+		 * Place a {@code cache_control} breakpoint on the last tool result message of the
+		 * request so that tool outputs are cached across tool-calling rounds. Takes
+		 * effect with {@link AnthropicCacheStrategy#CONVERSATION_HISTORY}.
+		 * @param cacheToolResults whether to cache tool result messages
+		 * @return this builder
+		 * @since 2.0.0
+		 */
+		public Builder cacheToolResults(@Nullable Boolean cacheToolResults) {
+			this.cacheToolResults = cacheToolResults;
+			return this;
+		}
+
 		public AnthropicCacheOptions build() {
 			return new AnthropicCacheOptions(this.strategy, this.contentLengthFunction, this.messageTypeTtl,
-					this.messageTypeMinContentLengths, this.multiBlockSystemCaching);
+					this.messageTypeMinContentLengths, this.multiBlockSystemCaching, this.cacheToolResults);
 		}
 
 	}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -664,6 +664,19 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			}
 		}
 
+		// Pre-compute last tool result message index for tool result caching. A
+		// breakpoint on the final tool result of the request caches the prior tool
+		// outputs so they are read from cache on subsequent tool-calling rounds.
+		int lastToolIndex = -1;
+		if (cacheResolver.isCachingEnabled() && requestOptions.getCacheOptions().isCacheToolResults()) {
+			for (int i = nonSystemMessages.size() - 1; i >= 0; i--) {
+				if (nonSystemMessages.get(i).getMessageType() == MessageType.TOOL) {
+					lastToolIndex = i;
+					break;
+				}
+			}
+		}
+
 		// Process non-system messages
 		for (int i = 0; i < nonSystemMessages.size(); i++) {
 			org.springframework.ai.chat.messages.Message message = nonSystemMessages.get(i);
@@ -739,13 +752,31 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolResponseMessage = (ToolResponseMessage) message;
-				List<ContentBlockParam> toolResultBlocks = toolResponseMessage.getResponses()
-					.stream()
-					.map(response -> ContentBlockParam.ofToolResult(ToolResultBlockParam.builder()
+				List<ToolResponseMessage.ToolResponse> responses = toolResponseMessage.getResponses();
+
+				// Compute cache control for the last tool result message of the request.
+				// The breakpoint is placed on its final block, caching everything before
+				// it (tools + system + prior messages + earlier tool results).
+				CacheControlEphemeral toolCacheControl = null;
+				if (i == lastToolIndex) {
+					String combinedText = combineToolResponsesText(responses);
+					toolCacheControl = cacheResolver.resolve(MessageType.TOOL, combinedText);
+				}
+
+				List<ContentBlockParam> toolResultBlocks = new ArrayList<>();
+				for (int r = 0; r < responses.size(); r++) {
+					ToolResponseMessage.ToolResponse response = responses.get(r);
+					ToolResultBlockParam.Builder toolResultBuilder = ToolResultBlockParam.builder()
 						.toolUseId(response.id())
-						.content(response.responseData())
-						.build()))
-					.toList();
+						.content(response.responseData());
+					if (toolCacheControl != null && r == responses.size() - 1) {
+						toolResultBuilder.cacheControl(toolCacheControl);
+					}
+					toolResultBlocks.add(ContentBlockParam.ofToolResult(toolResultBuilder.build()));
+				}
+				if (toolCacheControl != null) {
+					cacheResolver.useCacheBlock();
+				}
 				builder.addUserMessageOfBlockParams(toolResultBlocks);
 			}
 		}
@@ -889,6 +920,17 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			String text = messages.get(i).getText();
 			if (text != null) {
 				combined.append(text);
+			}
+		}
+		return combined.toString();
+	}
+
+	private String combineToolResponsesText(List<ToolResponseMessage.ToolResponse> responses) {
+		StringBuilder combined = new StringBuilder();
+		for (ToolResponseMessage.ToolResponse response : responses) {
+			String data = response.responseData();
+			if (data != null) {
+				combined.append(data);
 			}
 		}
 		return combined.toString();

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicCacheOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicCacheOptionsTests.java
@@ -68,6 +68,32 @@ class AnthropicCacheOptionsTests {
 	}
 
 	@Test
+	void cacheToolResultsDefaultsToFalse() {
+		AnthropicCacheOptions options = AnthropicCacheOptions.builder().build();
+		assertThat(options.isCacheToolResults()).isFalse();
+	}
+
+	@Test
+	void cacheToolResultsBuilderOverride() {
+		AnthropicCacheOptions options = AnthropicCacheOptions.builder().cacheToolResults(true).build();
+		assertThat(options.isCacheToolResults()).isTrue();
+	}
+
+	@Test
+	void cacheToolResultsParticipatesInEqualsAndHashCode() {
+		AnthropicCacheOptions withFlag = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+			.cacheToolResults(true)
+			.build();
+		AnthropicCacheOptions withoutFlag = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+			.build();
+
+		assertThat(withFlag).isNotEqualTo(withoutFlag);
+		assertThat(withFlag.hashCode()).isNotEqualTo(withoutFlag.hashCode());
+	}
+
+	@Test
 	void disabledSingletonHasNoneStrategy() {
 		assertThat(AnthropicCacheOptions.disabled().getStrategy()).isEqualTo(AnthropicCacheStrategy.NONE);
 	}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
@@ -28,12 +28,15 @@ import com.anthropic.core.JsonValue;
 import com.anthropic.core.http.Headers;
 import com.anthropic.core.http.HttpResponseFor;
 import com.anthropic.models.messages.ContentBlock;
+import com.anthropic.models.messages.ContentBlockParam;
 import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.MessageParam;
 import com.anthropic.models.messages.Model;
 import com.anthropic.models.messages.OutputConfig;
 import com.anthropic.models.messages.StopReason;
 import com.anthropic.models.messages.TextBlock;
+import com.anthropic.models.messages.ToolResultBlockParam;
 import com.anthropic.models.messages.ToolUseBlock;
 import com.anthropic.models.messages.Usage;
 import com.anthropic.services.blocking.MessageService;
@@ -48,6 +51,7 @@ import org.mockito.quality.Strictness;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.RateLimit;
@@ -240,6 +244,82 @@ class AnthropicChatModelTests {
 	}
 
 	@Test
+	void cacheToolResultsPlacesBreakpointOnLastToolResultBlock() {
+		Message mockResponse = createMockMessage("Done.", StopReason.END_TURN);
+		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(mockResponse);
+
+		AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+			.cacheToolResults(true)
+			.build();
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.cacheOptions(cacheOptions)
+			.internalToolExecutionEnabled(false)
+			.build();
+
+		this.chatModel.call(new Prompt(toolCallingConversation(), options));
+
+		ArgumentCaptor<MessageCreateParams> captor = ArgumentCaptor.forClass(MessageCreateParams.class);
+		verify(this.messageService).create(captor.capture());
+
+		assertThat(lastToolResultBlock(captor.getValue()).cacheControl()).isPresent();
+	}
+
+	@Test
+	void cacheToolResultsDisabledByDefaultLeavesToolResultsUncached() {
+		Message mockResponse = createMockMessage("Done.", StopReason.END_TURN);
+		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(mockResponse);
+
+		// CONVERSATION_HISTORY alone (without cacheToolResults) must not place a
+		// breakpoint on tool result blocks.
+		AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+			.build();
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.cacheOptions(cacheOptions)
+			.internalToolExecutionEnabled(false)
+			.build();
+
+		this.chatModel.call(new Prompt(toolCallingConversation(), options));
+
+		ArgumentCaptor<MessageCreateParams> captor = ArgumentCaptor.forClass(MessageCreateParams.class);
+		verify(this.messageService).create(captor.capture());
+
+		assertThat(lastToolResultBlock(captor.getValue()).cacheControl()).isEmpty();
+	}
+
+	@Test
+	void cacheToolResultsOnlyBreaksTheLastToolResultMessage() {
+		Message mockResponse = createMockMessage("Done.", StopReason.END_TURN);
+		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(mockResponse);
+
+		AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+			.cacheToolResults(true)
+			.build();
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.cacheOptions(cacheOptions)
+			.internalToolExecutionEnabled(false)
+			.build();
+
+		// Two tool-calling rounds: only the final tool result should carry a breakpoint.
+		List<org.springframework.ai.chat.messages.Message> messages = List.of(
+				new UserMessage("What's the weather in Paris and Berlin?"), assistantToolCall("toolu_1", "Paris"),
+				toolResult("toolu_1", "Sunny and 25C in Paris."), assistantToolCall("toolu_2", "Berlin"),
+				toolResult("toolu_2", "Cloudy and 12C in Berlin."));
+
+		this.chatModel.call(new Prompt(messages, options));
+
+		ArgumentCaptor<MessageCreateParams> captor = ArgumentCaptor.forClass(MessageCreateParams.class);
+		verify(this.messageService).create(captor.capture());
+
+		List<ToolResultBlockParam> toolResults = toolResultBlocks(captor.getValue());
+		assertThat(toolResults).hasSize(2);
+		assertThat(toolResults.get(0).cacheControl()).isEmpty();
+		assertThat(toolResults.get(1).cacheControl()).isPresent();
+	}
+
+	@Test
 	void multiTurnConversation() {
 		Message mockResponse = createMockMessage("Paris is the capital of France.", StopReason.END_TURN);
 		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(mockResponse);
@@ -349,6 +429,45 @@ class AnthropicChatModelTests {
 		assertThat(betaHeader).contains("files-api-2025-04-14");
 		// Verify container body property is set
 		assertThat(request._additionalBodyProperties()).containsKey("container");
+	}
+
+	private static List<org.springframework.ai.chat.messages.Message> toolCallingConversation() {
+		return List.of(new UserMessage("What's the weather in Paris?"), assistantToolCall("toolu_1", "Paris"),
+				toolResult("toolu_1", "Sunny and 25C in Paris."));
+	}
+
+	private static AssistantMessage assistantToolCall(String id, String city) {
+		return AssistantMessage.builder()
+			.content("")
+			.toolCalls(
+					List.of(new AssistantMessage.ToolCall(id, "function", "getWeather", "{\"city\":\"" + city + "\"}")))
+			.build();
+	}
+
+	private static ToolResponseMessage toolResult(String id, String data) {
+		return ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse(id, "getWeather", data)))
+			.build();
+	}
+
+	private static List<ToolResultBlockParam> toolResultBlocks(MessageCreateParams request) {
+		List<ToolResultBlockParam> blocks = new java.util.ArrayList<>();
+		for (MessageParam message : request.messages()) {
+			if (message.content().isBlockParams()) {
+				for (ContentBlockParam block : message.content().asBlockParams()) {
+					if (block.isToolResult()) {
+						blocks.add(block.asToolResult());
+					}
+				}
+			}
+		}
+		return blocks;
+	}
+
+	private static ToolResultBlockParam lastToolResultBlock(MessageCreateParams request) {
+		List<ToolResultBlockParam> blocks = toolResultBlocks(request);
+		assertThat(blocks).isNotEmpty();
+		return blocks.get(blocks.size() - 1);
 	}
 
 	private Message createMockMessage(String text, StopReason stopReason) {

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicPromptCachingIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicPromptCachingIT.java
@@ -34,9 +34,11 @@ import org.springframework.ai.anthropic.AnthropicCacheTtl;
 import org.springframework.ai.anthropic.AnthropicChatModel;
 import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.anthropic.AnthropicTestConfiguration;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -385,6 +387,82 @@ class AnthropicPromptCachingIT {
 				usage3.cacheReadInputTokens().orElse(0L));
 		logger.info("Turn 4 - Created: {}, Read: {}", usage4.cacheCreationInputTokens().orElse(0L),
 				usage4.cacheReadInputTokens().orElse(0L));
+	}
+
+	@Test
+	void shouldCacheToolResultsAcrossToolCallingRounds() {
+		// A deliberately large tool result, comfortably above Anthropic's minimum
+		// cacheable prefix (~1024 tokens). The system/tool/user prefix in front of it is
+		// intentionally small: on its own it is below the minimum and would not cache, so
+		// any cache read can only come from the tool result being part of the cached
+		// prefix, which is exactly what the cacheToolResults breakpoint enables.
+		StringBuilder largeToolResult = new StringBuilder("Detailed hourly weather report for San Francisco.\n");
+		for (int hour = 0; hour < 160; hour++) {
+			largeToolResult.append("Hour ")
+				.append(hour)
+				.append(": temperature 18C, humidity 72%, wind 12 km/h from the west, visibility 10 km, ")
+				.append("pressure 1013 hPa, no precipitation expected, UV index moderate.\n");
+		}
+
+		// A marker captured once keeps this test's two calls sharing a single cache entry
+		// while avoiding collisions with content cached by previous runs.
+		String runMarker = "Session " + System.currentTimeMillis();
+
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.model(Model.CLAUDE_SONNET_4_20250514.asString())
+			.cacheOptions(AnthropicCacheOptions.builder()
+				.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+				.cacheToolResults(true)
+				.messageTypeMinContentLength(MessageType.USER, 0)
+				.build())
+			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.description("Get current weather for a location")
+				.inputType(MockWeatherService.Request.class)
+				.build())
+			.internalToolExecutionEnabled(false)
+			.maxTokens(80)
+			.temperature(0.3)
+			.build();
+
+		List<Message> conversation = List.of(new SystemMessage("You are a weather assistant. " + runMarker),
+				new UserMessage("What's the detailed weather in San Francisco?"),
+				AssistantMessage.builder()
+					.content("")
+					.toolCalls(List.of(new AssistantMessage.ToolCall("toolu_sf_1", "function", "getCurrentWeather",
+							"{\"location\":\"San Francisco, CA\",\"unit\":\"C\"}")))
+					.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("toolu_sf_1", "getCurrentWeather",
+							largeToolResult.toString())))
+					.build());
+
+		Prompt prompt = new Prompt(conversation, options);
+
+		// First call writes the prefix, including the large tool result, to cache.
+		ChatResponse first = this.chatModel.call(prompt);
+		assertThat(first).isNotNull();
+		Usage firstUsage = getSdkUsage(first);
+		assertThat(firstUsage).isNotNull();
+		long firstCreation = firstUsage.cacheCreationInputTokens().orElse(0L);
+		long firstRead = firstUsage.cacheReadInputTokens().orElse(0L);
+		assertThat(firstCreation > 0 || firstRead > 0)
+			.withFailMessage("Expected the tool result prefix to be cached, but got creation=%d, read=%d",
+					firstCreation, firstRead)
+			.isTrue();
+
+		// Second identical call reads that prefix back. Because the non-tool-result
+		// prefix
+		// is below the cache minimum, a non-zero read confirms the tool result itself was
+		// cached by the cacheToolResults breakpoint.
+		ChatResponse second = this.chatModel.call(prompt);
+		assertThat(second).isNotNull();
+		Usage secondUsage = getSdkUsage(second);
+		assertThat(secondUsage).isNotNull();
+		long secondRead = secondUsage.cacheReadInputTokens().orElse(0L);
+		assertThat(secondRead).as("Second call should read the cached tool result").isGreaterThan(0);
+
+		logger.info("Tool result caching - call 1 creation: {}, read: {}; call 2 read: {}", firstCreation, firstRead,
+				secondRead);
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -1012,7 +1012,24 @@ var cacheOptions = AnthropicCacheOptions.builder()
 | `messageTypeMinContentLength` | Minimum content length required before caching a message type. | `1`
 | `contentLengthFunction` | Custom function to compute content length (e.g., token counting). | `String::length`
 | `multiBlockSystemCaching` | When `true`, each system message becomes a separate cacheable block; cache control is applied to the second-to-last block (static prefix pattern). When `false`, all system messages are joined into one block. | `false`
+| `cacheToolResults` | When `true`, a cache breakpoint is placed on the last tool result message of a request so tool outputs are cached across tool-calling rounds. Takes effect with `CONVERSATION_HISTORY`. | `false`
 |====
+
+=== Caching Tool Results
+
+When a turn triggers tool calls, each round appends an assistant `tool_use` message and a user `tool_result` message, and the growing history is sent back to Anthropic on every round. By default the `CONVERSATION_HISTORY` breakpoint lands on the last user message, so tool results — which are appended after it — fall outside every breakpoint and are billed as uncached input on each round. This is wasteful when tool outputs are large.
+
+Enable `cacheToolResults` to place a breakpoint on the last tool result block of the request. On the next round Anthropic reads the previous round's tool results from cache instead of reprocessing them:
+
+[source,java]
+----
+var cacheOptions = AnthropicCacheOptions.builder()
+    .strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+    .cacheToolResults(true)
+    .build();
+----
+
+The breakpoint moves to the latest tool result on each round, so the previous rounds' tool outputs are read from cache while the newest is written. This consumes one additional cache breakpoint (Anthropic allows up to four per request), leaving room for the tool, system, and last-user breakpoints under `CONVERSATION_HISTORY`. The TTL and minimum content length are configurable via `messageTypeTtl(MessageType.TOOL, ...)` and `messageTypeMinContentLength(MessageType.TOOL, ...)`.
 
 === Multi-Block System Caching
 


### PR DESCRIPTION
Closes #6261

https://github.com/spring-projects/spring-ai/issues/6261

Add a `cacheToolResults` flag to `AnthropicCacheOptions`. When enabled, place a `cache_control` breakpoint on the last block of the last tool result message of a request, so prior tool outputs are written to and read from the cache across tool-calling rounds instead of being billed as uncached input on every round.

Previously the `MessageType.TOOL` branch in `createRequest()` never consulted the cache resolver, and `CONVERSATION_HISTORY` only places a breakpoint on the last user message. During a multi-round tool-calling turn the tool results are appended after that user message, so they fell outside every breakpoint and large tool outputs were reprocessed as uncached input each round.

The flag is additive and takes effect with `CONVERSATION_HISTORY` (the strategy whose eligible message types already include tool results); no resolver change was needed, only the missing call site. The breakpoint moves to the latest tool result each round, consuming one of the four allowed breakpoints. TTL and minimum content length are configurable.

Adds unit tests for breakpoint placement and an integration test that verifies tool results are cached and read back across rounds.

Documentation updated accordingly.