### PR TITLE
refactor(chat-client): enforce non-null ToolCallAdvisor.Builder and fix advisor chain mutation

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -89,6 +89,32 @@ public interface ChatClient {
 				null);
 	}
 
+	/**
+	 * Creates a {@link Builder} for constructing a {@link ChatClient}.
+	 * <p>
+	 * When {@code toolCallAdvisorBuilder} is {@code null}, a default
+	 * {@link org.springframework.ai.chat.client.advisor.ToolCallAdvisor} is created with
+	 * a {@link org.springframework.ai.model.tool.ToolCallingManager} backed by the
+	 * supplied {@code observationRegistry}.
+	 * <p>
+	 * When {@code toolCallAdvisorBuilder} is non-null it is used as-is. The caller is
+	 * then responsible for configuring the builder's
+	 * {@link org.springframework.ai.model.tool.ToolCallingManager}, including any
+	 * {@link io.micrometer.observation.ObservationRegistry}, since the supplied
+	 * {@code observationRegistry} will not be automatically applied to it.
+	 * @param chatModel the chat model to use
+	 * @param observationRegistry the observation registry for client-level observations;
+	 * also used to configure the default {@code ToolCallingManager} when
+	 * {@code toolCallAdvisorBuilder} is {@code null}
+	 * @param chatClientObservationConvention optional custom observation convention for
+	 * the chat client
+	 * @param advisorObservationConvention optional custom observation convention for
+	 * advisors
+	 * @param toolCallAdvisorBuilder optional builder for the
+	 * {@link org.springframework.ai.chat.client.advisor.ToolCallAdvisor}; when
+	 * {@code null} a default is created
+	 * @return a new {@link Builder}
+	 */
 	static Builder builder(ChatModel chatModel, ObservationRegistry observationRegistry,
 			@Nullable ChatClientObservationConvention chatClientObservationConvention,
 			@Nullable AdvisorObservationConvention advisorObservationConvention,

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -912,23 +911,6 @@ public class DefaultChatClient implements ChatClient {
 					ccr.advisorObservationConvention, ccr.toolCallAdvisorBuilder);
 		}
 
