### PR TITLE
Remove internal tool execution from BedrockProxyChatModel

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfiguration.java
@@ -28,9 +28,7 @@ import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.model.bedrock.autoconfigure.BedrockAwsConnectionConfiguration;
 import org.springframework.ai.model.bedrock.autoconfigure.BedrockAwsConnectionProperties;
-import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -68,8 +66,7 @@ public class BedrockConverseProxyChatAutoConfiguration {
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<ChatModelObservationConvention> observationConvention,
 			ObjectProvider<BedrockRuntimeClient> bedrockRuntimeClient,
-			ObjectProvider<BedrockRuntimeAsyncClient> bedrockRuntimeAsyncClient,
-			ObjectProvider<ToolExecutionEligibilityPredicate> bedrockToolExecutionEligibilityPredicate) {
+			ObjectProvider<BedrockRuntimeAsyncClient> bedrockRuntimeAsyncClient) {
 
 		var chatModel = BedrockProxyChatModel.builder()
 			.credentialsProvider(credentialsProvider)
@@ -82,8 +79,6 @@ public class BedrockConverseProxyChatAutoConfiguration {
 			.options(chatProperties.toOptions())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.toolCallingManager(toolCallingManager)
-			.toolExecutionEligibilityPredicate(
-					bedrockToolExecutionEligibilityPredicate.getIfUnique(DefaultToolExecutionEligibilityPredicate::new))
 			.bedrockRuntimeClient(bedrockRuntimeClient.getIfAvailable())
 			.bedrockRuntimeAsyncClient(bedrockRuntimeAsyncClient.getIfAvailable())
 			.build();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,12 +28,15 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.ai.bedrock.converse.BedrockChatOptions;
 import org.springframework.ai.bedrock.converse.BedrockProxyChatModel;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.bedrock.autoconfigure.BedrockTestUtils;
 import org.springframework.ai.model.bedrock.autoconfigure.RequiresAwsCredentials;
 import org.springframework.ai.model.bedrock.converse.autoconfigure.BedrockConverseProxyChatAutoConfiguration;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -61,19 +65,31 @@ class FunctionCallWithFunctionBeanIT {
 			.run(context -> {
 
 				BedrockProxyChatModel chatModel = context.getBean(BedrockProxyChatModel.class);
+				ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
+
+				var chatClient = ChatClient
+					.builder(chatModel, ObservationRegistry.NOOP, null, null,
+							ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+					.build();
 
 				var userMessage = new UserMessage(
 						"What's the weather like in San Francisco, in Paris, France and in Tokyo, Japan? Return the temperature in Celsius.");
 
-				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-						BedrockChatOptions.builder().toolNames("weatherFunction").build()));
+				ChatResponse response = chatClient
+					.prompt(new Prompt(List.of(userMessage),
+							BedrockChatOptions.builder().toolNames("weatherFunction").build()))
+					.call()
+					.chatResponse();
 
 				logger.info("Response: {}", response);
 
 				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
-				response = chatModel.call(new Prompt(List.of(userMessage),
-						BedrockChatOptions.builder().toolNames("weatherFunction3").build()));
+				response = chatClient
+					.prompt(new Prompt(List.of(userMessage),
+							BedrockChatOptions.builder().toolNames("weatherFunction3").build()))
+					.call()
+					.chatResponse();
 
 				logger.info("Response: {}", response);
 
@@ -90,12 +106,21 @@ class FunctionCallWithFunctionBeanIT {
 			.run(context -> {
 
 				BedrockProxyChatModel chatModel = context.getBean(BedrockProxyChatModel.class);
+				ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
+
+				var chatClient = ChatClient
+					.builder(chatModel, ObservationRegistry.NOOP, null, null,
+							ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+					.build();
 
 				var userMessage = new UserMessage(
 						"What's the weather like in San Francisco, in Paris, France and in Tokyo, Japan? Return the temperature in Celsius.");
 
-				Flux<ChatResponse> responses = chatModel.stream(new Prompt(List.of(userMessage),
-						BedrockChatOptions.builder().toolNames("weatherFunction").build()));
+				Flux<ChatResponse> responses = chatClient
+					.prompt(new Prompt(List.of(userMessage),
+							BedrockChatOptions.builder().toolNames("weatherFunction").build()))
+					.stream()
+					.chatResponse();
 
 				String content = responses.collectList()
 					.block()

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.model.bedrock.converse.autoconfigure.tool;
 
 import java.util.List;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.bedrock.autoconfigure.BedrockTestUtils;
 import org.springframework.ai.model.bedrock.autoconfigure.RequiresAwsCredentials;
 import org.springframework.ai.model.bedrock.converse.autoconfigure.BedrockConverseProxyChatAutoConfiguration;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -54,6 +56,13 @@ public class FunctionCallWithPromptFunctionIT {
 			.run(context -> {
 
 				BedrockProxyChatModel chatModel = context.getBean(BedrockProxyChatModel.class);
+				ToolCallingManager toolCallingManager = context.getBean(ToolCallingManager.class);
+
+				var chatClient = org.springframework.ai.chat.client.ChatClient
+					.builder(chatModel, ObservationRegistry.NOOP, null, null,
+							org.springframework.ai.chat.client.advisor.ToolCallAdvisor.builder()
+								.toolCallingManager(toolCallingManager))
+					.build();
 
 				UserMessage userMessage = new UserMessage(
 						"What's the weather like in San Francisco, in Paris and in Tokyo? Return the temperature in Celsius.");
@@ -66,7 +75,9 @@ public class FunctionCallWithPromptFunctionIT {
 								.build()))
 					.build();
 
-				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), promptOptions));
+				ChatResponse response = chatClient.prompt(new Prompt(List.of(userMessage), promptOptions))
+					.call()
+					.chatResponse();
 
 				logger.info("Response: {}", response);
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -25,8 +25,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -35,7 +33,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.scheduler.Schedulers;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.document.Document;
@@ -64,7 +61,6 @@ import software.amazon.awssdk.services.bedrockruntime.model.OutputConfig;
 import software.amazon.awssdk.services.bedrockruntime.model.OutputFormat;
 import software.amazon.awssdk.services.bedrockruntime.model.OutputFormatStructure;
 import software.amazon.awssdk.services.bedrockruntime.model.S3Location;
-import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
 import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 import software.amazon.awssdk.services.bedrockruntime.model.Tool;
@@ -105,10 +101,6 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolExecutionResult;
-import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
 import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.util.JsonHelper;
@@ -155,8 +147,6 @@ public class BedrockProxyChatModel implements ChatModel {
 
 	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();
 
-	private static final ToolCallingManager DEFAULT_TOOL_CALLING_MANAGER = ToolCallingManager.builder().build();
-
 	private final BedrockRuntimeClient bedrockRuntimeClient;
 
 	private final BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient;
@@ -171,14 +161,6 @@ public class BedrockProxyChatModel implements ChatModel {
 	private final ToolCallingManager toolCallingManager;
 
 	/**
-	 * The tool execution eligibility predicate used to determine if a tool can be
-	 * executed.
-	 */
-	private final ToolExecutionEligibilityChecker toolExecutionEligibilityChecker;
-
-	private final AtomicBoolean internalToolExecutionWarned = new AtomicBoolean(false);
-
-	/**
 	 * Conventions to use for generating observations.
 	 */
 	private @Nullable ChatModelObservationConvention observationConvention;
@@ -189,26 +171,16 @@ public class BedrockProxyChatModel implements ChatModel {
 			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, BedrockChatOptions options,
 			ObservationRegistry observationRegistry, ToolCallingManager toolCallingManager) {
 		this(bedrockRuntimeClient, bedrockRuntimeAsyncClient, options, observationRegistry, toolCallingManager,
-				chatResponse -> chatResponse != null && chatResponse.hasToolCalls());
+				new MediaFetcher());
 	}
 
 	public BedrockProxyChatModel(BedrockRuntimeClient bedrockRuntimeClient,
 			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, BedrockChatOptions options,
-			ObservationRegistry observationRegistry, ToolCallingManager toolCallingManager,
-			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker) {
-		this(bedrockRuntimeClient, bedrockRuntimeAsyncClient, options, observationRegistry, toolCallingManager,
-				toolExecutionEligibilityChecker, new MediaFetcher());
-	}
-
-	public BedrockProxyChatModel(BedrockRuntimeClient bedrockRuntimeClient,
-			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, BedrockChatOptions options,
-			ObservationRegistry observationRegistry, ToolCallingManager toolCallingManager,
-			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, MediaFetcher mediaFetcher) {
+			ObservationRegistry observationRegistry, ToolCallingManager toolCallingManager, MediaFetcher mediaFetcher) {
 
 		Assert.notNull(bedrockRuntimeClient, "bedrockRuntimeClient must not be null");
 		Assert.notNull(bedrockRuntimeAsyncClient, "bedrockRuntimeAsyncClient must not be null");
 		Assert.notNull(toolCallingManager, "toolCallingManager must not be null");
-		Assert.notNull(toolExecutionEligibilityChecker, "toolExecutionEligibilityChecker must not be null");
 		Assert.notNull(mediaFetcher, "mediaFetcher must not be null");
 
 		this.bedrockRuntimeClient = bedrockRuntimeClient;
@@ -216,56 +188,7 @@ public class BedrockProxyChatModel implements ChatModel {
 		this.options = options;
 		this.observationRegistry = observationRegistry;
 		this.toolCallingManager = toolCallingManager;
-		this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
 		this.mediaFetcher = mediaFetcher;
-	}
-
-	/**
-	 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-	 * {@link #BedrockProxyChatModel(BedrockRuntimeClient, BedrockRuntimeAsyncClient, BedrockChatOptions, ObservationRegistry, ToolCallingManager, ToolExecutionEligibilityChecker, MediaFetcher)}.
-	 */
-	@Deprecated(since = "2.0.0", forRemoval = true)
-	@SuppressWarnings({ "deprecation", "removal" })
-	public BedrockProxyChatModel(BedrockRuntimeClient bedrockRuntimeClient,
-			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, BedrockChatOptions defaultOptions,
-			ObservationRegistry observationRegistry, ToolCallingManager toolCallingManager,
-			ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate) {
-		this(bedrockRuntimeClient, bedrockRuntimeAsyncClient, defaultOptions, observationRegistry, toolCallingManager,
-				toolExecutionEligibilityPredicate, new MediaFetcher());
-	}
-
-	/**
-	 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-	 * {@link #BedrockProxyChatModel(BedrockRuntimeClient, BedrockRuntimeAsyncClient, BedrockChatOptions, ObservationRegistry, ToolCallingManager, ToolExecutionEligibilityChecker, MediaFetcher)}.
-	 */
-	@Deprecated(since = "2.0.0", forRemoval = true)
-	@SuppressWarnings({ "deprecation", "removal" })
-	public BedrockProxyChatModel(BedrockRuntimeClient bedrockRuntimeClient,
-			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, BedrockChatOptions defaultOptions,
-			ObservationRegistry observationRegistry, ToolCallingManager toolCallingManager,
-			ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate, MediaFetcher mediaFetcher) {
-		this(bedrockRuntimeClient, bedrockRuntimeAsyncClient, defaultOptions, observationRegistry, toolCallingManager,
-				new ToolExecutionEligibilityChecker() {
-					@Override
-					public Boolean apply(ChatResponse chatResponse) {
-						return chatResponse != null && chatResponse.hasToolCalls();
-					}
-
-					@Override
-					public boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse) {
-						return toolExecutionEligibilityPredicate.test(promptOptions, chatResponse);
-					}
-				}, mediaFetcher);
-	}
-
-	private static BedrockChatOptions from(ChatOptions options) {
-		return BedrockChatOptions.builder()
-			.model(options.getModel())
-			.maxTokens(options.getMaxTokens())
-			.stopSequences(options.getStopSequences())
-			.temperature(options.getTemperature())
-			.topP(options.getTopP())
-			.build();
 	}
 
 	/**
@@ -307,29 +230,6 @@ public class BedrockProxyChatModel implements ChatModel {
 				return response;
 			});
 
-		ChatOptions options = prompt.getOptions();
-		Assert.state(options != null, "Prompt options must not be null");
-
-		if (this.toolExecutionEligibilityChecker.isToolExecutionRequired(options, chatResponse)
-				&& chatResponse.hasFinishReasons(Set.of(StopReason.TOOL_USE.toString()))) {
-			if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-				logger.warn(
-						"Internal tool execution in BedrockProxyChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-								+ "Use ChatClient with ToolCallAdvisor instead.");
-			}
-			var toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, chatResponse);
-			if (toolExecutionResult.returnDirect()) {
-				// Return tool execution result directly to the client.
-				return ChatResponse.builder()
-					.from(chatResponse)
-					.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-					.build();
-			}
-			else {
-				// Send the tool execution result back to the model.
-				return this.internalCall(new Prompt(toolExecutionResult.conversationHistory(), options), chatResponse);
-			}
-		}
 		return chatResponse;
 	}
 
@@ -864,50 +764,10 @@ public class BedrockProxyChatModel implements ChatModel {
 			ChatOptions options = prompt.getOptions();
 			Assert.state(options != null, "Prompt options must not be null");
 
-			Flux<ChatResponse> chatResponseFlux = chatResponses.concatMap(chatResponse -> {
-
-				if (this.toolExecutionEligibilityChecker.isToolExecutionRequired(options, chatResponse)
-						&& chatResponse.hasFinishReasons(Set.of(StopReason.TOOL_USE.toString()))) {
-
-					// FIXME: bounded elastic needs to be used since tool calling
-					// is currently only synchronous
-					return Flux.deferContextual(ctx -> {
-						ToolExecutionResult toolExecutionResult;
-						try {
-							if (this.internalToolExecutionWarned.compareAndSet(false, true)) {
-								logger.warn(
-										"Internal tool execution in BedrockProxyChatModel is deprecated since 2.0.0 and will be removed in 3.0.0. "
-												+ "Use ChatClient with ToolCallAdvisor instead.");
-							}
-							ToolCallReactiveContextHolder.setContext(ctx);
-							toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, chatResponse);
-						}
-						finally {
-							ToolCallReactiveContextHolder.clearContext();
-						}
-
-						if (toolExecutionResult.returnDirect()) {
-							// Return tool execution result directly to the client.
-							return Flux.just(ChatResponse.builder()
-								.from(chatResponse)
-								.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
-								.build());
-						}
-						else {
-							// Send the tool execution result back to the model.
-							return this.internalStream(new Prompt(toolExecutionResult.conversationHistory(), options),
-									chatResponse);
-						}
-					}).subscribeOn(Schedulers.boundedElastic());
-				}
-				else {
-					return Flux.just(chatResponse);
-				}
-			})// @formatter:off
-			.doOnError(observation::error)
-			.doFinally(s -> observation.stop())
-			.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
-			// @formatter:on
+			Flux<ChatResponse> chatResponseFlux = chatResponses.concatMap(chatResponse -> Flux.just(chatResponse))
+				.doOnError(observation::error)
+				.doFinally(s -> observation.stop())
+				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 
 			return new MessageAggregator().aggregate(chatResponseFlux, observationContext::setResponse);
 		});
@@ -944,9 +804,6 @@ public class BedrockProxyChatModel implements ChatModel {
 
 		private @Nullable ToolCallingManager toolCallingManager;
 
-		private ToolExecutionEligibilityChecker toolExecutionEligibilityChecker = chatResponse -> chatResponse != null
-				&& chatResponse.hasToolCalls();
-
 		private BedrockChatOptions options = BedrockChatOptions.builder().build();
 
 		private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
@@ -977,45 +834,6 @@ public class BedrockProxyChatModel implements ChatModel {
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		public Builder toolCallingManager(ToolCallingManager toolCallingManager) {
 			this.toolCallingManager = toolCallingManager;
-			return this;
-		}
-
-		/**
-		 * Sets the predicate to determine tool execution eligibility.
-		 * @param toolExecutionEligibilityPredicate the predicate
-		 * @return this builder
-		 * @deprecated since 2.0.0 for removal in 3.0.0 — replaced by
-		 * {@link #toolExecutionEligibilityChecker(ToolExecutionEligibilityChecker)}. For
-		 * the recommended long-term approach, internal tool execution in
-		 * {@link BedrockProxyChatModel} is superseded by {@code ToolCallAdvisor} used via
-		 * {@code ChatClient}.
-		 */
-		@Deprecated(since = "2.0.0", forRemoval = true)
-		@SuppressWarnings({ "deprecation", "removal" })
-		public Builder toolExecutionEligibilityPredicate(
-				ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate) {
-			this.toolExecutionEligibilityChecker = new ToolExecutionEligibilityChecker() {
-				@Override
-				public Boolean apply(ChatResponse chatResponse) {
-					return chatResponse != null && chatResponse.hasToolCalls();
-				}
-
-				@Override
-				public boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse) {
-					return toolExecutionEligibilityPredicate.test(promptOptions, chatResponse);
-				}
-			};
-			return this;
-		}
-
-		/**
-		 * Sets the checker to determine tool execution eligibility.
-		 * @param toolExecutionEligibilityChecker the checker
-		 * @return this builder
-		 */
-		public Builder toolExecutionEligibilityChecker(
-				ToolExecutionEligibilityChecker toolExecutionEligibilityChecker) {
-			this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
 			return this;
 		}
 
@@ -1123,19 +941,11 @@ public class BedrockProxyChatModel implements ChatModel {
 				this.bedrockRuntimeAsyncClient = builder.build();
 			}
 
-			BedrockProxyChatModel bedrockProxyChatModel = null;
+			this.toolCallingManager = this.toolCallingManager != null ? this.toolCallingManager
+					: ToolCallingManager.builder().observationRegistry(this.observationRegistry).build();
 
-			if (this.toolCallingManager != null) {
-				bedrockProxyChatModel = new BedrockProxyChatModel(this.bedrockRuntimeClient,
-						this.bedrockRuntimeAsyncClient, this.options, this.observationRegistry, this.toolCallingManager,
-						this.toolExecutionEligibilityChecker);
-
-			}
-			else {
-				bedrockProxyChatModel = new BedrockProxyChatModel(this.bedrockRuntimeClient,
-						this.bedrockRuntimeAsyncClient, this.options, this.observationRegistry,
-						DEFAULT_TOOL_CALLING_MANAGER, this.toolExecutionEligibilityChecker);
-			}
+			BedrockProxyChatModel bedrockProxyChatModel = new BedrockProxyChatModel(this.bedrockRuntimeClient,
+					this.bedrockRuntimeAsyncClient, this.options, this.observationRegistry, this.toolCallingManager);
 
 			if (this.customObservationConvention != null) {
 				bedrockProxyChatModel.setObservationConvention(this.customObservationConvention);

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseUsageAggregationTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseUsageAggregationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.bedrock.converse;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +36,12 @@ import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
 import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 import software.amazon.awssdk.services.bedrockruntime.model.ToolUseBlock;
 
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 
@@ -141,16 +147,26 @@ public class BedrockConverseUsageAggregationTests {
 			.inputType(Request.class)
 			.build();
 
-		var result = this.chatModel.call(new Prompt("What is the weather in Paris?",
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+
+		ChatResponse result = this.chatModel.call(new Prompt("What is the weather in Paris?",
 				BedrockChatOptions.builder().toolCallbacks(toolCallback).build()));
+
+		while (result.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager
+				.executeToolCalls(new Prompt("What is the weather in Paris?",
+						BedrockChatOptions.builder().toolCallbacks(toolCallback).build()), result);
+			result = this.chatModel.call(new Prompt(toolExecutionResult.conversationHistory(),
+					BedrockChatOptions.builder().toolCallbacks(toolCallback).build()));
+		}
 
 		assertThat(result).isNotNull();
 		assertThat(result.getResult().getOutput().getText())
 			.isSameAs(converseResponseFinal.output().message().content().get(0).text());
 
-		assertThat(result.getMetadata().getUsage().getPromptTokens()).isEqualTo(445 + 540);
-		assertThat(result.getMetadata().getUsage().getCompletionTokens()).isEqualTo(119 + 106);
-		assertThat(result.getMetadata().getUsage().getTotalTokens()).isEqualTo(564 + 646);
+		assertThat(result.getMetadata().getUsage().getPromptTokens()).isEqualTo(540);
+		assertThat(result.getMetadata().getUsage().getCompletionTokens()).isEqualTo(106);
+		assertThat(result.getMetadata().getUsage().getTotalTokens()).isEqualTo(646);
 	}
 
 	@Test
@@ -257,22 +273,33 @@ public class BedrockConverseUsageAggregationTests {
 			.inputType(Request.class)
 			.build();
 
-		var result = this.chatModel.call(new Prompt("What is the weather in Paris?",
-				BedrockChatOptions.builder().toolCallbacks(toolCallback).build()));
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+
+		var chatClient = ChatClient
+			.builder(this.chatModel, ObservationRegistry.NOOP, null, null,
+					ToolCallAdvisor.builder().toolCallingManager(toolCallingManager))
+			.build();
+
+		ChatResponse result = chatClient
+			.prompt(new Prompt("What is the weather in Paris?",
+					BedrockChatOptions.builder().toolCallbacks(toolCallback).build()))
+			.call()
+			.chatResponse();
 
 		assertThat(result).isNotNull();
 
-		// Verify aggregated standard usage metrics
-		assertThat(result.getMetadata().getUsage().getPromptTokens()).isEqualTo(200 + 300);
-		assertThat(result.getMetadata().getUsage().getCompletionTokens()).isEqualTo(50 + 30);
-		assertThat(result.getMetadata().getUsage().getTotalTokens()).isEqualTo(250 + 330);
+		// With external tool calling each chatModel.call() is independent, so only the
+		// last round's usage is reported (no cross-round accumulation).
+		assertThat(result.getMetadata().getUsage().getPromptTokens()).isEqualTo(300);
+		assertThat(result.getMetadata().getUsage().getCompletionTokens()).isEqualTo(30);
+		assertThat(result.getMetadata().getUsage().getTotalTokens()).isEqualTo(330);
 
-		// Verify aggregated cache metrics in native usage object
+		// Verify cache metrics in native usage object (last round only)
 		Object nativeUsage = result.getMetadata().getUsage().getNativeUsage();
 		assertThat(nativeUsage).isInstanceOf(TokenUsage.class);
 
 		TokenUsage tokenUsage = (TokenUsage) nativeUsage;
-		assertThat(tokenUsage.cacheReadInputTokens()).isEqualTo(150 + 150); // Aggregated
+		assertThat(tokenUsage.cacheReadInputTokens()).isEqualTo(150);
 		assertThat(tokenUsage.cacheWriteInputTokens()).isEqualTo(0);
 	}
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.awaitility.Awaitility;
@@ -44,6 +46,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.model.StreamingChatModel;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
@@ -52,7 +55,10 @@ import org.springframework.ai.content.Media;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.converter.ListOutputConverter;
 import org.springframework.ai.converter.MapOutputConverter;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -264,19 +270,29 @@ class BedrockProxyChatModelIT {
 	@Test
 	void functionCallTest() {
 
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
 		UserMessage userMessage = new UserMessage(
 				"What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.");
 
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
-		var promptOptions = BedrockChatOptions.builder()
+		var options = BedrockChatOptions.builder()
 			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description("Get the weather in location. Return in 36°C format")
 				.inputType(MockWeatherService.Request.class)
 				.build()))
 			.build();
 
-		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
+		var prompt = new Prompt(messages, options);
+
+		ChatResponse response = this.chatModel.call(prompt);
+
+		while (response.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+			response = this.chatModel.call(prompt);
+		}
 
 		logger.info("Response: {}", response);
 
@@ -286,6 +302,8 @@ class BedrockProxyChatModelIT {
 
 	@Test
 	void functionCallTestWithToolCallingOptions() {
+
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
 		UserMessage userMessage = new UserMessage(
 				"What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.");
@@ -299,7 +317,15 @@ class BedrockProxyChatModelIT {
 				.build()))
 			.build();
 
-		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
+		var prompt = new Prompt(messages, promptOptions);
+
+		ChatResponse response = this.chatModel.call(prompt);
+
+		while (response.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			response = this.chatModel.call(prompt);
+		}
 
 		logger.info("Response: {}", response);
 
@@ -309,6 +335,8 @@ class BedrockProxyChatModelIT {
 
 	@Test
 	void streamFunctionCallTest() {
+
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
 
 		UserMessage userMessage = new UserMessage(
 				// "What's the weather like in San Francisco? Return the result in
@@ -326,14 +354,19 @@ class BedrockProxyChatModelIT {
 				.build()))
 			.build();
 
-		Flux<ChatResponse> response = this.chatModel.stream(new Prompt(messages, promptOptions));
+		var prompt = new Prompt(messages, promptOptions);
 
-		String content = response.collectList()
-			.block()
-			.stream()
-			.filter(cr -> cr.getResult() != null)
-			.map(cr -> cr.getResult().getOutput().getText())
-			.collect(Collectors.joining());
+		AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+		new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+
+		while (aggregatedRef.get().hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, aggregatedRef.get());
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			aggregatedRef.set(null);
+			new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+		}
+
+		String content = aggregatedRef.get().getResult().getOutput().getText();
 
 		logger.info("Response: {}", content);
 		assertThat(content).contains("30", "10", "15");
@@ -343,9 +376,9 @@ class BedrockProxyChatModelIT {
 	@ValueSource(ints = { 50, 60 })
 	void streamFunctionCallTestWithMaxTokens(int maxTokens) {
 
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
 		UserMessage userMessage = new UserMessage(
-				// "What's the weather like in San Francisco? Return the result in
-				// Celsius.");
 				"What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.");
 
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
@@ -360,8 +393,19 @@ class BedrockProxyChatModelIT {
 				.build()))
 			.build();
 
-		Flux<ChatResponse> response = this.chatModel.stream(new Prompt(messages, promptOptions));
-		ChatResponse lastResponse = response.blockLast();
+		var prompt = new Prompt(messages, promptOptions);
+
+		AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+		new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+
+		while (aggregatedRef.get().hasToolCalls() && aggregatedRef.get().hasFinishReasons(Set.of("tool_use"))) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, aggregatedRef.get());
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), promptOptions);
+			aggregatedRef.set(null);
+			new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+		}
+
+		ChatResponse lastResponse = aggregatedRef.get();
 		String finishReason = lastResponse.getResult().getMetadata().getFinishReason();
 
 		logger.info("Finish reason: {}", finishReason);
@@ -536,6 +580,8 @@ class BedrockProxyChatModelIT {
 
 	@Test
 	void testToolsOnlyPromptCaching() {
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
 		// IMPORTANT: This test requires a Claude model - Amazon Nova models do NOT
 		// support tool caching and will return ValidationException.
 		// Claude Haiku 4.5 requires 4096+ tokens of tool definitions for caching.
@@ -564,7 +610,17 @@ class BedrockProxyChatModelIT {
 		AtomicInteger cityIndex = new AtomicInteger(0);
 		Awaitility.await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(3)).untilAsserted(() -> {
 			String city = cities.get(cityIndex.getAndIncrement() % cities.size());
-			ChatResponse response = this.chatModel.call(new Prompt("What's the weather in " + city + "?", chatOptions));
+
+			var prompt = new Prompt("What's the weather in " + city + "?", chatOptions);
+
+			ChatResponse response = this.chatModel.call(prompt);
+
+			while (response.hasToolCalls()) {
+				ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+				prompt = new Prompt(toolExecutionResult.conversationHistory(), chatOptions);
+				response = this.chatModel.call(prompt);
+			}
+
 			assertThat(response.getResults()).hasSize(1);
 			assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 			Integer cacheRead = response.getMetadata().get("cacheReadInputTokens");
@@ -579,6 +635,8 @@ class BedrockProxyChatModelIT {
 
 	@Test
 	void testSystemAndToolsPromptCaching() {
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
 		// NOTE: Testing combined caching requires both large system prompt and multiple
 		// tools
 		// IMPORTANT: This test requires a Claude model that supports tool caching.
@@ -629,8 +687,18 @@ class BedrockProxyChatModelIT {
 		AtomicInteger cityIndex = new AtomicInteger(0);
 		Awaitility.await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(3)).untilAsserted(() -> {
 			String city = cities.get(cityIndex.getAndIncrement() % cities.size());
-			ChatResponse response = this.chatModel.call(new Prompt(List.of(new SystemMessage(largeSystemPrompt),
-					new UserMessage("What's the weather in " + city + "?")), chatOptions));
+
+			var prompt = new Prompt(List.of(new SystemMessage(largeSystemPrompt),
+					new UserMessage("What's the weather in " + city + "?")), chatOptions);
+
+			ChatResponse response = this.chatModel.call(prompt);
+
+			while (response.hasToolCalls()) {
+				ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+				prompt = new Prompt(toolExecutionResult.conversationHistory(), chatOptions);
+				response = this.chatModel.call(prompt);
+			}
+
 			assertThat(response.getResults()).hasSize(1);
 			assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 			Integer cacheRead = response.getMetadata().get("cacheReadInputTokens");

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -40,7 +40,6 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
-import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.util.MimeType;
 
@@ -63,8 +62,7 @@ class BedrockProxyChatModelTest {
 
 	private BedrockProxyChatModel newModel() {
 		return new BedrockProxyChatModel(this.syncClient, this.asyncClient, BedrockChatOptions.builder().build(),
-				ObservationRegistry.NOOP, ToolCallingManager.builder().build(),
-				new DefaultToolExecutionEligibilityPredicate());
+				ObservationRegistry.NOOP, ToolCallingManager.builder().build());
 	}
 
 	@Test
@@ -200,7 +198,7 @@ class BedrockProxyChatModelTest {
 	void allowlistRejectsUnlistedStringUrlMediaThrowsRuntimeException() {
 		BedrockProxyChatModel model = new BedrockProxyChatModel(this.syncClient, this.asyncClient,
 				BedrockChatOptions.builder().build(), ObservationRegistry.NOOP, ToolCallingManager.builder().build(),
-				new DefaultToolExecutionEligibilityPredicate(), new MediaFetcher(java.util.Set.of("trusted-cdn.com")));
+				new MediaFetcher(java.util.Set.of("trusted-cdn.com")));
 		Media media = Media.builder().mimeType(MimeType.valueOf("image/png")).data("http://evil.com/image.png").build();
 
 		assertThatThrownBy(() -> model.mapMediaToContentBlock(media)).isInstanceOf(RuntimeException.class)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -790,17 +790,27 @@ AWS Bedrock pricing for prompt caching (approximate, varies by model):
 
 == Tool Calling
 
-The Bedrock Converse API supports tool calling capabilities, allowing models to use tools during conversations.
-Here's an example of how to define and use @Tool based tools:
+`BedrockProxyChatModel` does not execute tool calls internally.
+Tool execution must be handled externally using one of two supported approaches:
+
+* **ChatClient with ToolCallAdvisor** — the recommended approach for most use cases.
+  `ToolCallAdvisor` is automatically registered and manages the tool-call loop transparently.
+* **User-controlled tool execution** — use `DefaultToolCallingManager` directly when you need full control over the loop (for example, when combining tool calling with prompt caching).
+
+=== Tool Calling via ChatClient (Recommended)
+
+The simplest way to use tools is with the `ChatClient` high-level API.
+`ToolCallAdvisor` handles the tool-call loop automatically for both synchronous and streaming calls.
+
+Here's an example using `@Tool`-annotated methods:
 
 [source,java]
 ----
-
 public class WeatherService {
 
     @Tool(description = "Get the weather in location")
-    public String weatherByLocation(@ToolParam(description= "City or state name") String location) {
-        ...
+    public String weatherByLocation(@ToolParam(description = "City or state name") String location) {
+        // ...
     }
 }
 
@@ -811,7 +821,7 @@ String response = ChatClient.create(this.chatModel)
         .content();
 ----
 
-You can use the java.util.function beans as tools as well:
+You can use `java.util.function` beans as tools as well:
 
 [source,java]
 ----
@@ -824,9 +834,68 @@ public Function<Request, Response> weatherFunction() {
 String response = ChatClient.create(this.chatModel)
         .prompt("What's the weather like in Boston?")
         .toolNames("weatherFunction")
-        .inputType(Request.class)
         .call()
         .content();
+----
+
+=== User-Controlled Tool Execution
+
+For scenarios where you need explicit control over the tool-call loop — for example, when combining tool calling with prompt caching — you can drive the loop manually using `DefaultToolCallingManager`.
+
+==== Synchronous
+
+[source,java]
+----
+ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
+var options = BedrockChatOptions.builder()
+        .toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
+            .description("Get the weather in location. Return temperature in 36°F or 36°C format.")
+            .inputType(WeatherService.Request.class)
+            .build()))
+        .build();
+
+var prompt = new Prompt("What's the weather like in San Francisco, Tokyo and Paris?", options);
+
+ChatResponse response = chatModel.call(prompt);
+
+while (response.hasToolCalls()) {
+    ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+    prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+    response = chatModel.call(prompt);
+}
+
+System.out.println(response.getResult().getOutput().getText());
+----
+
+==== Streaming
+
+Because tool calls span multiple stream chunks, each streaming call must be aggregated first using `MessageAggregator` before checking for tool calls.
+
+[source,java]
+----
+ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
+var options = BedrockChatOptions.builder()
+        .toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
+            .description("Get the weather in location. Return temperature in 36°F or 36°C format.")
+            .inputType(WeatherService.Request.class)
+            .build()))
+        .build();
+
+var prompt = new Prompt("What's the weather like in San Francisco, Tokyo and Paris?", options);
+
+AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
+new MessageAggregator().aggregate(chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+
+while (aggregatedRef.get().hasToolCalls()) {
+    ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, aggregatedRef.get());
+    prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+    aggregatedRef.set(null);
+    new MessageAggregator().aggregate(chatModel.stream(prompt), aggregatedRef::set).collectList().block();
+}
+
+System.out.println(aggregatedRef.get().getResult().getOutput().getText());
 ----
 
 Find more in xref:api/tools.adoc[Tools] documentation.


### PR DESCRIPTION
- Tool calls are no longer handled internally by the model. Use ChatClient with ToolCallAdvisor (recommended) or drive the loop manually via DefaultToolCallingManager.
- Update docs and tests accordingly.

Part of #6251 