### PR TITLE
Add tool names to ToolSpec fluent API

### DIFF
--- a/advisors/tool-search-tool/spring-ai-tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/AbstractToolSearchToolCallingAdvisorIT.java
+++ b/advisors/tool-search-tool/spring-ai-tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/AbstractToolSearchToolCallingAdvisorIT.java
@@ -131,7 +131,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 				.prompt()
 				.advisors(createToolSearchToolCallingAdvisor(toolIndex))
 				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
 				.call()
 				.content();
@@ -149,7 +149,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
 							.build())
 				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
 				.call()
 				.content();
@@ -167,7 +167,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 
 			String response = chatClient.prompt()
 				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
 				.call()
 				.content();
@@ -186,7 +186,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 
 			String response = chatClient.prompt()
 				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
 				.call()
 				.content();
@@ -207,7 +207,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 				.prompt()
 				.advisors(createToolSearchToolCallingAdvisor(toolIndex))
 				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
 				.stream()
 				.content();
@@ -226,7 +226,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
 							.build())
 				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
 				.stream()
 				.content();
@@ -245,7 +245,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 
 			Flux<String> response = chatClient.prompt()
 				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
 				.stream()
 				.content();
@@ -265,7 +265,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 
 			Flux<String> response = chatClient.prompt()
 				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
-				.toolCallbacks(createWeatherToolCallback())
+				.tools(t -> t.callbacks(createWeatherToolCallback()))
 				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
 				.stream()
 				.content();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiFunctionCallback2IT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiFunctionCallback2IT.java
