### PR TITLE
GH-2588 Add name attribite to @ToolParam

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpToolParam.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpToolParam.java
@@ -31,6 +31,11 @@ import java.lang.annotation.Target;
 public @interface McpToolParam {
 
 	/**
+	 * The name of the tool argument.
+	 */
+	String name() default "";
+
+	/**
 	 * Whether the tool argument is required.
 	 */
 	boolean required() default true;

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpToolParam.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpToolParam.java
@@ -31,7 +31,9 @@ import java.lang.annotation.Target;
 public @interface McpToolParam {
 
 	/**
-	 * The name of the tool argument.
+	 * The name of the tool argument. Only effective on method parameters. For fields or
+	 * record components, use {@code @JsonProperty} or {@code @Schema} to customize schema
+	 * property names.
 	 */
 	String name() default "";
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -62,6 +62,8 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 		this.toolMethod = toolMethod;
 		this.toolObject = toolObject;
 		this.returnMode = returnMode;
+		// MCP callbacks can be built independently from schema generation, so runtime
+		// argument binding must validate duplicate effective names independently.
 		McpToolMethodParameterUtils.validateUniqueParameterNames(toolMethod, this::isInfrastructureParameter);
 	}
 
@@ -155,7 +157,7 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 	 * @param type The target type
 	 * @return The typed argument
 	 */
-	protected Object buildTypedArgument(@Nullable Object value, Type type) {
+	protected @Nullable Object buildTypedArgument(@Nullable Object value, Type type) {
 		if (value == null) {
 			return null;
 		}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -18,6 +18,7 @@ package org.springframework.ai.mcp.annotation.method.tool;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Objects;
@@ -61,6 +62,7 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 		this.toolMethod = toolMethod;
 		this.toolObject = toolObject;
 		this.returnMode = returnMode;
+		McpToolMethodParameterUtils.validateUniqueParameterNames(toolMethod, this::isInfrastructureParameter);
 	}
 
 	/**
@@ -131,9 +133,20 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 				return exchangeOrContext;
 			}
 
-			Object rawArgument = toolInputArguments.get(parameter.getName());
+			Object rawArgument = toolInputArguments.get(McpToolMethodParameterUtils.getParameterName(parameter));
 			return buildTypedArgument(rawArgument, parameter.getParameterizedType());
 		}).toArray();
+	}
+
+	private boolean isInfrastructureParameter(Parameter parameter) {
+		// Check if parameter is a common MCP infrastructure parameter
+		if (McpToolMethodParameterUtils.isInfrastructureParameter(parameter)) {
+			return true;
+		}
+
+		// Check if parameter is an injectable exchange or context type for this
+		// callback
+		return isExchangeOrContextType(parameter.getType());
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/McpToolMethodParameterUtils.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/McpToolMethodParameterUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.method.tool;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+
+import org.springframework.ai.mcp.annotation.McpMeta;
+import org.springframework.ai.mcp.annotation.McpProgressToken;
+import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.ai.mcp.annotation.context.McpAsyncRequestContext;
+import org.springframework.ai.mcp.annotation.context.McpSyncRequestContext;
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility methods for handling MCP tool method parameters.
+ * <p>
+ * This class contains only the common parameter handling shared by MCP tool schema
+ * generation and method invocation. Caller-specific exchange/context parameter handling
+ * remains in the caller.
+ *
+ * @author Michał Grandys
+ */
+public final class McpToolMethodParameterUtils {
+
+	private McpToolMethodParameterUtils() {
+	}
+
+	public static boolean isInfrastructureParameter(Parameter parameter) {
+		// Check if parameter is a request context type
+		if (McpSyncRequestContext.class.isAssignableFrom(parameter.getType())
+				|| McpAsyncRequestContext.class.isAssignableFrom(parameter.getType())) {
+			return true;
+		}
+
+		// Check if parameter is annotated with @McpProgressToken
+		if (parameter.isAnnotationPresent(McpProgressToken.class)) {
+			return true;
+		}
+
+		// Check if parameter is McpMeta type
+		if (McpMeta.class.isAssignableFrom(parameter.getType())) {
+			return true;
+		}
+
+		// Check if parameter is CallToolRequest type
+		if (CallToolRequest.class.isAssignableFrom(parameter.getType())) {
+			return true;
+		}
+
+		// Check if parameter is McpTransportContext type
+		return McpTransportContext.class.isAssignableFrom(parameter.getType());
+	}
+
+	public static String getParameterName(Parameter parameter) {
+		McpToolParam toolParamAnnotation = parameter.getAnnotation(McpToolParam.class);
+		if (toolParamAnnotation != null && StringUtils.hasText(toolParamAnnotation.name())) {
+			return toolParamAnnotation.name();
+		}
+		return parameter.getName();
+	}
+
+	public static void validateUniqueParameterNames(Method method,
+			Predicate<Parameter> infrastructureParameterPredicate) {
+		Set<String> parameterNames = new HashSet<>();
+		for (Parameter parameter : method.getParameters()) {
+			if (infrastructureParameterPredicate.test(parameter)) {
+				continue;
+			}
+			String parameterName = getParameterName(parameter);
+			if (!parameterNames.add(parameterName)) {
+				throw new IllegalArgumentException(
+						"Duplicate tool parameter name '" + parameterName + "' in method " + method);
+			}
+		}
+	}
+
+}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/McpToolMethodParameterUtils.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/McpToolMethodParameterUtils.java
@@ -18,8 +18,6 @@ package org.springframework.ai.mcp.annotation.method.tool;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import io.modelcontextprotocol.common.McpTransportContext;
@@ -30,6 +28,7 @@ import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpToolParam;
 import org.springframework.ai.mcp.annotation.context.McpAsyncRequestContext;
 import org.springframework.ai.mcp.annotation.context.McpSyncRequestContext;
+import org.springframework.ai.tool.support.ToolMethodParameterUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -40,12 +39,17 @@ import org.springframework.util.StringUtils;
  * remains in the caller.
  *
  * @author Michał Grandys
+ * @since 2.0.0
  */
 public final class McpToolMethodParameterUtils {
 
 	private McpToolMethodParameterUtils() {
 	}
 
+	/**
+	 * Return whether the parameter is a common MCP infrastructure parameter. Server
+	 * exchange types are caller-specific and must be handled by the caller.
+	 */
 	public static boolean isInfrastructureParameter(Parameter parameter) {
 		// Check if parameter is a request context type
 		if (McpSyncRequestContext.class.isAssignableFrom(parameter.getType())
@@ -72,27 +76,18 @@ public final class McpToolMethodParameterUtils {
 		return McpTransportContext.class.isAssignableFrom(parameter.getType());
 	}
 
+	public static void validateUniqueParameterNames(Method method,
+			Predicate<Parameter> infrastructureParameterPredicate) {
+		ToolMethodParameterUtils.validateUniqueParameterNames(method, infrastructureParameterPredicate,
+				McpToolMethodParameterUtils::getParameterName);
+	}
+
 	public static String getParameterName(Parameter parameter) {
 		McpToolParam toolParamAnnotation = parameter.getAnnotation(McpToolParam.class);
 		if (toolParamAnnotation != null && StringUtils.hasText(toolParamAnnotation.name())) {
 			return toolParamAnnotation.name();
 		}
 		return parameter.getName();
-	}
-
-	public static void validateUniqueParameterNames(Method method,
-			Predicate<Parameter> infrastructureParameterPredicate) {
-		Set<String> parameterNames = new HashSet<>();
-		for (Parameter parameter : method.getParameters()) {
-			if (infrastructureParameterPredicate.test(parameter)) {
-				continue;
-			}
-			String parameterName = getParameterName(parameter);
-			if (!parameterNames.add(parameterName)) {
-				throw new IllegalArgumentException(
-						"Duplicate tool parameter name '" + parameterName + "' in method " + method);
-			}
-		}
 	}
 
 }

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/package-info.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Method callbacks and utilities for MCP tool invocation (call_tool).
  */
+@NullMarked
 package org.springframework.ai.mcp.annotation.method.tool;
+
+import org.jspecify.annotations.NullMarked;

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
@@ -51,13 +51,13 @@ import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpToolParam;
 import org.springframework.ai.mcp.annotation.context.McpAsyncRequestContext;
 import org.springframework.ai.mcp.annotation.context.McpSyncRequestContext;
+import org.springframework.ai.mcp.annotation.method.tool.McpToolMethodParameterUtils;
 import org.springframework.ai.model.KotlinModule;
 import org.springframework.ai.util.JacksonUtils;
 import org.springframework.ai.util.json.schema.JsonSchemaGenerator.SchemaOption;
 import org.springframework.ai.util.json.schema.JsonSchemaUtils;
 import org.springframework.core.KotlinDetector;
 import org.springframework.core.Nullness;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.ConcurrentReferenceHashMap;
 
 public final class McpJsonSchemaGenerator {
@@ -150,33 +150,18 @@ public final class McpJsonSchemaGenerator {
 
 		ObjectNode properties = schema.putObject("properties");
 		List<String> required = new ArrayList<>();
+		McpToolMethodParameterUtils.validateUniqueParameterNames(method,
+				McpJsonSchemaGenerator::isInfrastructureParameter);
 
 		for (int i = 0; i < method.getParameterCount(); i++) {
 			Parameter parameter = method.getParameters()[i];
-			String parameterName = parameter.getName();
 			Type parameterType = method.getGenericParameterTypes()[i];
 
-			// Skip parameters annotated with @McpProgressToken
-			if (parameter.isAnnotationPresent(McpProgressToken.class)) {
+			if (isInfrastructureParameter(parameter)) {
 				continue;
 			}
 
-			// Skip McpMeta parameters
-			if (parameterType instanceof Class<?> parameterClass && McpMeta.class.isAssignableFrom(parameterClass)) {
-				continue;
-			}
-
-			// Skip MCP infrastructure parameter types
-			if (parameterType instanceof Class<?> parameterClass
-					&& (ClassUtils.isAssignable(McpSyncRequestContext.class, parameterClass)
-							|| ClassUtils.isAssignable(McpAsyncRequestContext.class, parameterClass)
-							|| ClassUtils.isAssignable(McpSyncServerExchange.class, parameterClass)
-							|| ClassUtils.isAssignable(McpAsyncServerExchange.class, parameterClass)
-							|| ClassUtils.isAssignable(McpTransportContext.class, parameterClass)
-							|| ClassUtils.isAssignable(CallToolRequest.class, parameterClass))) {
-				continue;
-			}
-
+			String parameterName = McpToolMethodParameterUtils.getParameterName(parameter);
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);
 			}
@@ -202,6 +187,17 @@ public final class McpJsonSchemaGenerator {
 		required.forEach(requiredArray::add);
 
 		return schema.toPrettyString();
+	}
+
+	private static boolean isInfrastructureParameter(Parameter parameter) {
+		// Check if parameter is a common MCP infrastructure parameter
+		if (McpToolMethodParameterUtils.isInfrastructureParameter(parameter)) {
+			return true;
+		}
+
+		// Check if parameter is an MCP server exchange type
+		return McpSyncServerExchange.class.isAssignableFrom(parameter.getType())
+				|| McpAsyncServerExchange.class.isAssignableFrom(parameter.getType());
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackTests.java
@@ -53,7 +53,7 @@ public class SyncMcpToolMethodCallbackTests {
 		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("simple-tool", Map.of("input", "test message"));
+		CallToolRequest request = new CallToolRequest("simple-tool", Map.of("message", "test message"));
 
 		CallToolResult result = callback.apply(exchange, request);
 
@@ -554,10 +554,21 @@ public class SyncMcpToolMethodCallbackTests {
 		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Date: 2026-04-22");
 	}
 
+	@Test
+	public void testToolWithDuplicateEffectiveParameterNamesThrowsException() throws Exception {
+		TestToolProvider provider = new TestToolProvider();
+		Method method = TestToolProvider.class.getMethod("duplicateEffectiveNames", String.class, String.class);
+
+		assertThatThrownBy(() -> new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Duplicate tool parameter name 'input'")
+			.hasMessageContaining("duplicateEffectiveNames");
+	}
+
 	private static class TestToolProvider {
 
 		@McpTool(name = "simple-tool", description = "A simple tool")
-		public String simpleTool(String input) {
+		public String simpleTool(@McpToolParam(name = "message") String input) {
 			return "Processed: " + input;
 		}
 
@@ -656,6 +667,11 @@ public class SyncMcpToolMethodCallbackTests {
 		@McpTool(name = "local-date-tool", description = "Tool with date input")
 		public String dateTool(@McpToolParam LocalDate date) {
 			return "Date: " + date.toString();
+		}
+
+		@McpTool(name = "duplicate-effective-names-tool", description = "Tool with duplicate parameter names")
+		public String duplicateEffectiveNames(@McpToolParam(name = "input") String first, String input) {
+			return first + input;
 		}
 
 	}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
@@ -17,11 +17,13 @@
 package org.springframework.ai.mcp.annotation.method.tool.utils;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 
+import org.springframework.ai.mcp.annotation.McpToolParam;
 import org.springframework.ai.util.JsonHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -131,6 +133,41 @@ class McpJsonSchemaGeneratorTests {
 	}
 
 	@Test
+	void generateSchemaForMethodWithExplicitMcpToolParamName() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("explicitToolParamNameMethod", String.class, int.class);
+
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = jsonHelper.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/properties/customer_id/type").asText()).isEqualTo("string");
+		assertThat(schemaNode.at("/properties/max_results/type").asText()).isEqualTo("integer");
+		assertThat(schemaNode.at("/properties/customerId").isMissingNode()).isTrue();
+		assertThat(textValues(schemaNode.at("/required"))).containsExactly("customer_id", "max_results");
+	}
+
+	@Test
+	void generateSchemaForMethodWithBlankMcpToolParamNameFallsBackToParameterName() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("blankToolParamNameMethod", String.class);
+
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = jsonHelper.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/properties/username/type").asText()).isEqualTo("string");
+		assertThat(textValues(schemaNode.at("/required"))).containsExactly("username");
+	}
+
+	@Test
+	void generateSchemaForMethodWithDuplicateEffectiveMcpToolParamNamesThrowsException() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("duplicateEffectiveToolParamNamesMethod", String.class,
+				String.class);
+
+		assertThatThrownBy(() -> McpJsonSchemaGenerator.generateForMethodInput(method))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Duplicate tool parameter name 'name'")
+			.hasMessageContaining("duplicateEffectiveToolParamNamesMethod");
+	}
+
+	@Test
 	void generateFromClassProducesValidObjectSchema() {
 		String schema = McpJsonSchemaGenerator.generateFromClass(SearchRequest.class);
 		JsonNode schemaNode = jsonHelper.fromJson(schema, JsonNode.class);
@@ -148,6 +185,12 @@ class McpJsonSchemaGeneratorTests {
 		assertThat(schemaNode.has("properties")).isTrue();
 	}
 
+	private static List<String> textValues(JsonNode arrayNode) {
+		List<String> values = new ArrayList<>();
+		arrayNode.forEach(node -> values.add(node.asText()));
+		return values;
+	}
+
 	static class TestMethods {
 
 		public void searchBooksMethod(SearchRequest request) {
@@ -160,6 +203,16 @@ class McpJsonSchemaGeneratorTests {
 		}
 
 		public void peerReferenceMethod(PeerA.SearchRequest a, PeerB.SearchRequest b) {
+		}
+
+		public void explicitToolParamNameMethod(@McpToolParam(name = "customer_id") String customerId,
+				@McpToolParam(name = "max_results") int maxResults) {
+		}
+
+		public void blankToolParamNameMethod(@McpToolParam(name = " ") String username) {
+		}
+
+		public void duplicateEffectiveToolParamNamesMethod(@McpToolParam(name = "name") String first, String name) {
 		}
 
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-overview.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-overview.adoc
@@ -104,21 +104,21 @@ public class CalculatorTools {
 
     @McpTool(name = "add", description = "Add two numbers together")
     public int add(
-            @McpToolParam(name = "a", description = "First number", required = true) int a,
-            @McpToolParam(name = "b", description = "Second number", required = true) int b) {
+            @McpToolParam(name = "first_number", description = "First number", required = true) int a,
+            @McpToolParam(name = "second_number", description = "Second number", required = true) int b) {
         return a + b;
     }
 
     @McpTool(name = "multiply", description = "Multiply two numbers")
     public double multiply(
-            @McpToolParam(name = "x", description = "First number", required = true) double x,
-            @McpToolParam(name = "y", description = "Second number", required = true) double y) {
+            @McpToolParam(description = "First number", required = true) double x,
+            @McpToolParam(description = "Second number", required = true) double y) {
         return x * y;
     }
 }
 ----
 
-Use `@McpToolParam(name = "...")` when publishing libraries or building without Java parameter metadata, so tool schemas and calls do not depend on reflective names such as `arg0`.
+Use `@McpToolParam(name = "...")` to expose a tool argument name that differs from the Java parameter name, or when publishing libraries or building without Java parameter metadata.
 
 And a simple client handler for logging:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-overview.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-overview.adoc
@@ -104,19 +104,21 @@ public class CalculatorTools {
 
     @McpTool(name = "add", description = "Add two numbers together")
     public int add(
-            @McpToolParam(description = "First number", required = true) int a,
-            @McpToolParam(description = "Second number", required = true) int b) {
+            @McpToolParam(name = "a", description = "First number", required = true) int a,
+            @McpToolParam(name = "b", description = "Second number", required = true) int b) {
         return a + b;
     }
 
     @McpTool(name = "multiply", description = "Multiply two numbers")
     public double multiply(
-            @McpToolParam(description = "First number", required = true) double x,
-            @McpToolParam(description = "Second number", required = true) double y) {
+            @McpToolParam(name = "x", description = "First number", required = true) double x,
+            @McpToolParam(name = "y", description = "Second number", required = true) double y) {
         return x * y;
     }
 }
 ----
+
+Use `@McpToolParam(name = "...")` when publishing libraries or building without Java parameter metadata, so tool schemas and calls do not depend on reflective names such as `arg0`.
 
 And a simple client handler for logging:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
@@ -18,12 +18,15 @@ public class CalculatorTools {
 
     @McpTool(name = "add", description = "Add two numbers together")
     public int add(
-            @McpToolParam(description = "First number", required = true) int a,
-            @McpToolParam(description = "Second number", required = true) int b) {
+            @McpToolParam(name = "a", description = "First number", required = true) int a,
+            @McpToolParam(name = "b", description = "Second number", required = true) int b) {
         return a + b;
     }
 }
 ----
+
+The `@McpToolParam` annotation supports `name`, `description`, and `required`.
+Use `name` when compiled Java parameter names may be unavailable, such as in libraries or builds that do not retain parameter metadata.
 
 ==== Annotation Attributes
 
@@ -74,8 +77,8 @@ The `@McpTool` annotation supports the following attributes:
              idempotentHint = true
          ))
 public AreaResult calculateRectangleArea(
-        @McpToolParam(description = "Width", required = true) double width,
-        @McpToolParam(description = "Height", required = true) double height) {
+        @McpToolParam(name = "width", description = "Width", required = true) double width,
+        @McpToolParam(name = "height", description = "Height", required = true) double height) {
 
     return new AreaResult(width * height, "square units");
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
@@ -18,15 +18,15 @@ public class CalculatorTools {
 
     @McpTool(name = "add", description = "Add two numbers together")
     public int add(
-            @McpToolParam(name = "a", description = "First number", required = true) int a,
-            @McpToolParam(name = "b", description = "Second number", required = true) int b) {
+            @McpToolParam(name = "first_number", description = "First number", required = true) int a,
+            @McpToolParam(name = "second_number", description = "Second number", required = true) int b) {
         return a + b;
     }
 }
 ----
 
 The `@McpToolParam` annotation supports `name`, `description`, and `required`.
-Use `name` when compiled Java parameter names may be unavailable, such as in libraries or builds that do not retain parameter metadata.
+Use `name` to expose a tool argument name that differs from the Java parameter name, or when compiled Java parameter names may be unavailable.
 
 ==== Annotation Attributes
 
@@ -77,8 +77,8 @@ The `@McpTool` annotation supports the following attributes:
              idempotentHint = true
          ))
 public AreaResult calculateRectangleArea(
-        @McpToolParam(name = "width", description = "Width", required = true) double width,
-        @McpToolParam(name = "height", description = "Height", required = true) double height) {
+        @McpToolParam(description = "Width", required = true) double width,
+        @McpToolParam(description = "Height", required = true) double height) {
 
     return new AreaResult(width * height, "square units");
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -184,7 +184,7 @@ You can define any number of arguments for the method (including no argument) wi
 
 NOTE: Some types are not supported. See xref:_method_tool_limitations[] for more details.
 
-Spring AI will generate the JSON schema for the input parameters of the `@Tool`-annotated method automatically. The schema is used by the model to understand how to call the tool and prepare the tool request. The `@ToolParam` annotation can be used to provide additional information about the input parameters, such as a description or whether the parameter is required or optional. By default, all input parameters are considered required.
+Spring AI will generate the JSON schema for the input parameters of the `@Tool`-annotated method automatically. The schema is used by the model to understand how to call the tool and prepare the tool request. The `@ToolParam` annotation can be used to provide additional information about the input parameters, such as an explicit name, a description, or whether the parameter is required or optional. By default, all input parameters are considered required.
 
 [source,java]
 ----
@@ -206,8 +206,12 @@ class DateTimeTools {
 
 The `@ToolParam` annotation allows you to provide key information about a tool parameter:
 
+- `name`: The explicit name for the parameter. When not provided, Spring AI uses the Java method parameter name.
 - `description`: The description for the parameter, which can be used by the model to understand better how to use it. For example, what format the parameter should be in, what values are allowed, and so on.
 - `required`: Whether the parameter is required or optional. By default, all parameters are considered required. 
+
+Using `@ToolParam(name = "...")` is recommended for libraries or builds that do not retain Java parameter metadata.
+The name override applies only to method parameters. For fields or record components, use Jackson or OpenAPI annotations such as `@JsonProperty` or `@Schema` to customize schema property names.
 
 If a parameter is annotated as `@Nullable`, it will be considered optional unless explicitly marked as required using the `@ToolParam` annotation.
 
@@ -773,7 +777,28 @@ NOTE: See xref:_tool_definition[] for more details on the `ToolDefinition` and h
 
 The `JsonSchemaGenerator` class is used under the hood to generate the JSON schema for the input parameters of a method or a function, using any of the strategies described in xref:_methods_as_tools[] and xref:_functions_as_tools[]. The JSON schema generation logic supports a series of annotations that you can use on the input parameters for methods and functions to customize the resulting schema.
 
-This section describes two main options you can customize when generating the JSON schema for the input parameters of a tool: description and required status.
+This section describes three main options you can customize when generating the JSON schema for the input parameters of a tool: name, description, and required status.
+
+==== Name
+
+By default, Spring AI uses the Java method parameter name as the JSON schema property name and as the input key used when invoking the tool.
+If your build does not retain Java parameter metadata, reflective names such as `arg0` and `arg1` may be used instead.
+You can provide an explicit method parameter name with `@ToolParam(name = "...")`.
+
+[source,java]
+----
+class CustomerTools {
+
+    @Tool(description = "Look up a customer")
+    String getCustomer(@ToolParam(name = "customer_id", description = "Customer identifier") String customerId) {
+        return customerId;
+    }
+
+}
+----
+
+The `name` attribute applies only to method parameters.
+For fields or record components, use Jackson or OpenAPI annotations such as `@JsonProperty` or `@Schema` to customize schema property names.
 
 ==== Description
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/annotation/ToolParam.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/annotation/ToolParam.java
@@ -34,6 +34,11 @@ import java.lang.annotation.Target;
 public @interface ToolParam {
 
 	/**
+	 * The name of the tool argument.
+	 */
+	String name() default "";
+
+	/**
 	 * Whether the tool argument is required.
 	 */
 	boolean required() default true;

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/annotation/ToolParam.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/annotation/ToolParam.java
@@ -34,7 +34,9 @@ import java.lang.annotation.Target;
 public @interface ToolParam {
 
 	/**
-	 * The name of the tool argument.
+	 * The name of the tool argument. Only effective on method parameters. For fields or
+	 * record components, use {@code @JsonProperty} or {@code @Schema} to customize schema
+	 * property names.
 	 */
 	String name() default "";
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
@@ -19,6 +19,7 @@ package org.springframework.ai.tool.method;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -35,6 +36,7 @@ import org.springframework.ai.tool.execution.DefaultToolCallResultConverter;
 import org.springframework.ai.tool.execution.ToolCallResultConverter;
 import org.springframework.ai.tool.execution.ToolExecutionException;
 import org.springframework.ai.tool.metadata.ToolMetadata;
+import org.springframework.ai.tool.support.ToolMethodParameterUtils;
 import org.springframework.ai.util.JsonHelper;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.Assert;
@@ -79,6 +81,7 @@ public final class MethodToolCallback implements ToolCallback {
 		this.toolObject = toolObject;
 		this.toolCallResultConverter = toolCallResultConverter != null ? toolCallResultConverter
 				: DEFAULT_RESULT_CONVERTER;
+		validateUniqueParameterNames(toolMethod);
 	}
 
 	@Override
@@ -143,16 +146,23 @@ public final class MethodToolCallback implements ToolCallback {
 		}
 	}
 
-	// Based on the implementation in MethodToolCallback.
 	@SuppressWarnings("null")
 	private Object[] buildMethodArguments(Map<String, Object> toolInputArguments, @Nullable ToolContext toolContext) {
 		return Stream.of(this.toolMethod.getParameters()).map(parameter -> {
 			if (parameter.getType().isAssignableFrom(ToolContext.class)) {
 				return toolContext;
 			}
-			Object rawArgument = toolInputArguments.get(parameter.getName());
+			Object rawArgument = toolInputArguments.get(ToolMethodParameterUtils.getParameterName(parameter));
 			return buildTypedArgument(rawArgument, parameter.getParameterizedType());
 		}).toArray();
+	}
+
+	private static void validateUniqueParameterNames(Method method) {
+		ToolMethodParameterUtils.validateUniqueParameterNames(method, MethodToolCallback::isToolContextParameter);
+	}
+
+	private static boolean isToolContextParameter(Parameter parameter) {
+		return parameter.getType().isAssignableFrom(ToolContext.class);
 	}
 
 	private @Nullable Object buildTypedArgument(@Nullable Object value, Type type) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
@@ -81,6 +81,8 @@ public final class MethodToolCallback implements ToolCallback {
 		this.toolObject = toolObject;
 		this.toolCallResultConverter = toolCallResultConverter != null ? toolCallResultConverter
 				: DEFAULT_RESULT_CONVERTER;
+		// MethodToolCallback can be built with a caller-provided schema, so runtime
+		// argument binding must validate duplicate effective names independently.
 		validateUniqueParameterNames(toolMethod);
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/support/ToolMethodParameterUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/support/ToolMethodParameterUtils.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -29,10 +30,17 @@ import org.springframework.util.StringUtils;
  * Utility methods for handling tool method parameters.
  *
  * @author Michał Grandys
+ * @since 2.0.0
  */
 public final class ToolMethodParameterUtils {
 
 	private ToolMethodParameterUtils() {
+	}
+
+	public static void validateUniqueParameterNames(Method method,
+			Predicate<Parameter> infrastructureParameterPredicate) {
+		validateUniqueParameterNames(method, infrastructureParameterPredicate,
+				ToolMethodParameterUtils::getParameterName);
 	}
 
 	public static String getParameterName(Parameter parameter) {
@@ -44,13 +52,13 @@ public final class ToolMethodParameterUtils {
 	}
 
 	public static void validateUniqueParameterNames(Method method,
-			Predicate<Parameter> infrastructureParameterPredicate) {
+			Predicate<Parameter> infrastructureParameterPredicate, Function<Parameter, String> parameterNameResolver) {
 		Set<String> parameterNames = new HashSet<>();
 		for (Parameter parameter : method.getParameters()) {
 			if (infrastructureParameterPredicate.test(parameter)) {
 				continue;
 			}
-			String parameterName = getParameterName(parameter);
+			String parameterName = parameterNameResolver.apply(parameter);
 			if (!parameterNames.add(parameterName)) {
 				throw new IllegalArgumentException(
 						"Duplicate tool parameter name '" + parameterName + "' in method " + method);

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/support/ToolMethodParameterUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/support/ToolMethodParameterUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.support;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility methods for handling tool method parameters.
+ *
+ * @author Michał Grandys
+ */
+public final class ToolMethodParameterUtils {
+
+	private ToolMethodParameterUtils() {
+	}
+
+	public static String getParameterName(Parameter parameter) {
+		ToolParam toolParamAnnotation = parameter.getAnnotation(ToolParam.class);
+		if (toolParamAnnotation != null && StringUtils.hasText(toolParamAnnotation.name())) {
+			return toolParamAnnotation.name();
+		}
+		return parameter.getName();
+	}
+
+	public static void validateUniqueParameterNames(Method method,
+			Predicate<Parameter> infrastructureParameterPredicate) {
+		Set<String> parameterNames = new HashSet<>();
+		for (Parameter parameter : method.getParameters()) {
+			if (infrastructureParameterPredicate.test(parameter)) {
+				continue;
+			}
+			String parameterName = getParameterName(parameter);
+			if (!parameterNames.add(parameterName)) {
+				throw new IllegalArgumentException(
+						"Duplicate tool parameter name '" + parameterName + "' in method " + method);
+			}
+		}
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -43,6 +43,7 @@ import tools.jackson.databind.node.ObjectNode;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.model.KotlinModule;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.tool.support.ToolMethodParameterUtils;
 import org.springframework.ai.util.JacksonUtils;
 import org.springframework.core.KotlinDetector;
 import org.springframework.core.Nullness;
@@ -59,7 +60,7 @@ import org.springframework.util.StringUtils;
  * following supported annotations:
  * <p>
  * <ul>
- * <li>{@code @ToolParam(required = ..., description = ...)}</li>
+ * <li>{@code @ToolParam(name = ..., required = ..., description = ...)}</li>
  * <li>{@code @JsonProperty(required = ...)}</li>
  * <li>{@code @JsonClassDescription(...)}</li>
  * <li>{@code @JsonPropertyDescription(...)}</li>
@@ -140,18 +141,19 @@ public final class JsonSchemaGenerator {
 
 		ObjectNode properties = schema.putObject("properties");
 		List<String> required = new ArrayList<>();
+		ToolMethodParameterUtils.validateUniqueParameterNames(method, JsonSchemaGenerator::isInfrastructureParameter);
 
 		for (int i = 0; i < method.getParameterCount(); i++) {
-			String parameterName = method.getParameters()[i].getName();
+			Parameter parameter = method.getParameters()[i];
 			Type parameterType = method.getGenericParameterTypes()[i];
-			if (parameterType instanceof Class<?> parameterClass
-					&& ClassUtils.isAssignable(ToolContext.class, parameterClass)) {
+			if (isInfrastructureParameter(parameter)) {
 				// A ToolContext method parameter is not included in the JSON Schema
 				// generation.
 				// It's a special type used by Spring AI to pass contextual data to tools
 				// outside the model interaction flow.
 				continue;
 			}
+			String parameterName = ToolMethodParameterUtils.getParameterName(parameter);
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);
 			}
@@ -181,6 +183,11 @@ public final class JsonSchemaGenerator {
 		processSchemaOptions(schemaOptions, schema);
 
 		return schema.toPrettyString();
+	}
+
+	private static boolean isInfrastructureParameter(Parameter parameter) {
+		return parameter.getParameterizedType() instanceof Class<?> parameterClass
+				&& ClassUtils.isAssignable(ToolContext.class, parameterClass);
 	}
 
 	/**

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackGenericTypesTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackGenericTypesTest.java
@@ -23,10 +23,12 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.tool.definition.DefaultToolDefinition;
 import org.springframework.ai.tool.definition.ToolDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link MethodToolCallback} with generic types.
@@ -90,7 +92,7 @@ class MethodToolCallbackGenericTypesTest {
 		// Create a JSON input with a map of string to integer
 		String toolInput = """
 				{
-					"map": {"one": 1, "two": 2, "three": 3}
+					"named_map": {"one": 1, "two": 2, "three": 3}
 				}
 				""";
 
@@ -173,6 +175,24 @@ class MethodToolCallbackGenericTypesTest {
 		assertThat(result).isEqualTo("1 entries processed {foo=bar}");
 	}
 
+	@Test
+	void testDuplicateEffectiveToolParamNamesThrowException() throws Exception {
+		TestGenericClass testObject = new TestGenericClass();
+		Method method = TestGenericClass.class.getMethod("duplicateEffectiveNames", String.class, String.class);
+
+		assertThatThrownBy(() -> MethodToolCallback.builder()
+			.toolDefinition(DefaultToolDefinition.builder()
+				.name("duplicateEffectiveNames")
+				.description("Duplicate names")
+				.inputSchema("{}")
+				.build())
+			.toolMethod(method)
+			.toolObject(testObject)
+			.build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Duplicate tool parameter name 'input'")
+			.hasMessageContaining("duplicateEffectiveNames");
+	}
+
 	/**
 	 * Test class with methods that use generic types.
 	 */
@@ -182,7 +202,7 @@ class MethodToolCallbackGenericTypesTest {
 			return strings.size() + " strings processed: " + strings;
 		}
 
-		public String processStringIntMap(Map<String, Integer> map) {
+		public String processStringIntMap(@ToolParam(name = "named_map") Map<String, Integer> map) {
 			return map.size() + " entries processed: " + map;
 		}
 
@@ -193,6 +213,10 @@ class MethodToolCallbackGenericTypesTest {
 		public String processStringListInToolContext(ToolContext toolContext) {
 			Map<String, Object> context = toolContext.getContext();
 			return context.size() + " entries processed " + context;
+		}
+
+		public String duplicateEffectiveNames(@ToolParam(name = "input") String first, String input) {
+			return first + input;
 		}
 
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackGenericTypesTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackGenericTypesTest.java
@@ -176,6 +176,30 @@ class MethodToolCallbackGenericTypesTest {
 	}
 
 	@Test
+	void testExplicitToolParamNameForSimpleString() throws Exception {
+		TestGenericClass testObject = new TestGenericClass();
+		Method method = TestGenericClass.class.getMethod("processCustomer", String.class);
+
+		MethodToolCallback callback = MethodToolCallback.builder()
+			.toolDefinition(DefaultToolDefinition.builder()
+				.name("processCustomer")
+				.description("Process customer")
+				.inputSchema("{}")
+				.build())
+			.toolMethod(method)
+			.toolObject(testObject)
+			.build();
+
+		String result = callback.call("""
+				{
+					"customer_id": "abc-123"
+				}
+				""");
+
+		assertThat(result).contains("Customer: abc-123");
+	}
+
+	@Test
 	void testDuplicateEffectiveToolParamNamesThrowException() throws Exception {
 		TestGenericClass testObject = new TestGenericClass();
 		Method method = TestGenericClass.class.getMethod("duplicateEffectiveNames", String.class, String.class);
@@ -213,6 +237,10 @@ class MethodToolCallbackGenericTypesTest {
 		public String processStringListInToolContext(ToolContext toolContext) {
 			Map<String, Object> context = toolContext.getContext();
 			return context.size() + " entries processed " + context;
+		}
+
+		public String processCustomer(@ToolParam(name = "customer_id") String customerId) {
+			return "Customer: " + customerId;
 		}
 
 		public String duplicateEffectiveNames(@ToolParam(name = "input") String first, String input) {

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -99,7 +99,7 @@ class JsonSchemaGeneratorTests {
 				    "$schema": "https://json-schema.org/draft/2020-12/schema",
 				    "type": "object",
 				    "properties": {
-				        "username": {
+				        "customer_id": {
 				            "type": "string",
 				            "description": "The username of the customer"
 				        },
@@ -423,6 +423,17 @@ class JsonSchemaGeneratorTests {
 				""";
 
 		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForMethodWithDuplicateEffectiveToolParamNamesThrowsException() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("duplicateEffectiveToolParamNamesMethod", String.class,
+				String.class);
+
+		assertThatThrownBy(() -> JsonSchemaGenerator.generateForMethodInput(method))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Duplicate tool parameter name 'name'")
+			.hasMessageContaining("duplicateEffectiveToolParamNamesMethod");
 	}
 
 	// TYPES
@@ -950,11 +961,12 @@ class JsonSchemaGeneratorTests {
 		}
 
 		public void annotatedMethod(
-				@ToolParam(required = false, description = "The username of the customer") String username,
+				@ToolParam(name = "customer_id", required = false,
+						description = "The username of the customer") String username,
 				@ToolParam(required = true) String password) {
 		}
 
-		public void anotherAnnotatedMethod(String username, @ToolParam String password) {
+		public void anotherAnnotatedMethod(String username, @ToolParam(name = " ") String password) {
 		}
 
 		public void openApiMethod(
@@ -978,6 +990,9 @@ class JsonSchemaGeneratorTests {
 		}
 
 		public void contextMethod(String deliveryStatus, LocalDateTime expectedDelivery, ToolContext toolContext) {
+		}
+
+		public void duplicateEffectiveToolParamNamesMethod(@ToolParam(name = "name") String first, String name) {
 		}
 
 		public void searchBooksMethod(SearchRequest request) {


### PR DESCRIPTION
Fixes #2588
Adds explicit parameter name support for `@ToolParam` and `@McpToolParam`, allowing stable tool schema property names and argument binding even when Java parameter metadata is unavailable.

Also adds duplicate effective-name validation for tool method parameters, keeps schema generation and invocation lookup aligned, updates documentation, and covers core and MCP paths with tests.