### PR TITLE
Remove `ToolSpec` consumer API from `ChatClient`

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsWithLLMIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsWithLLMIT.java
@@ -150,8 +150,8 @@ public class StreamableMcpAnnotationsWithLLMIT {
 
 						assertThat(builder).isNotNull();
 
-						ChatClient chatClient = builder
-							.defaultTools(t -> t.callbacks(tcp).context(Map.of("progressToken", "test-progress-token")))
+						ChatClient chatClient = builder.defaultTools(tcp)
+							.defaultToolContext(Map.of("progressToken", "test-progress-token"))
 							.build();
 
 						String cResponse = chatClient.prompt()

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMethodInvokingFunctionCallbackIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMethodInvokingFunctionCallbackIT.java
@@ -146,14 +146,14 @@ class OpenAiChatClientMethodInvokingFunctionCallbackIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris?  Use Celsius.")
-				.tools(t -> t.callbacks(MethodToolCallback.builder()
+				.tools(MethodToolCallback.builder()
 								.toolDefinition(ToolDefinitions.builder(toolMethod)
 									.description("Get the weather in location")
 									.build())
 								.toolMethod(toolMethod)
 								.toolObject(targetObject)
 								.build())
-							.context(Map.of("tool", "value")))
+				.toolContext(Map.of("tool", "value"))
 				.call()
 				.content();
 		// @formatter:on

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
@@ -158,10 +158,11 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", biFunction)
+				.defaultTools(FunctionToolCallback.builder("getCurrentWeather", biFunction)
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build()).context(Map.of("sessionId", "123")))
+					.build())
+				.defaultToolContext(Map.of("sessionId", "123"))
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities."))
 			.build()
 			.prompt().call().content();
@@ -200,10 +201,11 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultTools(t -> t.callbacks(FunctionToolCallback.builder("getCurrentWeather", biFunction)
+				.defaultTools(FunctionToolCallback.builder("getCurrentWeather", biFunction)
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
-					.build()).context(Map.of("sessionId", "123")))
+					.build())
+				.defaultToolContext(Map.of("sessionId", "123"))
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Please use the provided tools to get the weather for all 3 cities."))
 				.build()
 			.prompt()

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -29,7 +29,6 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
-import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
 import org.springframework.ai.chat.client.observation.ChatClientObservationConvention;
 import org.springframework.ai.chat.messages.Message;
@@ -389,43 +388,76 @@ public interface ChatClient {
 
 		<B extends ChatOptions.Builder<?>> ChatClientRequestSpec options(B customizer);
 
-		ChatClientRequestSpec tools(Consumer<ToolSpec> consumer);
-
-		ChatClientRequestSpec tools(Object... toolObjects);
+		/**
+		 * Register one or more tools for this chat request. The method accepts a
+		 * heterogeneous mix of tool representations and routes each element to the
+		 * appropriate internal list automatically:
+		 *
+		 * <ul>
+		 * <li>{@link org.springframework.ai.tool.ToolCallback} — registered directly as a
+		 * callback.</li>
+		 * <li>{@link org.springframework.ai.tool.ToolCallbackProvider} — registered
+		 * directly as a provider; its callbacks are resolved lazily at request time.</li>
+		 * <li>{@code ToolCallback[]} or {@code ToolCallbackProvider[]} — every element of
+		 * the array is registered as above.</li>
+		 * <li>{@link java.util.Collection} — iterated and each element is dispatched by
+		 * the same rules.</li>
+		 * <li>Any other object — treated as a {@code @Tool}-annotated POJO; a
+		 * {@link org.springframework.ai.tool.ToolCallback} is generated for each
+		 * {@link org.springframework.ai.tool.annotation.Tool}-annotated method it
+		 * contains.</li>
+		 * </ul>
+		 *
+		 * <p>
+		 * Mixed calls are fully supported:
+		 *
+		 * <pre>{@code
+		 * chatClient.prompt()
+		 *     .tools(new DateTimeTools(), existingCallback, myProvider)
+		 *     .toolContext(Map.of("tenantId", "acme"))
+		 *     .call().content();
+		 * }</pre>
+		 *
+		 * <p>
+		 * Tools registered here are available only for this specific request. Use
+		 * {@link Builder#defaultTools(Object...)} to register tools that apply to every
+		 * request built from the same {@link Builder}.
+		 * @param tools tool objects to register; must not be {@code null} and must not
+		 * contain {@code null} elements
+		 * @return this spec for chaining
+		 * @throws IllegalArgumentException if {@code tools} is {@code null}, contains
+		 * {@code null} elements, or if a POJO argument has no
+		 * {@link org.springframework.ai.tool.annotation.Tool}-annotated methods
+		 */
+		ChatClientRequestSpec tools(Object... tools);
 
 		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)}. To be removed in
