### PR TITLE
Register MCP meta providers for AOT processing

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor.java
@@ -18,21 +18,28 @@ package org.springframework.ai.mcp.annotation.spring.scan;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.ai.mcp.annotation.context.MetaProvider;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.log.LogAccessor;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Josh Long
+ * @author Nikita Kibitkin
  */
 public class AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor extends AnnotatedMethodDiscovery
 		implements BeanFactoryInitializationAotProcessor {
+
+	private static final String META_PROVIDER_ATTRIBUTE_NAME = "metaProvider";
 
 	private static final LogAccessor logger = new LogAccessor(AbstractAnnotatedMethodBeanPostProcessor.class);
 
@@ -44,6 +51,7 @@ public class AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor extend
 	@Override
 	public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
 		List<Class<?>> types = new ArrayList<>();
+		Set<Class<? extends MetaProvider>> metaProviderTypes = new LinkedHashSet<>();
 		for (String beanName : beanFactory.getBeanDefinitionNames()) {
 			Class<?> beanClass = beanFactory.getType(beanName);
 			if (beanClass == null) {
@@ -52,6 +60,7 @@ public class AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor extend
 			Set<Class<? extends Annotation>> classes = this.scan(beanClass);
 			if (!classes.isEmpty()) {
 				types.add(beanClass);
+				metaProviderTypes.addAll(this.scanMetaProviderTypes(beanClass));
 			}
 		}
 		return (generationContext, beanFactoryInitializationCode) -> {
@@ -60,7 +69,29 @@ public class AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor extend
 				runtimeHints.reflection().registerType(typeReference, MemberCategory.values());
 				logger.info("registering " + typeReference.getName() + " for reflection");
 			}
+			for (Class<? extends MetaProvider> metaProviderType : metaProviderTypes) {
+				runtimeHints.reflection().registerType(metaProviderType, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+				logger.info("registering " + metaProviderType.getName() + " for reflective constructor invocation");
+			}
 		};
+	}
+
+	private Set<Class<? extends MetaProvider>> scanMetaProviderTypes(Class<?> beanClass) {
+		Set<Class<? extends MetaProvider>> metaProviderTypes = new LinkedHashSet<>();
+		ReflectionUtils.doWithMethods(beanClass, method -> this.targetAnnotations.forEach(annotationType -> {
+			Annotation annotation = AnnotationUtils.findAnnotation(method, annotationType);
+			if (annotation != null) {
+				this.addMetaProviderType(annotation, metaProviderTypes);
+			}
+		}));
+		return metaProviderTypes;
+	}
+
+	private void addMetaProviderType(Annotation annotation, Set<Class<? extends MetaProvider>> metaProviderTypes) {
+		Object metaProviderType = AnnotationUtils.getValue(annotation, META_PROVIDER_ATTRIBUTE_NAME);
+		if (metaProviderType instanceof Class<?> type && MetaProvider.class.isAssignableFrom(type)) {
+			metaProviderTypes.add(type.asSubclass(MetaProvider.class));
+		}
 	}
 
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanFactoryInitializationAotProcessorTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanFactoryInitializationAotProcessorTests.java
@@ -22,11 +22,18 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.mcp.annotation.McpPrompt;
+import org.springframework.ai.mcp.annotation.McpResource;
+import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.context.DefaultMetaProvider;
+import org.springframework.ai.mcp.annotation.context.MetaProvider;
 import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.TypeHint;
 import org.springframework.aot.hint.TypeReference;
@@ -43,6 +50,7 @@ import static org.mockito.Mockito.when;
  * Unit Tests for {@link AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor}.
  *
  * @author lance
+ * @author Nikita Kibitkin
  */
 class AbstractAnnotatedMethodBeanFactoryInitializationAotProcessorTests {
 
@@ -81,6 +89,38 @@ class AbstractAnnotatedMethodBeanFactoryInitializationAotProcessorTests {
 			.doesNotMatch(t -> t.getName().equals(PlainBean.class.getName()));
 	}
 
+	@Test
+	void processAheadOfTimeRegistersMetaProviderConstructors() {
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerBeanDefinition(McpAnnotatedBean.class.getName(),
+				new RootBeanDefinition(McpAnnotatedBean.class));
+
+		Set<Class<? extends Annotation>> annotations = Set.of(McpTool.class, McpPrompt.class, McpResource.class);
+		AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor processor = new AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor(
+				annotations);
+
+		BeanFactoryInitializationAotContribution aotContribution = processor.processAheadOfTime(beanFactory);
+		assertThat(aotContribution).isNotNull();
+
+		GenerationContext generationContext = mock(GenerationContext.class);
+		when(generationContext.getRuntimeHints()).thenReturn(new RuntimeHints());
+
+		BeanFactoryInitializationCode initializationCode = mock(BeanFactoryInitializationCode.class);
+		aotContribution.applyTo(generationContext, initializationCode);
+
+		List<TypeHint> typeHints = generationContext.getRuntimeHints().reflection().typeHints().toList();
+		assertHasDeclaredConstructorHint(typeHints, DefaultMetaProvider.class);
+		assertHasDeclaredConstructorHint(typeHints, PromptMetaProvider.class);
+		assertHasDeclaredConstructorHint(typeHints, ResourceMetaProvider.class);
+	}
+
+	private static void assertHasDeclaredConstructorHint(List<TypeHint> typeHints, Class<?> type) {
+		assertThat(typeHints).anySatisfy(typeHint -> {
+			assertThat(typeHint.getType()).isEqualTo(TypeReference.of(type));
+			assertThat(typeHint.getMemberCategories()).contains(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+		});
+	}
+
 	@Target(ElementType.METHOD)
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface MyAnnotation {
@@ -94,6 +134,43 @@ class AbstractAnnotatedMethodBeanFactoryInitializationAotProcessorTests {
 
 		@MyAnnotation
 		public void doSomething() {
+		}
+
+	}
+
+	static class McpAnnotatedBean {
+
+		@McpTool(name = "default-tool")
+		public String defaultTool() {
+			return "default";
+		}
+
+		@McpPrompt(name = "custom-prompt", metaProvider = PromptMetaProvider.class)
+		public String customPrompt() {
+			return "prompt";
+		}
+
+		@McpResource(uri = "custom://resource", metaProvider = ResourceMetaProvider.class)
+		public String customResource() {
+			return "resource";
+		}
+
+	}
+
+	static class PromptMetaProvider implements MetaProvider {
+
+		@Override
+		public Map<String, Object> getMeta() {
+			return Map.of("type", "prompt");
+		}
+
+	}
+
+	static class ResourceMetaProvider implements MetaProvider {
+
+		@Override
+		public Map<String, Object> getMeta() {
+			return Map.of("type", "resource");
 		}
 
 	}


### PR DESCRIPTION
## Summary

`MetaUtils.getMeta(...)` instantiates MCP annotation `metaProvider()` classes reflectively when building tool, prompt, and resource specifications. In a native image those constructors need runtime hints; otherwise the default `DefaultMetaProvider` path can fail with `NoSuchMethodException`.

This updates the MCP annotation AOT processor to collect `metaProvider()` classes from discovered `@McpTool`, `@McpPrompt`, and `@McpResource` methods and register their declared constructors for reflection. The test covers the default provider and custom prompt/resource providers.

Closes #6278

## Testing

- Verified the new regression test fails without the production change
- `./mvnw -pl mcp/mcp-annotations -Dtest=AbstractAnnotatedMethodBeanFactoryInitializationAotProcessorTests -Dmaven.build.cache.enabled=false test`
- `./mvnw -pl mcp/mcp-annotations -Dmaven.build.cache.enabled=false test`