### PR TITLE
Improve ChatClient tools API type safety and deprecate tools(Object...)

### DIFF
--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatClientIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatClientIT.java
@@ -348,7 +348,7 @@ class AnthropicChatClientIT {
 
 		Flux<ChatResponse> responses = chatClient.prompt()
 			.options(ToolCallingChatOptions.builder().model(modelName))
-			.tools(new MyTools())
+			.tools(t -> t.instances(new MyTools()))
 			.user("Get current weather in Amsterdam and Paris")
 			.stream()
 			.chatResponse();

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
@@ -180,7 +180,7 @@ public class BedrockNovaChatClientIT {
 		ChatClient chatClient = ChatClient.builder(this.chatModel).build();
 
 		String response = chatClient.prompt()
-			.tools(new DummyWeatherForecastTools())
+			.tools(t -> t.instances(new DummyWeatherForecastTools()))
 			.user("Get current weather in Amsterdam")
 			.call()
 			.content();
@@ -198,7 +198,7 @@ public class BedrockNovaChatClientIT {
 
 		Flux<ChatResponse> responses = chatClient.prompt()
 			.options(ToolCallingChatOptions.builder().model(modelName))
-			.tools(new DummyWeatherForecastTools())
+			.tools(t -> t.instances(new DummyWeatherForecastTools()))
 			.user("Get current weather in Amsterdam")
 			.stream()
 			.chatResponse();

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelIT.java
@@ -452,7 +452,7 @@ class GoogleGenAiChatModelIT {
 		// Create a prompt that will trigger the tool call with a specific request that
 		// should invoke the tool
 		String response = chatClient.prompt()
-			.tools(new ScientistTools())
+			.tools(t -> t.instances(new ScientistTools()))
 			.user("List 3 famous scientists and their discoveries. Make sure to use the tool to get this information.")
 			.call()
 			.content();
@@ -490,7 +490,7 @@ class GoogleGenAiChatModelIT {
 		// Create a prompt that will trigger the tool call with a specific request that
 		// should invoke the tool
 		String response = chatClient.prompt()
-			.tools(new CurrentTimeTools())
+			.tools(t -> t.instances(new CurrentTimeTools()))
 			.user("Get the current time in the users timezone. Make sure to use the getCurrentDateTime tool to get this information.")
 			.call()
 			.content();

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tool/GoogleGenAiPaymentTransactionToolsIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tool/GoogleGenAiPaymentTransactionToolsIT.java
@@ -75,7 +75,7 @@ public class GoogleGenAiPaymentTransactionToolsIT {
 		// @formatter:off
 		String content = this.chatClient.prompt()
 				.advisors(new SimpleLoggerAdvisor())
-				.tools(new MyTools())
+				.tools(t -> t.instances(new MyTools()))
 				.user("""
 				What is the status of my payment transactions 001, 002 and 003?
 				If required invoke the function per transaction.
@@ -92,7 +92,7 @@ public class GoogleGenAiPaymentTransactionToolsIT {
 
 		Flux<String> streamContent = this.chatClient.prompt()
 			.advisors(new SimpleLoggerAdvisor())
-			.tools(new MyTools())
+			.tools(t -> t.instances(new MyTools()))
 			.user("""
 					What is the status of my payment transactions 001, 002 and 003?
 					If required invoke the function per transaction.

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -365,7 +365,12 @@ public interface ChatClient {
 
 		ChatClientRequestSpec tools(Consumer<ToolSpec> consumer);
 
-		ChatClientRequestSpec tools(Object... toolObjects);
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@code t -> t.instances(Object...)} in
+		 * {@link #tools(Consumer)}. To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		ChatClientRequestSpec tools(Object... toolInstances);
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)}. To be removed in
@@ -426,22 +431,68 @@ public interface ChatClient {
 
 	}
 
+	/**
+	 * Specification for configuring tools on a {@link ChatClient} request or default
+	 * builder. Combining tool instances, callbacks, context, and a custom advisor in a
+	 * single consumer lambda.
+	 */
 	interface ToolSpec {
 
-		ToolSpec instances(Object... toolObjects);
+		/**
+		 * Register objects whose {@link org.springframework.ai.tool.annotation.Tool
+		 * @Tool}-annotated methods are exposed as tools.
+		 * @param toolInstances one or more objects with {@code @Tool}-annotated methods;
+		 * must not contain {@link ToolCallback} or {@link ToolCallbackProvider} instances
+		 */
+		ToolSpec instances(Object... toolInstances);
 
-		ToolSpec instances(List<Object> toolObjects);
+		/**
+		 * Register objects whose {@link org.springframework.ai.tool.annotation.Tool
+		 * @Tool}-annotated methods are exposed as tools.
+		 * @param toolInstances list of objects with {@code @Tool}-annotated methods; must
+		 * not contain {@link ToolCallback} or {@link ToolCallbackProvider} instances
+		 */
+		ToolSpec instances(List<Object> toolInstances);
 
+		/**
+		 * Register pre-built {@link ToolCallback} instances directly.
+		 * @param toolCallbacks one or more tool callbacks
+		 */
 		ToolSpec callbacks(ToolCallback... toolCallbacks);
 
+		/**
+		 * Register pre-built {@link ToolCallback} instances directly.
+		 * @param toolCallbacks list of tool callbacks
+		 */
 		ToolSpec callbacks(List<ToolCallback> toolCallbacks);
 
+		/**
+		 * Register a {@link ToolCallbackProvider} whose callbacks are resolved lazily at
+		 * call time.
+		 * @param toolCallbackProvider one or more providers
+		 */
 		ToolSpec callbacks(ToolCallbackProvider... toolCallbackProvider);
 
+		/**
+		 * Supply additional context entries made available to tools during execution via
+		 * {@link org.springframework.ai.tool.execution.ToolExecutionContext}.
+		 * @param toolContext map of context key-value pairs
+		 */
 		ToolSpec context(Map<String, Object> toolContext);
 
+		/**
+		 * Supply a single context entry made available to tools during execution.
+		 * @param key context key
+		 * @param value context value
+		 */
 		ToolSpec context(String key, Object value);
 
+		/**
+		 * Use a custom {@link ToolAdvisor} to handle tool execution for this request.
+		 * Suppresses the auto-registration of the default
+		 * {@link org.springframework.ai.chat.client.advisor.ToolCallAdvisor}.
+		 * @param toolAdvisor the advisor to use
+		 */
 		ToolSpec advisor(ToolAdvisor toolAdvisor);
 
 	}
@@ -479,7 +530,12 @@ public interface ChatClient {
 
 		Builder defaultTools(Consumer<ToolSpec> consumer);
 
-		Builder defaultTools(Object... toolObjects);
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@code t -> t.instances(Object...)} in
+		 * {@link #defaultTools(Consumer)}. To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		Builder defaultTools(Object... toolInstances);
 
 		/**
 		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +103,30 @@ public class DefaultChatClient implements ChatClient {
 	private static final ChatClientMessageAggregator CHAT_CLIENT_MESSAGE_AGGREGATOR = new ChatClientMessageAggregator();
 
 	private final DefaultChatClientRequestSpec defaultChatClientRequest;
+
+	static void assertNoToolCallbackInstances(Object... toolObjects) {
+		for (Object obj : toolObjects) {
+			if (obj instanceof ToolCallback) {
+				throw new IllegalArgumentException(
+						"ToolCallback instances are not accepted here. Use toolCallbacks(ToolCallback...) or tools(t -> t.callbacks(...)) instead.");
+			}
+			if (obj instanceof ToolCallbackProvider) {
+				throw new IllegalArgumentException(
+						"ToolCallbackProvider instances are not accepted here. Use toolCallbacks(ToolCallbackProvider...) or tools(t -> t.callbacks(...)) instead.");
+			}
+			if (obj instanceof Collection<?> col) {
+				for (Object element : col) {
+					if (element instanceof ToolCallback || element instanceof ToolCallbackProvider) {
+						throw new IllegalArgumentException(
+								"Collections containing ToolCallback or ToolCallbackProvider instances are not accepted here. Use toolCallbacks() or tools(t -> t.callbacks(...)) instead.");
+					}
+				}
+			}
+			if (obj instanceof Object[] arr) {
+				assertNoToolCallbackInstances(arr);
+			}
+		}
+	}
 
 	public DefaultChatClient(DefaultChatClientRequestSpec defaultChatClientRequest) {
 		Assert.notNull(defaultChatClientRequest, "defaultChatClientRequest cannot be null");
@@ -802,6 +827,7 @@ public class DefaultChatClient implements ChatClient {
 		public ToolSpec instances(Object... toolObjects) {
 			Assert.notNull(toolObjects, "toolObjects cannot be null");
 			Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
+			assertNoToolCallbackInstances(toolObjects);
 			this.toolCallbacks.addAll(Arrays.asList(ToolCallbacks.from(toolObjects)));
 			return this;
 		}
@@ -810,6 +836,7 @@ public class DefaultChatClient implements ChatClient {
 		public ToolSpec instances(List<Object> toolObjects) {
 			Assert.notNull(toolObjects, "toolObjects cannot be null");
 			Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
+			assertNoToolCallbackInstances(toolObjects.toArray());
 			this.toolCallbacks.addAll(Arrays.asList(ToolCallbacks.from(toolObjects.toArray(new Object[0]))));
 			return this;
 		}
@@ -1166,6 +1193,7 @@ public class DefaultChatClient implements ChatClient {
 		public ChatClientRequestSpec tools(Object... toolObjects) {
 			Assert.notNull(toolObjects, "toolObjects cannot be null");
 			Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
+			assertNoToolCallbackInstances(toolObjects);
 			this.toolCallbacks.addAll(Arrays.asList(ToolCallbacks.from(toolObjects)));
 			return this;
 		}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -2111,6 +2111,67 @@ class DefaultChatClientTests {
 	}
 
 	@Test
+	void whenToolObjectsContainsToolCallbackThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolCallback toolCallback = mock(ToolCallback.class);
+		assertThatThrownBy(() -> chatClient.prompt().tools(toolCallback)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("ToolCallback instances are not accepted here");
+	}
+
+	@Test
+	void whenToolObjectsContainsToolCallbackProviderThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolCallbackProvider provider = mock(ToolCallbackProvider.class);
+		assertThatThrownBy(() -> chatClient.prompt().tools(provider)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("ToolCallbackProvider instances are not accepted here");
+	}
+
+	@Test
+	void whenToolObjectsContainsCollectionWithToolCallbackThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolCallback toolCallback = mock(ToolCallback.class);
+		assertThatThrownBy(() -> chatClient.prompt().tools(List.of(toolCallback)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Collections containing ToolCallback or ToolCallbackProvider");
+	}
+
+	@Test
+	void whenToolObjectsContainsArrayWithToolCallbackThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolCallback toolCallback = mock(ToolCallback.class);
+		assertThatThrownBy(() -> chatClient.prompt().tools(new Object[] { new ToolCallback[] { toolCallback } }))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("ToolCallback instances are not accepted here");
+	}
+
+	@Test
+	void whenToolSpecInstancesContainsToolCallbackThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolCallback toolCallback = mock(ToolCallback.class);
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.instances(toolCallback)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("ToolCallback instances are not accepted here");
+	}
+
+	@Test
+	void whenToolSpecInstancesContainsToolCallbackProviderThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolCallbackProvider provider = mock(ToolCallbackProvider.class);
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.instances(provider)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("ToolCallbackProvider instances are not accepted here");
+	}
+
+	@Test
+	void whenToolSpecInstancesListContainsToolCallbackThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolCallback toolCallback = mock(ToolCallback.class);
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.instances(List.of(toolCallback))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("ToolCallback instances are not accepted here");
+	}
+
+	@Test
 	void whenSystemTextIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -816,7 +816,7 @@ public class WeatherService {
 
 String response = ChatClient.create(this.chatModel)
         .prompt("What's the weather like in Boston?")
-        .tools(new WeatherService())
+        .tools(t -> t.instances(new WeatherService()))
         .call()
         .content();
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
@@ -176,7 +176,7 @@ public class WeatherService {
 
 String response = ChatClient.create(this.chatModel)
         .prompt("What's the weather like in Boston?")
-        .tools(new WeatherService())
+        .tools(t -> t.instances(new WeatherService()))
         .call()
         .content();
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -850,7 +850,7 @@ This means you do not need to add a `ToolCallAdvisor` manually for the common ca
 String response = ChatClient.builder(chatModel)
     .build()
     .prompt("What day is tomorrow?")
-    .tools(new DateTimeTools())   // ToolCallAdvisor is auto-registered here
+    .tools(t -> t.instances(new DateTimeTools()))   // ToolCallAdvisor is auto-registered here
     .call()
     .content();
 ----
@@ -864,7 +864,7 @@ You can disable the auto-registration per call using `AdvisorParams.toolCallAdvi
 [source,java]
 ----
 chatClient.prompt("What day is tomorrow?")
-    .tools(new DateTimeTools())
+    .tools(t -> t.instances(new DateTimeTools()))
     .advisors(AdvisorParams.toolCallAdvisorAutoRegister(false))
     .call()
     .content();
@@ -893,7 +893,7 @@ Alternatively, you can pass the advisor separately via `.advisors()`:
 [source,java]
 ----
 chatClient.prompt("What day is tomorrow?")
-    .tools(new DateTimeTools())
+    .tools(t -> t.instances(new DateTimeTools()))
     .advisors(customAdvisor)    // auto-registration suppressed
     .call()
     .content();
@@ -958,7 +958,7 @@ ChatClient chatClient = ChatClient
 
 // Every prompt that registers tools will use customManager in the auto-registered advisor
 chatClient.prompt("What day is tomorrow?")
-    .tools(new DateTimeTools())
+    .tools(t -> t.instances(new DateTimeTools()))
     .call()
     .content();
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools-migration.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools-migration.adoc
@@ -133,7 +133,7 @@ Or with the declarative approach:
 String response = ChatClient.create(chatModel)
     .prompt()
     .user("What's the weather like in San Francisco?")
-    .tools(new WeatherTools())
+    .tools(t -> t.instances(new WeatherTools()))
     .call()
     .content();
 ----
@@ -255,7 +255,7 @@ class Home {
 
 String response = ChatClient.create(this.chatModel).prompt()
         .user("Turn the light in the living room On.")
-        .tools(new Home())
+        .tools(t -> t.instances(new Home()))
         .call()
         .content();
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -50,7 +50,7 @@ ChatModel chatModel = ...
 
 String response = ChatClient.create(chatModel)
         .prompt("What day is tomorrow?")
-        .tools(new DateTimeTools())
+        .tools(t -> t.instances(new DateTimeTools()))
         .call()
         .content();
 
@@ -112,7 +112,7 @@ ChatModel chatModel = ...
 
 String response = ChatClient.create(chatModel)
         .prompt("Can you set an alarm 10 minutes from now?")
-        .tools(new DateTimeTools())
+        .tools(t -> t.instances(new DateTimeTools()))
         .call()
         .content();
 
@@ -221,7 +221,7 @@ When using the declarative specification approach, you can pass the tool class i
 ----
 ChatClient.create(chatModel)
     .prompt("What day is tomorrow?")
-    .tools(new DateTimeTools())
+    .tools(t -> t.instances(new DateTimeTools()))
     .call()
     .content();
 ----
@@ -244,7 +244,7 @@ WARNING: Default tools are shared across all the chat requests performed by all 
 ----
 ChatModel chatModel = ...
 ChatClient chatClient = ChatClient.builder(chatModel)
-    .defaultTools(new DateTimeTools())
+    .defaultTools(t -> t.instances(new DateTimeTools()))
     .build();
 ----
 
@@ -1140,7 +1140,7 @@ var chatClient = ChatClient.builder(chatModel)
     .build();
 
 String response = chatClient.prompt("What day is tomorrow?")
-    .tools(new DateTimeTools())
+    .tools(t -> t.instances(new DateTimeTools()))
     .call()
     .content();
 ----
@@ -1515,7 +1515,7 @@ var smartToolRetrieverAdvisor = ToolSearchToolCallingAdvisor.builder()
 
 // 3. Use with ChatClient — tools are registered but NOT sent to the LLM initially
 ChatClient chatClient = ChatClient.builder(chatModel)
-    .defaultTools(new MyTools())
+    .defaultTools(t -> t.instances(new MyTools()))
     .defaultAdvisors(smartToolRetrieverAdvisor)
     .build();
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/guides/llm-as-judge.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/guides/llm-as-judge.adoc
@@ -229,7 +229,7 @@ public class EvaluationAdvisorDemoApplication {
         return args -> {
 
             ChatClient chatClient = ChatClient.builder(anthropicChatModel)
-                    .defaultTools(new MyTools())
+                    .defaultTools(t -> t.instances(new MyTools()))
                     .defaultAdvisors(
 
                         SelfRefineEvaluationAdvisor.builder()

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -269,6 +269,96 @@ import org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails
 import org.springframework.ai.google.genai.embedding.GoogleGenAiEmbeddingConnectionDetails;
 ----
 
+=== ChatClient Tool API Changes
+
+==== Deprecated: `tools(Object...)` and `defaultTools(Object...)`
+
+`ChatClientRequestSpec.tools(Object... toolInstances)` and `ChatClient.Builder.defaultTools(Object... toolInstances)` are deprecated for removal in 3.0.0.
+The replacement is the `Consumer<ToolSpec>` form, which gives access to the full tool configuration including instances, callbacks, context, and a custom advisor — all in one place.
+
+===== Impact
+
+Code that calls `.tools(myBean)` or `.defaultTools(myBean)` will produce deprecation warnings at compile time.
+
+===== Migration
+
+[source,java]
+----
+// Before
+chatClient.prompt("What day is tomorrow?")
+    .tools(new DateTimeTools())
+    .call().content();
+
+ChatClient.builder(chatModel)
+    .defaultTools(new DateTimeTools())
+    .build();
+
+// After
+chatClient.prompt("What day is tomorrow?")
+    .tools(t -> t.instances(new DateTimeTools()))
+    .call().content();
+
+ChatClient.builder(chatModel)
+    .defaultTools(t -> t.instances(new DateTimeTools()))
+    .build();
+----
+
+==== New: Runtime Guard Against Wrong Types in `tools(Object...)` and `ToolSpec.instances()`
+
+Passing a `ToolCallback` or `ToolCallbackProvider` instance — or a `Collection` or array containing them — to `tools(Object...)` or `ToolSpec.instances()` now throws `IllegalArgumentException` immediately.
+Previously this would fail deep inside `MethodToolCallbackProvider` with a confusing `IllegalStateException` after an unnecessary reflection scan.
+
+===== Impact
+
+Code that accidentally passes a `ToolCallback` or `ToolCallbackProvider` to these methods will now fail fast at the call site rather than later during callback resolution.
+
+===== Migration
+
+Use the dedicated `callbacks()` method on `ToolSpec` or the `toolCallbacks()` method directly:
+
+[source,java]
+----
+// Before — accidentally passed a ToolCallback to tools()
+ToolCallback cb = FunctionToolCallback.builder("name", fn).build();
+chatClient.prompt("...").tools(cb); // silently failed or confusing error
+
+// After — use the correct method
+chatClient.prompt("...")
+    .tools(t -> t.callbacks(cb))
+    .call().content();
+
+// Or for a ToolCallbackProvider
+chatClient.prompt("...")
+    .tools(t -> t.callbacks(myToolCallbackProvider))
+    .call().content();
+----
+
+==== Changed: `MethodToolCallbackProvider` Exception Type
+
+`MethodToolCallbackProvider` now throws `IllegalArgumentException` (was `IllegalStateException`) when an object with no `@Tool`-annotated methods is passed to it.
+The error message also now includes the fully qualified class name to make the offending type immediately identifiable.
+
+===== Impact
+
+Code that catches `IllegalStateException` from `MethodToolCallbackProvider` will no longer catch this error.
+
+===== Migration
+
+Update any catch clauses from `IllegalStateException` to `IllegalArgumentException`, or catch `IllegalArgumentException` in addition:
+
+[source,java]
+----
+// Before
+try {
+    MethodToolCallbackProvider.builder().toolObjects(myBean).build();
+} catch (IllegalStateException e) { ... }
+
+// After
+try {
+    MethodToolCallbackProvider.builder().toolObjects(myBean).build();
+} catch (IllegalArgumentException e) { ... }
+----
+
 [[upgrading-to-2-0-0-M7]]
 == Upgrading to 2.0.0-M7
 
@@ -290,18 +380,18 @@ Remove the explicit `ToolCallAdvisor` from the chain and let auto-registration h
 ----
 // Before — manual registration
 chatClient.prompt("What's the weather?")
-    .tools(weatherTool)
+    .tools(t -> t.instances(weatherTool))
     .advisors(ToolCallAdvisor.builder().build())
     .call().content();
 
 // After — auto-registration handles it; no explicit advisor needed
 chatClient.prompt("What's the weather?")
-    .tools(weatherTool)
+    .tools(t -> t.instances(weatherTool))
     .call().content();
 
 // Or, to keep full control, disable auto-registration explicitly
 chatClient.prompt("What's the weather?")
-    .tools(weatherTool)
+    .tools(t -> t.instances(weatherTool))
     .advisors(
         AdvisorParams.toolCallAdvisorAutoRegister(false),
         ToolCallAdvisor.builder().build()

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/tool/MethodToolCallbackTests.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/tool/MethodToolCallbackTests.java
@@ -59,7 +59,7 @@ public class MethodToolCallbackTests {
 			.build()
 			.prompt()
 			.user("Welcome the user to the library")
-			.tools(this.tools)
+			.tools(t -> t.instances(this.tools))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty();
@@ -71,7 +71,7 @@ public class MethodToolCallbackTests {
 			.build()
 			.prompt()
 			.user("Welcome %s to the library".formatted("James Bond"))
-			.tools(this.tools)
+			.tools(t -> t.instances(this.tools))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty();
@@ -83,7 +83,7 @@ public class MethodToolCallbackTests {
 			.build()
 			.prompt()
 			.user("What books written by %s are available in the library?".formatted("J.R.R. Tolkien"))
-			.tools(this.tools)
+			.tools(t -> t.instances(this.tools))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty()
@@ -99,7 +99,7 @@ public class MethodToolCallbackTests {
 			.prompt()
 			.user("What authors wrote the books %s and %s available in the library?".formatted("The Hobbit",
 					"The Lion, the Witch and the Wardrobe"))
-			.tools(this.tools)
+			.tools(t -> t.instances(this.tools))
 			.call()
 			.content();
 		assertThat(content).isNotEmpty().contains("J.R.R. Tolkien").contains("C.S. Lewis");
@@ -121,7 +121,7 @@ public class MethodToolCallbackTests {
 	@Test
 	void chatMethodCallbackDefault() {
 		var content = ChatClient.builder(this.openAiChatModel)
-			.defaultTools(this.tools)
+			.defaultTools(t -> t.instances(this.tools))
 			.build()
 			.prompt()
 			.user("How many books written by %s are available in the library?".formatted("J.R.R. Tolkien"))

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
@@ -59,6 +59,7 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 	private MethodToolCallbackProvider(List<Object> toolObjects) {
 		Assert.notNull(toolObjects, "toolObjects cannot be null");
 		Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
+		Assert.notEmpty(toolObjects, "toolObjects cannot be empty");
 		assertToolAnnotatedMethodsPresent(toolObjects);
 		this.toolObjects = toolObjects;
 		validateToolCallbacks(getToolCallbacks());
@@ -75,9 +76,11 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 				.toList();
 
 			if (toolMethods.isEmpty()) {
-				throw new IllegalStateException("No @Tool annotated methods found in " + toolObject + ". "
-						+ "Did you mean to pass a ToolCallback or ToolCallbackProvider? If so, you have to use"
-						+ " .tools(toolSpec -> toolSpec.callbacks(...)) instead of .tools(...)");
+				throw new IllegalArgumentException("No @Tool annotated methods found in class '%s'. "
+					.formatted(toolObject.getClass().getName())
+						+ "Each object passed to tools() or ToolSpec.instances() must declare at least one @Tool annotated method. "
+						+ "To register a ToolCallback or ToolCallbackProvider directly, "
+						+ "use toolCallbacks() or tools(t -> t.callbacks(...)) instead.");
 			}
 		}
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
@@ -60,16 +60,18 @@ class MethodToolCallbackProviderTests {
 	void whenToolObjectHasNoToolAnnotatedMethodThenThrow() {
 		assertThatThrownBy(
 				() -> MethodToolCallbackProvider.builder().toolObjects(new NoToolAnnotatedMethodObject()).build())
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessageContaining("No @Tool annotated methods found in");
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("No @Tool annotated methods found in class")
+			.hasMessageContaining(NoToolAnnotatedMethodObject.class.getName());
 	}
 
 	@Test
 	void whenToolObjectHasOnlyFunctionalTypeToolMethodsThenThrow() {
 		assertThatThrownBy(() -> MethodToolCallbackProvider.builder()
 			.toolObjects(new OnlyFunctionalTypeToolMethodsObject())
-			.build()).isInstanceOf(IllegalStateException.class)
-			.hasMessageContaining("No @Tool annotated methods found in");
+			.build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("No @Tool annotated methods found in class")
+			.hasMessageContaining(OnlyFunctionalTypeToolMethodsObject.class.getName());
 	}
 
 	@Test


### PR DESCRIPTION
- Deprecate ChatClientRequestSpec.tools(Object...) and Builder.defaultTools(Object...) in favour of the Consumer<ToolSpec> form: tools(t -> t.instances(...))
- Add assertNoToolCallbackInstances() guard in DefaultChatClient that throws IllegalArgumentException early when a ToolCallback, ToolCallbackProvider, or a Collection/array containing them is passed to tools(Object...) or ToolSpec.instances(), replacing a confusing delayed failure deep in MethodToolCallbackProvider
- Change MethodToolCallbackProvider.assertToolAnnotatedMethodsPresent() to throw IllegalArgumentException (was IllegalStateException) and include the fully qualified class name in the message
- Add seven unit tests in DefaultChatClientTests covering the new guard
- Update MethodToolCallbackProviderTests to match the new exception type and message
- Migrate all deprecated tools(Object...) call sites in integration and model tests to tools(t -> t.instances(...))
- Update reference documentation (tools.adoc, chatclient.adoc, upgrade-notes.adoc, tools-migration.adoc, bedrock-converse.adoc, google-genai-chat.adoc, llm-as-judge.adoc) to use the non-deprecated form and document all breaking changes under the 2.0.0-RC1 upgrade notes
- Add Javadoc to all ChatClient.ToolSpec methods

Related to #6206