-		@Deprecated(since = "2.0.0", forRemoval = true)
-		public DefaultChatClientRequestSpec(ChatModel chatModel, @Nullable String userText,
-				Map<String, Object> userParams, Map<String, Object> userMetadata, @Nullable String systemText,
-				Map<String, Object> systemParams, Map<String, Object> systemMetadata, List<ToolCallback> toolCallbacks,
-				List<ToolCallbackProvider> toolCallbackProviders, List<Message> messages, List<String> toolNames,
-				List<Media> media, ChatOptions.@Nullable Builder<?> customizer, List<Advisor> advisors,
-				Map<String, Object> advisorParams, ObservationRegistry observationRegistry,
-				@Nullable ChatClientObservationConvention chatClientObservationConvention,
-				Map<String, Object> toolContext, @Nullable TemplateRenderer templateRenderer,
-				@Nullable AdvisorObservationConvention advisorObservationConvention) {
-
-			this(chatModel, userText, userParams, userMetadata, systemText, systemParams, systemMetadata, toolCallbacks,
-					toolCallbackProviders, messages, toolNames, media, customizer, advisors, advisorParams,
-					observationRegistry, chatClientObservationConvention, toolContext, templateRenderer,
-					advisorObservationConvention, null);
-		}
-
 		public DefaultChatClientRequestSpec(ChatModel chatModel, @Nullable String userText,
 				Map<String, Object> userParams, Map<String, Object> userMetadata, @Nullable String systemText,
 				Map<String, Object> systemParams, Map<String, Object> systemMetadata, List<ToolCallback> toolCallbacks,
@@ -938,7 +920,7 @@ public class DefaultChatClient implements ChatClient {
 				@Nullable ChatClientObservationConvention chatClientObservationConvention,
 				Map<String, Object> toolContext, @Nullable TemplateRenderer templateRenderer,
 				@Nullable AdvisorObservationConvention advisorObservationConvention,
-				ToolCallAdvisor.@Nullable Builder<?> toolCallAdvisorBuilder) {
+				ToolCallAdvisor.Builder<?> toolCallAdvisorBuilder) {
 
 			Assert.notNull(chatModel, "chatModel cannot be null");
 			Assert.notNull(userParams, "userParams cannot be null");
@@ -954,9 +936,10 @@ public class DefaultChatClient implements ChatClient {
 			Assert.notNull(advisorParams, "advisorParams cannot be null");
 			Assert.notNull(observationRegistry, "observationRegistry cannot be null");
 			Assert.notNull(toolContext, "toolContext cannot be null");
+			Assert.notNull(toolCallAdvisorBuilder, "toolCallAdvisorBuilder cannot be null");
 
 			this.chatModel = chatModel;
-			this.toolCallAdvisorBuilder = Objects.requireNonNullElse(toolCallAdvisorBuilder, ToolCallAdvisor.builder());
+			this.toolCallAdvisorBuilder = toolCallAdvisorBuilder;
 			this.optionsCustomizer = customizer != null ? customizer.clone() : null;
 
 			this.userText = userText;
@@ -1299,12 +1282,13 @@ public class DefaultChatClient implements ChatClient {
 
 			// At the stack bottom add the model call advisors.
 			// They play the role of the last advisors in the advisor chain.
-			this.advisors.add(ChatModelCallAdvisor.builder().chatModel(this.chatModel).build());
-			this.advisors.add(ChatModelStreamAdvisor.builder().chatModel(this.chatModel).build());
+			List<Advisor> chain = new ArrayList<>(this.advisors);
+			chain.add(ChatModelCallAdvisor.builder().chatModel(this.chatModel).build());
+			chain.add(ChatModelStreamAdvisor.builder().chatModel(this.chatModel).build());
 
 			return DefaultAroundAdvisorChain.builder(this.observationRegistry)
 				.observationConvention(this.advisorObservationConvention)
-				.pushAll(this.advisors)
+				.pushAll(chain)
 				.build();
 		}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import io.micrometer.observation.ObservationRegistry;
@@ -37,6 +38,7 @@ import org.springframework.ai.chat.client.observation.ChatClientObservationConve
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.template.TemplateRenderer;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -70,12 +72,38 @@ public class DefaultChatClientBuilder implements Builder {
 		this(chatModel, observationRegistry, chatClientObservationConvention, advisorObservationConvention, null);
 	}
 
+	/**
+	 * Creates a new {@link DefaultChatClientBuilder}.
+	 * <p>
+	 * When {@code toolCallAdvisorBuilder} is {@code null}, a default
+	 * {@link org.springframework.ai.chat.client.advisor.ToolCallAdvisor} is created with
+	 * a {@link ToolCallingManager} backed by the supplied {@code observationRegistry}.
+	 * <p>
+	 * When {@code toolCallAdvisorBuilder} is non-null it is used as-is. The caller is
+	 * then responsible for configuring the builder's {@link ToolCallingManager},
+	 * including any {@link io.micrometer.observation.ObservationRegistry}, since the
+	 * supplied {@code observationRegistry} will not be automatically applied to it.
+	 * @param chatModel the chat model to use
+	 * @param observationRegistry the observation registry for client-level observations;
+	 * also used to configure the default {@code ToolCallingManager} when
+	 * {@code toolCallAdvisorBuilder} is {@code null}
+	 * @param chatClientObservationConvention optional custom observation convention for
+	 * the chat client
+	 * @param advisorObservationConvention optional custom observation convention for
+	 * advisors
+	 * @param toolCallAdvisorBuilder optional builder for the
+	 * {@link org.springframework.ai.chat.client.advisor.ToolCallAdvisor}; when
+	 * {@code null} a default is created
+	 */
 	public DefaultChatClientBuilder(ChatModel chatModel, ObservationRegistry observationRegistry,
 			@Nullable ChatClientObservationConvention chatClientObservationConvention,
 			@Nullable AdvisorObservationConvention advisorObservationConvention,
 			ToolCallAdvisor.@Nullable Builder<?> toolCallAdvisorBuilder) {
 		Assert.notNull(chatModel, "the " + ChatModel.class.getName() + " must be non-null");
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
+
+		toolCallAdvisorBuilder = Objects.requireNonNullElse(toolCallAdvisorBuilder, ToolCallAdvisor.builder()
+			.toolCallingManager(ToolCallingManager.builder().observationRegistry(observationRegistry).build()));
 
 		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), Map.of(), null, Map.of(),
 				Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1598,7 +1598,8 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mockChatModel();
 		DefaultChatClient.DefaultChatClientRequestSpec spec = new DefaultChatClient.DefaultChatClientRequestSpec(
 				chatModel, null, Map.of(), Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(),
-				List.of(), List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null);
+				List.of(), List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null,
+				ToolCallAdvisor.builder());
 		assertThat(spec).isNotNull();
 	}
 
@@ -1606,7 +1607,7 @@ class DefaultChatClientTests {
 	void whenChatModelIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(null, null, Map.of(), Map.of(),
 				null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(),
-				Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null))
+				Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null, ToolCallAdvisor.builder()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("chatModel cannot be null");
 	}