@@ -64,7 +64,7 @@ public class OpenAiFunctionCallback2IT {
 			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
 			ChatClient chatClient = ChatClient.builder(chatModel)
 				.defaultAdvisors(ToolCallAdvisor.builder().toolCallingManager(toolCallingManager).build())
-				.defaultToolNames("WeatherInfo")
+				.defaultTools(t -> t.names("WeatherInfo"))
 				.defaultUser(u -> u.text("What's the weather like in {cities}? Please use the provided tools to get the weather for all 3 cities."))
 				.build();
 
@@ -93,7 +93,7 @@ public class OpenAiFunctionCallback2IT {
 			String content = ChatClient.builder(chatModel)
 				.defaultAdvisors(ToolCallAdvisor.builder().toolCallingManager(toolCallingManager).build())
 				.build().prompt()
-				.toolNames("WeatherInfo")
+				.tools(t -> t.names("WeatherInfo"))
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities.")
 				.stream().content()
 				.collectList().block().stream().collect(Collectors.joining());

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -184,8 +184,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			String content = chatClient.prompt(
 					"What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities.")
-				.toolNames("weatherFunctionWithContext")
-				.toolContext(Map.of("sessionId", "123"))
+				.tools(t -> t.names("weatherFunctionWithContext").context(Map.of("sessionId", "123")))
 				.call()
 				.content();
 			logger.info(content);
@@ -219,8 +218,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			String content = chatClient.prompt(
 					"What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities.")
-				.toolNames("weatherFunctionWithClassBiFunction")
-				.toolContext(Map.of("sessionId", "123"))
+				.tools(t -> t.names("weatherFunctionWithClassBiFunction").context(Map.of("sessionId", "123")))
 				.call()
 				.content();
 			logger.info(content);

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/OpenAiFunctionCallback2IT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/OpenAiFunctionCallback2IT.java
@@ -37,10 +37,10 @@ import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
 /**
  * @author Sebastien Deleuze
  */
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
 public class OpenAiFunctionCallback2IT {
 
 	private final Logger logger = LoggerFactory.getLogger(OpenAiFunctionCallback2IT.class);
@@ -62,7 +62,7 @@ public class OpenAiFunctionCallback2IT {
 			ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
 			ChatClient chatClient = ChatClient.builder(chatModel)
 				.defaultAdvisors(ToolCallAdvisor.builder().toolCallingManager(toolCallingManager).build())
-				.defaultToolNames("WeatherInfo")
+				.defaultTools(t -> t.names("WeatherInfo"))
 				.defaultUser(u -> u.text("What's the weather like in {cities}? Please use the provided tools to get the weather for all 3 cities."))
 				.build();
 
@@ -88,7 +88,7 @@ public class OpenAiFunctionCallback2IT {
 			String content = ChatClient.builder(chatModel)
 				.defaultAdvisors(ToolCallAdvisor.builder().toolCallingManager(toolCallingManager).build())
 				.build().prompt()
-				.toolNames("WeatherInfo")
+				.tools(t -> t.names("WeatherInfo"))
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities.")
 				.stream().content()
 				.collectList().block().stream().collect(Collectors.joining());

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tool/GoogleGenAiPaymentTransactionIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tool/GoogleGenAiPaymentTransactionIT.java
@@ -73,16 +73,17 @@ public class GoogleGenAiPaymentTransactionIT {
 
 	@Test
 	public void paymentStatuses() {
-		// @formatter:off
 		String content = this.chatClient.prompt()
-				.advisors(new SimpleLoggerAdvisor())
-				.toolNames("paymentStatus")
-				.user("""
-				What is the status of my payment transactions 001, 002 and 003?
-				If required invoke the function per transaction.
-				""").call().content();
-		// @formatter:on
-		logger.info("" + content);
+			.advisors(new SimpleLoggerAdvisor())
+			.tools(t -> t.names("paymentStatusWithContext"))
+			.user("""
+					What is the status of my payment transactions 001, 002 and 003?
+					If required invoke the function per transaction.
+					""")
+			.call()
+			.content();
+
+		logger.info(content);
 
 		assertThat(content).contains("001", "002", "003");
 		assertThat(content).contains("pending", "approved", "rejected");
@@ -93,7 +94,7 @@ public class GoogleGenAiPaymentTransactionIT {
 
 		Flux<String> streamContent = this.chatClient.prompt()
 			.advisors(new SimpleLoggerAdvisor())
-			.toolNames("paymentStatus")
+			.tools(t -> t.names("paymentStatusWithContext"))
 			.user("""
 					What is the status of my payment transactions 001, 002 and 003?
 					If required invoke the function per transaction.

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tool/GoogleGenAiPaymentTransactionMethodIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tool/GoogleGenAiPaymentTransactionMethodIT.java
@@ -78,7 +78,7 @@ public class GoogleGenAiPaymentTransactionMethodIT {
 
 		String content = this.chatClient.prompt()
 			.advisors(new SimpleLoggerAdvisor())
-			.toolNames("getPaymentStatus")
+			.tools(t -> t.names("getPaymentStatus"))
 			.user("""
 					What is the status of my payment transactions 001, 002 and 003?
 					If required invoke the function per transaction.
@@ -96,7 +96,7 @@ public class GoogleGenAiPaymentTransactionMethodIT {
 
 		Flux<String> streamContent = this.chatClient.prompt()
 			.advisors(new SimpleLoggerAdvisor())
-			.toolNames("getPaymentStatuses")
+			.tools(t -> t.names("getPaymentStatuses"))
 			.user("""
 					What is the status of my payment transactions 001, 002 and 003?
 					If required invoke the function per transaction.

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiPaymentTransactionIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiPaymentTransactionIT.java
@@ -78,7 +78,7 @@ public class OpenAiPaymentTransactionIT {
 	public void transactionPaymentStatuses(String functionName) {
 		List<TransactionStatusResponse> content = this.chatClient.prompt()
 			.advisors(new SimpleLoggerAdvisor())
-			.toolNames(functionName)
+			.tools(t -> t.names(functionName))
 			.user("""
 					What is the status of my payment transactions 001, 002 and 003?
 					""")
@@ -109,7 +109,7 @@ public class OpenAiPaymentTransactionIT {
 
 		Flux<String> flux = this.chatClient.prompt()
 			.advisors(new SimpleLoggerAdvisor())
-			.toolNames(functionName)
+			.tools(t -> t.names(functionName))
 			.user(u -> u.text("""
 					What is the status of my payment transactions 001, 002 and 003?
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -57,6 +57,7 @@ import org.springframework.util.MimeType;
  * @author Josh Long
  * @author Arjen Poutsma
  * @author Thomas Vitale
+ * @author guan xu
  * @since 1.0.0
  */
 public interface ChatClient {
@@ -427,6 +428,10 @@ public interface ChatClient {
 	}
 
 	interface ToolSpec {
+
+		ToolSpec names(String... names);
+
+		ToolSpec names(List<String> names);
 
 		ToolSpec instances(Object... toolObjects);
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -89,6 +89,7 @@ import org.springframework.util.StringUtils;
  * @author Jonatan Ivanov
  * @author Wenli Tian
  * @author Sebastien Deleuze
+ * @author guan xu
  * @since 1.0.0
  */
 public class DefaultChatClient implements ChatClient {
@@ -757,6 +758,8 @@ public class DefaultChatClient implements ChatClient {
 
 	public static class DefaultToolSpec implements ToolSpec {
 
+		private final List<String> toolNames = new ArrayList<>();
+
 		private final Map<String, Object> context = new HashMap<>();
 
 		private final List<ToolCallback> toolCallbacks = new ArrayList<>();
@@ -764,6 +767,10 @@ public class DefaultChatClient implements ChatClient {
 		private final List<ToolCallbackProvider> toolCallbackProviders = new ArrayList<>();
 
 		private @Nullable ToolAdvisor toolAdvisor;
+
+		public List<String> getToolNames() {
+			return this.toolNames;
+		}
 
 		public Map<String, Object> getContext() {
 			return this.context;
@@ -795,6 +802,22 @@ public class DefaultChatClient implements ChatClient {
 			Assert.noNullElements(context.keySet(), "context keys cannot contain null elements");
 			Assert.noNullElements(context.values(), "context values cannot contain null elements");
 			this.context.putAll(context);
+			return this;
+		}
+
+		@Override
+		public ToolSpec names(String... names) {
+			Assert.notNull(names, "toolNames cannot be null");
+			Assert.noNullElements(names, "toolNames cannot contain null elements");
+			this.toolNames.addAll(Arrays.asList(names));
+			return this;
+		}
+
+		@Override
+		public ToolSpec names(List<String> names) {
+			Assert.notNull(names, "toolNames cannot be null");
+			Assert.noNullElements(names, "toolNames cannot contain null elements");
+			this.toolNames.addAll(names);
 			return this;
 		}
 
@@ -1048,10 +1071,10 @@ public class DefaultChatClient implements ChatClient {
 				.builder(this.chatModel, this.observationRegistry, this.chatClientObservationConvention,
 						this.advisorObservationConvention, this.toolCallAdvisorBuilder)
 				.defaultTemplateRenderer(this.templateRenderer)
-				.defaultTools(t -> t.callbacks(this.toolCallbacks)
+				.defaultTools(t -> t.names(StringUtils.toStringArray(this.toolNames))
+					.callbacks(this.toolCallbacks)
 					.callbacks(this.toolCallbackProviders.toArray(new ToolCallbackProvider[0]))
-					.context(this.toolContext))
-				.defaultToolNames(StringUtils.toStringArray(this.toolNames));
+					.context(this.toolContext));
 
 			if (!CollectionUtils.isEmpty(this.advisors)) {
 				builder.defaultAdvisors(a -> a.advisors(this.advisors).params(this.advisorParams));
@@ -1085,6 +1108,7 @@ public class DefaultChatClient implements ChatClient {
 			var toolSpec = new DefaultToolSpec();
 			consumer.accept(toolSpec);
 
+			this.toolNames.addAll(toolSpec.getToolNames());
 			this.toolContext.putAll(toolSpec.getContext());
 			this.toolCallbacks.addAll(toolSpec.getToolCallbacks());
 			this.toolCallbackProviders.addAll(toolSpec.getToolCallbackProviders());
@@ -1146,10 +1170,7 @@ public class DefaultChatClient implements ChatClient {
 
 		@Override
 		public ChatClientRequestSpec toolNames(String... toolNames) {
-			Assert.notNull(toolNames, "toolNames cannot be null");
-			Assert.noNullElements(toolNames, "toolNames cannot contain null elements");
-			this.toolNames.addAll(List.of(toolNames));
-			return this;
+			return tools(t -> t.names(toolNames));
 		}
 
 		@Override

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -53,6 +53,7 @@ import org.springframework.util.Assert;
  * @author Josh Long
  * @author Arjen Poutsma
  * @author Thomas Vitale
+ * @author guan xu
  * @since 1.0.0
  */
 public class DefaultChatClientBuilder implements Builder {
@@ -169,6 +170,12 @@ public class DefaultChatClientBuilder implements Builder {
 		return this;
 	}
 
+	@Override
+	public Builder defaultTools(Object... toolObjects) {
+		this.defaultRequest.tools(toolObjects);
+		return this;
+	}
+
 	/**
 	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be removed
 	 * in 3.0.0.
@@ -176,13 +183,7 @@ public class DefaultChatClientBuilder implements Builder {
 	@Deprecated(since = "2.0.0", forRemoval = true)
 	@Override
 	public Builder defaultToolNames(String... toolNames) {
-		this.defaultRequest.toolNames(toolNames);
-		return this;
-	}
-
-	@Override
-	public Builder defaultTools(Object... toolObjects) {
-		this.defaultRequest.tools(toolObjects);
+		this.defaultRequest.tools(t -> t.names(toolNames));
 		return this;
 	}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1754,7 +1754,7 @@ class DefaultChatClientTests {
 	void whenToolNamesElementIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolNames("myTool", null)).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> spec.tools(t -> t.names("myTool", null))).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("toolNames cannot contain null elements");
 	}
 
@@ -1763,7 +1763,7 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		String toolName = "myTool";
-		spec = spec.toolNames(toolName);
+		spec = spec.tools(t -> t.names(toolName));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolNames()).contains(toolName);
 	}
@@ -1917,7 +1917,8 @@ class DefaultChatClientTests {
 	void whenFunctionBeanNamesElementIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolNames("myFunction", null)).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> spec.tools(t -> t.names("myFunction", null)))
+			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("toolNames cannot contain null elements");
 	}
 
@@ -1926,7 +1927,7 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		String functionBeanName = "myFunction";
-		spec = spec.toolNames(functionBeanName);
+		spec = spec.tools(t -> t.names(functionBeanName));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolNames()).contains(functionBeanName);
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
@@ -220,7 +220,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.toolNames(toolNames.toArray(new String[0]));
+			.tools(t -> t.names(toolNames.toArray(new String[0])));
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -284,7 +284,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.toolNames(toolNames2.toArray(new String[0]));
+			.tools(t -> t.names(toolNames2.toArray(new String[0])));
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -349,7 +349,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.toolNames(toolNames1.toArray(new String[0]));
+			.tools(t -> t.names(toolNames1.toArray(new String[0])));
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -466,7 +466,7 @@ class DefaultChatClientUtilsTests {
 			.system(s -> s.text(systemText).params(systemParams))
 			.user(u -> u.text(userText).params(userParams).media(media))
 			.messages(messages)
-			.toolNames(toolNames.toArray(new String[0]))
+			.tools(t -> t.names(toolNames.toArray(new String[0])))
 			.tools(t -> t.callbacks(toolCallback).context(toolContext))
 			.options(chatOptions)
 			.advisors(a -> a.params(advisorParams));

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/tool/FunctionToolCallbackTests.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/tool/FunctionToolCallbackTests.java
@@ -72,7 +72,7 @@ public class FunctionToolCallbackTests {
 			.build()
 			.prompt()
 			.user("Welcome the users to the library")
-			.toolNames(Tools.WELCOME)
+			.tools(t -> t.names(Tools.WELCOME))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty();
@@ -102,7 +102,7 @@ public class FunctionToolCallbackTests {
 			.build()
 			.prompt()
 			.user("Welcome %s to the library".formatted("James Bond"))
-			.toolNames(Tools.WELCOME_USER)
+			.tools(t -> t.names(Tools.WELCOME_USER))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty();
@@ -132,7 +132,7 @@ public class FunctionToolCallbackTests {
 			.build()
 			.prompt()
 			.user("What books written by %s are available in the library?".formatted("J.R.R. Tolkien"))
-			.toolNames(Tools.BOOKS_BY_AUTHOR)
+			.tools(t -> t.names(Tools.BOOKS_BY_AUTHOR))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty()
@@ -171,7 +171,7 @@ public class FunctionToolCallbackTests {
 			.build()
 			.prompt()
 			.user("What authors wrote the books %s and %s available in the library?".formatted("The Hobbit", "The Lion, the Witch and the Wardrobe"))
-			.toolNames(Tools.AUTHORS_BY_BOOKS)
+			.tools(t -> t.names(Tools.AUTHORS_BY_BOOKS))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty().contains("J.R.R. Tolkien").contains("C.S. Lewis");


### PR DESCRIPTION
# Related
Related to #6085.

# Summary
- Add names(String...) and names(List<String>) to the ToolSpec interface with implementations in DefaultToolSpec.
- Migrate ChatClient tool fluent API for unit tests and integration tests.