### PR TITLE
fix: place memory advisors outside ToolCallingAdvisor by default

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -32,8 +32,6 @@ import java.util.function.Consumer;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 
@@ -92,8 +90,6 @@ import org.springframework.util.StringUtils;
  * @since 1.0.0
  */
 public class DefaultChatClient implements ChatClient {
-
-	private static final Log logger = LogFactory.getLog(DefaultChatClient.class);
 
 	private static final ChatClientObservationConvention DEFAULT_CHAT_CLIENT_OBSERVATION_CONVENTION = new DefaultChatClientObservationConvention();
 
@@ -1195,7 +1191,6 @@ public class DefaultChatClient implements ChatClient {
 		private BaseAdvisorChain buildAdvisorChain() {
 			autoRegisterToolCallingAdvisor();
 			validateSingleToolAdvisor();
-			warnOnMemoryAdvisorOrderMismatch();
 
 			// At the stack bottom add the model call advisors.
 			// They play the role of the last advisors in the advisor chain.
@@ -1268,28 +1263,6 @@ public class DefaultChatClient implements ChatClient {
 				throw new IllegalStateException("At most one ToolAdvisor is allowed in the advisor chain, but found "
 						+ toolAdvisors.size() + ": [" + names + "]");
 			}
-		}
-
-		/**
-		 * Warns when a {@link MemoryAdvisor} is ordered before (lower order than) a
-		 * {@link ToolAdvisor}. In that configuration the memory advisor is not part of
-		 * the recursive tool-call chain, so tool messages will not be stored between
-		 * iterations and streaming memory updates will not be sequenced correctly.
-		 */
-		private void warnOnMemoryAdvisorOrderMismatch() {
-			this.advisors.stream()
-				.filter(a -> a instanceof ToolAdvisor)
-				.forEach(tca -> this.advisors.stream()
-					.filter(a -> a instanceof MemoryAdvisor && a.getOrder() <= tca.getOrder())
-					.forEach(mem -> {
-						if (logger.isWarnEnabled()) {
-							logger.warn("ChatMemoryAdvisor '" + mem.getName() + "' (order=" + mem.getOrder()
-									+ ") is ordered at or before ToolCallingAdvisor '" + tca.getName() + "' (order="
-									+ tca.getOrder() + "). "
-									+ "Memory will not be updated between tool-call iterations. "
-									+ "Set the memory advisor order above " + tca.getOrder() + " to fix this.");
-						}
-					}));
 		}
 
 	}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -60,11 +60,10 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 	private static final ChatClientMessageAggregator CHAT_CLIENT_MESSAGE_AGGREGATOR = new ChatClientMessageAggregator();
 
 	/**
-	 * Default advisor order. Placed early in the chain so that all downstream advisors
-	 * (e.g. {@link org.springframework.ai.chat.client.advisor.api.BaseChatMemoryAdvisor})
-	 * participate in every tool-call iteration.
-	 *
-	 * @see org.springframework.ai.chat.client.advisor.api.Advisor#DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER
+	 * Default advisor order. Higher than
+	 * {@link org.springframework.ai.chat.client.advisor.api.Advisor#DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER}
+	 * (+200) so that memory advisors at their default order are placed outside this
+	 * advisor and do not participate in each tool-call iteration.
 	 */
 	public static final int DEFAULT_ORDER = Ordered.HIGHEST_PRECEDENCE + 300;
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/Advisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/Advisor.java
@@ -31,12 +31,12 @@ import org.springframework.core.Ordered;
 public interface Advisor extends Ordered {
 
 	/**
-	 * Useful constant for the default Chat Memory precedence order. Ensures this order
-	 * has lower priority (e.g. precedences) than the Spring AI internal advisors. It
-	 * leaves room (1000 slots) for the user to plug in their own advisors with higher
-	 * priority.
+	 * Default order for chat-memory advisors. Placed before (outside)
+	 * {@link org.springframework.ai.chat.client.advisor.ToolCallingAdvisor#DEFAULT_ORDER}
+	 * so the memory advisor wraps the tool-call loop, and the {@code ToolCallingAdvisor}
+	 * manages its own intermediate conversation history.
 	 */
-	int DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER = Ordered.HIGHEST_PRECEDENCE + 1000;
+	int DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER = Ordered.HIGHEST_PRECEDENCE + 200;
 
 	/**
 	 * Return the name of the advisor.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -60,24 +60,34 @@ The `ToolCallingAdvisor` includes a `conversationHistoryEnabled` configuration o
 
 By default (`conversationHistoryEnabled=true`), the advisor maintains the full conversation history internally during tool call iterations. This means each subsequent LLM call in the tool calling loop includes all previous messages (user message, assistant responses, tool responses).
 
-Use the `.disableInternalConversationHistory()` method to disable internal conversation history management. When disabled, only the last tool response message is passed to the next iteration. This is useful when:
+By default, memory advisors (`DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER = HIGHEST_PRECEDENCE + 200`) are placed _outside_ the tool-call loop. The `ToolCallingAdvisor` (at `HIGHEST_PRECEDENCE + 300`) manages conversation history internally across iterations. The memory advisor loads history once before the loop and persists only the final user/assistant exchange after it ends. This is the recommended setup because most `ChatMemoryRepository` implementations do not support tool-call message types.
 
-* You have a Chat Memory Advisor registered next in the chain that already manages conversation history
-* You want to reduce token usage by not duplicating history management
-* You're integrating with external conversation memory systems
+[source,java]
+----
+// Default setup: memory advisor is outside the tool-call loop (no explicit order needed)
+var chatMemoryAdvisor = MessageChatMemoryAdvisor.builder(chatMemory).build();
+// DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER = HIGHEST_PRECEDENCE + 200 < ToolCallingAdvisor.DEFAULT_ORDER (+300)
+// ToolCallingAdvisor manages its own conversation history across tool-call iterations
 
-Example with conversation history disabled:
+var chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(chatMemoryAdvisor)
+    .build();
+----
+
+Use the `.disableInternalConversationHistory()` method only when placing a memory advisor _inside_ the tool-call loop (order above `ToolCallingAdvisor.DEFAULT_ORDER`). The memory advisor then handles history on every iteration. Note that only `InMemoryChatMemoryRepository` supports persisting tool-call messages; other repositories should use the default outside-loop setup above.
+
+TIP: The https://github.com/spring-ai-community/spring-ai-session[spring-ai-session] community project provides a session-aware memory implementation that fully supports tool-call messages and can be safely used inside the tool-call loop with any backend. See the https://spring-ai-community.github.io/spring-ai-session/latest-snapshot/[spring-ai-session documentation].
 
 [source,java]
 ----
 var toolCallingAdvisor = ToolCallingAdvisor.builder()
     .toolCallingManager(toolCallingManager)
-    .disableInternalConversationHistory()  // Disable internal history - let ChatMemory handle it
+    .disableInternalConversationHistory()  // Memory advisor inside the loop handles history
     .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 300)
     .build();
 
 var chatMemoryAdvisor = MessageChatMemoryAdvisor.builder(chatMemory)
-    .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 200)  // Positioned before ToolCallingAdvisor
+    .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 400)  // Inside (after) ToolCallingAdvisor
     .build();
 
 var chatClient = ChatClient.builder(chatModel)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1109,18 +1109,32 @@ The `ToolCallingAdvisor.Builder` supports the following configuration options:
 
 By default (`conversationHistoryEnabled=true`), the `ToolCallingAdvisor` maintains the full conversation history internally during tool call iterations. Each subsequent LLM call includes all previous messages.
 
-Use the `.disableInternalConversationHistory()` method to disable internal conversation history management. When disabled, only the last tool response message is passed to the next iteration. This is useful when integrating with a Chat Memory advisor that already manages conversation history:
+The default ordering keeps memory advisors _outside_ the tool-call loop: `DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER` is `HIGHEST_PRECEDENCE + 200`, which is lower than `ToolCallingAdvisor.DEFAULT_ORDER` (`HIGHEST_PRECEDENCE + 300`). The memory advisor loads history once before the loop and persists only the final user/assistant exchange afterward. This works with all `ChatMemoryRepository` implementations because tool-call messages are never written to the repository.
+
+[source,java]
+----
+// Default: memory advisor outside the tool-call loop; ToolCallingAdvisor manages intermediate history
+var chatMemoryAdvisor = MessageChatMemoryAdvisor.builder(chatMemory).build();
+
+var chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(chatMemoryAdvisor)
+    .build();
+----
+
+Use `.disableInternalConversationHistory()` only when placing the memory advisor _inside_ the loop (order above `ToolCallingAdvisor.DEFAULT_ORDER`). The memory advisor then handles history on every iteration. This requires a `ChatMemoryRepository` that supports tool-call messages (such as `InMemoryChatMemoryRepository`).
+
+TIP: The https://github.com/spring-ai-community/spring-ai-session[spring-ai-session] community project provides a session-aware memory implementation that fully supports tool-call messages and can be safely used inside the tool-call loop with any backend. See the https://spring-ai-community.github.io/spring-ai-session/latest-snapshot/[spring-ai-session documentation].
 
 [source,java]
 ----
 var toolCallingAdvisor = ToolCallingAdvisor.builder()
     .toolCallingManager(toolCallingManager)
-    .disableInternalConversationHistory()  // Let ChatMemory handle history
+    .disableInternalConversationHistory()  // Memory advisor inside the loop handles history
     .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 300)
     .build();
 
 var chatMemoryAdvisor = MessageChatMemoryAdvisor.builder(chatMemory)
-    .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 200)  // Before ToolCallingAdvisor
+    .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 400)  // Inside (after) ToolCallingAdvisor
     .build();
 
 var chatClient = ChatClient.builder(chatModel)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -27,6 +27,26 @@ Update your dependency and import statements accordingly:
 </dependency>
 ----
 
+==== Changed: `Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER` default value
+
+`Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER` changed from `Ordered.HIGHEST_PRECEDENCE + 1000` to `Ordered.HIGHEST_PRECEDENCE + 200`, placing memory advisors at their default order _outside_ the `ToolCallingAdvisor` (`HIGHEST_PRECEDENCE + 300`).
+
+The `ToolCallingAdvisor` now manages conversation history internally across tool-call iterations by default. The memory advisor only stores the final user/assistant exchange, never writing tool-call messages to the `ChatMemoryRepository`. This is the correct default because most repository implementations do not support those message types.
+
+If you need memory _inside_ the loop (e.g. with `InMemoryChatMemoryRepository`), explicitly set the advisor order above `ToolCallingAdvisor.DEFAULT_ORDER` and call `.disableInternalConversationHistory()`:
+
+[source,java]
+----
+var toolCallingAdvisor = ToolCallingAdvisor.builder()
+    .disableInternalConversationHistory()
+    .build();
+var chatMemoryAdvisor = MessageChatMemoryAdvisor.builder(chatMemory)
+    .advisorOrder(Ordered.HIGHEST_PRECEDENCE + 400)
+    .build();
+----
+
+TIP: The https://github.com/spring-ai-community/spring-ai-session[spring-ai-session] community project provides a session-aware memory implementation that fully supports tool-call messages and can be safely used inside the tool-call loop with any backend. It is planned to replace `ChatMemory` in Spring AI 2.1. See the https://spring-ai-community.github.io/spring-ai-session/latest-snapshot/[spring-ai-session documentation] for details.
+
 === Tool Calling
 
 ==== Removed: `internalToolExecutionEnabled` from `ToolCallingChatOptions`


### PR DESCRIPTION
Lower DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER from HIGHEST_PRECEDENCE+1000 to HIGHEST_PRECEDENCE+200 so memory advisors wrap the tool-call loop rather than participating in each iteration. 
Most ChatMemoryRepository implementations do not support AssistantMessage tool-call content or ToolResponseMessage; the ToolCallingAdvisor manages its own intermediate conversation history internally.

- Update Advisor and ToolCallingAdvisor Javadoc to explain the ordering intent
- Fix advisors-recursive.adoc and tools.adoc examples that incorrectly paired memory at +200 with disableInternalConversationHistory()
- Add upgrade note and spring-ai-session tip to relevant doc sections

