### PR TITLE
Fix tool callback example in user-controlled tool execution docs

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1190,7 +1190,7 @@ ChatModel chatModel = ...
 ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
 
 ChatOptions chatOptions = ToolCallingChatOptions.builder()
-    .toolCallbacks(new CustomerTools())
+    .toolCallbacks(ToolCallbacks.from(new CustomerTools()))
     .build();
 Prompt prompt = new Prompt("Tell me more about the customer with ID 42", chatOptions);
 


### PR DESCRIPTION
## Summary

This PR fixes a small documentation issue in the user-controlled tool execution example.

The streaming API example now wraps `new CustomerTools()` with `ToolCallbacks.from(...)`, matching the expected `toolCallbacks` usage and the surrounding examples.

## Changes

- Updated `.toolCallbacks(new CustomerTools())` to `.toolCallbacks(ToolCallbacks.from(new CustomerTools()))`

## Notes

This is a documentation-only change.

