### PR TITLE
Document spring-ai-test utilities and base classes

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testing.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testing.adoc
@@ -22,11 +22,11 @@ public class EvaluationRequest {
 
 	private final String userText;
 
-	private final List<Content> dataList;
+	private final List<Document> dataList;
 
 	private final String responseContent;
 
-	public EvaluationRequest(String userText, List<Content> dataList, String responseContent) {
+	public EvaluationRequest(String userText, List<Document> dataList, String responseContent) {
 		this.userText = userText;
 		this.dataList = dataList;
 		this.responseContent = responseContent;
@@ -131,13 +131,22 @@ The 'claim' and 'document' are presented to the AI model for evaluation. Smaller
 
 
 === Usage
-The FactCheckingEvaluator constructor takes a ChatClient.Builder as a parameter:
+The `FactCheckingEvaluator` is created through a factory method or its builder rather than a public constructor.
+
+For the Bespoke Minicheck model there is a dedicated factory method that wires the appropriate prompt:
 [source,java]
 ----
-public FactCheckingEvaluator(ChatClient.Builder chatClientBuilder) {
-  this.chatClientBuilder = chatClientBuilder;
-}
+FactCheckingEvaluator evaluator = FactCheckingEvaluator.forBespokeMinicheck(chatClientBuilder);
 ----
+
+For any other model, use the builder, optionally supplying a custom evaluation prompt:
+[source,java]
+----
+FactCheckingEvaluator evaluator = FactCheckingEvaluator.builder(chatClientBuilder)
+    .evaluationPrompt(myCustomPrompt) // optional
+    .build();
+----
+
 The evaluator uses the following prompt template for fact-checking:
 [source,text]
 ----
@@ -147,21 +156,26 @@ Claim: {claim}
 Where `+{document}+` is the context information, and `+{claim}+` is the AI model's response to be evaluated.
 
 === Example
-Here's an example of how to use the FactCheckingEvaluator with an Ollama-based ChatModel, specifically the Bespoke-Minicheck model:
+Here's an example of how to use the `FactCheckingEvaluator` with an Ollama-based `ChatModel`, specifically the Bespoke-Minicheck model:
 
 [source,java]
 ----
 @Test
 void testFactChecking() {
   // Set up the Ollama API
-  OllamaApi ollamaApi = new OllamaApi("http://localhost:11434");
+  OllamaApi ollamaApi = OllamaApi.builder().baseUrl("http://localhost:11434").build();
 
-  ChatModel chatModel = new OllamaChatModel(ollamaApi,
-				OllamaChatOptions.builder().model(BESPOKE_MINICHECK).numPredict(2).temperature(0.0d).build())
+  ChatModel chatModel = OllamaChatModel.builder()
+      .ollamaApi(ollamaApi)
+      .defaultOptions(OllamaChatOptions.builder()
+          .model(BESPOKE_MINICHECK)
+          .numPredict(2)
+          .temperature(0.0d)
+          .build())
+      .build();
 
-
-  // Create the FactCheckingEvaluator
-  var factCheckingEvaluator = new FactCheckingEvaluator(ChatClient.builder(chatModel));
+  // Create the FactCheckingEvaluator using the Bespoke Minicheck factory method
+  FactCheckingEvaluator factCheckingEvaluator = FactCheckingEvaluator.forBespokeMinicheck(ChatClient.builder(chatModel));
 
   // Example context and claim
   String context = "The Earth is the third planet from the Sun and the only astronomical object known to harbor life.";
@@ -177,3 +191,123 @@ void testFactChecking() {
 
 }
 ----
+
+== Writing a Custom Evaluator
+
+Because `Evaluator` is a functional interface, you can implement your own evaluation logic for criteria the built-in evaluators do not cover (for example, tone, format compliance, or a domain-specific rubric). Implement `evaluate(EvaluationRequest)` and return an `EvaluationResponse` describing whether the response passed, an optional score, feedback, and metadata.
+
+The `Evaluator` interface also provides a default `doGetSupportingData(EvaluationRequest)` method that concatenates the text of the `dataList` documents, which is convenient when your evaluator needs the retrieved context as a single string.
+
+[source,java]
+----
+public class JsonFormatEvaluator implements Evaluator {
+
+    @Override
+    public EvaluationResponse evaluate(EvaluationRequest evaluationRequest) {
+        String response = evaluationRequest.getResponseContent();
+        boolean pass = isValidJson(response);
+        float score = pass ? 1.0f : 0.0f;
+        String feedback = pass ? "Response is valid JSON" : "Response is not valid JSON";
+        return new EvaluationResponse(pass, score, feedback, Map.of());
+    }
+
+    private boolean isValidJson(String candidate) {
+        // ... your validation logic ...
+    }
+}
+----
+
+You can then use it like any other evaluator:
+
+[source,java]
+----
+Evaluator evaluator = new JsonFormatEvaluator();
+EvaluationResponse response = evaluator.evaluate(
+    new EvaluationRequest(userQuestion, List.of(), modelResponse));
+assertThat(response.isPass()).isTrue();
+----
+
+== Reusable Test Base Classes
+
+The `spring-ai-test` module ships abstract base classes that contribute ready-made conformance tests. They are primarily used to validate Spring AI's own providers, but they are equally useful if you build a custom `VectorStore`, `ChatModel`, or `ChatOptions` implementation: extend the base class, implement one or two template methods, and you inherit the full test suite.
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-test</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+=== BaseVectorStoreTests
+
+`BaseVectorStoreTests` contributes delete-behavior tests (`deleteById`, `deleteWithStringFilterExpression`, and `deleteByFilter`) to any `VectorStore`. Extend it and implement `executeTest(Consumer<VectorStore>)`, which is responsible for providing a live `VectorStore` to the inherited test logic. A common approach uses Spring Boot's `ApplicationContextRunner`:
+
+[source,java]
+----
+class MyVectorStoreIT extends BaseVectorStoreTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(TestApplication.class);
+
+    @Override
+    protected void executeTest(Consumer<VectorStore> testFunction) {
+        this.contextRunner.run(context -> {
+            VectorStore vectorStore = context.getBean(VectorStore.class);
+            testFunction.accept(vectorStore);
+        });
+    }
+}
+----
+
+Override the protected `createDocument(String country, Integer year)` helper if your store needs documents shaped a particular way. Several built-in stores extend this class (for example, `PgVectorStoreIT` and `CassandraVectorStoreIT`).
+
+=== AbstractToolCallAdvisorIT
+
+`AbstractToolCallAdvisorIT` is a conformance suite for tool (function) calling through the `ChatClient`. It exercises both synchronous (`call`) and streaming (`stream`) flows, with and without external chat memory, grouped into nested `CallTests` and `StreamTests` classes. Extend it and return your `ChatModel` from `getChatModel()`:
+
+[source,java]
+----
+class MyToolCallAdvisorIT extends AbstractToolCallAdvisorIT {
+
+    @Override
+    protected ChatModel getChatModel() {
+        return MyChatModel.builder()
+            .options(MyChatOptions.builder()
+                .apiKey(System.getenv("MY_API_KEY"))
+                .model("my-default-model")
+                .build())
+            .build();
+    }
+}
+----
+
+The suite drives a shared `MockWeatherService` tool (returning 30°C for San Francisco, 10°C for Tokyo, and 15°C for Paris), so your model integration is tested against deterministic tool results. The built-in `OpenAiToolCallAdvisorIT` is a concrete example.
+
+=== AbstractChatOptionsTests
+
+`AbstractChatOptionsTests<O extends ChatOptions, B extends ChatOptions.Builder<B>>` verifies that a `ChatOptions` implementation returns fresh instances from its builder (`builderShouldReturnNewInstances`) and supports `mutate()` correctly (`testMutateBehavior`). Implement the two template methods:
+
+[source,java]
+----
+class MyChatOptionsTests extends AbstractChatOptionsTests<MyChatOptions, MyChatOptions.Builder> {
+
+    @Override
+    protected Class<MyChatOptions> getConcreteOptionsClass() {
+        return MyChatOptions.class;
+    }
+
+    @Override
+    protected MyChatOptions.Builder readyToBuildBuilder() {
+        return MyChatOptions.builder().model("my-default-model").maxTokens(500);
+    }
+}
+----
+
+`AnthropicChatOptionsTests` is a concrete example.
+
+=== Other utilities
+
+* `ObservationTestUtil.assertObservationRegistry(registry, provider, operation)` asserts that a vector store operation produced the expected Micrometer observation against a `TestObservationRegistry`.
+* `CurlyBracketEscaper.escapeCurlyBrackets(input)` / `unescapeCurlyBrackets(input)` are null-safe helpers to escape `{` and `}` in user-provided content so it does not collide with prompt-template placeholders.

--- a/spring-ai-test/README.md
+++ b/spring-ai-test/README.md
@@ -1,48 +1,111 @@
 # Spring AI Test
 
-The Spring AI Test module provides utilities and base classes for testing AI applications built with Spring AI.
+The Spring AI Test module provides reusable base classes and utilities for testing AI
+applications and Spring AI provider integrations (chat models, vector stores, tool calling,
+chat options, observability).
 
-## Features
+It is published as a `test`-scoped artifact and is consumed by the Spring AI modules
+themselves, so the same conformance tests that validate the built-in providers are available
+when you implement your own.
 
-- **BasicEvaluationTest**: A base test class for evaluating question-answer quality using AI models
-- **Vector Store Testing**: Utilities for testing vector store implementations
-- **Audio Testing**: Utilities for testing audio-related functionality
+> For the public, end-user evaluation guide (writing assertions over generative responses with
+> `RelevancyEvaluator` / `FactCheckingEvaluator`, or your own `Evaluator`), see the reference
+> documentation:
+> [Model Evaluation](https://docs.spring.io/spring-ai/reference/api/testing.html).
 
-## BasicEvaluationTest
+## What's inside
 
-The `BasicEvaluationTest` class provides a framework for evaluating the quality and relevance of AI-generated answers to questions.
+| Class | Purpose |
+|-------|---------|
+| `org.springframework.ai.test.vectorstore.BaseVectorStoreTests` | Base class that contributes ready-made delete tests (by id, by string filter, by `Filter.Expression`) to any `VectorStore` implementation. |
+| `org.springframework.ai.test.chat.client.advisor.AbstractToolCallAdvisorIT` | Conformance suite for tool/function calling through `ChatClient`, for both `call` and `stream`, with and without external chat memory. |
+| `org.springframework.ai.test.chat.client.advisor.AbstractToolCallAdvisorAutoRegistrationIT` | Variant that exercises automatic tool registration. |
+| `org.springframework.ai.test.chat.client.advisor.MockWeatherService` | The canonical mock tool used by the tool-calling suites (San Francisco = 30°C, Tokyo = 10°C, Paris = 15°C). |
+| `org.springframework.ai.test.options.AbstractChatOptionsTests` | Generic tests that verify a `ChatOptions` implementation builds fresh instances and mutates correctly. |
+| `org.springframework.ai.test.vectorstore.ObservationTestUtil` | Asserts that a vector store operation produced the expected Micrometer observation. |
+| `org.springframework.ai.test.CurlyBracketEscaper` | Null-safe helpers to escape/unescape `{` and `}` so user content does not collide with template placeholders. |
+| `org.springframework.ai.utils.AudioPlayer` | Small helper for audio-related tests. |
 
-### Usage
+## Testing a custom VectorStore
 
-Extend the `BasicEvaluationTest` class in your test classes:
+Extend `BaseVectorStoreTests` and implement `executeTest`, which hands a live `VectorStore`
+to the inherited test logic. A typical implementation stands up an application context (here
+with Spring Boot's `ApplicationContextRunner`) and passes the bean through:
 
 ```java
-@SpringBootTest
-public class MyAiEvaluationTest extends BasicEvaluationTest {
+class MyVectorStoreIT extends BaseVectorStoreTests {
 
-    @Test
-    public void testQuestionAnswerAccuracy() {
-        String question = "What is the capital of France?";
-        String answer = "The capital of France is Paris.";
-        
-        // Evaluate if the answer is accurate and related to the question
-        evaluateQuestionAndAnswer(question, answer, true);
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(TestApplication.class);
+
+    @Override
+    protected void executeTest(Consumer<VectorStore> testFunction) {
+        this.contextRunner.run(context -> {
+            VectorStore vectorStore = context.getBean(VectorStore.class);
+            testFunction.accept(vectorStore);
+        });
     }
 }
 ```
 
-### Configuration
+The base class then runs `deleteById`, `deleteWithStringFilterExpression` and
+`deleteByFilter` against your store. Override `createDocument(String country, Integer year)`
+if your store needs documents shaped a particular way.
 
-The test requires:
-- A `ChatModel` bean (typically OpenAI)
-- Evaluation prompt templates located in `classpath:/prompts/spring/test/evaluation/`
+## Testing tool/function calling
 
-### Evaluation Types
+Extend `AbstractToolCallAdvisorIT` and return your `ChatModel` from `getChatModel()`. The
+suite uses the shared `MockWeatherService` and runs the full matrix of `call`/`stream`
+scenarios (nested `CallTests` and `StreamTests`):
 
-- **Fact-based evaluation**: Use `factBased = true` for questions requiring factual accuracy
-- **General evaluation**: Use `factBased = false` for more subjective questions
+```java
+class MyToolCallAdvisorIT extends AbstractToolCallAdvisorIT {
 
-The evaluation process:
-1. Checks if the answer is related to the question
-2. Evaluates the accuracy/appropriateness of the answer
-3. Fails the test with detailed feedback if the answer is inadequate
+    @Override
+    protected ChatModel getChatModel() {
+        return MyChatModel.builder()
+            .options(MyChatOptions.builder()
+                .apiKey(System.getenv("MY_API_KEY"))
+                .model("my-default-model")
+                .build())
+            .build();
+    }
+}
+```
+
+## Testing ChatOptions
+
+Extend `AbstractChatOptionsTests<O, B>` to verify that your options type returns new
+instances from its builder and supports `mutate()`:
+
+```java
+class MyChatOptionsTests extends AbstractChatOptionsTests<MyChatOptions, MyChatOptions.Builder> {
+
+    @Override
+    protected Class<MyChatOptions> getConcreteOptionsClass() {
+        return MyChatOptions.class;
+    }
+
+    @Override
+    protected MyChatOptions.Builder readyToBuildBuilder() {
+        return MyChatOptions.builder().model("my-default-model").maxTokens(500);
+    }
+}
+```
+
+## Other utilities
+
+- **`ObservationTestUtil`** — after running a vector store operation against a
+  `TestObservationRegistry`, assert the observation was recorded:
+
+  ```java
+  ObservationTestUtil.assertObservationRegistry(observationRegistry,
+      VectorStoreProvider.PG_VECTOR, VectorStoreObservationContext.Operation.ADD);
+  ```
+
+- **`CurlyBracketEscaper`** — escape user-provided text before it reaches a prompt template
+  so literal braces are not treated as placeholders:
+
+  ```java
+  String safe = CurlyBracketEscaper.escapeCurlyBrackets(userInput);
+  ```


### PR DESCRIPTION
Documents the `spring-ai-test` module, whose reusable test base classes and evaluation utilities were undocumented and partly stale.

- Rewrite `spring-ai-test/README.md`: it documented a `BasicEvaluationTest` class that no longer exists; replace it with the classes that actually ship, with extension examples.
- Fix `testing.adoc`: `EvaluationRequest` uses `List<Document>`, not `List<Content>`; the `FactCheckingEvaluator` example used its now-`protected` constructor (would not compile), replaced with the `forBespokeMinicheck(...)` factory and `builder(...)` API.
- Add sections on writing a custom `Evaluator` and on the reusable test base classes, each citing a real in-repo subclass.

Closes #88