### PR TITLE
GH-5971: Add failing regression test for streaming observation stop order

### DIFF
--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import org.junit.jupiter.api.Disabled;
@@ -1474,6 +1476,53 @@ class DefaultChatClientTests {
 				assertThat(context.getResponse().chatResponse().getResults())
 					.isEqualTo(chatClientResponse.chatResponse().getResults());
 			});
+	}
+
+	@Test
+	@Disabled("GH-5971: streaming observations stop in reverse order (outer-first instead of LIFO). "
+			+ "Re-enable once the streaming observation lifecycle is fixed.")
+	void streamingChatClientStopsObservationsInLifoOrder() {
+		// Regression test for https://github.com/spring-projects/spring-ai/issues/5971.
+		// Expected behaviour: when the streaming Flux terminates, observations
+		// must be stopped in reverse-of-start order — `spring.ai.advisor` stops
+		// before `spring.ai.chat.client`. The observed buggy behaviour is the
+		// opposite (outer chat.client.stop fires before advisor.stop).
+		ChatModel chatModel = mockChatModel();
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		given(chatModel.stream(promptCaptor.capture()))
+			.willReturn(Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage("response"))))));
+
+		List<String> startEvents = new java.util.concurrent.CopyOnWriteArrayList<>();
+		List<String> stopEvents = new java.util.concurrent.CopyOnWriteArrayList<>();
+		TestObservationRegistry observationRegistry = TestObservationRegistry.create();
+		observationRegistry.observationConfig().observationHandler(new ObservationHandler<Observation.Context>() {
+			@Override
+			public boolean supportsContext(Observation.Context context) {
+				return true;
+			}
+
+			@Override
+			public void onStart(Observation.Context context) {
+				startEvents.add(context.getName());
+			}
+
+			@Override
+			public void onStop(Observation.Context context) {
+				stopEvents.add(context.getName());
+			}
+		});
+
+		ChatClient chatClient = new DefaultChatClientBuilder(chatModel, observationRegistry, null, null).build();
+		chatClient.prompt("hello").stream().chatResponse().blockLast();
+
+		// The two observations of interest must both have been started.
+		assertThat(startEvents).contains("spring.ai.chat.client", "spring.ai.advisor");
+		// LIFO order: the inner advisor observation must stop before the outer
+		// chat.client observation. Under the bug the order is reversed.
+		int chatClientStop = stopEvents.indexOf("spring.ai.chat.client");
+		int advisorStop = stopEvents.indexOf("spring.ai.advisor");
+		assertThat(advisorStop).as("spring.ai.advisor must stop before spring.ai.chat.client")
+			.isLessThan(chatClientStop);
 	}
 
 	@Test


### PR DESCRIPTION
Adds a `@Disabled` regression test that encodes the expected observation lifecycle for #5971.

### Background

Per #5971, `ChatClient.prompt(...).stream()` stops its observations in the **wrong** order: `spring.ai.chat.client` fires its `.doFinally(... .stop())` *before* the inner `spring.ai.advisor`, instead of the LIFO order one would expect for nested observations.

### What this PR adds

A new test in `DefaultChatClientTests`, `streamingChatClientStopsObservationsInLifoOrder`, that:

- Registers a custom `ObservationHandler` on a `TestObservationRegistry` capturing every `onStart` and `onStop` event by name.
- Runs `ChatClient.prompt("hello").stream().chatResponse().blockLast()` against a mocked `ChatModel`.
- Asserts that both `spring.ai.chat.client` and `spring.ai.advisor` were started, and that `spring.ai.advisor`'s stop event appears *before* `spring.ai.chat.client`'s in the captured sequence.

Without the fix the test fails as expected:

```
[spring.ai.advisor must stop before spring.ai.chat.client]
Expecting actual:  1
to be less than:   0
```

i.e. the observed `stopEvents` is `["spring.ai.chat.client", "spring.ai.advisor", ...]` — `chat.client` stops at index 0 (first), `advisor` at index 1 (second).

### Why `@Disabled`

The bug in #5971 has not yet been root-caused on `main`, so the test is kept `@Disabled` for now to avoid red CI. The `@Disabled` message references the issue and asks the next contributor who fixes the lifecycle to flip the annotation off.

### Scope

- One test class touched, one test method added (`spring-ai-client-chat`).
- No production code changes.
- No new dependencies.
- The reverse-order assertion was confirmed to fail locally on `main` (commit at HEAD when the test was written) using the `ChatModel` mock pattern already established in this file.

### Follow-ups

The other half of #5971 — `spring.ai.tool` observations getting `null` parent in streaming — is not covered by this PR. The tool-call path involves a `Schedulers.boundedElastic()` boundary inside `ToolCallingAdvisor.handleToolCallRecursion`, and the Reactor context that `ToolCallReactiveContextHolder` reads from there appears not to carry the parent observation that the call (blocking) path inherits via `Observation.observe(...)`. Happy to fold a second `@Disabled` test for that on top of this PR if maintainers prefer one PR over two.