### PR TITLE
Support Metadata of `RedisAutoConfiguration` for indexing

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
@@ -16,10 +16,13 @@
 
 package org.springframework.ai.vectorstore.redis.autoconfigure;
 
+import java.util.List;
+
 import io.micrometer.observation.ObservationRegistry;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.search.Schema.FieldType;
 
 import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
@@ -27,6 +30,7 @@ import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.vectorstore.SpringAIVectorStoreTypes;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationConvention;
 import org.springframework.ai.vectorstore.redis.RedisVectorStore;
+import org.springframework.ai.vectorstore.redis.RedisVectorStore.MetadataField;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -35,6 +39,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.util.CollectionUtils;
 
 /**
  * {@link AutoConfiguration Auto-configuration} for Redis Vector Store.
@@ -92,6 +97,19 @@ public class RedisVectorStoreAutoConfiguration {
 
 		// Configure HNSW parameters if available
 		hnswConfiguration(builder, properties);
+
+		// Configure metadata fields if provided
+		if (!CollectionUtils.isEmpty(properties.getMetadataFields())) {
+			List<MetadataField> fields = properties.getMetadataFields().stream().map(m -> {
+				String name = m.get("name");
+				String type = m.get("type");
+				if (name == null || type == null) {
+					throw new IllegalArgumentException("Metadata field must have both 'name' and 'type' defined: " + m);
+				}
+				return new MetadataField(name, FieldType.valueOf(type.toUpperCase()));
+			}).toList();
+			builder.metadataFields(fields);
+		}
 
 		return builder.build();
 	}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreProperties.java
@@ -16,6 +16,10 @@
 
 package org.springframework.ai.vectorstore.redis.autoconfigure;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.ai.vectorstore.properties.CommonVectorStoreProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -66,6 +70,11 @@ public class RedisVectorStoreProperties extends CommonVectorStoreProperties {
 	private HnswProperties hnsw = new HnswProperties();
 
 	/**
+	 * Metadata field definitions for indexing.
+	 */
+	private List<Map<String, String>> metadataFields = new ArrayList<>();
+
+	/**
 	 * Returns the index name.
 	 * @return the index name
 	 */
@@ -111,6 +120,22 @@ public class RedisVectorStoreProperties extends CommonVectorStoreProperties {
 	 */
 	public final void setHnsw(final HnswProperties hnswProperties) {
 		this.hnsw = hnswProperties;
+	}
+
+	/**
+	 * Returns the metadata fields.
+	 * @return the metadata fields
+	 */
+	public final List<Map<String, String>> getMetadataFields() {
+		return this.metadataFields;
+	}
+
+	/**
+	 * Sets the metadata fields.
+	 * @param metadataFields the metadata fields
+	 */
+	public final void setMetadataFields(final List<Map<String, String>> metadataFields) {
+		this.metadataFields = metadataFields;
 	}
 
 	/**

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/test/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/test/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfigurationIT.java
@@ -139,6 +139,50 @@ class RedisVectorStoreAutoConfigurationIT {
 		});
 	}
 
+	@Test
+	public void addAndSearchWithMetadataFiltering() {
+		List<Document> docs = List.of(
+				new Document("Artificial intelligence is progressing rapidly.",
+						Map.of("country", "USA", "year", 2024, "description", "Artificial intelligence")),
+				new Document("Machine learning makes it possible for computers to learn from data.",
+						Map.of("country", "UK", "year", 2025, "description", "Machine learning")),
+				new Document("Deep learning can model complex patterns in data",
+						Map.of("country", "CN", "year", 2026, "description", "Deep learning")));
+
+		this.contextRunner
+			.withPropertyValues("spring.ai.vectorstore.redis.metadata-fields[0].name=country",
+					"spring.ai.vectorstore.redis.metadata-fields[0].type=TAG",
+					"spring.ai.vectorstore.redis.metadata-fields[1].name=year",
+					"spring.ai.vectorstore.redis.metadata-fields[1].type=NUMERIC",
+					"spring.ai.vectorstore.redis.metadata-fields[2].name=description",
+					"spring.ai.vectorstore.redis.metadata-fields[2].type=TEXT")
+			.run(context -> {
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				vectorStore.add(docs);
+
+				// Filter by TAG
+				List<Document> results = vectorStore.similaritySearch(
+						SearchRequest.builder().query("AI").topK(5).filterExpression("country == 'USA'").build());
+				assertThat(results).hasSize(1);
+
+				// Filter by NUMERIC
+				results = vectorStore.similaritySearch(
+						SearchRequest.builder().query("learning").topK(5).filterExpression("year >= 2025").build());
+				assertThat(results).hasSize(2);
+
+				// Filter by TEXT
+				results = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("learning")
+					.topK(5)
+					.filterExpression("description == 'learning'")
+					.build());
+				assertThat(results).hasSize(2);
+
+				vectorStore.delete(docs.stream().map(Document::getId).toList());
+			});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class Config {
 

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/test/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStorePropertiesTests.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/test/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStorePropertiesTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.vectorstore.redis.autoconfigure;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +64,16 @@ class RedisVectorStorePropertiesTests {
 		assertThat(props.getHnsw().getM()).isEqualTo(32);
 		assertThat(props.getHnsw().getEfConstruction()).isEqualTo(100);
 		assertThat(props.getHnsw().getEfRuntime()).isEqualTo(50);
+	}
+
+	@Test
+	void customMetadataFields() {
+		var props = new RedisVectorStoreProperties();
+		props.setMetadataFields(List.of(Map.of("name", "conversationId", "type", "TAG")));
+
+		assertThat(props.getMetadataFields()).hasSize(1);
+		assertThat(props.getMetadataFields().get(0)).containsEntry("name", "conversationId")
+			.containsEntry("type", "TAG");
 	}
 
 }


### PR DESCRIPTION
Close #6308 

This PR allows developers to configure metadata for `RedisAutoConfiguration` like this:

```
spring:
  ai:
    vectorstore:
      redis:
        initialize-schema: true
        metadata-fields:
          - name: country
            type: tag
          - name: year
            type: numeric
          - name: description
            type: text
```

`RedisVectorStore` only supports three types: `TAG`, `NUMERIC` and `TEXT`. This PR only supports them as well, without out `GEO` and `VECTOR` defined in `edis.clients.jedis.search.Schema.FieldType`.

https://github.com/spring-projects/spring-ai/blob/c52f675445cb563a9f37c54f3489e3a6e049db97/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java#L94

https://github.com/redis/jedis/blob/33fc911a2aa01e93fa4bb2e0caae72e85a26ec4e/src/main/java/redis/clients/jedis/search/Schema.java#L16-L24