### PR TITLE
Extract OllamaCommonOptions base class for shared Ollama model-loading fields

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
@@ -35,6 +35,12 @@ import org.springframework.ai.util.JsonHelper;
 /**
  * Helper class for creating strongly-typed Ollama options.
  *
+ * <p>Extends {@link OllamaCommonOptions} to inherit the model-loading fields
+ * ({@code useNUMA}, {@code numCtx}, {@code numBatch}, {@code numGPU}, {@code mainGPU},
+ * {@code lowVRAM}, {@code f16KV}, {@code logitsAll}, {@code vocabOnly}, {@code useMMap},
+ * {@code useMLock}, {@code numThread}) and common request fields ({@code model},
+ * {@code keepAlive}, {@code truncate}).
+ *
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
@@ -46,152 +52,18 @@ import org.springframework.ai.util.JsonHelper;
  * Valid Parameters and Values</a>
  * @see <a href="https://github.com/ollama/ollama/blob/main/api/types.go">Ollama Types</a>
  */
-public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutputChatOptions {
+public class OllamaChatOptions extends OllamaCommonOptions implements ToolCallingChatOptions, StructuredOutputChatOptions {
 
 	private static final JsonHelper jsonHelper = new JsonHelper();
 
 	private static final List<String> NON_SUPPORTED_FIELDS = List.of("model", "format", "keep_alive", "truncate");
 
-	protected OllamaChatOptions(@Nullable Boolean useNUMA, @Nullable Integer numCtx, @Nullable Integer numBatch,
-			@Nullable Integer numGPU, @Nullable Integer mainGPU, @Nullable Boolean lowVRAM, @Nullable Boolean f16KV,
-			@Nullable Boolean logitsAll, @Nullable Boolean vocabOnly, @Nullable Boolean useMMap,
-			@Nullable Boolean useMLock, @Nullable Integer numThread, @Nullable Integer numKeep, @Nullable Integer seed,
-			@Nullable Integer numPredict, @Nullable Integer topK, @Nullable Double topP, @Nullable Double minP,
-			@Nullable Float tfsZ, @Nullable Float typicalP, @Nullable Integer repeatLastN, @Nullable Double temperature,
-			@Nullable Double repeatPenalty, @Nullable Double presencePenalty, @Nullable Double frequencyPenalty,
-			@Nullable Integer mirostat, @Nullable Float mirostatTau, @Nullable Float mirostatEta,
-			@Nullable Boolean penalizeNewline, @Nullable List<String> stop, @Nullable String model,
-			@Nullable Object format, @Nullable String keepAlive, @Nullable Boolean truncate,
-			@Nullable ThinkOption thinkOption, @Nullable Boolean internalToolExecutionEnabled,
-			@Nullable List<ToolCallback> toolCallbacks, @Nullable Set<String> toolNames,
-			@Nullable Map<String, Object> toolContext) {
-		this.useNUMA = useNUMA;
-		this.numCtx = numCtx;
-		this.numBatch = numBatch;
-		this.numGPU = numGPU;
-		this.mainGPU = mainGPU;
-		this.lowVRAM = lowVRAM;
-		this.f16KV = f16KV;
-		this.logitsAll = logitsAll;
-		this.vocabOnly = vocabOnly;
-		this.useMMap = useMMap;
-		this.useMLock = useMLock;
-		this.numThread = numThread;
-		this.numKeep = numKeep;
-		this.seed = seed;
-		this.numPredict = numPredict;
-		this.topK = topK;
-		this.topP = topP;
-		this.minP = minP;
-		this.tfsZ = tfsZ;
-		this.typicalP = typicalP;
-		this.repeatLastN = repeatLastN;
-		this.temperature = temperature;
-		this.repeatPenalty = repeatPenalty;
-		this.presencePenalty = presencePenalty;
-		this.frequencyPenalty = frequencyPenalty;
-		this.mirostat = mirostat;
-		this.mirostatTau = mirostatTau;
-		this.mirostatEta = mirostatEta;
-		this.penalizeNewline = penalizeNewline;
-		this.stop = stop != null ? List.copyOf(stop) : null;
-		this.model = model != null ? model : OllamaModel.MISTRAL.id();
-		this.format = format;
-		this.keepAlive = keepAlive;
-		this.truncate = truncate;
-		this.thinkOption = thinkOption;
-		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
-		this.toolCallbacks = toolCallbacks != null ? List.copyOf(toolCallbacks) : null;
-		this.toolNames = toolNames != null ? Set.copyOf(toolNames) : null;
-		this.toolContext = toolContext != null ? Map.copyOf(toolContext) : null;
-	}
-
-	// Following fields are options which must be set when the model is loaded into
-	// memory.
-	// See: https://github.com/ggerganov/llama.cpp/blob/master/examples/main/README.md
+	// Following fields are predict options used at runtime.
+	// Model-loading options (useNUMA, numCtx, numBatch, numGPU, mainGPU, lowVRAM,
+	// f16KV, logitsAll, vocabOnly, useMMap, useMLock, numThread) and common request
+	// fields (model, keepAlive, truncate) are inherited from OllamaCommonOptions.
 
 	// @formatter:off
-
-	/**
-	 * Whether to use NUMA. (Default: false)
-	 */
-	private final @Nullable Boolean useNUMA;
-
-	/**
-	 * Sets the size of the context window used to generate the next token. (Default: 2048)
-	 */
-	private final @Nullable Integer numCtx;
-
-	/**
-	 * Prompt processing maximum batch size. (Default: 512)
-	 */
-	private final @Nullable Integer numBatch;
-
-	/**
-	 * The number of layers to send to the GPU(s). On macOS, it defaults to 1
-	 * to enable metal support, 0 to disable.
-	 * (Default: -1, which indicates that numGPU should be set dynamically)
-	 */
-	private final @Nullable Integer numGPU;
-
-	/**
-	 * When using multiple GPUs this option controls which GPU is used
-	 * for small tensors for which the overhead of splitting the computation
-	 * across all GPUs is not worthwhile. The GPU in question will use slightly
-	 * more VRAM to store a scratch buffer for temporary results.
-	 * By default, GPU 0 is used.
-	 */
-	private final @Nullable Integer mainGPU;
-
-	/**
-	 * (Default: false)
-	 */
-	private final @Nullable Boolean lowVRAM;
-
-	/**
-	 * (Default: true)
-	 */
-	private final @Nullable Boolean f16KV;
-
-	/**
-	 * Return logits for all the tokens, not just the last one.
-	 * To enable completions to return logprobs, this must be true.
-	 */
-	private final @Nullable Boolean logitsAll;
-
-	/**
-	 * Load only the vocabulary, not the weights.
-	 */
-	private final @Nullable Boolean vocabOnly;
-
-	/**
-	 * By default, models are mapped into memory, which allows the system to load only the necessary parts
-	 * of the model as needed. However, if the model is larger than your total amount of RAM or if your system is low
-	 * on available memory, using mmap might increase the risk of pageouts, negatively impacting performance.
-	 * Disabling mmap results in slower load times but may reduce pageouts if you're not using mlock.
-	 * Note that if the model is larger than the total amount of RAM, turning off mmap would prevent
-	 * the model from loading at all.
-	 * (Default: null)
-	 */
-	private final @Nullable Boolean useMMap;
-
-	/**
-	 * Lock the model in memory, preventing it from being swapped out when memory-mapped.
-	 * This can improve performance but trades away some of the advantages of memory-mapping
-	 * by requiring more RAM to run and potentially slowing down load times as the model loads into RAM.
-	 * (Default: false)
-	 */
-	private final @Nullable Boolean useMLock;
-
-	/**
-	 * Set the number of threads to use during generation. For optimal performance, it is recommended to set this value
-	 * to the number of physical CPU cores your system has (as opposed to the logical number of cores).
-	 * Using the correct number of threads can greatly improve performance.
-	 * By default, Ollama will detect this value for optimal performance.
-	 */
-	private final @Nullable Integer numThread;
-
-	// Following fields are predict options used at runtime.
 
 	/**
 	 * (Default: 4)
@@ -306,34 +178,14 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 	 */
 	private final @Nullable List<String> stop;
 
-
 	// Following fields are not part of the Ollama Options API but part of the Request.
-
-	/**
-	 * NOTE: Synthetic field not part of the official Ollama API.
-	 * Used to allow overriding the model name with prompt options.
-	 * Part of Chat completion <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#parameters-1">parameters</a>.
-	 */
-	private final String model;
+	// model, keepAlive and truncate are inherited from OllamaCommonOptions.
 
 	/**
 	 * Sets the desired format of output from the LLM. The only valid values are null or "json".
 	 * Part of Chat completion <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#parameters-1">advanced parameters</a>.
 	 */
 	private final @Nullable Object format;
-
-	/**
-	 * Sets the length of time for Ollama to keep the model loaded. Valid values for this
-	 * setting are parsed by <a href="https://pkg.go.dev/time#ParseDuration">ParseDuration in Go</a>.
-	 * Part of Chat completion <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#parameters-1">advanced parameters</a>.
-	 */
-	private final @Nullable String keepAlive;
-
-	/**
-	 * Truncates the end of each input to fit within context length. Returns error if false and context length is exceeded.
-	 * Defaults to true.
-	 */
-	private final @Nullable Boolean truncate;
 
 	/**
 	 * The model should think before responding, if supported.
@@ -381,6 +233,49 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 
 	private final @Nullable Map<String, Object> toolContext;
 
+	// @formatter:on
+
+	protected OllamaChatOptions(@Nullable Boolean useNUMA, @Nullable Integer numCtx, @Nullable Integer numBatch,
+			@Nullable Integer numGPU, @Nullable Integer mainGPU, @Nullable Boolean lowVRAM, @Nullable Boolean f16KV,
+			@Nullable Boolean logitsAll, @Nullable Boolean vocabOnly, @Nullable Boolean useMMap,
+			@Nullable Boolean useMLock, @Nullable Integer numThread, @Nullable Integer numKeep, @Nullable Integer seed,
+			@Nullable Integer numPredict, @Nullable Integer topK, @Nullable Double topP, @Nullable Double minP,
+			@Nullable Float tfsZ, @Nullable Float typicalP, @Nullable Integer repeatLastN, @Nullable Double temperature,
+			@Nullable Double repeatPenalty, @Nullable Double presencePenalty, @Nullable Double frequencyPenalty,
+			@Nullable Integer mirostat, @Nullable Float mirostatTau, @Nullable Float mirostatEta,
+			@Nullable Boolean penalizeNewline, @Nullable List<String> stop, @Nullable String model,
+			@Nullable Object format, @Nullable String keepAlive, @Nullable Boolean truncate,
+			@Nullable ThinkOption thinkOption, @Nullable Boolean internalToolExecutionEnabled,
+			@Nullable List<ToolCallback> toolCallbacks, @Nullable Set<String> toolNames,
+			@Nullable Map<String, Object> toolContext) {
+		super(model != null ? model : OllamaModel.MISTRAL.id(), keepAlive, truncate, useNUMA, numCtx, numBatch, numGPU,
+				mainGPU, lowVRAM, f16KV, logitsAll, vocabOnly, useMMap, useMLock, numThread);
+		this.numKeep = numKeep;
+		this.seed = seed;
+		this.numPredict = numPredict;
+		this.topK = topK;
+		this.topP = topP;
+		this.minP = minP;
+		this.tfsZ = tfsZ;
+		this.typicalP = typicalP;
+		this.repeatLastN = repeatLastN;
+		this.temperature = temperature;
+		this.repeatPenalty = repeatPenalty;
+		this.presencePenalty = presencePenalty;
+		this.frequencyPenalty = frequencyPenalty;
+		this.mirostat = mirostat;
+		this.mirostatTau = mirostatTau;
+		this.mirostatEta = mirostatEta;
+		this.penalizeNewline = penalizeNewline;
+		this.stop = stop != null ? List.copyOf(stop) : null;
+		this.format = format;
+		this.thinkOption = thinkOption;
+		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+		this.toolCallbacks = toolCallbacks != null ? List.copyOf(toolCallbacks) : null;
+		this.toolNames = toolNames != null ? Set.copyOf(toolNames) : null;
+		this.toolContext = toolContext != null ? Map.copyOf(toolContext) : null;
+	}
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -397,8 +292,13 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 	}
 
 	// -------------------
-	// Getters and Setters
+	// Getters
 	// -------------------
+
+	// getModel, getKeepAlive, getTruncate, getUseNUMA, getNumCtx, getNumBatch,
+	// getNumGPU, getMainGPU, getLowVRAM, getF16KV, getLogitsAll, getVocabOnly,
+	// getUseMMap, getUseMLock, getNumThread are inherited from OllamaCommonOptions.
+
 	@Override
 	public String getModel() {
 		return this.model;
@@ -407,71 +307,6 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 
 	public @Nullable Object getFormat() {
 		return this.format;
-	}
-
-
-	public @Nullable String getKeepAlive() {
-		return this.keepAlive;
-	}
-
-
-	public @Nullable Boolean getUseNUMA() {
-		return this.useNUMA;
-	}
-
-
-	public @Nullable Integer getNumCtx() {
-		return this.numCtx;
-	}
-
-
-	public @Nullable Integer getNumBatch() {
-		return this.numBatch;
-	}
-
-
-	public @Nullable Integer getNumGPU() {
-		return this.numGPU;
-	}
-
-
-	public @Nullable Integer getMainGPU() {
-		return this.mainGPU;
-	}
-
-
-	public @Nullable Boolean getLowVRAM() {
-		return this.lowVRAM;
-	}
-
-
-	public @Nullable Boolean getF16KV() {
-		return this.f16KV;
-	}
-
-
-	public @Nullable Boolean getLogitsAll() {
-		return this.logitsAll;
-	}
-
-
-	public @Nullable Boolean getVocabOnly() {
-		return this.vocabOnly;
-	}
-
-
-	public @Nullable Boolean getUseMMap() {
-		return this.useMMap;
-	}
-
-
-	public @Nullable Boolean getUseMLock() {
-		return this.useMLock;
-	}
-
-
-	public @Nullable Integer getNumThread() {
-		return this.numThread;
 	}
 
 
@@ -579,11 +414,6 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 
 	public @Nullable List<String> getStop() {
 		return this.stop;
-	}
-
-
-	public @Nullable Boolean getTruncate() {
-		return this.truncate;
 	}
 
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaCommonOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaCommonOptions.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.ollama.api;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Abstract base class holding the model-loading options and common request fields shared
+ * between {@link OllamaChatOptions} and {@link OllamaEmbeddingOptions}.
+ *
+ * <p>The model-loading fields correspond to llama.cpp parameters that must be set when a
+ * model is loaded into memory. The request fields ({@code model}, {@code keepAlive},
+ * {@code truncate}) appear in both Ollama Chat and Embedding requests.
+ *
+ * @author Adira Denis Muhando
+ * @since 1.1.0
+ * @see OllamaChatOptions
+ * @see OllamaEmbeddingOptions
+ * @see <a href=
+ * "https://github.com/ollama/ollama/blob/main/docs/modelfile.mdx#valid-parameters-and-values">Ollama
+ * Valid Parameters and Values</a>
+ * @see <a href="https://github.com/ollama/ollama/blob/main/api/types.go">Ollama Types</a>
+ */
+public abstract class OllamaCommonOptions {
+
+	// -------------------------------------------------------------------------
+	// Model-loading options (must be set when the model is loaded into memory).
+	// See: https://github.com/ggerganov/llama.cpp/blob/master/examples/main/README.md
+	// -------------------------------------------------------------------------
+
+	// @formatter:off
+
+	/**
+	 * Whether to use NUMA. (Default: false)
+	 */
+	protected final @Nullable Boolean useNUMA;
+
+	/**
+	 * Sets the size of the context window used to generate the next token. (Default: 2048)
+	 */
+	protected final @Nullable Integer numCtx;
+
+	/**
+	 * Prompt processing maximum batch size. (Default: 512)
+	 */
+	protected final @Nullable Integer numBatch;
+
+	/**
+	 * The number of layers to send to the GPU(s). On macOS, it defaults to 1
+	 * to enable metal support, 0 to disable.
+	 * (Default: -1, which indicates that numGPU should be set dynamically)
+	 */
+	protected final @Nullable Integer numGPU;
+
+	/**
+	 * When using multiple GPUs this option controls which GPU is used
+	 * for small tensors for which the overhead of splitting the computation
+	 * across all GPUs is not worthwhile. The GPU in question will use slightly
+	 * more VRAM to store a scratch buffer for temporary results.
+	 * By default, GPU 0 is used.
+	 */
+	protected final @Nullable Integer mainGPU;
+
+	/**
+	 * (Default: false)
+	 */
+	protected final @Nullable Boolean lowVRAM;
+
+	/**
+	 * (Default: true)
+	 */
+	protected final @Nullable Boolean f16KV;
+
+	/**
+	 * Return logits for all the tokens, not just the last one.
+	 * To enable completions to return logprobs, this must be true.
+	 */
+	protected final @Nullable Boolean logitsAll;
+
+	/**
+	 * Load only the vocabulary, not the weights.
+	 */
+	protected final @Nullable Boolean vocabOnly;
+
+	/**
+	 * By default, models are mapped into memory, which allows the system to load only the necessary parts
+	 * of the model as needed. However, if the model is larger than your total amount of RAM or if your system is low
+	 * on available memory, using mmap might increase the risk of pageouts, negatively impacting performance.
+	 * Disabling mmap results in slower load times but may reduce pageouts if you're not using mlock.
+	 * Note that if the model is larger than the total amount of RAM, turning off mmap would prevent
+	 * the model from loading at all.
+	 * (Default: null)
+	 */
+	protected final @Nullable Boolean useMMap;
+
+	/**
+	 * Lock the model in memory, preventing it from being swapped out when memory-mapped.
+	 * This can improve performance but trades away some of the advantages of memory-mapping
+	 * by requiring more RAM to run and potentially slowing down load times as the model loads into RAM.
+	 * (Default: false)
+	 */
+	protected final @Nullable Boolean useMLock;
+
+	/**
+	 * Set the number of threads to use during generation. For optimal performance, it is recommended to set this value
+	 * to the number of physical CPU cores your system has (as opposed to the logical number of cores).
+	 * Using the correct number of threads can greatly improve performance.
+	 * By default, Ollama will detect this value for optimal performance.
+	 */
+	protected final @Nullable Integer numThread;
+
+	// -------------------------------------------------------------------------
+	// Common request-level fields present in both Chat and Embedding requests.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * NOTE: Synthetic field not part of the official Ollama API.
+	 * Used to allow overriding the model name with prompt options.
+	 */
+	protected final String model;
+
+	/**
+	 * Sets the length of time for Ollama to keep the model loaded. Valid values for this
+	 * setting are parsed by <a href="https://pkg.go.dev/time#ParseDuration">ParseDuration in Go</a>.
+	 */
+	protected final @Nullable String keepAlive;
+
+	/**
+	 * Truncates the end of each input to fit within context length. Returns error if false
+	 * and context length is exceeded. Defaults to true.
+	 */
+	protected final @Nullable Boolean truncate;
+
+	// @formatter:on
+
+	protected OllamaCommonOptions(String model, @Nullable String keepAlive, @Nullable Boolean truncate,
+			@Nullable Boolean useNUMA, @Nullable Integer numCtx, @Nullable Integer numBatch, @Nullable Integer numGPU,
+			@Nullable Integer mainGPU, @Nullable Boolean lowVRAM, @Nullable Boolean f16KV,
+			@Nullable Boolean logitsAll, @Nullable Boolean vocabOnly, @Nullable Boolean useMMap,
+			@Nullable Boolean useMLock, @Nullable Integer numThread) {
+		this.model = model;
+		this.keepAlive = keepAlive;
+		this.truncate = truncate;
+		this.useNUMA = useNUMA;
+		this.numCtx = numCtx;
+		this.numBatch = numBatch;
+		this.numGPU = numGPU;
+		this.mainGPU = mainGPU;
+		this.lowVRAM = lowVRAM;
+		this.f16KV = f16KV;
+		this.logitsAll = logitsAll;
+		this.vocabOnly = vocabOnly;
+		this.useMMap = useMMap;
+		this.useMLock = useMLock;
+		this.numThread = numThread;
+	}
+
+	// -------------------------------------------------------------------------
+	// Getters (no setters — instances are immutable)
+	// -------------------------------------------------------------------------
+
+	public String getModel() {
+		return this.model;
+	}
+
+	public @Nullable String getKeepAlive() {
+		return this.keepAlive;
+	}
+
+	public @Nullable Boolean getTruncate() {
+		return this.truncate;
+	}
+
+	public @Nullable Boolean getUseNUMA() {
+		return this.useNUMA;
+	}
+
+	public @Nullable Integer getNumCtx() {
+		return this.numCtx;
+	}
+
+	public @Nullable Integer getNumBatch() {
+		return this.numBatch;
+	}
+
+	public @Nullable Integer getNumGPU() {
+		return this.numGPU;
+	}
+
+	public @Nullable Integer getMainGPU() {
+		return this.mainGPU;
+	}
+
+	public @Nullable Boolean getLowVRAM() {
+		return this.lowVRAM;
+	}
+
+	public @Nullable Boolean getF16KV() {
+		return this.f16KV;
+	}
+
+	public @Nullable Boolean getLogitsAll() {
+		return this.logitsAll;
+	}
+
+	public @Nullable Boolean getVocabOnly() {
+		return this.vocabOnly;
+	}
+
+	public @Nullable Boolean getUseMMap() {
+		return this.useMMap;
+	}
+
+	public @Nullable Boolean getUseMLock() {
+		return this.useMLock;
+	}
+
+	public @Nullable Integer getNumThread() {
+		return this.numThread;
+	}
+
+}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaEmbeddingOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaEmbeddingOptions.java
@@ -26,7 +26,11 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.ai.embedding.EmbeddingOptions;
 
 /**
- * Helper class for creating strongly-typed Ollama options.
+ * Options for the Ollama Embedding API. Extends {@link OllamaCommonOptions} to inherit
+ * the shared model-loading fields ({@code useNUMA}, {@code numCtx}, {@code numBatch},
+ * {@code numGPU}, {@code mainGPU}, {@code lowVRAM}, {@code f16KV}, {@code logitsAll},
+ * {@code vocabOnly}, {@code useMMap}, {@code useMLock}, {@code numThread}) and common
+ * request fields ({@code model}, {@code keepAlive}, {@code truncate}).
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
@@ -38,33 +42,11 @@ import org.springframework.ai.embedding.EmbeddingOptions;
  * Valid Parameters and Values</a>
  * @see <a href="https://github.com/ollama/ollama/blob/main/api/types.go">Ollama Types</a>
  */
-public class OllamaEmbeddingOptions implements EmbeddingOptions {
+public class OllamaEmbeddingOptions extends OllamaCommonOptions implements EmbeddingOptions {
 
 	private static final List<String> NON_SUPPORTED_FIELDS = List.of("model", "keep_alive", "truncate", "dimensions");
 
-	// Following fields are options which must be set when the model is loaded into
-	// memory.
-	// See: https://github.com/ggerganov/llama.cpp/blob/master/examples/main/README.md
-
 	// @formatter:off
-
-
-	// Following fields are not part of the Ollama Options API but part of the Request.
-
-	/**
-	 * NOTE: Synthetic field not part of the official Ollama API.
-	 * Used to allow overriding the model name with prompt options.
-	 * Part of Chat completion <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#parameters-1">parameters</a>.
-	 */
-	private final String model;
-
-	/**
-	 * Sets the length of time for Ollama to keep the model loaded. Valid values for this
-	 * setting are parsed by <a href="https://pkg.go.dev/time#ParseDuration">ParseDuration in Go</a>.
-	 * Part of Chat completion <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#parameters-1">advanced parameters</a>.
-	 */
-	private final @Nullable String keepAlive;
-
 
 	/**
 	 * The dimensions of the embedding output. This allows you to specify the size of the embedding vector
@@ -72,97 +54,17 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 */
 	private final @Nullable Integer dimensions;
 
+	// @formatter:on
 
-	/**
-	 * Truncates the end of each input to fit within context length. Returns error if false and context length is exceeded.
-	 * Defaults to true.
-	 */
-	private final @Nullable Boolean truncate;
-
-	// @formatter:off
-
-	/**
-	 * Whether to use NUMA. (Default: false)
-	 */
-	private final @Nullable Boolean useNUMA;
-
-	/**
-	 * Prompt processing maximum batch size. (Default: 512)
-	 */
-	private final @Nullable Integer numBatch;
-
-	/**
-	 * The number of layers to send to the GPU(s). On macOS, it defaults to 1
-	 * to enable metal support, 0 to disable.
-	 * (Default: -1, which indicates that numGPU should be set dynamically)
-	 */
-	private final @Nullable Integer numGPU;
-
-	/**
-	 * When using multiple GPUs this option controls which GPU is used
-	 * for small tensors for which the overhead of splitting the computation
-	 * across all GPUs is not worthwhile. The GPU in question will use slightly
-	 * more VRAM to store a scratch buffer for temporary results.
-	 * By default, GPU 0 is used.
-	 */
-	private final @Nullable Integer mainGPU;
-
-	/**
-	 * (Default: false)
-	 */
-	private final @Nullable Boolean lowVRAM;
-
-	/**
-	 * Load only the vocabulary, not the weights.
-	 */
-	private final @Nullable Boolean vocabOnly;
-
-	/**
-	 * By default, models are mapped into memory, which allows the system to load only the necessary parts
-	 * of the model as needed. However, if the model is larger than your total amount of RAM or if your system is low
-	 * on available memory, using mmap might increase the risk of pageouts, negatively impacting performance.
-	 * Disabling mmap results in slower load times but may reduce pageouts if you're not using mlock.
-	 * Note that if the model is larger than the total amount of RAM, turning off mmap would prevent
-	 * the model from loading at all.
-	 * (Default: null)
-	 */
-	private final @Nullable Boolean useMMap;
-
-	/**
-	 * Lock the model in memory, preventing it from being swapped out when memory-mapped.
-	 * This can improve performance but trades away some of the advantages of memory-mapping
-	 * by requiring more RAM to run and potentially slowing down load times as the model loads into RAM.
-	 * (Default: false)
-	 */
-	private final @Nullable Boolean useMLock;
-
-	/**
-	 * Set the number of threads to use during generation. For optimal performance, it is recommended to set this value
-	 * to the number of physical CPU cores your system has (as opposed to the logical number of cores).
-	 * Using the correct number of threads can greatly improve performance.
-	 * By default, Ollama will detect this value for optimal performance.
-	 */
-	private final @Nullable Integer numThread;
-
-	protected OllamaEmbeddingOptions(
-			@Nullable String model, @Nullable String keepAlive, @Nullable Integer dimensions,
-			@Nullable Boolean truncate, @Nullable Boolean useNUMA, @Nullable Integer numBatch,
-			@Nullable Integer numGPU, @Nullable Integer mainGPU, @Nullable Boolean lowVRAM,
-			@Nullable Boolean vocabOnly, @Nullable Boolean useMMap, @Nullable Boolean useMLock,
-			@Nullable Integer numThread) {
-		this.model = model != null ? model : OllamaModel.MXBAI_EMBED_LARGE.id();
-		this.keepAlive = keepAlive;
+	protected OllamaEmbeddingOptions(@Nullable String model, @Nullable String keepAlive,
+			@Nullable Integer dimensions, @Nullable Boolean truncate, @Nullable Boolean useNUMA,
+			@Nullable Integer numCtx, @Nullable Integer numBatch, @Nullable Integer numGPU,
+			@Nullable Integer mainGPU, @Nullable Boolean lowVRAM, @Nullable Boolean f16KV,
+			@Nullable Boolean logitsAll, @Nullable Boolean vocabOnly, @Nullable Boolean useMMap,
+			@Nullable Boolean useMLock, @Nullable Integer numThread) {
+		super(model != null ? model : OllamaModel.MXBAI_EMBED_LARGE.id(), keepAlive, truncate, useNUMA, numCtx,
+				numBatch, numGPU, mainGPU, lowVRAM, f16KV, logitsAll, vocabOnly, useMMap, useMLock, numThread);
 		this.dimensions = dimensions;
-		this.truncate = truncate;
-		this.useNUMA = useNUMA;
-		this.numBatch = numBatch;
-		this.numGPU = numGPU;
-		this.mainGPU = mainGPU;
-		this.lowVRAM = lowVRAM;
-		this.vocabOnly = vocabOnly;
-		this.useMMap = useMMap;
-		this.useMLock = useMLock;
-		this.numThread = numThread;
 	}
 
 	public static OllamaEmbeddingOptions.Builder builder() {
@@ -183,53 +85,14 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	// -------------------
 	// Getters
 	// -------------------
+
+	// getModel, getKeepAlive, getTruncate, getUseNUMA, getNumCtx, getNumBatch,
+	// getNumGPU, getMainGPU, getLowVRAM, getF16KV, getLogitsAll, getVocabOnly,
+	// getUseMMap, getUseMLock, getNumThread are inherited from OllamaCommonOptions.
+
 	@Override
 	public String getModel() {
 		return this.model;
-	}
-
-	public @Nullable String getKeepAlive() {
-		return this.keepAlive;
-	}
-
-	public @Nullable Boolean getTruncate() {
-		return this.truncate;
-	}
-
-	public @Nullable Boolean getUseNUMA() {
-		return this.useNUMA;
-	}
-
-	public @Nullable Integer getNumBatch() {
-		return this.numBatch;
-	}
-
-	public @Nullable Integer getNumGPU() {
-		return this.numGPU;
-	}
-
-	public @Nullable Integer getMainGPU() {
-		return this.mainGPU;
-	}
-
-	public @Nullable Boolean getLowVRAM() {
-		return this.lowVRAM;
-	}
-
-	public @Nullable Boolean getVocabOnly() {
-		return this.vocabOnly;
-	}
-
-	public @Nullable Boolean getUseMMap() {
-		return this.useMMap;
-	}
-
-	public @Nullable Boolean getUseMLock() {
-		return this.useMLock;
-	}
-
-	public @Nullable Integer getNumThread() {
-		return this.numThread;
 	}
 
 	@Override
@@ -258,6 +121,9 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 		if (this.useNUMA != null) {
 			map.put("numa", this.useNUMA);
 		}
+		if (this.numCtx != null) {
+			map.put("num_ctx", this.numCtx);
+		}
 		if (this.numBatch != null) {
 			map.put("num_batch", this.numBatch);
 		}
@@ -269,6 +135,12 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 		}
 		if (this.lowVRAM != null) {
 			map.put("low_vram", this.lowVRAM);
+		}
+		if (this.f16KV != null) {
+			map.put("f16_kv", this.f16KV);
+		}
+		if (this.logitsAll != null) {
+			map.put("logits_all", this.logitsAll);
 		}
 		if (this.vocabOnly != null) {
 			map.put("vocab_only", this.vocabOnly);
@@ -316,6 +188,8 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 
 		private @Nullable Boolean useNUMA;
 
+		private @Nullable Integer numCtx;
+
 		private @Nullable Integer numBatch;
 
 		private @Nullable Integer numGPU;
@@ -323,6 +197,10 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 		private @Nullable Integer mainGPU;
 
 		private @Nullable Boolean lowVRAM;
+
+		private @Nullable Boolean f16KV;
+
+		private @Nullable Boolean logitsAll;
 
 		private @Nullable Boolean vocabOnly;
 
@@ -357,6 +235,11 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 			return this;
 		}
 
+		public Builder numCtx(@Nullable Integer numCtx) {
+			this.numCtx = numCtx;
+			return this;
+		}
+
 		public Builder numBatch(@Nullable Integer numBatch) {
 			this.numBatch = numBatch;
 			return this;
@@ -374,6 +257,16 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 
 		public Builder lowVRAM(@Nullable Boolean lowVRAM) {
 			this.lowVRAM = lowVRAM;
+			return this;
+		}
+
+		public Builder f16KV(@Nullable Boolean f16KV) {
+			this.f16KV = f16KV;
+			return this;
+		}
+
+		public Builder logitsAll(@Nullable Boolean logitsAll) {
+			this.logitsAll = logitsAll;
 			return this;
 		}
 
@@ -404,8 +297,8 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 
 		public OllamaEmbeddingOptions build() {
 			return new OllamaEmbeddingOptions(this.model, this.keepAlive, this.dimensions, this.truncate, this.useNUMA,
-					this.numBatch, this.numGPU, this.mainGPU, this.lowVRAM, this.vocabOnly, this.useMMap, this.useMLock,
-					this.numThread);
+					this.numCtx, this.numBatch, this.numGPU, this.mainGPU, this.lowVRAM, this.f16KV, this.logitsAll,
+					this.vocabOnly, this.useMMap, this.useMLock, this.numThread);
 		}
 
 	}


### PR DESCRIPTION
## Summary

Closes #3926.

\`OllamaChatOptions\` and \`OllamaEmbeddingOptions\` duplicated 12 model-loading fields
(\`useNUMA\`, \`numCtx\`, \`numBatch\`, \`numGPU\`, \`mainGPU\`, \`lowVRAM\`, \`f16KV\`, \`logitsAll\`,
\`vocabOnly\`, \`useMMap\`, \`useMLock\`, \`numThread\`) and 3 common request fields
(\`model\`, \`keepAlive\`, \`truncate\`) — 15 fields total with duplicate getters/setters.

This PR introduces an abstract \`OllamaCommonOptions\` base class in the same package
(\`org.springframework.ai.ollama.api\`) following the same pattern as \`AbstractOpenAiOptions\`.
Both option classes now extend it.

### Changes

- **New**: \`OllamaCommonOptions\` — abstract base class with all 15 shared fields and their getters
- **Refactored**: \`OllamaChatOptions extends OllamaCommonOptions\` — retains only chat-specific fields: sampling parameters (\`temperature\`, \`topK\`, \`topP\`, \`seed\`, \`stop\`, penalties, \`mirostat\` family, \`numKeep\`, \`minP\`, \`tfsZ\`, \`typicalP\`, \`repeatLastN\`), \`format\`, \`thinkOption\`, and tool-calling fields
- **Refactored**: \`OllamaEmbeddingOptions extends OllamaCommonOptions\` — retains only \`dimensions\`; gains \`numCtx\`, \`f16KV\`, and \`logitsAll\` (previously missing from the embedding surface) via the shared base

### Bonus

\`OllamaEmbeddingOptions\` previously lacked \`numCtx\`, \`f16KV\`, and \`logitsAll\`. These are now available through the base class, making the embedding API surface consistent with the chat API.

### No breaking changes

- All existing public getters on both classes are preserved (either directly or via inheritance)
- \`OllamaEmbeddingOptions.Builder\` and \`OllamaChatOptions.Builder\`/\`AbstractBuilder\` APIs are unchanged
- \`OllamaChatModel\` and \`OllamaEmbeddingModel\` required no changes
- Autoconfiguration classes required no changes

## Test plan

- [x] \`./mvnw compile -pl models/spring-ai-ollama --also-make -Denforcer.skip=true\` passes (exit 0)
- [x] \`./mvnw compile -pl auto-configurations/models/spring-ai-autoconfigure-model-ollama -Denforcer.skip=true\` passes (exit 0)
- [ ] All existing unit tests in \`OllamaChatOptionsTests\` should pass (pre-existing test-compile failures in \`OllamaApiIT\` and \`OllamaDurationFieldsTests\` due to unrelated \`ModelOptionsUtils\` API changes block isolated test runs)