### PR TITLE
Make OpenAI HTTP Client configurable

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.util.List;
+
 import com.openai.client.OpenAIClient;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
@@ -23,6 +25,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.openai.OpenAiAudioSpeechModel;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -52,12 +55,16 @@ public class OpenAiAudioSpeechAutoConfiguration {
 	@ConditionalOnMissingBean
 	public OpenAiAudioSpeechModel openAiSdkAudioSpeechModel(OpenAiCommonProperties commonProperties,
 			OpenAiAudioSpeechProperties speechProperties, ObjectProvider<ObservationRegistry> observationRegistry,
-			ObjectProvider<MeterRegistry> meterRegistry) {
+			ObjectProvider<MeterRegistry> meterRegistry,
+			ObjectProvider<OpenAiHttpClientBuilderCustomizer> httpClientBuilderCustomizers) {
 
 		var resolvedProperties = OpenAiAutoConfigurationUtil.resolveCommonProperties(commonProperties,
 				speechProperties);
 
-		OpenAIClient openAIClient = this.openAiClient(resolvedProperties, observationRegistry, meterRegistry);
+		List<OpenAiHttpClientBuilderCustomizer> customizers = httpClientBuilderCustomizers.orderedStream().toList();
+
+		OpenAIClient openAIClient = this.openAiClient(resolvedProperties, observationRegistry, meterRegistry,
+				customizers);
 
 		return OpenAiAudioSpeechModel.builder()
 			.openAiClient(openAIClient)
@@ -66,7 +73,8 @@ public class OpenAiAudioSpeechAutoConfiguration {
 	}
 
 	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
-			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry) {
+			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
+			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		MeterRegistry meterRegistryToUse = commonProperties.isConnectionPoolMetricsEnabled()
 				? meterRegistry.getIfAvailable() : null;
@@ -77,7 +85,7 @@ public class OpenAiAudioSpeechAutoConfiguration {
 				commonProperties.isMicrosoftFoundry(), commonProperties.isGitHubModels(), commonProperties.getModel(),
 				commonProperties.getTimeout(), commonProperties.getMaxRetries(), commonProperties.getProxy(),
 				commonProperties.getCustomHeaders(), observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
-				meterRegistryToUse, null);
+				meterRegistryToUse, httpClientCustomizers);
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.util.List;
+
 import com.openai.client.OpenAIClient;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
@@ -23,6 +25,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -53,10 +56,12 @@ public class OpenAiAudioTranscriptionAutoConfiguration {
 	@ConditionalOnMissingBean
 	public OpenAiAudioTranscriptionModel openAiSdkAudioTranscriptionModel(OpenAiCommonProperties commonProperties,
 			OpenAiAudioTranscriptionProperties transcriptionProperties,
-			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry) {
+			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
+			ObjectProvider<OpenAiHttpClientBuilderCustomizer> httpClientBuilderCustomizers) {
 		var resolvedProperties = OpenAiAutoConfigurationUtil.resolveCommonProperties(commonProperties,
 				transcriptionProperties);
-		OpenAIClient client = openAiClient(resolvedProperties, observationRegistry, meterRegistry);
+		List<OpenAiHttpClientBuilderCustomizer> customizers = httpClientBuilderCustomizers.orderedStream().toList();
+		OpenAIClient client = openAiClient(resolvedProperties, observationRegistry, meterRegistry, customizers);
 		return OpenAiAudioTranscriptionModel.builder()
 			.openAiClient(client)
 			.options(transcriptionProperties.toOptions())
@@ -64,7 +69,8 @@ public class OpenAiAudioTranscriptionAutoConfiguration {
 	}
 
 	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
-			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry) {
+			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
+			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		MeterRegistry meterRegistryToUse = commonProperties.isConnectionPoolMetricsEnabled()
 				? meterRegistry.getIfAvailable() : null;
@@ -75,7 +81,7 @@ public class OpenAiAudioTranscriptionAutoConfiguration {
 				commonProperties.isMicrosoftFoundry(), commonProperties.isGitHubModels(), commonProperties.getModel(),
 				commonProperties.getTimeout(), commonProperties.getMaxRetries(), commonProperties.getProxy(),
 				commonProperties.getCustomHeaders(), observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
-				meterRegistryToUse, null);
+				meterRegistryToUse, httpClientCustomizers);
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.util.List;
+
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -27,6 +29,7 @@ import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -58,17 +61,21 @@ public class OpenAiChatAutoConfiguration {
 	public OpenAiChatModel openAiChatModel(OpenAiCommonProperties commonProperties, OpenAiChatProperties chatProperties,
 			ToolCallingManager toolCallingManager, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<MeterRegistry> meterRegistry,
-			ObjectProvider<ChatModelObservationConvention> observationConvention) {
+			ObjectProvider<ChatModelObservationConvention> observationConvention,
+			ObjectProvider<OpenAiHttpClientBuilderCustomizer> httpClientBuilderCustomizers) {
 
 		var resolvedProperties = OpenAiAutoConfigurationUtil.resolveCommonProperties(commonProperties, chatProperties);
 
 		MeterRegistry meterRegistryToUse = resolvedProperties.isConnectionPoolMetricsEnabled()
 				? meterRegistry.getIfAvailable() : null;
 
-		OpenAIClient openAIClient = this.openAiClient(resolvedProperties, observationRegistry, meterRegistryToUse);
+		List<OpenAiHttpClientBuilderCustomizer> customizers = httpClientBuilderCustomizers.orderedStream().toList();
+
+		OpenAIClient openAIClient = this.openAiClient(resolvedProperties, observationRegistry, meterRegistryToUse,
+				customizers);
 
 		OpenAIClientAsync openAIClientAsync = this.openAiClientAsync(resolvedProperties, observationRegistry,
-				meterRegistryToUse);
+				meterRegistryToUse, customizers);
 
 		var chatModel = OpenAiChatModel.builder()
 			.openAiClient(openAIClient)
@@ -85,7 +92,8 @@ public class OpenAiChatAutoConfiguration {
 	}
 
 	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
-			ObjectProvider<ObservationRegistry> observationRegistry, @Nullable MeterRegistry meterRegistry) {
+			ObjectProvider<ObservationRegistry> observationRegistry, @Nullable MeterRegistry meterRegistry,
+			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		return OpenAiSetup.setupSyncClient(commonProperties.getBaseUrl(), commonProperties.getApiKey(),
 				commonProperties.getCredential(), commonProperties.getMicrosoftDeploymentName(),
@@ -93,11 +101,12 @@ public class OpenAiChatAutoConfiguration {
 				commonProperties.isMicrosoftFoundry(), commonProperties.isGitHubModels(), commonProperties.getModel(),
 				commonProperties.getTimeout(), commonProperties.getMaxRetries(), commonProperties.getProxy(),
 				commonProperties.getCustomHeaders(), observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
-				meterRegistry, null);
+				meterRegistry, httpClientCustomizers);
 	}
 
 	private OpenAIClientAsync openAiClientAsync(OpenAiCommonProperties commonProperties,
-			ObjectProvider<ObservationRegistry> observationRegistry, @Nullable MeterRegistry meterRegistry) {
+			ObjectProvider<ObservationRegistry> observationRegistry, @Nullable MeterRegistry meterRegistry,
+			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		return OpenAiSetup.setupAsyncClient(commonProperties.getBaseUrl(), commonProperties.getApiKey(),
 				commonProperties.getCredential(), commonProperties.getMicrosoftDeploymentName(),
@@ -105,7 +114,7 @@ public class OpenAiChatAutoConfiguration {
 				commonProperties.isMicrosoftFoundry(), commonProperties.isGitHubModels(), commonProperties.getModel(),
 				commonProperties.getTimeout(), commonProperties.getMaxRetries(), commonProperties.getProxy(),
 				commonProperties.getCustomHeaders(), observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
-				meterRegistry, null);
+				meterRegistry, httpClientCustomizers);
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.util.List;
+
 import com.openai.client.OpenAIClient;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
@@ -24,6 +26,7 @@ import org.springframework.ai.embedding.observation.EmbeddingModelObservationCon
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -54,13 +57,16 @@ public class OpenAiEmbeddingAutoConfiguration {
 	public OpenAiEmbeddingModel openAiEmbeddingModel(OpenAiCommonProperties commonProperties,
 			OpenAiEmbeddingProperties embeddingProperties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<MeterRegistry> meterRegistry,
-			ObjectProvider<EmbeddingModelObservationConvention> observationConvention) {
+			ObjectProvider<EmbeddingModelObservationConvention> observationConvention,
+			ObjectProvider<OpenAiHttpClientBuilderCustomizer> httpClientBuilderCustomizers) {
 
 		var resolvedProperties = OpenAiAutoConfigurationUtil.resolveCommonProperties(commonProperties,
 				embeddingProperties);
 
+		List<OpenAiHttpClientBuilderCustomizer> customizers = httpClientBuilderCustomizers.orderedStream().toList();
+
 		var embeddingModel = new OpenAiEmbeddingModel(
-				this.openAiClient(resolvedProperties, observationRegistry, meterRegistry),
+				this.openAiClient(resolvedProperties, observationRegistry, meterRegistry, customizers),
 				embeddingProperties.getMetadataMode(), embeddingProperties.toOptions(),
 				observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP));
 
@@ -70,7 +76,8 @@ public class OpenAiEmbeddingAutoConfiguration {
 	}
 
 	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
-			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry) {
+			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
+			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		MeterRegistry meterRegistryToUse = commonProperties.isConnectionPoolMetricsEnabled()
 				? meterRegistry.getIfAvailable() : null;
@@ -81,7 +88,7 @@ public class OpenAiEmbeddingAutoConfiguration {
 				commonProperties.isMicrosoftFoundry(), commonProperties.isGitHubModels(), commonProperties.getModel(),
 				commonProperties.getTimeout(), commonProperties.getMaxRetries(), commonProperties.getProxy(),
 				commonProperties.getCustomHeaders(), observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
-				meterRegistryToUse, null);
+				meterRegistryToUse, httpClientCustomizers);
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.util.List;
+
 import com.openai.client.OpenAIClient;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
@@ -24,6 +26,7 @@ import org.springframework.ai.image.observation.ImageModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.openai.OpenAiImageModel;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -55,11 +58,15 @@ public class OpenAiImageAutoConfiguration {
 	public OpenAiImageModel openAiImageModel(OpenAiCommonProperties commonProperties,
 			OpenAiImageProperties imageProperties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<MeterRegistry> meterRegistry,
-			ObjectProvider<ImageModelObservationConvention> observationConvention) {
+			ObjectProvider<ImageModelObservationConvention> observationConvention,
+			ObjectProvider<OpenAiHttpClientBuilderCustomizer> httpClientBuilderCustomizers) {
 
 		var resolvedProperties = OpenAiAutoConfigurationUtil.resolveCommonProperties(commonProperties, imageProperties);
 
-		var imageModel = new OpenAiImageModel(openAiClient(resolvedProperties, observationRegistry, meterRegistry),
+		List<OpenAiHttpClientBuilderCustomizer> customizers = httpClientBuilderCustomizers.orderedStream().toList();
+
+		var imageModel = new OpenAiImageModel(
+				openAiClient(resolvedProperties, observationRegistry, meterRegistry, customizers),
 				imageProperties.toOptions(), observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP));
 
 		observationConvention.ifAvailable(imageModel::setObservationConvention);
@@ -68,7 +75,8 @@ public class OpenAiImageAutoConfiguration {
 	}
 
 	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
-			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry) {
+			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
+			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		MeterRegistry meterRegistryToUse = commonProperties.isConnectionPoolMetricsEnabled()
 				? meterRegistry.getIfAvailable() : null;
@@ -79,7 +87,7 @@ public class OpenAiImageAutoConfiguration {
 				commonProperties.isMicrosoftFoundry(), commonProperties.isGitHubModels(), commonProperties.getModel(),
 				commonProperties.getTimeout(), commonProperties.getMaxRetries(), commonProperties.getProxy(),
 				commonProperties.getCustomHeaders(), observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
-				meterRegistryToUse, null);
+				meterRegistryToUse, httpClientCustomizers);
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModerationAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModerationAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.util.List;
+
 import com.openai.client.OpenAIClient;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
@@ -23,6 +25,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.openai.OpenAiModerationModel;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -52,12 +55,16 @@ public class OpenAiModerationAutoConfiguration {
 	@ConditionalOnMissingBean
 	public OpenAiModerationModel openAiSdkModerationModel(OpenAiCommonProperties commonProperties,
 			OpenAiModerationProperties moderationProperties, ObjectProvider<ObservationRegistry> observationRegistry,
-			ObjectProvider<MeterRegistry> meterRegistry) {
+			ObjectProvider<MeterRegistry> meterRegistry,
+			ObjectProvider<OpenAiHttpClientBuilderCustomizer> httpClientBuilderCustomizers) {
 
 		var resolvedProperties = OpenAiAutoConfigurationUtil.resolveCommonProperties(commonProperties,
 				moderationProperties);
 
-		OpenAIClient openAIClient = this.openAiClient(resolvedProperties, observationRegistry, meterRegistry);
+		List<OpenAiHttpClientBuilderCustomizer> customizers = httpClientBuilderCustomizers.orderedStream().toList();
+
+		OpenAIClient openAIClient = this.openAiClient(resolvedProperties, observationRegistry, meterRegistry,
+				customizers);
 
 		return OpenAiModerationModel.builder()
 			.openAiClient(openAIClient)
@@ -66,7 +73,8 @@ public class OpenAiModerationAutoConfiguration {
 	}
 
 	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
-			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry) {
+			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
+			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		MeterRegistry meterRegistryToUse = commonProperties.isConnectionPoolMetricsEnabled()
 				? meterRegistry.getIfAvailable() : null;
@@ -77,7 +85,7 @@ public class OpenAiModerationAutoConfiguration {
 				commonProperties.isMicrosoftFoundry(), commonProperties.isGitHubModels(), commonProperties.getModel(),
 				commonProperties.getTimeout(), commonProperties.getMaxRetries(), commonProperties.getProxy(),
 				commonProperties.getCustomHeaders(), observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
-				meterRegistryToUse, null);
+				meterRegistryToUse, httpClientCustomizers);
 	}
 
 }

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,6 +37,7 @@ import org.springframework.ai.audio.tts.TextToSpeechModel;
 import org.springframework.ai.audio.tts.TextToSpeechOptions;
 import org.springframework.ai.audio.tts.TextToSpeechPrompt;
 import org.springframework.ai.audio.tts.TextToSpeechResponse;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.metadata.OpenAiAudioSpeechResponseMetadata;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.util.Assert;
@@ -59,20 +61,16 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 
 	private final OpenAiAudioSpeechOptions options;
 
-	/**
-	 * Private constructor that takes individual configuration parameters.
-	 * @param openAiClient The OpenAI client instance.
-	 * @param options The default options for speech generation.
-	 */
-	private OpenAiAudioSpeechModel(@Nullable OpenAIClient openAiClient, @Nullable OpenAiAudioSpeechOptions options) {
-		this.options = Objects.requireNonNullElseGet(options, () -> OpenAiAudioSpeechOptions.builder().build());
-		this.openAiClient = Objects.requireNonNullElseGet(openAiClient,
+	private OpenAiAudioSpeechModel(Builder builder) {
+		this.options = Objects.requireNonNullElseGet(builder.options, () -> OpenAiAudioSpeechOptions.builder().build());
+		this.openAiClient = Objects.requireNonNullElseGet(builder.openAiClient,
 				() -> OpenAiSetup.setupSyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
 						this.options.getCredential(), this.options.getMicrosoftDeploymentName(),
 						this.options.getMicrosoftFoundryServiceVersion(), this.options.getOrganizationId(),
 						this.options.isMicrosoftFoundry(), this.options.isGitHubModels(), this.options.getModel(),
 						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(), ObservationRegistry.NOOP, null, null));
+						this.options.getCustomHeaders(), ObservationRegistry.NOOP, null,
+						builder.httpClientCustomizers));
 	}
 
 	/**
@@ -206,6 +204,8 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 
 		private @Nullable OpenAiAudioSpeechOptions options;
 
+		private List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers = new ArrayList<>();
+
 		/**
 		 * Default constructor with default options.
 		 */
@@ -245,11 +245,36 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 		}
 
 		/**
+		 * Registers an {@link OpenAiHttpClientBuilderCustomizer} that mutates the
+		 * underlying OkHttp client builder before the OpenAI clients are constructed. Use
+		 * this to attach OkHttp interceptors (e.g. OAuth2 bearer-token injection), swap
+		 * the dispatcher executor, or tweak any other OkHttp setting. Customizers are
+		 * applied in the order they are registered, after Spring AI's own defaults, so
+		 * user code wins.
+		 */
+		public Builder httpClientBuilderCustomizer(OpenAiHttpClientBuilderCustomizer customizer) {
+			Assert.notNull(customizer, "customizer cannot be null");
+			this.httpClientCustomizers.add(customizer);
+			return this;
+		}
+
+		/**
+		 * Sets the full list of {@link OpenAiHttpClientBuilderCustomizer customizers} to
+		 * apply, replacing any customizers registered earlier on this builder. The order
+		 * of the list is preserved when invoking the customizers.
+		 */
+		public Builder httpClientBuilderCustomizers(List<OpenAiHttpClientBuilderCustomizer> customizers) {
+			Assert.notNull(customizers, "customizers cannot be null");
+			this.httpClientCustomizers = new ArrayList<>(customizers);
+			return this;
+		}
+
+		/**
 		 * Builds the OpenAiAudioSpeechModel instance.
 		 * @return A new OpenAiAudioSpeechModel instance
 		 */
 		public OpenAiAudioSpeechModel build() {
-			return new OpenAiAudioSpeechModel(this.openAiClient, this.options);
+			return new OpenAiAudioSpeechModel(this);
 		}
 
 	}

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -19,6 +19,8 @@ package org.springframework.ai.openai;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import com.openai.client.OpenAIClient;
@@ -35,6 +37,7 @@ import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
 import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
 import org.springframework.ai.audio.transcription.AudioTranscriptionResponseMetadata;
 import org.springframework.ai.audio.transcription.TranscriptionModel;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
