### PR TITLE
Replay `reasoning_content` in OpenAI assistant history

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -122,6 +122,8 @@ public final class OpenAiChatModel implements ChatModel {
 
 	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();
 
+	private static final String REASONING_CONTENT = "reasoningContent";
+
 	private final Log logger = LogFactory.getLog(OpenAiChatModel.class);
 
 	private final OpenAIClient openAiClient;
@@ -216,7 +218,7 @@ public final class OpenAiChatModel implements ChatModel {
 									: "",
 							"index", choice.index(), "finishReason", choice.finishReason().value().toString(),
 							"refusal", choice.message().refusal().orElse(""), "annotations",
-							choice.message().annotations().orElse((List) List.of(Map.of())), "reasoningContent",
+							choice.message().annotations().orElse((List) List.of(Map.of())), REASONING_CONTENT,
 							getReasoningContent(choice));
 					return buildGeneration(choice, metadata, request);
 				}).toList();
@@ -316,7 +318,7 @@ public final class OpenAiChatModel implements ChatModel {
 							"finishReason", choice.finishReason().value(), //
 							"refusal", choice.message().refusal().orElse(""), //
 							"annotations", choice.message().annotations().orElseGet(List::of), //
-							"reasoningContent", getReasoningContent(choice) //
+							REASONING_CONTENT, getReasoningContent(choice) //
 					);
 
 					return buildGeneration(choice, metadata, request);
@@ -583,6 +585,15 @@ public final class OpenAiChatModel implements ChatModel {
 							.toList();
 
 						builder.toolCalls(toolCalls);
+					}
+
+					// Replay reasoning content only when present - plain OpenAI is
+					// unaffected
+					Object reasoningContent = assistantMessage.getMetadata().get(REASONING_CONTENT);
+					if (reasoningContent instanceof String reasoning && StringUtils.hasText(reasoning)) {
+						// "reasoning_content" is the wire field; REASONING_CONTENT is the
+						// metadata key
+						builder.putAdditionalProperty("reasoning_content", JsonValue.from(reasoning));
 					}
 
 					return List.of(ChatCompletionMessageParam.ofAssistant(builder.build()));

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -25,8 +25,10 @@ import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
 import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionAssistantMessageParam;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessage;
+import com.openai.models.chat.completions.ChatCompletionMessageParam;
 import com.openai.models.completions.CompletionUsage;
 import com.openai.services.blocking.ChatService;
 import com.openai.services.blocking.chat.ChatCompletionService;
@@ -35,6 +37,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -343,6 +347,60 @@ class OpenAiChatModelTests {
 
 		ChatResponseMetadata metadata = response.getMetadata();
 		assertThat((Object) metadata.get("created")).isEqualTo(1234567890L);
+	}
+
+	@Test
+	void reasoningContentReplayedWhenPresentInAssistantHistory() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("100")
+			.properties(Map.of("reasoningContent", "25 * 4 = 100."))
+			.build();
+		Prompt prompt = new Prompt(
+				List.of(new UserMessage("What's 25 * 4?"), assistantMessage, new UserMessage("Now divide that by 5")),
+				options);
+
+		ChatCompletionCreateParams request = chatModel.createRequest(prompt, false);
+
+		ChatCompletionAssistantMessageParam assistantParam = request.messages()
+			.stream()
+			.filter(ChatCompletionMessageParam::isAssistant)
+			.map(ChatCompletionMessageParam::asAssistant)
+			.findFirst()
+			.orElseThrow();
+		assertThat(assistantParam._additionalProperties()).containsEntry("reasoning_content",
+				JsonValue.from("25 * 4 = 100."));
+	}
+
+	@Test
+	void reasoningContentOmittedWhenAbsentFromAssistantHistory() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		AssistantMessage assistantMessage = AssistantMessage.builder().content("100").build();
+		Prompt prompt = new Prompt(
+				List.of(new UserMessage("What's 25 * 4?"), assistantMessage, new UserMessage("Now divide that by 5")),
+				options);
+
+		ChatCompletionCreateParams request = chatModel.createRequest(prompt, false);
+
+		ChatCompletionAssistantMessageParam assistantParam = request.messages()
+			.stream()
+			.filter(ChatCompletionMessageParam::isAssistant)
+			.map(ChatCompletionMessageParam::asAssistant)
+			.findFirst()
+			.orElseThrow();
+		assertThat(assistantParam._additionalProperties()).doesNotContainKey("reasoning_content");
 	}
 
 }


### PR DESCRIPTION
Closes #6016 (OpenAI path).

## Summary
`OpenAiChatModel` stores a reasoning model's `reasoning_content` in `AssistantMessage`
metadata on the receive side but dropped it when serializing assistant history back into
a request. OpenAI-compatible reasoning endpoints (e.g. DeepSeek thinking mode) require
`reasoning_content` to be echoed back and return HTTP 400 when it is missing — especially
when it coexists with `tool_calls` in an agentic loop.

This emits `reasoning_content` as an additional property on the assistant message param,
guarded so it is only sent when a non-blank value is present (genuine OpenAI requests are
unchanged). Adds a `REASONING_CONTENT` constant reused at the existing receive sites.

Scope: the replay targets the `reasoning_content` wire key. The receive side also accepts
a `reasoning` key as a fallback; faithfully round-tripping a `reasoning`-keyed provider
under its original name would require storing the source key and is left as a follow-up.

## Test Plan
- [x] New unit tests in `OpenAiChatModelTests`: `reasoning_content` replayed when present;
      omitted when absent.