-		 * 3.0.0.
+		 * @deprecated as of 2.0.0
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolNames(String... toolNames);
 
 		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
-		 * {@link #tools(Consumer<ToolSpec>)} To be removed in 3.0.0.
+		 * @deprecated as of 2.0.0, in favor of {@link #tools(Object...)}. To be removed
+		 * in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolCallbacks(ToolCallback... toolCallbacks);
 
 		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
-		 * {@link #tools(Consumer<ToolSpec>)} To be removed in 3.0.0.
+		 * @deprecated as of 2.0.0, in favor of {@link #tools(Object...)}. To be removed
+		 * in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolCallbacks(List<ToolCallback> toolCallbacks);
 
 		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
-		 * {@link #tools(Consumer<ToolSpec>)} To be removed in 3.0.0.
+		 * @deprecated as of 2.0.0, in favor of {@link #tools(Object...)}. To be removed
+		 * in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolCallbacks(ToolCallbackProvider... toolCallbackProviders);
 
-		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
-		 * {@link #tools(Consumer<ToolSpec>)} To be removed in 3.0.0.
-		 */
-		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolContext(Map<String, Object> toolContext);
 
 		ChatClientRequestSpec system(String text);
@@ -449,26 +481,6 @@ public interface ChatClient {
 		CallResponseSpec call();
 
 		StreamResponseSpec stream();
-
-	}
-
-	interface ToolSpec {
-
-		ToolSpec instances(Object... toolObjects);
-
-		ToolSpec instances(List<Object> toolObjects);
-
-		ToolSpec callbacks(ToolCallback... toolCallbacks);
-
-		ToolSpec callbacks(List<ToolCallback> toolCallbacks);
-
-		ToolSpec callbacks(ToolCallbackProvider... toolCallbackProvider);
-
-		ToolSpec context(Map<String, Object> toolContext);
-
-		ToolSpec context(String key, Object value);
-
-		ToolSpec advisor(ToolAdvisor toolAdvisor);
 
 	}
 
@@ -503,43 +515,72 @@ public interface ChatClient {
 
 		Builder defaultTemplateRenderer(TemplateRenderer templateRenderer);
 
-		Builder defaultTools(Consumer<ToolSpec> consumer);
-
-		Builder defaultTools(Object... toolObjects);
+		/**
+		 * Register one or more default tools that will be available to every request
+		 * built from this {@link Builder}. The method accepts the same heterogeneous mix
+		 * of tool representations as {@link ChatClientRequestSpec#tools(Object...)} and
+		 * applies the same automatic dispatch rules:
+		 *
+		 * <ul>
+		 * <li>{@link org.springframework.ai.tool.ToolCallback} — registered directly as a
+		 * callback.</li>
+		 * <li>{@link org.springframework.ai.tool.ToolCallbackProvider} — registered
+		 * directly as a provider; its callbacks are resolved lazily at request time.</li>
+		 * <li>{@code ToolCallback[]} or {@code ToolCallbackProvider[]} — every element of
+		 * the array is registered as above.</li>
+		 * <li>{@link java.util.Collection} — iterated and each element is dispatched by
+		 * the same rules.</li>
+		 * <li>Any other object — treated as a {@code @Tool}-annotated POJO; a
+		 * {@link org.springframework.ai.tool.ToolCallback} is generated for each
+		 * {@link org.springframework.ai.tool.annotation.Tool}-annotated method it
+		 * contains.</li>
+		 * </ul>
+		 *
+		 * <p>
+		 * Default tools are shared across all requests produced by {@link ChatClient}
+		 * instances built from this builder. If a request also provides its own tools via
+		 * {@link ChatClientRequestSpec#tools(Object...)}, those runtime tools completely
+		 * override the defaults for that request.
+		 *
+		 * <p>
+		 * WARNING: Because default tools are shared, be careful not to register tools
+		 * that should only be available in specific contexts.
+		 * @param tools tool objects to register; must not be {@code null} and must not
+		 * contain {@code null} elements
+		 * @return this builder for chaining
+		 * @throws IllegalArgumentException if {@code tools} is {@code null}, contains
+		 * {@code null} elements, or if a POJO argument has no
+		 * {@link org.springframework.ai.tool.annotation.Tool}-annotated methods
+		 */
+		Builder defaultTools(Object... tools);
 
 		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be
-		 * removed in 3.0.0.
+		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolNames(String... toolNames);
 
 		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
-		 * {@link #defaultTools(Consumer<ToolSpec>)} To be removed in 3.0.0.
+		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Object...)}. To be
+		 * removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolCallbacks(ToolCallback... toolCallbacks);
 
 		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
-		 * {@link #defaultTools(Consumer<ToolSpec>)} To be removed in 3.0.0.
+		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Object...)}. To be
+		 * removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolCallbacks(List<ToolCallback> toolCallbacks);
 
 		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
-		 * {@link #defaultTools(Consumer<ToolSpec>)} To be removed in 3.0.0.
+		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Object...)}. To be
+		 * removed in 3.0.0.
 		 */
 		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolCallbacks(ToolCallbackProvider... toolCallbackProviders);
 
-		/**
-		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
-		 * {@link #defaultTools(Consumer<ToolSpec>)} To be removed in 3.0.0.
-		 */
-		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolContext(Map<String, Object> toolContext);
 
 		Builder clone();

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -767,98 +767,6 @@ public class DefaultChatClient implements ChatClient {
 
 	}
 
-	public static class DefaultToolSpec implements ToolSpec {
-
-		private final Map<String, Object> context = new HashMap<>();
-
-		private final List<ToolCallback> toolCallbacks = new ArrayList<>();
-
-		private final List<ToolCallbackProvider> toolCallbackProviders = new ArrayList<>();
-
-		private @Nullable ToolAdvisor toolAdvisor;
-
-		public Map<String, Object> getContext() {
-			return this.context;
-		}
-
-		public List<ToolCallback> getToolCallbacks() {
-			return this.toolCallbacks;
-		}
-
-		public List<ToolCallbackProvider> getToolCallbackProviders() {
-			return this.toolCallbackProviders;
-		}
-
-		public @Nullable ToolAdvisor getAdvisor() {
-			return this.toolAdvisor;
-		}
-
-		@Override
-		public ToolSpec context(String key, Object value) {
-			Assert.hasText(key, "context key cannot be null or empty");
-			Assert.notNull(value, "context value cannot be null");
-			this.context.put(key, value);
-			return this;
-		}
-
-		@Override
-		public ToolSpec context(Map<String, Object> context) {
-			Assert.notNull(context, "context cannot be null");
-			Assert.noNullElements(context.keySet(), "context keys cannot contain null elements");
-			Assert.noNullElements(context.values(), "context values cannot contain null elements");
-			this.context.putAll(context);
-			return this;
-		}
-
-		@Override
-		public ToolSpec instances(Object... toolObjects) {
-			Assert.notNull(toolObjects, "toolObjects cannot be null");
-			Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
-			this.toolCallbacks.addAll(Arrays.asList(ToolCallbacks.from(toolObjects)));
-			return this;
-		}
-
-		@Override
-		public ToolSpec instances(List<Object> toolObjects) {
-			Assert.notNull(toolObjects, "toolObjects cannot be null");
-			Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
-			this.toolCallbacks.addAll(Arrays.asList(ToolCallbacks.from(toolObjects.toArray(new Object[0]))));
-			return this;
-		}
-
-		@Override
-		public ToolSpec callbacks(ToolCallback... toolCallbacks) {
-			Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
-			Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
-			this.toolCallbacks.addAll(Arrays.asList(toolCallbacks));
-			return this;
-		}
-
-		@Override
-		public ToolSpec callbacks(List<ToolCallback> toolCallbacks) {
-			Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
-			Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
-			this.toolCallbacks.addAll(toolCallbacks);
-			return this;
-		}
-
-		@Override
-		public ToolSpec callbacks(ToolCallbackProvider... toolCallbackProvider) {
-			Assert.notNull(toolCallbackProvider, "toolCallbackProvider cannot be null");
-			Assert.noNullElements(toolCallbackProvider, "toolCallbackProvider cannot contain null elements");
-			this.toolCallbackProviders.addAll(Arrays.asList(toolCallbackProvider));
-			return this;
-		}
-
-		@Override
-		public ToolSpec advisor(ToolAdvisor toolAdvisor) {
-			Assert.notNull(toolAdvisor, "toolAdvisor cannot be null");
-			this.toolAdvisor = toolAdvisor;
-			return this;
-		}
-
-	}
-
 	public static class DefaultChatClientRequestSpec implements ChatClientRequestSpec {
 
 		private final ObservationRegistry observationRegistry;
@@ -1044,9 +952,9 @@ public class DefaultChatClient implements ChatClient {
 				.builder(this.chatModel, this.observationRegistry, this.chatClientObservationConvention,
 						this.advisorObservationConvention, this.toolCallAdvisorBuilder)
 				.defaultTemplateRenderer(this.templateRenderer)
-				.defaultTools(t -> t.callbacks(this.toolCallbacks)
-					.callbacks(this.toolCallbackProviders.toArray(new ToolCallbackProvider[0]))
-					.context(this.toolContext))
+				.defaultTools(this.toolCallbacks.toArray(new ToolCallback[0]))
+				.defaultTools((Object[]) this.toolCallbackProviders.toArray(new ToolCallbackProvider[0]))
+				.defaultToolContext(this.toolContext)
 				.defaultToolNames(StringUtils.toStringArray(this.toolNames));
 
 			if (!CollectionUtils.isEmpty(this.advisors)) {
@@ -1073,22 +981,6 @@ public class DefaultChatClient implements ChatClient {
 			builder.addMessages(this.messages);
 
 			return builder;
-		}
-
-		@Override
-		public ChatClientRequestSpec tools(Consumer<ToolSpec> consumer) {
-			Assert.notNull(consumer, "consumer cannot be null");
-			var toolSpec = new DefaultToolSpec();
-			consumer.accept(toolSpec);
-
-			this.toolContext.putAll(toolSpec.getContext());
-			this.toolCallbacks.addAll(toolSpec.getToolCallbacks());
-			this.toolCallbackProviders.addAll(toolSpec.getToolCallbackProviders());
-			if (toolSpec.getAdvisor() != null) {
-				this.advisors.add(toolSpec.getAdvisor());
-			}
-
-			return this;
 		}
 
 		@Override
@@ -1150,12 +1042,12 @@ public class DefaultChatClient implements ChatClient {
 
 		@Override
 		public ChatClientRequestSpec toolCallbacks(ToolCallback... toolCallbacks) {
-			return tools(t -> t.callbacks(toolCallbacks));
+			return tools(toolCallbacks);
 		}
 
 		@Override
 		public ChatClientRequestSpec toolCallbacks(List<ToolCallback> toolCallbacks) {
-			return tools(t -> t.callbacks(toolCallbacks));
+			return tools(toolCallbacks);
 		}
 
 		@Override
@@ -1207,12 +1099,17 @@ public class DefaultChatClient implements ChatClient {
 
 		@Override
 		public ChatClientRequestSpec toolCallbacks(ToolCallbackProvider... toolCallbackProviders) {
-			return tools(t -> t.callbacks(toolCallbackProviders));
+			return tools(toolCallbackProviders);
 		}
 
 		@Override
 		public ChatClientRequestSpec toolContext(Map<String, Object> toolContext) {
-			return tools(t -> t.context(toolContext));
+			Assert.notNull(toolContext, "context cannot be null");
+			Assert.noNullElements(toolContext.keySet(), "context keys cannot contain null elements");
+			Assert.noNullElements(toolContext.values(), "context values cannot contain null elements");
+			toolContext.keySet().forEach(key -> Assert.hasText(key, "context key cannot be null or empty"));
+			this.toolContext.putAll(toolContext);
+			return this;
 		}
 
 		@Override

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -29,7 +29,6 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.client.ChatClient.Builder;
 import org.springframework.ai.chat.client.ChatClient.PromptSystemSpec;
 import org.springframework.ai.chat.client.ChatClient.PromptUserSpec;
-import org.springframework.ai.chat.client.ChatClient.ToolSpec;
 import org.springframework.ai.chat.client.DefaultChatClient.DefaultChatClientRequestSpec;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
@@ -191,12 +190,6 @@ public class DefaultChatClientBuilder implements Builder {
 		return this;
 	}
 
-	@Override
-	public Builder defaultTools(Consumer<ToolSpec> consumer) {
-		this.defaultRequest.tools(consumer);
-		return this;
-	}
-
 	/**
 	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be removed
 	 * in 3.0.0.
@@ -215,13 +208,13 @@ public class DefaultChatClientBuilder implements Builder {
 	}
 
 	/**
-	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be removed
-	 * in 3.0.0.
+	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Object...)}. To be
+	 * removed in 3.0.0.
 	 */
 	@Deprecated(since = "2.0.0", forRemoval = true)
 	@Override
 	public Builder defaultToolCallbacks(ToolCallback... toolCallbacks) {
-		this.defaultRequest.tools(t -> t.callbacks(toolCallbacks));
+		this.defaultRequest.tools(toolCallbacks);
 		return this;
 	}
 
@@ -232,7 +225,7 @@ public class DefaultChatClientBuilder implements Builder {
 	@Deprecated(since = "2.0.0", forRemoval = true)
 	@Override
 	public Builder defaultToolCallbacks(List<ToolCallback> toolCallbacks) {
-		this.defaultRequest.tools(t -> t.callbacks(toolCallbacks));
+		this.defaultRequest.tools(toolCallbacks);
 		return this;
 	}
 
@@ -243,18 +236,12 @@ public class DefaultChatClientBuilder implements Builder {
 	@Deprecated(since = "2.0.0", forRemoval = true)
 	@Override
 	public Builder defaultToolCallbacks(ToolCallbackProvider... toolCallbackProviders) {
-		this.defaultRequest.tools(t -> t.callbacks(toolCallbackProviders));
+		this.defaultRequest.tools(toolCallbackProviders);
 		return this;
 	}
 
-	/**
-	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be removed
-	 * in 3.0.0.
-	 */
-	@Deprecated(since = "2.0.0", forRemoval = true)
-	@Override
 	public Builder defaultToolContext(Map<String, Object> toolContext) {
-		this.defaultRequest.tools(t -> t.context(toolContext));
+		this.defaultRequest.toolContext(toolContext);
 		return this;
 	}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -37,7 +37,6 @@ import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.BaseAdvisorChain;
-import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
 import org.springframework.ai.chat.client.observation.ChatClientObservationContext;
 import org.springframework.ai.chat.client.observation.ChatClientObservationConvention;
@@ -81,6 +80,7 @@ import static org.mockito.Mockito.when;
  * @author Thomas Vitale
  * @author Jonatan Ivanov
  * @author Sebastien Deleuze
+ * @author Christian Tzolov
  */
 class DefaultChatClientTests {
 
@@ -180,6 +180,7 @@ class DefaultChatClientTests {
 		var copyChatOptions = mock(ChatOptions.Builder.class);
 		when(chatOptions.clone()).thenReturn(copyChatOptions);
 		var toolContext = new HashMap<String, Object>();
+		toolContext.put("key", "value");
 		var userMessage1 = mock(UserMessage.class);
 		var userMessage2 = mock(UserMessage.class);
 
@@ -193,7 +194,8 @@ class DefaultChatClientTests {
 				.metadata("userMetadata", "user data3"))
 			.defaultSystem(s -> s.text("original system {sysParams}").param("sysParams", "system value1"))
 			.defaultTemplateRenderer(templateRenderer)
-			.defaultTools(t -> t.callbacks(toolCallback).context(toolContext))
+			.defaultTools(toolCallback)
+			.defaultToolContext(toolContext)
 			.build();
 		var originalSpec = (DefaultChatClient.DefaultChatClientRequestSpec) originalChatClient.prompt();
 
@@ -1917,8 +1919,8 @@ class DefaultChatClientTests {
 	void whenBiFunctionNameIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.tools(t -> t
-			.callbacks(FunctionToolCallback.builder(null, (input, ctx) -> "hello").description("description").build())))
+		assertThatThrownBy(() -> spec
+			.tools(FunctionToolCallback.builder(null, (input, ctx) -> "hello").description("description").build()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("name cannot be null or empty");
 	}
@@ -1927,8 +1929,8 @@ class DefaultChatClientTests {
 	void whenBiFunctionNameIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.tools(t -> t
-			.callbacks(FunctionToolCallback.builder("", (input, ctx) -> "hello").description("description").build())))
+		assertThatThrownBy(() -> spec
+			.tools(FunctionToolCallback.builder("", (input, ctx) -> "hello").description("description").build()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("name cannot be null or empty");
 	}
@@ -1949,8 +1951,8 @@ class DefaultChatClientTests {
 	void whenBiFunctionDescriptionIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.tools(t -> t
-			.callbacks(FunctionToolCallback.builder("name", (input, ctx) -> "hello").description("").build())))
+		assertThatThrownBy(
+				() -> spec.tools(FunctionToolCallback.builder("name", (input, ctx) -> "hello").description("").build()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Description must not be empty");
 	}
@@ -2009,7 +2011,7 @@ class DefaultChatClientTests {
 	void whenToolContextIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.tools(t -> t.context(null))).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> spec.toolContext(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("context cannot be null");
 	}
 
@@ -2019,7 +2021,7 @@ class DefaultChatClientTests {
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		Map<String, Object> toolContext = new HashMap<>();
 		toolContext.put(null, "value");
-		assertThatThrownBy(() -> spec.tools(t -> t.context(toolContext))).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> spec.toolContext(toolContext)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("context keys cannot contain null elements");
 	}
 
@@ -2029,7 +2031,7 @@ class DefaultChatClientTests {
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		Map<String, Object> toolContext = new HashMap<>();
 		toolContext.put("key", null);
-		assertThatThrownBy(() -> spec.tools(t -> t.context(toolContext))).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> spec.toolContext(toolContext)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("context values cannot contain null elements");
 	}
 
@@ -2038,7 +2040,7 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		Map<String, Object> toolContext = Map.of("key", "value");
-		spec = spec.tools(t -> t.context(toolContext));
+		spec = spec.toolContext(toolContext);
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolContext()).containsEntry("key", "value");
 	}
@@ -2077,8 +2079,7 @@ class DefaultChatClientTests {
 	@Test
 	void whenToolSpecContextIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
-		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context((Map<String, Object>) null)))
-			.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> chatClient.prompt().toolContext(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("context cannot be null");
 	}
 
@@ -2087,8 +2088,7 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		Map<String, Object> ctx = new HashMap<>();
 		ctx.put(null, "value");
-		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context(ctx)))
-			.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> chatClient.prompt().toolContext(ctx)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("context keys cannot contain null elements");
 	}
 
@@ -2097,15 +2097,14 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		Map<String, Object> ctx = new HashMap<>();
 		ctx.put("key", null);
-		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context(ctx)))
-			.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> chatClient.prompt().toolContext(ctx)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("context values cannot contain null elements");
 	}
 
 	@Test
 	void whenToolSpecContextThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().tools(t -> t.context("key", "value"));
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().toolContext(Map.of("key", "value"));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getToolContext()).containsEntry("key", "value");
 	}
@@ -2113,55 +2112,16 @@ class DefaultChatClientTests {
 	@Test
 	void whenToolSpecContextSingleKvKeyIsBlankThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
-		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context("", "value")))
+		assertThatThrownBy(() -> chatClient.prompt().toolContext(Map.of("", "value")))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("context key cannot be null or empty");
 	}
 
 	@Test
-	void whenToolSpecContextSingleKvValueIsNullThenThrow() {
+	void whenToolsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
-		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context("key", null)))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("context value cannot be null");
-	}
-
-	@Test
-	void whenToolSpecConsumerIsNullThenThrow() {
-		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
-		assertThatThrownBy(() -> chatClient.prompt().tools((Consumer<ChatClient.ToolSpec>) null))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("consumer cannot be null");
-	}
-
-	@Test
-	void whenToolSpecAdvisorIsNullThenThrow() {
-		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
-		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.advisor(null)))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("toolAdvisor cannot be null");
-	}
-
-	@Test
-	void whenToolSpecAdvisorThenAddedToAdvisors() {
-		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
-		ToolAdvisor toolAdvisor = mock(ToolAdvisor.class);
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().tools(t -> t.advisor(toolAdvisor));
-		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
-		assertThat(defaultSpec.getAdvisors()).contains(toolAdvisor);
-	}
-
-	@Test
-	void whenToolSpecCombinesAllTypesTheyAreAllPresent() {
-		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
-		ToolCallback cb = mock(ToolCallback.class);
-		ToolAdvisor toolAdvisor = mock(ToolAdvisor.class);
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt()
-			.tools(t -> t.callbacks(cb).context("k", "v").advisor(toolAdvisor));
-		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
-		assertThat(defaultSpec.getToolCallbacks()).contains(cb);
-		assertThat(defaultSpec.getToolContext()).containsEntry("k", "v");
-		assertThat(defaultSpec.getAdvisors()).contains(toolAdvisor);
+		assertThatThrownBy(() -> chatClient.prompt().tools(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("toolObjects cannot be null");
 	}
 
 	@Test

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
@@ -262,7 +262,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.tools(t -> t.context(toolContext));
+			.toolContext(toolContext);
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -327,7 +327,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(ToolCallingChatOptions.builder().toolContext(toolContext1))
-			.tools(t -> t.context(toolContext2));
+			.toolContext(toolContext2);
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 
@@ -391,7 +391,7 @@ class DefaultChatClientUtilsTests {
 			.create(chatModel)
 			.prompt()
 			.options(chatOptions)
-			.tools(t -> t.context(toolContext1));
+			.toolContext(toolContext1);
 
 		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
 		assertThat(result.prompt().getOptions()).isInstanceOf(ToolCallingChatOptions.class);
@@ -467,7 +467,8 @@ class DefaultChatClientUtilsTests {
 			.user(u -> u.text(userText).params(userParams).media(media))
 			.messages(messages)
 			.toolNames(toolNames.toArray(new String[0]))
-			.tools(t -> t.callbacks(toolCallback).context(toolContext))
+			.toolCallbacks(toolCallback)
+			.toolContext(toolContext)
 			.options(chatOptions)
 			.advisors(a -> a.params(advisorParams));
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -886,23 +886,7 @@ chatClient.prompt("What day is tomorrow?")
 
 Or you can provide your own `ToolCallAdvisor` (or any other advisor implementing `ToolAdvisor`) — in that case auto-registration is suppressed automatically because the chain already contains a `ToolAdvisor`.
 
-The preferred way is to pass the advisor directly inside the `ToolSpec` consumer, keeping tools and their advisor co-located:
-
-[source,java]
-----
-var customAdvisor = ToolCallAdvisor.builder()
-    .toolCallingManager(myToolCallingManager)
-    .build();
-
-chatClient.prompt("What day is tomorrow?")
-    .tools(t -> t
-        .instances(new DateTimeTools())
-        .advisor(customAdvisor))   // auto-registration suppressed
-    .call()
-    .content();
-----
-
-Alternatively, you can pass the advisor separately via `.advisors()`:
+You can pass a custom advisor via `.advisors()`:
 
 [source,java]
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -975,7 +975,8 @@ ChatModel chatModel = ...
 
 String response = ChatClient.create(chatModel)
         .prompt("Tell me more about the customer with ID 42")
-        .tools(t -> t.instances(new CustomerTools()).context(Map.of("tenantId", "acme")))
+        .tools(new CustomerTools())
+        .toolContext(Map.of("tenantId", "acme"))
         .call()
         .content();
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -443,9 +443,9 @@ Spring Boot users should prefer one of the following instead:
 * Set `spring.ai.chat.client.tool-calling.advisor-order` to control the advisor's position in the chain.
 * Declare a `ToolCallAdvisor.Builder<?>` bean to fully replace the auto-configured builder (suppressed via `@ConditionalOnMissingBean`).
 
-==== Deprecated: Scattered Tool Methods on `ChatClient`
+==== Removed: `ToolSpec` Consumer API on `ChatClient`
 
-The individual `toolCallbacks()`, `toolContext()`, and `toolNames()` methods on `ChatClientRequestSpec`, and their `defaultToolCallbacks()`, `defaultToolContext()`, and `defaultToolNames()` counterparts on `ChatClient.Builder`, are deprecated in favour of the unified `tools(Consumer<ToolSpec>)` / `defaultTools(Consumer<ToolSpec>)` API.
+The `tools(Consumer<ToolSpec>)` / `defaultTools(Consumer<ToolSpec>)` API and the `ChatClient.ToolSpec` interface have been removed. The `tools(Object...)` / `defaultTools(Object...)` methods now directly accept `ToolCallback`, `ToolCallbackProvider`, `@Tool`-annotated POJO instances, and collections or arrays of any of these types. Context is set separately via the dedicated `toolContext()` / `defaultToolContext()` methods.
 
 ===== Migration
 
@@ -453,14 +453,42 @@ The individual `toolCallbacks()`, `toolContext()`, and `toolNames()` methods on 
 ----
 // Before
 chatClient.prompt()
-    .toolCallbacks(myCallback)
-    .toolContext(Map.of("tenantId", "acme"))
+    .tools(t -> t.callbacks(myCallback).context("tenantId", "acme"))
     .call().content();
 
 // After
 chatClient.prompt()
-    .tools(t -> t.callbacks(myCallback).context("tenantId", "acme"))
+    .tools(myCallback)
+    .toolContext(Map.of("tenantId", "acme"))
     .call().content();
+----
+
+The individual `toolCallbacks()` and `toolNames()` methods on `ChatClientRequestSpec`, and their `defaultToolCallbacks()` and `defaultToolNames()` counterparts on `ChatClient.Builder`, are deprecated in favour of `tools(Object...)` / `defaultTools(Object...)`.
+
+==== Changed: `MethodToolCallbackProvider` throws `IllegalArgumentException` instead of `IllegalStateException`
+
+`MethodToolCallbackProvider` now throws `IllegalArgumentException` (instead of `IllegalStateException`) in two cases:
+
+* When a tool object has no `@Tool`-annotated methods.
+* When multiple tool objects produce callbacks with duplicate names.
+
+===== Impact
+
+Code that catches `IllegalStateException` from `MethodToolCallbackProvider` (directly or via `ToolCallbacks.from()`) must be updated.
+
+[source,java]
+----
+// Before
+try {
+    ToolCallbacks.from(myObject);
+}
+catch (IllegalStateException e) { ... }
+
+// After
+try {
+    ToolCallbacks.from(myObject);
+}
+catch (IllegalArgumentException e) { ... }
 ----
 
 ==== Deprecated: Spring Bean Tool Resolution (`SpringBeanToolCallbackResolver`)
@@ -490,7 +518,7 @@ ToolCallback currentWeather() {
 }
 ----
 
-Then register the bean via the `ToolSpec` consumer:
+Then register the bean directly with `tools()`:
 
 [source,java]
 ----

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
@@ -75,7 +75,7 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 				.toList();
 
 			if (toolMethods.isEmpty()) {
-				throw new IllegalStateException("No @Tool annotated methods found in " + toolObject + ". "
+				throw new IllegalArgumentException("No @Tool annotated methods found in " + toolObject + ". "
 						+ "Did you mean to pass a ToolCallback or ToolCallbackProvider? If so, use"
 						+ " .tools(toolCallback) or .toolCallbacks(toolCallback) instead.");
 			}
@@ -128,7 +128,7 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 	private void validateToolCallbacks(ToolCallback[] toolCallbacks) {
 		List<String> duplicateToolNames = ToolUtils.getDuplicateToolNames(toolCallbacks);
 		if (!duplicateToolNames.isEmpty()) {
-			throw new IllegalStateException("Multiple tools with the same name (%s) found in sources: %s".formatted(
+			throw new IllegalArgumentException("Multiple tools with the same name (%s) found in sources: %s".formatted(
 					String.join(", ", duplicateToolNames),
 					this.toolObjects.stream().map(o -> o.getClass().getName()).collect(Collectors.joining(", "))));
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
@@ -60,7 +60,7 @@ class MethodToolCallbackProviderTests {
 	void whenToolObjectHasNoToolAnnotatedMethodThenThrow() {
 		assertThatThrownBy(
 				() -> MethodToolCallbackProvider.builder().toolObjects(new NoToolAnnotatedMethodObject()).build())
-			.isInstanceOf(IllegalStateException.class)
+			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("No @Tool annotated methods found in");
 	}
 
@@ -68,7 +68,7 @@ class MethodToolCallbackProviderTests {
 	void whenToolObjectHasOnlyFunctionalTypeToolMethodsThenThrow() {
 		assertThatThrownBy(() -> MethodToolCallbackProvider.builder()
 			.toolObjects(new OnlyFunctionalTypeToolMethodsObject())
-			.build()).isInstanceOf(IllegalStateException.class)
+			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("No @Tool annotated methods found in");
 	}
 
@@ -86,7 +86,7 @@ class MethodToolCallbackProviderTests {
 	void whenMultipleToolObjectsWithSameToolNameThenThrow() {
 		assertThatThrownBy(() -> MethodToolCallbackProvider.builder()
 			.toolObjects(new ValidToolObject(), new DuplicateToolNameObject())
-			.build()).isInstanceOf(IllegalStateException.class)
+			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Multiple tools with the same name (validTool) found in sources");
 	}
 


### PR DESCRIPTION
Follow-up to #6263: now that tools(Object...) accepts ToolCallback and ToolCallbackProvider directly, the ToolSpec consumer overloads are no longer needed. 
Remove tools(Consumer<ToolSpec>), defaultTools(Consumer<ToolSpec>), and the ChatClient.ToolSpec interface entirely.

The toolContext() and defaultToolContext() are promoted to first-class non-deprecated methods with full key/value validation. mutate() is fixed to propagate toolCallbackProviders and toolContext to the cloned builder.

Update docs and tests accordingly.

See #6206