@@ -1615,9 +1616,42 @@ class DefaultChatClientTests {
 	void whenObservationRegistryIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(mockChatModel(), null, Map.of(),
 				Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null,
-				List.of(), Map.of(), null, null, Map.of(), null, null))
+				List.of(), Map.of(), null, null, Map.of(), null, null, ToolCallAdvisor.builder()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("observationRegistry cannot be null");
+	}
+
+	@Test
+	void whenToolCallAdvisorBuilderIsNullThenThrow() {
+		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(mockChatModel(), null, Map.of(),
+				Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null,
+				List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("toolCallAdvisorBuilder cannot be null");
+	}
+
+	@Test
+	void whenNullToolCallAdvisorBuilderThenObservationRegistryWiredIntoToolCallingManager() {
+		var registry = TestObservationRegistry.create();
+		var spec = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.builder(mockChatModel(), registry, null, null, null)
+			.build()
+			.prompt();
+		var advisorBuilder = ReflectionTestUtils.getField(spec, "toolCallAdvisorBuilder");
+		var manager = ReflectionTestUtils.getField(advisorBuilder, "toolCallingManager");
+		assertThat(ReflectionTestUtils.getField(manager, "observationRegistry")).isSameAs(registry);
+	}
+
+	@Test
+	void buildAdvisorChainIsIdempotentOnRepeatedCall() {
+		ChatModel chatModel = mockChatModel();
+		ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+		given(chatModel.call(captor.capture()))
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("response")))));
+		var spec = ChatClient.builder(chatModel).build().prompt().user("hello");
+		spec.call().content();
+		spec.call().content();
+		assertThat(captor.getAllValues()).hasSize(2);
 	}
 
 	@Test


### PR DESCRIPTION
- Make toolCallAdvisorBuilder non-nullable in DefaultChatClientRequestSpec; move null-defaulting responsibility up to DefaultChatClientBuilder where the observationRegistry is available to wire into the default ToolCallingManager
- Fix buildAdvisorChain() mutating this.advisors by appending terminal advisors (ChatModelCallAdvisor, ChatModelStreamAdvisor) on every call(); they are now added only to a local chain snapshot, making repeated invocations idempotent
- Document that a caller-supplied (non-null) toolCallAdvisorBuilder is used as-is and the caller is responsible for configuring its ToolCallingManager, including any ObservationRegistry
- Add tests