@@ -82,7 +85,8 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 						this.options.getMicrosoftFoundryServiceVersion(), this.options.getOrganizationId(),
 						this.options.isMicrosoftFoundry(), this.options.isGitHubModels(), this.options.getModel(),
 						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(), ObservationRegistry.NOOP, null, null));
+						this.options.getCustomHeaders(), ObservationRegistry.NOOP, null,
+						builder.httpClientCustomizers));
 	}
 
 	/**
@@ -197,6 +201,8 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 
 		private @Nullable OpenAiAudioTranscriptionOptions options;
 
+		private List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers = new ArrayList<>();
+
 		private Builder() {
 		}
 
@@ -222,6 +228,31 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 		 */
 		public Builder options(OpenAiAudioTranscriptionOptions options) {
 			this.options = options;
+			return this;
+		}
+
+		/**
+		 * Registers an {@link OpenAiHttpClientBuilderCustomizer} that mutates the
+		 * underlying OkHttp client builder before the OpenAI clients are constructed. Use
+		 * this to attach OkHttp interceptors (e.g. OAuth2 bearer-token injection), swap
+		 * the dispatcher executor, or tweak any other OkHttp setting. Customizers are
+		 * applied in the order they are registered, after Spring AI's own defaults, so
+		 * user code wins.
+		 */
+		public Builder httpClientBuilderCustomizer(OpenAiHttpClientBuilderCustomizer customizer) {
+			Assert.notNull(customizer, "customizer cannot be null");
+			this.httpClientCustomizers.add(customizer);
+			return this;
+		}
+
+		/**
+		 * Sets the full list of {@link OpenAiHttpClientBuilderCustomizer customizers} to
+		 * apply, replacing any customizers registered earlier on this builder. The order
+		 * of the list is preserved when invoking the customizers.
+		 */
+		public Builder httpClientBuilderCustomizers(List<OpenAiHttpClientBuilderCustomizer> customizers) {
+			Assert.notNull(customizers, "customizers cannot be null");
+			this.httpClientCustomizers = new ArrayList<>(customizers);
 			return this;
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -97,6 +96,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.observation.conventions.AiProvider;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
@@ -1177,7 +1177,7 @@ public final class OpenAiChatModel implements ChatModel {
 
 		private @Nullable MeterRegistry meterRegistry;
 
-		private @Nullable ExecutorService dispatcherExecutor;
+		private List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers = new ArrayList<>();
 
 		private Builder() {
 		}
@@ -1242,18 +1242,27 @@ public final class OpenAiChatModel implements ChatModel {
 		}
 
 		/**
-		 * Sets the executor used by the underlying OkHttp dispatcher for both the sync
-		 * and async clients. The caller owns the executor's lifecycle — Spring AI will
-		 * not shut it down. Typical use: pass
-		 * {@code Executors.newVirtualThreadPerTaskExecutor()} on Java 21+ to back HTTP
-		 * dispatch with virtual threads. When omitted, an internal platform-thread
-		 * executor is created and managed by the HTTP client.
-		 * @param dispatcherExecutor the dispatcher executor; null restores the default
-		 * @return this builder
-		 * @since 2.0.0
+		 * Registers an {@link OpenAiHttpClientBuilderCustomizer} that mutates the
+		 * underlying OkHttp client builder before the OpenAI clients are constructed. Use
+		 * this to attach OkHttp interceptors (e.g. OAuth2 bearer-token injection), swap
+		 * the dispatcher executor, or tweak any other OkHttp setting. Customizers are
+		 * applied in the order they are registered, after Spring AI's own defaults, so
+		 * user code wins.
 		 */
-		public Builder dispatcherExecutor(java.util.concurrent.ExecutorService dispatcherExecutor) {
-			this.dispatcherExecutor = dispatcherExecutor;
+		public Builder httpClientBuilderCustomizer(OpenAiHttpClientBuilderCustomizer customizer) {
+			Assert.notNull(customizer, "customizer cannot be null");
+			this.httpClientCustomizers.add(customizer);
+			return this;
+		}
+
+		/**
+		 * Sets the full list of {@link OpenAiHttpClientBuilderCustomizer customizers} to
+		 * apply, replacing any customizers registered earlier on this builder. The order
+		 * of the list is preserved when invoking the customizers.
+		 */
+		public Builder httpClientBuilderCustomizers(List<OpenAiHttpClientBuilderCustomizer> customizers) {
+			Assert.notNull(customizers, "customizers cannot be null");
+			this.httpClientCustomizers = new ArrayList<>(customizers);
 			return this;
 		}
 
@@ -1274,7 +1283,7 @@ public final class OpenAiChatModel implements ChatModel {
 							resolvedOptions.isMicrosoftFoundry(), resolvedOptions.isGitHubModels(),
 							resolvedOptions.getModel(), resolvedOptions.getTimeout(), resolvedOptions.getMaxRetries(),
 							resolvedOptions.getProxy(), resolvedOptions.getCustomHeaders(), resolvedObservationRegistry,
-							this.meterRegistry, this.dispatcherExecutor));
+							this.meterRegistry, this.httpClientCustomizers));
 
 			OpenAIClientAsync resolvedClientAsync = Objects.requireNonNullElseGet(this.openAiClientAsync,
 					() -> OpenAiSetup.setupAsyncClient(resolvedOptions.getBaseUrl(), resolvedOptions.getApiKey(),
@@ -1283,7 +1292,7 @@ public final class OpenAiChatModel implements ChatModel {
 							resolvedOptions.isMicrosoftFoundry(), resolvedOptions.isGitHubModels(),
 							resolvedOptions.getModel(), resolvedOptions.getTimeout(), resolvedOptions.getMaxRetries(),
 							resolvedOptions.getProxy(), resolvedOptions.getCustomHeaders(), resolvedObservationRegistry,
-							this.meterRegistry, this.dispatcherExecutor));
+							this.meterRegistry, this.httpClientCustomizers));
 
 			ToolCallingManager resolvedToolCallingManager = Objects.requireNonNullElse(this.toolCallingManager,
 					ToolCallingManager.builder().observationRegistry(resolvedObservationRegistry).build());

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
@@ -42,6 +42,7 @@ import org.springframework.ai.embedding.observation.EmbeddingModelObservationCon
 import org.springframework.ai.embedding.observation.EmbeddingModelObservationDocumentation;
 import org.springframework.ai.model.EmbeddingUtils;
 import org.springframework.ai.observation.conventions.AiProvider;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -73,7 +74,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	/**
 	 * Creates a new OpenAiEmbeddingModel with default options.
+	 * @deprecated in favor of {@link OpenAiEmbeddingModel#builder()}
 	 */
