### PR TITLE
Add turn-boundary snapping to MessageWindowChatMemory eviction

### DIFF
--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisorTests.java
@@ -230,8 +230,11 @@ public class MessageChatMemoryAdvisorTests {
 
 		assertThat(processedRequest.prompt().getInstructions()).containsExactly(userMessage, firstAssistantMessage,
 				firstToolResponse, secondAssistantMessage, secondToolResponse);
-		assertThat(chatMemory.get("test-conversation")).containsExactly(firstToolResponse, secondAssistantMessage,
-				secondToolResponse);
+		// Turn-boundary snapping: the initial add of [U, A, TR, A] with maxMessages=3
+		// places the raw cut at position 1 (firstAssistantMessage). Snapping advances
+		// through A, TR, A without finding a USER boundary, so all four messages are
+		// evicted.
+		assertThat(chatMemory.get("test-conversation")).containsExactly(secondToolResponse);
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -30,7 +30,7 @@ The `ChatMemory` abstraction allows you to implement various types of memory to 
 
 === Message Window Chat Memory
 
-`MessageWindowChatMemory` maintains a window of messages up to a specified maximum size. When the number of messages exceeds the maximum, older messages are removed while preserving system messages. The default window size is 20 messages.
+`MessageWindowChatMemory` maintains a sliding window of messages up to a specified maximum size. When the number of messages exceeds the maximum, older messages are evicted while always preserving `SystemMessage` instances. The default window size is 20 messages.
 
 [source,java]
 ----
@@ -40,6 +40,14 @@ MessageWindowChatMemory memory = MessageWindowChatMemory.builder()
 ----
 
 This is the default message type used by Spring AI to auto-configure a `ChatMemory` bean.
+
+==== Turn-boundary eviction
+
+When eviction is needed, `MessageWindowChatMemory` always removes whole turns rather than cutting mid-turn. A _turn_ starts at a `UserMessage` and includes all subsequent assistant replies, tool calls, and tool responses up to the next `UserMessage`. If the raw eviction point lands on a non-user message (for example, an assistant reply in the middle of a tool-calling exchange), the cut is advanced forward to the next `UserMessage` so that the kept window always begins at a complete turn.
+
+This means `maxMessages` is an _upper bound_ on the number of messages stored — the actual count may be somewhat lower when snapping is needed to find the next turn boundary.
+
+NOTE: If `maxMessages` is smaller than a single complete turn (for example, a multi-step tool-calling exchange that exceeds the window size), all non-system messages may be evicted until a new `UserMessage` is added. Size `maxMessages` generously enough to hold at least one representative turn for your use case.
 
 == Memory Storage
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.util.Assert;
 
@@ -95,19 +96,36 @@ public final class MessageWindowChatMemory implements ChatMemory {
 			return processedMessages;
 		}
 
-		int messagesToRemove = processedMessages.size() - this.maxMessages;
-
-		List<Message> trimmedMessages = new ArrayList<>();
-		int removed = 0;
-		for (Message message : processedMessages) {
-			if (message instanceof SystemMessage || removed >= messagesToRemove) {
-				trimmedMessages.add(message);
-			}
-			else {
-				removed++;
+		// Collect the indices of non-system messages; SystemMessages are always
+		// preserved.
+		List<Integer> nonSystemIndices = new ArrayList<>();
+		for (int i = 0; i < processedMessages.size(); i++) {
+			if (!(processedMessages.get(i) instanceof SystemMessage)) {
+				nonSystemIndices.add(i);
 			}
 		}
 
+		// Raw cut: the number of non-system messages that must be removed to fit within
+		// maxMessages. This index into nonSystemIndices is where the kept window would
+		// start based on count alone.
+		int cutIndex = processedMessages.size() - this.maxMessages;
+
+		// Snap the cut forward to the nearest USER message so the kept window always
+		// starts at a complete turn. This prevents keeping an assistant reply or tool
+		// result without the user message that originated its turn.
+		while (cutIndex < nonSystemIndices.size()
+				&& processedMessages.get(nonSystemIndices.get(cutIndex)).getMessageType() != MessageType.USER) {
+			cutIndex++;
+		}
+		cutIndex = Math.min(cutIndex, nonSystemIndices.size());
+
+		Set<Integer> removeIndices = new HashSet<>(nonSystemIndices.subList(0, cutIndex));
+		List<Message> trimmedMessages = new ArrayList<>();
+		for (int i = 0; i < processedMessages.size(); i++) {
+			if (!removeIndices.contains(i)) {
+				trimmedMessages.add(processedMessages.get(i));
+			}
+		}
 		return trimmedMessages;
 	}
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
@@ -157,7 +157,10 @@ public class MessageWindowChatMemoryTests {
 		customChatMemory.add(conversationId, messages);
 		List<Message> result = customChatMemory.get(conversationId);
 
-		assertThat(result).hasSize(2);
+		// Turn-boundary snapping: the raw cut lands on "Response 2" (ASSISTANT), which
+		// is mid-turn, so the cut advances to "Message 3" (USER). Only the incomplete
+		// last turn is kept rather than producing an orphaned assistant message.
+		assertThat(result).containsExactly(new UserMessage("Message 3"));
 	}
 
 	@Test
@@ -238,9 +241,12 @@ public class MessageWindowChatMemoryTests {
 
 		List<Message> result = customChatMemory.get(conversationId);
 
-		assertThat(result).hasSize(limit);
+		// Two system messages occupy 2 of the 3 slots, leaving only 1 for non-system
+		// messages. A single slot cannot hold a complete turn (USER + ASSISTANT = 2),
+		// so turn-boundary snapping evicts all non-system messages rather than keeping
+		// an orphaned assistant message.
 		assertThat(result).containsExactly(new SystemMessage("System instruction 1"),
-				new SystemMessage("System instruction 2"), new AssistantMessage("Response 2"));
+				new SystemMessage("System instruction 2"));
 	}
 
 	@Test
@@ -250,6 +256,83 @@ public class MessageWindowChatMemoryTests {
 		List<Message> result = this.chatMemory.get(conversationId);
 
 		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void turnBoundarySnappingPreventsOrphanedAssistantMessage() {
+		// Turn 1: [U1, A1] Turn 2: [U2, A2] Turn 3: [U3, A3]
+		// With limit=3 and 6 total messages, the raw cut index is 3 — landing on A2
+		// (ASSISTANT), which is mid-turn 2. Snapping advances to U3, evicting both
+		// turns 1 and 2 rather than producing an orphaned assistant message.
+		int limit = 3;
+		MessageWindowChatMemory customChatMemory = MessageWindowChatMemory.builder().maxMessages(limit).build();
+
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messages = List.of(new UserMessage("Question 1"), new AssistantMessage("Answer 1"),
+				new UserMessage("Question 2"), new AssistantMessage("Answer 2"), new UserMessage("Question 3"),
+				new AssistantMessage("Answer 3"));
+		customChatMemory.add(conversationId, messages);
+
+		List<Message> result = customChatMemory.get(conversationId);
+
+		assertThat(result).containsExactly(new UserMessage("Question 3"), new AssistantMessage("Answer 3"));
+	}
+
+	@Test
+	void turnBoundarySnappingEvictsAllMessagesWithinTheSameTurn() {
+		// Turn 1: [U1, A1a, A1b, A1c] Turn 2: [U2, A2]
+		// With limit=4 and 6 total messages, the raw cut index is 2 — landing on A1b
+		// (ASSISTANT), still inside turn 1. Snapping skips A1b and A1c to reach U2,
+		// evicting all four messages of turn 1 rather than leaving a partial turn.
+		int limit = 4;
+		MessageWindowChatMemory customChatMemory = MessageWindowChatMemory.builder().maxMessages(limit).build();
+
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messages = List.of(new UserMessage("Question 1"), new AssistantMessage("Step 1"),
+				new AssistantMessage("Step 2"), new AssistantMessage("Final answer"), new UserMessage("Question 2"),
+				new AssistantMessage("Answer 2"));
+		customChatMemory.add(conversationId, messages);
+
+		List<Message> result = customChatMemory.get(conversationId);
+
+		assertThat(result).containsExactly(new UserMessage("Question 2"), new AssistantMessage("Answer 2"));
+	}
+
+	@Test
+	void noSnapWhenRawCutAlreadyLandsOnUserMessage() {
+		// When the raw cut happens to fall exactly on a USER message no additional
+		// messages should be evicted.
+		int limit = 4;
+		MessageWindowChatMemory customChatMemory = MessageWindowChatMemory.builder().maxMessages(limit).build();
+
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messages = List.of(new UserMessage("Message 1"), new AssistantMessage("Response 1"),
+				new UserMessage("Message 2"), new AssistantMessage("Response 2"), new UserMessage("Message 3"),
+				new AssistantMessage("Response 3"));
+		customChatMemory.add(conversationId, messages);
+
+		List<Message> result = customChatMemory.get(conversationId);
+
+		// Raw cut lands at "Message 2" (USER) — no snapping needed; exactly 4 kept.
+		assertThat(result).containsExactly(new UserMessage("Message 2"), new AssistantMessage("Response 2"),
+				new UserMessage("Message 3"), new AssistantMessage("Response 3"));
+	}
+
+	@Test
+	void noExceptionWhenSystemMessagesExceedMaxMessages() {
+		// If more SystemMessages accumulate than maxMessages, cutIndex would exceed
+		// nonSystemIndices.size() and subList would throw without the min() clamp.
+		int limit = 2;
+		MessageWindowChatMemory customChatMemory = MessageWindowChatMemory.builder().maxMessages(limit).build();
+
+		String conversationId = UUID.randomUUID().toString();
+		customChatMemory.add(conversationId, List.of(new SystemMessage("S1"), new SystemMessage("S2")));
+		customChatMemory.add(conversationId,
+				List.of(new UserMessage("Hello"), new AssistantMessage("Hi"), new UserMessage("Again")));
+
+		List<Message> result = customChatMemory.get(conversationId);
+
+		assertThat(result).containsExactly(new SystemMessage("S1"), new SystemMessage("S2"));
 	}
 
 	@Test


### PR DESCRIPTION
- When the message window overflows, the eviction cut is now advanced forward to the nearest USER message instead of stopping mid-turn. 
    This prevents the kept window from opening with an orphaned assistant reply or tool result that has no corresponding user message.
- Add related tests and docs
