### PR TITLE
Refine `RedisChatMemoryProperties` to align with other configuration properties

### DIFF
--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfiguration.java
@@ -64,17 +64,11 @@ public class RedisChatMemoryAutoConfiguration {
 			builder.timeToLive(properties.getTimeToLive());
 		}
 
-		if (properties.getInitializeSchema() != null) {
-			builder.initializeSchema(properties.getInitializeSchema());
-		}
+		builder.initializeSchema(properties.isInitializeSchema());
 
-		if (properties.getMaxConversationIds() != null) {
-			builder.maxConversationIds(properties.getMaxConversationIds());
-		}
+		builder.maxConversationIds(properties.getMaxConversationIds());
 
-		if (properties.getMaxMessagesPerConversation() != null) {
-			builder.maxMessagesPerConversation(properties.getMaxMessagesPerConversation());
-		}
+		builder.maxMessagesPerConversation(properties.getMaxMessagesPerConversation());
 
 		if (properties.getMetadataFields() != null && !properties.getMetadataFields().isEmpty()) {
 			builder.metadataFields(properties.getMetadataFields());

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryProperties.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryProperties.java
@@ -30,9 +30,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for Redis-based chat memory.
  *
  * @author Brian Sam-Bodden
+ * @author Yanming Zhou
  */
-@ConfigurationProperties(prefix = "spring.ai.chat.memory.redis")
+@ConfigurationProperties(prefix = RedisChatMemoryProperties.CONFIG_PREFIX)
 public class RedisChatMemoryProperties {
+
+	/**
+	 * Configuration prefix for Redis vector store properties.
+	 */
+	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.redis";
 
 	/**
 	 * Redis server host.
@@ -62,17 +68,17 @@ public class RedisChatMemoryProperties {
 	/**
 	 * Whether to initialize the Redis schema. Default is true.
 	 */
-	private Boolean initializeSchema = true;
+	private boolean initializeSchema = true;
 
 	/**
 	 * Maximum number of conversation IDs to return (defaults to 1000).
 	 */
-	private Integer maxConversationIds = RedisChatMemoryConfig.DEFAULT_MAX_RESULTS;
+	private int maxConversationIds = RedisChatMemoryConfig.DEFAULT_MAX_RESULTS;
 
 	/**
 	 * Maximum number of messages to return per conversation (defaults to 1000).
 	 */
-	private Integer maxMessagesPerConversation = RedisChatMemoryConfig.DEFAULT_MAX_RESULTS;
+	private int maxMessagesPerConversation = RedisChatMemoryConfig.DEFAULT_MAX_RESULTS;
 
 	/**
 	 * Metadata field definitions for proper indexing. Compatible with RedisVL schema
@@ -125,27 +131,27 @@ public class RedisChatMemoryProperties {
 		this.timeToLive = timeToLive;
 	}
 
-	public Boolean getInitializeSchema() {
+	public boolean isInitializeSchema() {
 		return this.initializeSchema;
 	}
 
-	public void setInitializeSchema(Boolean initializeSchema) {
+	public void setInitializeSchema(boolean initializeSchema) {
 		this.initializeSchema = initializeSchema;
 	}
 
-	public Integer getMaxConversationIds() {
+	public int getMaxConversationIds() {
 		return this.maxConversationIds;
 	}
 
-	public void setMaxConversationIds(Integer maxConversationIds) {
+	public void setMaxConversationIds(int maxConversationIds) {
 		this.maxConversationIds = maxConversationIds;
 	}
 
-	public Integer getMaxMessagesPerConversation() {
+	public int getMaxMessagesPerConversation() {
 		return this.maxMessagesPerConversation;
 	}
 
-	public void setMaxMessagesPerConversation(Integer maxMessagesPerConversation) {
+	public void setMaxMessagesPerConversation(int maxMessagesPerConversation) {
 		this.maxMessagesPerConversation = maxMessagesPerConversation;
 	}
 


### PR DESCRIPTION
1. Change some type from boxed to primitive
2. Make configuration prefix as constant field