### PR TITLE
Update OllamaModel with Mistral AI's recent models

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
@@ -93,7 +93,7 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 		this.mirostatEta = mirostatEta;
 		this.penalizeNewline = penalizeNewline;
 		this.stop = stop != null ? List.copyOf(stop) : null;
-		this.model = model != null ? model : OllamaModel.MISTRAL.id();
+		this.model = model != null ? model : OllamaModel.MINISTRAL_3_8B.id();
 		this.format = format;
 		this.keepAlive = keepAlive;
 		this.truncate = truncate;

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaModel.java
@@ -115,15 +115,25 @@ public enum OllamaModel implements ChatModelDescription {
 	LLAMA3_2_3B("llama3.2:3b"),
 
 	/**
-	 * The 7B parameters model
-	 */
-	MISTRAL("mistral"),
-
-	/**
 	 * A 12B model with 128k context length, built by Mistral AI in collaboration with
 	 * NVIDIA.
 	 */
 	MISTRAL_NEMO("mistral-nemo"),
+
+	/**
+	 * The Ministral 3 3B language model from Mistral AI.
+	 */
+	MINISTRAL_3_3B("ministral-3:3b"),
+
+	/**
+	 * The Ministral 3 8B language model from Mistral AI.
+	 */
+	MINISTRAL_3_8B("ministral-3:8b"),
+
+	/**
+	 * The Ministral 3 14B language model from Mistral AI.
+	 */
+	MINISTRAL_3_14B("ministral-3:14b"),
 
 	/**
 	 * A small vision language model designed to run efficiently on edge devices.

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
@@ -24,7 +24,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -57,19 +57,21 @@ import static org.mockito.Mockito.when;
  * @author Alexandros Pappas
  * @author Thomas Vitale
  * @author Sebastien Deleuze
+ * @author Nicolas Krier
  * @since 1.0.0
  */
 @ExtendWith(MockitoExtension.class)
 class OllamaChatModelTests {
 
 	@Mock
-	OllamaApi ollamaApi;
+	private OllamaApi ollamaApi;
 
 	@Test
 	void buildOllamaChatModelWithConstructor() {
 		ChatModel chatModel = new OllamaChatModel(this.ollamaApi,
-				OllamaChatOptions.builder().model(OllamaModel.MISTRAL).build(), ToolCallingManager.builder().build(),
-				ObservationRegistry.NOOP, ModelManagementOptions.builder().build());
+				OllamaChatOptions.builder().model(OllamaModel.MINISTRAL_3_8B).build(),
+				ToolCallingManager.builder().build(), ObservationRegistry.NOOP,
+				ModelManagementOptions.builder().build());
 		assertThat(chatModel).isNotNull();
 	}
 
@@ -242,9 +244,8 @@ class OllamaChatModelTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "LLAMA2", "MISTRAL", "CODELLAMA", "LLAMA3", "GEMMA" })
-	void buildOllamaChatModelWithDifferentModels(String modelName) {
-		OllamaModel model = OllamaModel.valueOf(modelName);
+	@EnumSource(value = OllamaModel.class, names = { "LLAMA2", "MINISTRAL_3_8B", "CODELLAMA", "LLAMA3", "GEMMA" })
+	void buildOllamaChatModelWithDifferentModels(OllamaModel model) {
 		OllamaChatOptions options = OllamaChatOptions.builder().model(model).build();
 
 		ChatModel chatModel = OllamaChatModel.builder().ollamaApi(this.ollamaApi).options(options).build();
@@ -314,7 +315,10 @@ class OllamaChatModelTests {
 	@Test
 	void buildOllamaChatModelImmutability() {
 		// Test that the builder creates immutable instances
-		OllamaChatOptions options = OllamaChatOptions.builder().model(OllamaModel.MISTRAL).temperature(0.5).build();
+		OllamaChatOptions options = OllamaChatOptions.builder()
+			.model(OllamaModel.MINISTRAL_3_14B)
+			.temperature(0.5)
+			.build();
 
 		ChatModel chatModel1 = OllamaChatModel.builder().ollamaApi(this.ollamaApi).options(options).build();
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaChatOptionsTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaChatOptionsTests.java
@@ -49,9 +49,8 @@ class OllamaChatOptionsTests extends AbstractChatOptionsTests<OllamaChatOptions,
 
 	@Test
 	void testBasicOptions() {
-		var b1 = OllamaChatOptions.builder().model("model").mainGPU(12);
-
-		var b = OllamaChatOptions.builder().mainGPU(12).model("model");
+		OllamaChatOptions.builder().model("model").mainGPU(12);
+		OllamaChatOptions.builder().mainGPU(12).model("model");
 
 		var options = OllamaChatOptions.builder().temperature(3.14).topK(30).stop(List.of("a", "b", "c")).build();
 
@@ -236,9 +235,9 @@ class OllamaChatOptionsTests extends AbstractChatOptionsTests<OllamaChatOptions,
 
 		var optionsMap = options.toMap();
 		assertThat(optionsMap).containsOnlyKeys("model");
-		assertThat(optionsMap.get("model")).isEqualTo(OllamaModel.MISTRAL.id());
+		assertThat(optionsMap.get("model")).isEqualTo(OllamaModel.MINISTRAL_3_8B.id());
 
-		assertThat(options.getModel()).isEqualTo(OllamaModel.MISTRAL.id());
+		assertThat(options.getModel()).isEqualTo(OllamaModel.MINISTRAL_3_8B.id());
 
 		// Verify all getters return null
 		assertThat(options.getTemperature()).isNull();
@@ -272,9 +271,10 @@ class OllamaChatOptionsTests extends AbstractChatOptionsTests<OllamaChatOptions,
 
 	/**
 	 * Demonstrates the difference between simple "json" format and JSON Schema format.
-	 *
+	 * <p>
 	 * Simple "json" format: Tells Ollama to return any valid JSON structure. JSON Schema
 	 * format: Tells Ollama to return JSON matching a specific schema.
+	 * </p>
 	 */
 	@Test
 	void testSimpleJsonFormatVsJsonSchema() {


### PR DESCRIPTION
## Description

- Remove Mistral deprecated model
- Add Ministral 3 model family
- Polish unit tests

## Explanations

Recently integration tests have failed for Ollama model due to model `mistral` not found:

```shell
Error:  Errors: 
Error:  org.springframework.ai.ollama.OllamaChatModelIT.jsonStructuredOutputWithFormatOption
Error:    Run 1: OllamaChatModelIT.jsonStructuredOutputWithFormatOption:284 » NonTransientAi 404 - {"error":"model 'mistral' not found"}
Error:    Run 2: OllamaChatModelIT.jsonStructuredOutputWithFormatOption:284 » NonTransientAi 404 - {"error":"model 'mistral' not found"}
Error:    Run 3: OllamaChatModelIT.jsonStructuredOutputWithFormatOption:284 » NonTransientAi 404 - {"error":"model 'mistral' not found"}
[INFO] 
Error:  org.springframework.ai.ollama.OllamaChatModelIT.jsonStructuredOutputWithOutputSchemaOption
Error:    Run 1: OllamaChatModelIT.jsonStructuredOutputWithOutputSchemaOption:300 » NonTransientAi 404 - {"error":"model 'mistral' not found"}
Error:    Run 2: OllamaChatModelIT.jsonStructuredOutputWithOutputSchemaOption:300 » NonTransientAi 404 - {"error":"model 'mistral' not found"}
Error:    Run 3: OllamaChatModelIT.jsonStructuredOutputWithOutputSchemaOption:300 » NonTransientAi 404 - {"error":"model 'mistral' not found"}
[INFO] 
Error:  org.springframework.ai.ollama.OllamaChatModelIT.roleTest
Error:    Run 1: OllamaChatModelIT.roleTest:130 » NonTransientAi 404 - {"error":"model 'mistral' not found"}
Error:    Run 2: OllamaChatModelIT.roleTest:130 » NonTransientAi 404 - {"error":"model 'mistral' not found"}
Error:    Run 3: OllamaChatModelIT.roleTest:130 » NonTransientAi 404 - {"error":"model 'mistral' not found"}
```

## Proposed milestone

**2.0.0**