+	@Deprecated
 	public OpenAiEmbeddingModel() {
 		this(null, null, null, null);
 	}
@@ -81,7 +84,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	/**
 	 * Creates a new OpenAiEmbeddingModel with the given options.
 	 * @param options the embedding options
+	 * @deprecated in favor of {@link OpenAiEmbeddingModel#builder()}
 	 */
+	@Deprecated
 	public OpenAiEmbeddingModel(@Nullable OpenAiEmbeddingOptions options) {
 		this(null, null, options, null);
 	}
@@ -90,7 +95,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	 * Creates a new OpenAiEmbeddingModel with the given metadata mode and options.
 	 * @param metadataMode the metadata mode
 	 * @param options the embedding options
+	 * @deprecated in favor of {@link OpenAiEmbeddingModel#builder()}
 	 */
+	@Deprecated
 	public OpenAiEmbeddingModel(@Nullable MetadataMode metadataMode, @Nullable OpenAiEmbeddingOptions options) {
 		this(null, metadataMode, options, null);
 	}
@@ -99,7 +106,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	 * Creates a new OpenAiEmbeddingModel with the given options and observation registry.
 	 * @param options the embedding options
 	 * @param observationRegistry the observation registry
+	 * @deprecated in favor of {@link OpenAiEmbeddingModel#builder()}
 	 */
+	@Deprecated
 	public OpenAiEmbeddingModel(@Nullable OpenAiEmbeddingOptions options,
 			@Nullable ObservationRegistry observationRegistry) {
 		this(null, null, options, observationRegistry);
@@ -111,7 +120,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	 * @param metadataMode the metadata mode
 	 * @param options the embedding options
 	 * @param observationRegistry the observation registry
+	 * @deprecated in favor of {@link OpenAiEmbeddingModel#builder()}
 	 */
+	@Deprecated
 	public OpenAiEmbeddingModel(@Nullable MetadataMode metadataMode, @Nullable OpenAiEmbeddingOptions options,
 			@Nullable ObservationRegistry observationRegistry) {
 		this(null, metadataMode, options, observationRegistry);
@@ -120,7 +131,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	/**
 	 * Creates a new OpenAiEmbeddingModel with the given OpenAI client.
 	 * @param openAiClient the OpenAI client
+	 * @deprecated in favor of {@link OpenAiEmbeddingModel#builder()}
 	 */
+	@Deprecated
 	public OpenAiEmbeddingModel(@Nullable OpenAIClient openAiClient) {
 		this(openAiClient, null, null, null);
 	}
@@ -129,7 +142,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	 * Creates a new OpenAiEmbeddingModel with the given OpenAI client and metadata mode.
 	 * @param openAiClient the OpenAI client
 	 * @param metadataMode the metadata mode
+	 * @deprecated in favor of {@link OpenAiEmbeddingModel#builder()}
 	 */
+	@Deprecated
 	public OpenAiEmbeddingModel(@Nullable OpenAIClient openAiClient, @Nullable MetadataMode metadataMode) {
 		this(openAiClient, metadataMode, null, null);
 	}
@@ -139,7 +154,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	 * @param openAiClient the OpenAI client
 	 * @param metadataMode the metadata mode
 	 * @param options the embedding options
+	 * @deprecated in favor of {@link OpenAiEmbeddingModel#builder()}
 	 */
+	@Deprecated
 	public OpenAiEmbeddingModel(@Nullable OpenAIClient openAiClient, @Nullable MetadataMode metadataMode,
 			@Nullable OpenAiEmbeddingOptions options) {
 		this(openAiClient, metadataMode, options, null);
@@ -151,26 +168,34 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	 * @param metadataMode the metadata mode
 	 * @param options the embedding options
 	 * @param observationRegistry the observation registry
+	 * @deprecated in favor of {@link OpenAiEmbeddingModel#builder()}
 	 */
+	@Deprecated
 	public OpenAiEmbeddingModel(@Nullable OpenAIClient openAiClient, @Nullable MetadataMode metadataMode,
 			@Nullable OpenAiEmbeddingOptions options, @Nullable ObservationRegistry observationRegistry) {
 
-		if (options == null) {
-			this.options = OpenAiEmbeddingOptions.builder().build();
-		}
-		else {
-			this.options = options;
-		}
-		this.openAiClient = Objects.requireNonNullElseGet(openAiClient,
+		this(builder().openAiClient(openAiClient)
+			.metadataMode(metadataMode)
+			.options(options)
+			.observationRegistry(observationRegistry));
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private OpenAiEmbeddingModel(Builder builder) {
+		this.options = builder.options != null ? builder.options : OpenAiEmbeddingOptions.builder().build();
+		this.metadataMode = Objects.requireNonNullElse(builder.metadataMode, MetadataMode.EMBED);
+		this.observationRegistry = Objects.requireNonNullElse(builder.observationRegistry, ObservationRegistry.NOOP);
+		this.openAiClient = Objects.requireNonNullElseGet(builder.openAiClient,
 				() -> OpenAiSetup.setupSyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
 						this.options.getCredential(), this.options.getMicrosoftDeploymentName(),
 						this.options.getMicrosoftFoundryServiceVersion(), this.options.getOrganizationId(),
 						this.options.isMicrosoftFoundry(), this.options.isGitHubModels(), this.options.getModel(),
 						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(),
-						observationRegistry != null ? observationRegistry : ObservationRegistry.NOOP, null, null));
-		this.metadataMode = Objects.requireNonNullElse(metadataMode, MetadataMode.EMBED);
-		this.observationRegistry = Objects.requireNonNullElse(observationRegistry, ObservationRegistry.NOOP);
+						this.options.getCustomHeaders(), this.observationRegistry, null,
+						builder.httpClientCustomizers));
 	}
 
 	@Override
@@ -267,6 +292,72 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	public void setObservationConvention(EmbeddingModelObservationConvention observationConvention) {
 		Assert.notNull(observationConvention, "observationConvention cannot be null");
 		this.observationConvention = observationConvention;
+	}
+
+	public static final class Builder {
+
+		private @Nullable OpenAIClient openAiClient;
+
+		private @Nullable OpenAiEmbeddingOptions options;
+
+		private @Nullable MetadataMode metadataMode;
+
+		private @Nullable ObservationRegistry observationRegistry;
+
+		private List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers = new ArrayList<>();
+
+		private Builder() {
+		}
+
+		public Builder openAiClient(@Nullable OpenAIClient openAiClient) {
+			this.openAiClient = openAiClient;
+			return this;
+		}
+
+		public Builder options(@Nullable OpenAiEmbeddingOptions options) {
+			this.options = options;
+			return this;
+		}
+
+		public Builder metadataMode(@Nullable MetadataMode metadataMode) {
+			this.metadataMode = metadataMode;
+			return this;
+		}
+
+		public Builder observationRegistry(@Nullable ObservationRegistry observationRegistry) {
+			this.observationRegistry = observationRegistry;
+			return this;
+		}
+
+		/**
+		 * Registers an {@link OpenAiHttpClientBuilderCustomizer} that mutates the
+		 * underlying OkHttp client builder before the OpenAI clients are constructed. Use
+		 * this to attach OkHttp interceptors (e.g. OAuth2 bearer-token injection), swap
+		 * the dispatcher executor, or tweak any other OkHttp setting. Customizers are
+		 * applied in the order they are registered, after Spring AI's own defaults, so
+		 * user code wins.
+		 */
+		public Builder httpClientBuilderCustomizer(OpenAiHttpClientBuilderCustomizer customizer) {
+			Assert.notNull(customizer, "customizer cannot be null");
+			this.httpClientCustomizers.add(customizer);
+			return this;
+		}
+
+		/**
+		 * Sets the full list of {@link OpenAiHttpClientBuilderCustomizer customizers} to
+		 * apply, replacing any customizers registered earlier on this builder. The order
+		 * of the list is preserved when invoking the customizers.
+		 */
+		public Builder httpClientBuilderCustomizers(List<OpenAiHttpClientBuilderCustomizer> customizers) {
+			Assert.notNull(customizers, "customizers cannot be null");
+			this.httpClientCustomizers = new ArrayList<>(customizers);
+			return this;
+		}
+
+		public OpenAiEmbeddingModel build() {
+			return new OpenAiEmbeddingModel(this);
+		}
+
 	}
 
 }

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.openai;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -37,6 +38,7 @@ import org.springframework.ai.image.observation.ImageModelObservationContext;
 import org.springframework.ai.image.observation.ImageModelObservationConvention;
 import org.springframework.ai.image.observation.ImageModelObservationDocumentation;
 import org.springframework.ai.observation.conventions.AiProvider;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.metadata.OpenAiImageGenerationMetadata;
 import org.springframework.ai.openai.metadata.OpenAiImageResponseMetadata;
 import org.springframework.ai.openai.setup.OpenAiSetup;
@@ -132,22 +134,24 @@ public class OpenAiImageModel implements ImageModel {
 	 */
 	public OpenAiImageModel(@Nullable OpenAIClient openAiClient, @Nullable OpenAiImageOptions options,
 			@Nullable ObservationRegistry observationRegistry) {
+		this(builder().openAiClient(openAiClient).options(options).observationRegistry(observationRegistry));
+	}
 
-		if (options == null) {
-			this.options = OpenAiImageOptions.builder().build();
-		}
-		else {
-			this.options = options;
-		}
-		this.openAiClient = Objects.requireNonNullElseGet(openAiClient,
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private OpenAiImageModel(Builder builder) {
+		this.options = builder.options != null ? builder.options : OpenAiImageOptions.builder().build();
+		this.observationRegistry = Objects.requireNonNullElse(builder.observationRegistry, ObservationRegistry.NOOP);
+		this.openAiClient = Objects.requireNonNullElseGet(builder.openAiClient,
 				() -> OpenAiSetup.setupSyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
 						this.options.getCredential(), this.options.getMicrosoftDeploymentName(),
 						this.options.getMicrosoftFoundryServiceVersion(), this.options.getOrganizationId(),
 						this.options.isMicrosoftFoundry(), this.options.isGitHubModels(), this.options.getModel(),
 						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(),
-						observationRegistry != null ? observationRegistry : ObservationRegistry.NOOP, null, null));
-		this.observationRegistry = Objects.requireNonNullElse(observationRegistry, ObservationRegistry.NOOP);
+						this.options.getCustomHeaders(), this.observationRegistry, null,
+						builder.httpClientCustomizers));
 	}
 
 	/**
@@ -217,6 +221,65 @@ public class OpenAiImageModel implements ImageModel {
 	public void setObservationConvention(ImageModelObservationConvention observationConvention) {
 		Assert.notNull(observationConvention, "observationConvention cannot be null");
 		this.observationConvention = observationConvention;
+	}
+
+	public static final class Builder {
+
+		private @Nullable OpenAIClient openAiClient;
+
+		private @Nullable OpenAiImageOptions options;
+
+		private @Nullable ObservationRegistry observationRegistry;
+
+		private List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers = new ArrayList<>();
+
+		private Builder() {
+		}
+
+		public Builder openAiClient(@Nullable OpenAIClient openAiClient) {
+			this.openAiClient = openAiClient;
+			return this;
+		}
+
+		public Builder options(@Nullable OpenAiImageOptions options) {
+			this.options = options;
+			return this;
+		}
+
+		public Builder observationRegistry(@Nullable ObservationRegistry observationRegistry) {
+			this.observationRegistry = observationRegistry;
+			return this;
+		}
+
+		/**
+		 * Registers an {@link OpenAiHttpClientBuilderCustomizer} that mutates the
+		 * underlying OkHttp client builder before the OpenAI clients are constructed. Use
+		 * this to attach OkHttp interceptors (e.g. OAuth2 bearer-token injection), swap
+		 * the dispatcher executor, or tweak any other OkHttp setting. Customizers are
+		 * applied in the order they are registered, after Spring AI's own defaults, so
+		 * user code wins.
+		 */
+		public Builder httpClientBuilderCustomizer(OpenAiHttpClientBuilderCustomizer customizer) {
+			Assert.notNull(customizer, "customizer cannot be null");
+			this.httpClientCustomizers.add(customizer);
+			return this;
+		}
+
+		/**
+		 * Sets the full list of {@link OpenAiHttpClientBuilderCustomizer customizers} to
+		 * apply, replacing any customizers registered earlier on this builder. The order
+		 * of the list is preserved when invoking the customizers.
+		 */
+		public Builder httpClientBuilderCustomizers(List<OpenAiHttpClientBuilderCustomizer> customizers) {
+			Assert.notNull(customizers, "customizers cannot be null");
+			this.httpClientCustomizers = new ArrayList<>(customizers);
+			return this;
+		}
+
+		public OpenAiImageModel build() {
+			return new OpenAiImageModel(this);
+		}
+
 	}
 
 }

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
@@ -36,6 +36,7 @@ import org.springframework.ai.moderation.ModerationOptions;
 import org.springframework.ai.moderation.ModerationPrompt;
 import org.springframework.ai.moderation.ModerationResponse;
 import org.springframework.ai.moderation.ModerationResult;
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.util.Assert;
 
 /**
@@ -47,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Ahmed Yousri
  * @author Ilayaperumal Gopinathan
  * @author Sebastien Deleuze
+ * @author Thomas Vitale
  */
 public final class OpenAiModerationModel implements ModerationModel {
 
@@ -73,7 +75,7 @@ public final class OpenAiModerationModel implements ModerationModel {
 						this.options.getOrganizationId(), this.options.isMicrosoftFoundry(),
 						this.options.isGitHubModels(), this.options.getModel(), this.options.getTimeout(),
 						this.options.getMaxRetries(), this.options.getProxy(), this.options.getCustomHeaders(),
-						ObservationRegistry.NOOP, null, null));
+						ObservationRegistry.NOOP, null, builder.httpClientCustomizers));
 	}
 
 	public static Builder builder() {
@@ -179,6 +181,8 @@ public final class OpenAiModerationModel implements ModerationModel {
 
 		private @Nullable OpenAiModerationOptions options;
 
+		private List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers = new ArrayList<>();
+
 		private Builder() {
 		}
 
@@ -194,6 +198,31 @@ public final class OpenAiModerationModel implements ModerationModel {
 
 		public Builder options(OpenAiModerationOptions options) {
 			this.options = options;
+			return this;
+		}
+
+		/**
+		 * Registers an {@link OpenAiHttpClientBuilderCustomizer} that mutates the
+		 * underlying OkHttp client builder before the OpenAI clients are constructed. Use
+		 * this to attach OkHttp interceptors (e.g. OAuth2 bearer-token injection), swap
+		 * the dispatcher executor, or tweak any other OkHttp setting. Customizers are
+		 * applied in the order they are registered, after Spring AI's own defaults, so
+		 * user code wins.
+		 */
+		public Builder httpClientBuilderCustomizer(OpenAiHttpClientBuilderCustomizer customizer) {
+			Assert.notNull(customizer, "customizer cannot be null");
+			this.httpClientCustomizers.add(customizer);
+			return this;
+		}
+
+		/**
+		 * Sets the full list of {@link OpenAiHttpClientBuilderCustomizer customizers} to
+		 * apply, replacing any customizers registered earlier on this builder. The order
+		 * of the list is preserved when invoking the customizers.
+		 */
+		public Builder httpClientBuilderCustomizers(List<OpenAiHttpClientBuilderCustomizer> customizers) {
+			Assert.notNull(customizers, "customizers cannot be null");
+			this.httpClientCustomizers = new ArrayList<>(customizers);
 			return this;
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/http/okhttp/OpenAiHttpClientBuilderCustomizer.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/http/okhttp/OpenAiHttpClientBuilderCustomizer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.http.okhttp;
+
+/**
+ * Callback for customizing the {@link SpringAiOpenAiHttpClient.Builder} used by every
+ * OpenAI {@code *Model} before the underlying {@code OkHttpClient} is built. Implement
+ * this interface to register OkHttp interceptors (for example, a Spring Security OAuth2
+ * client-credentials interceptor), swap the dispatcher {@code ExecutorService}, or tweak
+ * any other OkHttp setting exposed by the builder.
+ *
+ * @author Thomas Vitale
+ * @since 2.0.0
+ */
+@FunctionalInterface
+public interface OpenAiHttpClientBuilderCustomizer {
+
+	/**
+	 * Customize the {@link SpringAiOpenAiHttpClient.Builder} prior to building the
+	 * underlying OkHttp client.
+	 * @param builder the builder to customize
+	 */
+	void customize(SpringAiOpenAiHttpClient.Builder builder);
+
+}

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/http/okhttp/SpringAiOpenAiHttpClient.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/http/okhttp/SpringAiOpenAiHttpClient.java
@@ -21,7 +21,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Proxy;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
@@ -59,6 +61,7 @@ import okhttp3.Callback;
 import okhttp3.ConnectionPool;
 import okhttp3.Dispatcher;
 import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -84,6 +87,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Soby Chacko
  * @author Ilayaperumal Gopinathan
+ * @author Thomas Vitale
  * @since 2.0.0
  */
 public final class SpringAiOpenAiHttpClient implements HttpClient {
@@ -423,6 +427,8 @@ public final class SpringAiOpenAiHttpClient implements HttpClient {
 
 		private Iterable<Tag> meterTags = Collections.emptyList();
 
+		private final List<Interceptor> interceptors = new ArrayList<>();
+
 		private Builder() {
 		}
 
@@ -511,6 +517,17 @@ public final class SpringAiOpenAiHttpClient implements HttpClient {
 			return this;
 		}
 
+		/**
+		 * Registers an OkHttp {@link Interceptor} to run at the end of the chain.
+		 * Interceptors appear in the chain in the order they are added here. Use this to
+		 * attach cross-cutting concerns such as OAuth2 bearer-token injection, custom
+		 * logging, or tenant-propagation headers.
+		 */
+		public Builder interceptor(Interceptor interceptor) {
+			this.interceptors.add(Objects.requireNonNull(interceptor, "interceptor"));
+			return this;
+		}
+
 		public SpringAiOpenAiHttpClient build() {
 			OkHttpClient.Builder okBuilder = new OkHttpClient.Builder()
 				// SDK's RetryingHttpClient owns retries; disable here to avoid doubling.
@@ -526,6 +543,10 @@ public final class SpringAiOpenAiHttpClient implements HttpClient {
 				.builder(this.observationRegistry, OBSERVATION_NAME)
 				.build();
 			okBuilder.addInterceptor(observationInterceptor);
+
+			for (Interceptor interceptor : this.interceptors) {
+				okBuilder.addInterceptor(interceptor);
+			}
 
 			if (this.proxyAuthenticator != null) {
 				final ProxyAuthenticator pa = this.proxyAuthenticator;
@@ -576,15 +597,6 @@ public final class SpringAiOpenAiHttpClient implements HttpClient {
 			}
 
 			return new SpringAiOpenAiHttpClient(okClient, ownsDispatcherExecutor);
-		}
-
-		public SpringAiOpenAiHttpClient buildWithInterceptor(okhttp3.Interceptor interceptor) {
-			SpringAiOpenAiHttpClient baseClient = build();
-			OkHttpClient modifiedOkClient = baseClient.getOkHttpClient()
-				.newBuilder()
-				.addInterceptor(interceptor)
-				.build();
-			return new SpringAiOpenAiHttpClient(modifiedOkClient, baseClient.ownsDispatcherExecutor);
 		}
 
 		// Replicates OkHttp's default dispatcher so wrapping for context propagation

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/setup/OpenAiSetup.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/setup/OpenAiSetup.java
@@ -19,8 +19,8 @@ package org.springframework.ai.openai.setup;
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 import com.openai.azure.AzureOpenAIServiceVersion;
@@ -33,10 +33,12 @@ import com.openai.core.ClientOptions;
 import com.openai.credential.Credential;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
+import okhttp3.OkHttpClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.http.okhttp.SpringAiOpenAiHttpClient;
 
 /**
@@ -46,6 +48,7 @@ import org.springframework.ai.openai.http.okhttp.SpringAiOpenAiHttpClient;
  * coded by the same author (Julien Dubois, from Microsoft).
  *
  * @author Julien Dubois
+ * @author Thomas Vitale
  */
 public final class OpenAiSetup {
 
@@ -94,7 +97,7 @@ public final class OpenAiSetup {
 			@Nullable AzureOpenAIServiceVersion azureOpenAiServiceVersion, @Nullable String organizationId,
 			boolean isAzure, boolean isGitHubModels, @Nullable String modelName, Duration timeout, int maxRetries,
 			@Nullable Proxy proxy, @Nullable Map<String, String> customHeaders, ObservationRegistry observationRegistry,
-			@Nullable MeterRegistry meterRegistry, @Nullable ExecutorService dispatcherExecutor) {
+			@Nullable MeterRegistry meterRegistry, List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		baseUrl = detectBaseUrlFromEnv(baseUrl);
 		var modelProvider = detectModelProvider(isAzure, isGitHubModels, baseUrl, azureDeploymentName,
@@ -107,12 +110,12 @@ public final class OpenAiSetup {
 			// requests.
 			return new OpenAIClientImpl(buildNoAuthClientOptions(baseUrl, modelProvider, modelName, azureDeploymentName,
 					azureOpenAiServiceVersion, organizationId, timeout, maxRetries, proxy, customHeaders,
-					observationRegistry, meterRegistry, dispatcherExecutor));
+					observationRegistry, meterRegistry, httpClientCustomizers));
 		}
 
 		ClientOptions opts = buildClientOptions(baseUrl, modelProvider, modelName, azureDeploymentName,
 				azureOpenAiServiceVersion, organizationId, timeout, maxRetries, proxy, customHeaders, calculatedApiKey,
-				credential, observationRegistry, meterRegistry, dispatcherExecutor);
+				credential, observationRegistry, meterRegistry, httpClientCustomizers);
 		return new OpenAIClientImpl(opts);
 	}
 
@@ -121,7 +124,7 @@ public final class OpenAiSetup {
 			@Nullable AzureOpenAIServiceVersion azureOpenAiServiceVersion, @Nullable String organizationId,
 			boolean isAzure, boolean isGitHubModels, @Nullable String modelName, Duration timeout, int maxRetries,
 			@Nullable Proxy proxy, @Nullable Map<String, String> customHeaders, ObservationRegistry observationRegistry,
-			@Nullable MeterRegistry meterRegistry, @Nullable ExecutorService dispatcherExecutor) {
+			@Nullable MeterRegistry meterRegistry, List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		baseUrl = detectBaseUrlFromEnv(baseUrl);
 		var modelProvider = detectModelProvider(isAzure, isGitHubModels, baseUrl, azureDeploymentName,
@@ -134,12 +137,12 @@ public final class OpenAiSetup {
 			// sending requests.
 			return new OpenAIClientAsyncImpl(buildNoAuthClientOptions(baseUrl, modelProvider, modelName,
 					azureDeploymentName, azureOpenAiServiceVersion, organizationId, timeout, maxRetries, proxy,
-					customHeaders, observationRegistry, meterRegistry, dispatcherExecutor));
+					customHeaders, observationRegistry, meterRegistry, httpClientCustomizers));
 		}
 
 		ClientOptions opts = buildClientOptions(baseUrl, modelProvider, modelName, azureDeploymentName,
 				azureOpenAiServiceVersion, organizationId, timeout, maxRetries, proxy, customHeaders, calculatedApiKey,
-				credential, observationRegistry, meterRegistry, dispatcherExecutor);
+				credential, observationRegistry, meterRegistry, httpClientCustomizers);
 		return new OpenAIClientAsyncImpl(opts);
 	}
 
@@ -148,14 +151,17 @@ public final class OpenAiSetup {
 			@Nullable AzureOpenAIServiceVersion azureOpenAiServiceVersion, @Nullable String organizationId,
 			Duration timeout, int maxRetries, @Nullable Proxy proxy, @Nullable Map<String, String> customHeaders,
 			@Nullable String calculatedApiKey, @Nullable Credential credential, ObservationRegistry observationRegistry,
-			@Nullable MeterRegistry meterRegistry, @Nullable ExecutorService dispatcherExecutor) {
+			@Nullable MeterRegistry meterRegistry, List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		SpringAiOpenAiHttpClient.Builder httpBuilder = SpringAiOpenAiHttpClient.builder()
 			.observationRegistry(observationRegistry)
 			.meterRegistry(meterRegistry)
 			.timeout(timeout)
-			.proxy(proxy)
-			.dispatcherExecutorService(dispatcherExecutor);
+			.proxy(proxy);
+
+		for (OpenAiHttpClientBuilderCustomizer customizer : httpClientCustomizers) {
+			customizer.customize(httpBuilder);
+		}
 
 		ClientOptions.Builder clientOptions = ClientOptions.builder()
 			.httpClient(httpBuilder.build())
@@ -204,22 +210,24 @@ public final class OpenAiSetup {
 			@Nullable AzureOpenAIServiceVersion azureOpenAiServiceVersion, @Nullable String organizationId,
 			Duration timeout, int maxRetries, @Nullable Proxy proxy, @Nullable Map<String, String> customHeaders,
 			ObservationRegistry observationRegistry, @Nullable MeterRegistry meterRegistry,
-			@Nullable ExecutorService dispatcherExecutor) {
+			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		SpringAiOpenAiHttpClient.Builder httpBuilder = SpringAiOpenAiHttpClient.builder()
 			.observationRegistry(observationRegistry)
 			.meterRegistry(meterRegistry)
 			.timeout(timeout)
-			.proxy(proxy)
-			.dispatcherExecutorService(dispatcherExecutor);
+			.proxy(proxy);
 
-		SpringAiOpenAiHttpClient httpClient = httpBuilder.buildWithInterceptor(chain -> {
-			okhttp3.Request request = chain.request().newBuilder().removeHeader("Authorization").build();
-			return chain.proceed(request);
-		});
+		// No API Key defined, so remove the mandatory "Authorization" header.
+		httpBuilder
+			.interceptor(chain -> chain.proceed(chain.request().newBuilder().removeHeader("Authorization").build()));
+
+		for (OpenAiHttpClientBuilderCustomizer customizer : httpClientCustomizers) {
+			customizer.customize(httpBuilder);
+		}
 
 		ClientOptions.Builder clientOptions = ClientOptions.builder()
-			.httpClient(httpClient)
+			.httpClient(httpBuilder.build())
 			.apiKey(NO_AUTH_PLACEHOLDER_KEY)
 			.baseUrl(calculateBaseUrl(baseUrl, modelProvider, modelName, azureDeploymentName))
 			.organization(organizationId)

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/http/okhttp/OpenAiHttpClientBuilderCustomizerTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/http/okhttp/OpenAiHttpClientBuilderCustomizerTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.openai.setup;
+package org.springframework.ai.openai.http.okhttp;
 
 import java.time.Duration;
 import java.util.List;
@@ -28,70 +28,33 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.ai.model.NoopApiKey;
-import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.setup.OpenAiSetup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests that an empty API key (or {@link NoopApiKey}) results in no {@code Authorization}
- * header being sent to the server.
+ * Unit tests for {@link OpenAiHttpClientBuilderCustomizer}.
  *
- * @author Ilayaperumal Gopinathan
  * @author Thomas Vitale
  */
-public class OpenAiSetupEmptyApiKeyTests {
+class OpenAiHttpClientBuilderCustomizerTests {
 
 	private static final String CHAT_COMPLETION_RESPONSE = """
 			{"id":"chatcmpl-test","object":"chat.completion","created":1700000000,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}
 			""";
 
 	@Test
-	void emptyApiKeyDoesNotSendAuthorizationHeader() throws Exception {
+	void userInterceptorRunsAfterNoAuthStripper() throws Exception {
 		try (MockWebServer server = new MockWebServer()) {
-			server.enqueue(new MockResponse().setResponseCode(200)
-				.setHeader("Content-Type", "application/json")
-				.setBody(CHAT_COMPLETION_RESPONSE));
+			server.enqueue(mockChatCompletion());
 			server.start();
+
+			OpenAiHttpClientBuilderCustomizer customizer = builder -> builder.interceptor(chain -> chain
+				.proceed(chain.request().newBuilder().header("Authorization", "Bearer oauth2-token").build()));
 
 			OpenAIClient client = OpenAiSetup.setupSyncClient(server.url("/v1").toString(), "", null, null, null, null,
 					false, false, "gpt-4", Duration.ofSeconds(10), 0, null, null, ObservationRegistry.NOOP, null,
-					List.of());
-
-			assertThat(client).isNotNull();
-
-			// Trigger an actual HTTP request so we can inspect received headers.
-			client.chat()
-				.completions()
-				.create(ChatCompletionCreateParams.builder().model(ChatModel.GPT_4).addUserMessage("Hi").build());
-
-			RecordedRequest request = server.takeRequest();
-			assertThat(request.getHeader("Authorization")).as("Authorization header must be absent in no-auth mode")
-				.isNull();
-		}
-	}
-
-	@Test
-	void noopApiKeyDoesNotSendAuthorizationHeader() throws Exception {
-		try (MockWebServer server = new MockWebServer()) {
-			server.enqueue(new MockResponse().setResponseCode(200)
-				.setHeader("Content-Type", "application/json")
-				.setBody(CHAT_COMPLETION_RESPONSE));
-			server.start();
-
-			// NoopApiKey is the 1.x migration path: users who previously relied on
-			// NoopApiKey can now pass it via the ApiKey-typed builder overload.
-			OpenAiChatOptions options = OpenAiChatOptions.builder()
-				.baseUrl(server.url("/v1").toString())
-				.apiKey(new NoopApiKey())
-				.model("gpt-4")
-				.build();
-
-			assertThat(options.getApiKey()).as("NoopApiKey.getValue() should return empty string").isEmpty();
-
-			OpenAIClient client = OpenAiSetup.setupSyncClient(options.getBaseUrl(), options.getApiKey(), null, null,
-					null, null, false, false, "gpt-4", Duration.ofSeconds(10), 0, null, null, ObservationRegistry.NOOP,
-					null, List.of());
+					List.of(customizer));
 
 			client.chat()
 				.completions()
@@ -99,9 +62,39 @@ public class OpenAiSetupEmptyApiKeyTests {
 
 			RecordedRequest request = server.takeRequest();
 			assertThat(request.getHeader("Authorization"))
-				.as("Authorization header must be absent when NoopApiKey is used")
-				.isNull();
+				.as("User interceptor sets Authorization after the no-auth stripper, so the bearer token is preserved")
+				.isEqualTo("Bearer oauth2-token");
 		}
+	}
+
+	@Test
+	void userInterceptorRunsWithApiKeyAndCanOverrideAuthorization() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.enqueue(mockChatCompletion());
+			server.start();
+
+			OpenAiHttpClientBuilderCustomizer customizer = builder -> builder.interceptor(chain -> chain
+				.proceed(chain.request().newBuilder().header("Authorization", "Bearer user-override").build()));
+
+			OpenAIClient client = OpenAiSetup.setupSyncClient(server.url("/v1").toString(), "real-api-key", null, null,
+					null, null, false, false, "gpt-4", Duration.ofSeconds(10), 0, null, null, ObservationRegistry.NOOP,
+					null, List.of(customizer));
+
+			client.chat()
+				.completions()
+				.create(ChatCompletionCreateParams.builder().model(ChatModel.GPT_4).addUserMessage("Hi").build());
+
+			RecordedRequest request = server.takeRequest();
+			assertThat(request.getHeader("Authorization"))
+				.as("User interceptor runs last so it can override the SDK-attached API key header")
+				.isEqualTo("Bearer user-override");
+		}
+	}
+
+	private static MockResponse mockChatCompletion() {
+		return new MockResponse().setResponseCode(200)
+			.setHeader("Content-Type", "application/json")
+			.setBody(CHAT_COMPLETION_RESPONSE);
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/setup/OpenAiSetupTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/setup/OpenAiSetupTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai.setup;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import com.openai.azure.credential.AzureApiKeyCredential;
@@ -75,7 +76,7 @@ public class OpenAiSetupTests {
 	void setupSyncClient_returnsClient_whenValidApiKeyProvided() {
 		OpenAIClient client = OpenAiSetup.setupSyncClient(null, "valid-api-key", null, null, null, null, false, false,
 				null, Duration.ofSeconds(30), 2, null, null, io.micrometer.observation.ObservationRegistry.NOOP, null,
-				null);
+				List.of());
 
 		assertNotNull(client);
 	}
@@ -86,7 +87,7 @@ public class OpenAiSetupTests {
 
 		OpenAIClient client = OpenAiSetup.setupSyncClient(null, "valid-api-key", null, null, null, null, false, false,
 				null, Duration.ofSeconds(30), 2, null, customHeaders,
-				io.micrometer.observation.ObservationRegistry.NOOP, null, null);
+				io.micrometer.observation.ObservationRegistry.NOOP, null, List.of());
 
 		assertNotNull(client);
 	}
@@ -122,7 +123,7 @@ public class OpenAiSetupTests {
 
 		OpenAIClient client = OpenAiSetup.setupSyncClient(endpoint, apiKey, null, deploymentName, null, null, true,
 				false, null, Duration.ofSeconds(30), 2, null, null, io.micrometer.observation.ObservationRegistry.NOOP,
-				null, null);
+				null, List.of());
 
 		assertNotNull(client);
 	}
@@ -131,7 +132,7 @@ public class OpenAiSetupTests {
 	void setupSyncClient_usesApiKeyHeader_notBearerToken_forMicrosoftFoundry() throws Exception {
 		OpenAIClient client = OpenAiSetup.setupSyncClient("https://my-resource.openai.azure.com/", "my-foundry-key",
 				null, null, null, null, true, false, null, Duration.ofSeconds(30), 2, null, null,
-				io.micrometer.observation.ObservationRegistry.NOOP, null, null);
+				io.micrometer.observation.ObservationRegistry.NOOP, null, List.of());
 
 		Field field = client.getClass().getDeclaredField("clientOptions");
 		field.setAccessible(true);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
@@ -201,6 +201,8 @@ Flux<TextToSpeechResponse> responseStream = openAiAudioSpeechModel.stream(speech
 Flux<byte[]> audioByteStream = openAiAudioSpeechModel.stream("Hello, world!");
 ----
 
+include::partial$openai/openai-http-client-customization.adoc[]
+
 == Migration Guide
 
 If you're upgrading from the deprecated `SpeechModel` and `SpeechPrompt` classes, this guide provides detailed instructions for migrating to the new shared interfaces.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
@@ -165,5 +165,7 @@ AudioTranscriptionPrompt transcriptionRequest = new AudioTranscriptionPrompt(thi
 AudioTranscriptionResponse response = openAiTranscriptionModel.call(this.transcriptionRequest);
 ----
 
+include::partial$openai/openai-http-client-customization.adoc[]
+
 == Example Code
 * The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/transcription/OpenAiTranscriptionModelIT.java[OpenAiTranscriptionModelIT.java] test provides some general examples how to use the library.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -842,6 +842,8 @@ If you need to correlate streaming HTTP spans with their parent chat-model span 
 Built-in parent linkage for streaming is being pursued upstream in the OpenAI Java SDK.
 ====
 
+include::partial$openai/openai-http-client-customization.adoc[]
+
 == Using Extra Parameters with OpenAI-Compatible Servers [[openai-compatible-servers]]
 
 OpenAI-compatible inference servers like vLLM, Ollama, and others often support additional parameters beyond those defined in OpenAI's standard API.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
@@ -258,4 +258,4 @@ EmbeddingResponse embeddingResponse = this.embeddingModel
 The `OpenAiEmbeddingOptions` provides the configuration information for the embedding requests.
 The api and options class offers a `builder()` for easy options creation.
 
-
+include::partial$openai/openai-http-client-customization.adoc[]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/openai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/openai-image.adoc
@@ -178,3 +178,5 @@ ImageResponse response = openaiImageModel.call(
 ----
 
 TIP: In addition to the model specific https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java[OpenAiImageOptions] you can use a portable https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/image/ImageOptions.java[ImageOptions] instance, created with the https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/image/ImageOptionsBuilder.java[ImageOptionsBuilder#builder()].
+
+include::partial$openai/openai-http-client-customization.adoc[]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation/openai-moderation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation/openai-moderation.adoc
@@ -192,5 +192,7 @@ ModerationPrompt moderationPrompt = new ModerationPrompt("Text to be moderated",
 ModerationResponse response = this.openAiModerationModel.call(this.moderationPrompt);
 ----
 
+include::partial$openai/openai-http-client-customization.adoc[]
+
 == Example Code
 The `OpenAiModerationModelIT` test provides some general examples of how to use the library. You can refer to this test for more detailed usage examples.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/partials/openai/openai-http-client-customization.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/partials/openai/openai-http-client-customization.adoc
@@ -1,0 +1,31 @@
+== Customizing the HTTP Client
+
+Spring AI uses the official `openai-java` SDK under the hood and configures its HTTP transport with a custom OkHttp client built by `SpringAiOpenAiHttpClient.Builder`.
+You can intercept that builder before the underlying `OkHttpClient` is created by exposing one or more `OpenAiHttpClientBuilderCustomizer` beans.
+Each customizer receives the same builder used by every OpenAI model (chat, embedding, image, audio, moderation), so the customization applies uniformly.
+
+[source,java]
+----
+@FunctionalInterface
+public interface OpenAiHttpClientBuilderCustomizer {
+    void customize(SpringAiOpenAiHttpClient.Builder builder);
+}
+----
+
+Typical use cases include:
+
+* registering OkHttp `Interceptor` instances (authentication, propagation headers, custom logging);
+* swapping the dispatcher `ExecutorService` (for example, to route async I/O through virtual threads);
+* configuring proxy, SSL, hostname verification, or the connection-pool sizing exposed by the builder.
+
+When several customizers are present, they are applied in `@Order` order, after Spring AI's own defaults, so user code wins.
+
+The same hook is available when wiring a model manually via the `OpenAi*Model.Builder`:
+
+[source,java]
+----
+var chatModel = OpenAiChatModel.builder()
+    .options(OpenAiChatOptions.builder().model("gpt-4o").build())
+    .httpClientBuilderCustomizer(myCustomizer)
+    .build();
+----


### PR DESCRIPTION
The official OpenAI Java SDK doesn't support any customization of the underlying HTTP Client, which makes it unsuitable for production scenarios.

In a previous PR, a custom `SpringAiOpenAiHttpClient` has been introduced to add support for observability instrumentation and context propagation. This PR builds on top of that and introduces a `OpenAiHttpClientBuilderCustomizer` interface that can be used to customize the `SpringAiOpenAiHttpClient.Builder`.

Examples of real-world customizations:

* add an interceptor to integrate Spring Security and configure OAuth2 Client Credentials authentication instead of the weaker API Key approach
* configure a custom certificate for TLS communication based on a private PKI
* use a virtual thread-based executor instead of platform threads.

Any `OpenAiHttpClientBuilderCustomizer` bean is used in the auto-configuration and passed down to each `OpenAi*Model` class for uniform customization support.