### PR TITLE
GH-6163: Omit null fields from Bedrock inferenceConfig

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -428,12 +428,20 @@ public class BedrockProxyChatModel implements ChatModel {
 			toolConfiguration = ToolConfiguration.builder().tools(bedrockTools).build();
 		}
 
-		InferenceConfiguration inferenceConfiguration = InferenceConfiguration.builder()
-			.maxTokens(options.getMaxTokens())
-			.stopSequences(options.getStopSequences())
-			.temperature(options.getTemperature() != null ? options.getTemperature().floatValue() : null)
-			.topP(options.getTopP() != null ? options.getTopP().floatValue() : null)
-			.build();
+		InferenceConfiguration.Builder configBuilder = InferenceConfiguration.builder();
+		if (options.getMaxTokens() != null) {
+			configBuilder.maxTokens(options.getMaxTokens());
+		}
+		if (options.getStopSequences() != null && !options.getStopSequences().isEmpty()) {
+			configBuilder.stopSequences(options.getStopSequences());
+		}
+		if (options.getTemperature() != null) {
+			configBuilder.temperature(options.getTemperature().floatValue());
+		}
+		if (options.getTopP() != null) {
+			configBuilder.topP(options.getTopP().floatValue());
+		}
+		InferenceConfiguration inferenceConfiguration = configBuilder.build();
 
 		BedrockChatOptions bedrockOptions = (BedrockChatOptions) prompt.getOptions();
 		Assert.notNull(bedrockOptions, "options can't be null here");

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.InferenceConfiguration;
 import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
 
 import org.springframework.ai.bedrock.converse.api.BedrockCacheOptions;
@@ -327,6 +328,50 @@ class BedrockProxyChatModelTest {
 		assertThat(system).hasSize(2);
 		assertThat(system.get(0).cachePoint()).isNull();
 		assertThat(system.get(1).cachePoint()).isNull();
+	}
+
+	// -------------------------------------------------------------------------
+	// Inference configuration null-field omission
+	// -------------------------------------------------------------------------
+
+	@Test
+	void shouldOmitNullValuesFromInferenceConfigBySdkFields() {
+		// Build reference config with only maxTokens explicitly set
+		InferenceConfiguration expected = InferenceConfiguration.builder().maxTokens(400).build();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.model("eu.anthropic.claude-opus-4-7")
+			.maxTokens(400)
+			.build();
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("Hello")), options);
+		ConverseRequest request = newModel().createRequest(prompt);
+
+		// equalsBySdkFields considers which fields were explicitly set, not just
+		// their values. If the old code called .temperature(null), the config
+		// objects would NOT be equal — this test catches the regression.
+		assertThat(request.inferenceConfig().equalsBySdkFields(expected)).isTrue();
+	}
+
+	@Test
+	void shouldIncludeExplicitlySetTemperatureAndTopP() {
+		InferenceConfiguration expected = InferenceConfiguration.builder()
+			.temperature(0.7f)
+			.topP(0.9f)
+			.maxTokens(1000)
+			.build();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.model("us.anthropic.claude-3-5-sonnet-20241022-v2:0")
+			.temperature(0.7)
+			.topP(0.9)
+			.maxTokens(1000)
+			.build();
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("Hello")), options);
+		ConverseRequest request = newModel().createRequest(prompt);
+
+		assertThat(request.inferenceConfig().equalsBySdkFields(expected)).isTrue();
 	}
 
 }


### PR DESCRIPTION
## :bug: Bug Fix
Closes https://github.com/spring-projects/spring-ai/issues/6163

## Summary
`BedrockProxyChatModel` unconditionally sets all fields on `InferenceConfiguration.Builder`, including `temperature` and `topP` when they are null. The AWS SDK serializes these null values into the request body as `"temperature": null`, which Claude Opus 4.7 rejects with a 400 `ValidationException`.

## Changes
- Conditionally set `maxTokens`, `stopSequences`, `temperature`, and `topP` on `InferenceConfiguration.Builder` only when the corresponding option value is non-null
- Add unit tests using `equalsBySdkFields()` to verify null fields are truly absent (not just null-valued)
- Streaming path is also fixed — `internalStream()` reuses the same `createRequest()`

## Verification
- [x] `./mvnw -pl models/spring-ai-bedrock-converse -am test` passes
- [x] No behavior change for models that accept temperature (set values still round-trip correctly)
- [x] Linear commit history, rebased on `main`
- [x] Signed-off-by present (DCO)