### PR TITLE
Add auto-configuration and starter for `ToolSearchToolCallingAdvisor`

### DIFF
--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/pom.xml
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-autoconfigure-tool-search-advisor</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Tool Search Advisor Auto Configuration</name>
+	<description>Spring AI Tool Search Advisor Auto Configuration</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-tool-search-advisor</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Optional: VectorStore support for VectorToolIndex auto-configuration -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-vector-store</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-core</artifactId>
+			<version>${lucene.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.toolsearch.autoconfigure;
+
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.chat.client.advisor.toolsearch.ToolSearchToolCallingAdvisor;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
+import org.springframework.ai.tool.toolsearch.ToolIndex;
+import org.springframework.ai.tool.toolsearch.eviction.CompositeEvictionStrategy;
+import org.springframework.ai.tool.toolsearch.eviction.LruEvictionStrategy;
+import org.springframework.ai.tool.toolsearch.eviction.ToolIndexEvictionStrategy;
+import org.springframework.ai.tool.toolsearch.eviction.TtlEvictionStrategy;
+import org.springframework.ai.tool.toolsearch.index.lucene.LuceneToolIndex;
+import org.springframework.ai.tool.toolsearch.index.regex.RegexToolIndex;
+import org.springframework.ai.tool.toolsearch.index.vectorstore.VectorToolIndex;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for
+ * {@link ToolSearchToolCallingAdvisor}.
+ * <p>
+ * When {@code spring.ai.chat.client.tool-search-advisor.enabled=true} this configuration
+ * registers a {@link ToolSearchToolCallingAdvisor.Builder} bean typed as
+ * {@link ToolCallingAdvisor.Builder}. Because {@code ChatClientAutoConfiguration} guards
+ * its own builder bean with {@code @ConditionalOnMissingBean}, the subtype registered
+ * here satisfies that condition and the default {@link ToolCallingAdvisor} is replaced
+ * transparently.
+ * <p>
+ * When no {@link ToolIndex} bean is declared by the application, one is registered
+ * automatically. {@link RegexToolIndex} is the default when
+ * {@code spring.ai.chat.client.tool-search-advisor.tool-index-type} is not set. Set the
+ * property explicitly to switch implementations:
+ * <ul>
+ * <li>{@code tool-index-type=regex} — lightweight regex/keyword matching; no additional
+ * dependencies (default).</li>
+ * <li>{@code tool-index-type=lucene} — Apache Lucene keyword search; requires
+ * {@code org.apache.lucene:lucene-core} on the classpath.</li>
+ * <li>{@code tool-index-type=vector} — embedding-based semantic search; requires a
+ * {@link VectorStore} bean and {@code spring-ai-vector-store} on the classpath.</li>
+ * </ul>
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+@AutoConfiguration(beforeName = "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration")
+@ConditionalOnClass(ToolSearchToolCallingAdvisor.class)
+@EnableConfigurationProperties(ToolSearchAdvisorProperties.class)
+@ConditionalOnProperty(prefix = ToolSearchAdvisorProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")
+public class ToolSearchAdvisorAutoConfiguration {
+
+	/**
+	 * Registers a {@link ToolSearchToolCallingAdvisor.Builder} typed as
+	 * {@link ToolCallingAdvisor.Builder}. The broader declared return type ensures that
+	 * {@code ChatClientAutoConfiguration#toolCallingAdvisorBuilder} is skipped due to its
+	 * {@code @ConditionalOnMissingBean}.
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean({ ToolCallingManager.class, ToolIndex.class })
+	ToolCallingAdvisor.Builder<?> toolCallingAdvisorBuilder(ToolSearchAdvisorProperties properties,
+			ToolCallingManager toolCallingManager, ToolIndex toolIndex,
+			ObjectProvider<ToolExecutionEligibilityChecker> toolExecutionEligibilityChecker) {
+
+		var builder = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(toolCallingManager)
+			.toolIndex(toolIndex)
+			.advisorOrder(properties.getAdvisorOrder())
+			.streamToolCallResponses(properties.isStreamToolCallResponses())
+			.referenceToolNameAccumulation(properties.isReferenceToolNameAccumulation())
+			.sessionIdKeyName(properties.getSessionIdKeyName())
+			.evictionStrategy(buildEvictionStrategy(properties.getEviction()));
+
+		if (properties.getMaxResults() != null) {
+			builder.maxResults(properties.getMaxResults());
+		}
+		if (StringUtils.hasText(properties.getSystemMessageSuffix())) {
+			builder.systemMessageSuffix(properties.getSystemMessageSuffix());
+		}
+
+		toolExecutionEligibilityChecker.ifAvailable(builder::toolExecutionEligibilityChecker);
+
+		return builder;
+	}
+
+	private static ToolIndexEvictionStrategy buildEvictionStrategy(ToolSearchAdvisorProperties.Eviction eviction) {
+		LruEvictionStrategy lru = new LruEvictionStrategy(eviction.getLruMaxSessions());
+		if (eviction.getTtl() != null) {
+			return new CompositeEvictionStrategy(lru, new TtlEvictionStrategy(eviction.getTtl()));
+		}
+		return lru;
+	}
+
+	/**
+	 * Registers a {@link VectorToolIndex}.
+	 * <p>
+	 * Activated only when {@code tool-index-type=vector} is set explicitly. Also requires
+	 * {@code VectorToolIndex} on the classpath and a {@link VectorStore} bean in the
+	 * context.
+	 */
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(VectorToolIndex.class)
+	@ConditionalOnBean(VectorStore.class)
+	@ConditionalOnMissingBean(ToolIndex.class)
+	@ConditionalOnProperty(prefix = ToolSearchAdvisorProperties.CONFIG_PREFIX, name = "tool-index-type",
+			havingValue = "vector", matchIfMissing = false)
+	static class VectorToolIndexConfiguration {
+
+		@Bean
+		VectorToolIndex vectorToolIndex(VectorStore vectorStore) {
+			return new VectorToolIndex(vectorStore);
+		}
+
+	}
+
+	/**
+	 * Registers a {@link LuceneToolIndex}.
+	 * <p>
+	 * Activated only when {@code tool-index-type=lucene} is set explicitly. Also requires
+	 * {@code LuceneToolIndex} on the classpath (i.e.
+	 * {@code org.apache.lucene:lucene-core} present).
+	 */
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(LuceneToolIndex.class)
+	@ConditionalOnMissingBean(ToolIndex.class)
+	@ConditionalOnProperty(prefix = ToolSearchAdvisorProperties.CONFIG_PREFIX, name = "tool-index-type",
+			havingValue = "lucene", matchIfMissing = false)
+	static class LuceneToolIndexConfiguration {
+
+		@Bean
+		LuceneToolIndex luceneToolIndex(ToolSearchAdvisorProperties properties) {
+			return new LuceneToolIndex(properties.getLucene().getMinScoreThreshold());
+		}
+
+	}
+
+	/**
+	 * Registers a {@link RegexToolIndex} — the default when no {@code tool-index-type} is
+	 * set.
+	 * <p>
+	 * Activated by {@code tool-index-type=regex} or when the property is absent
+	 * ({@code matchIfMissing=true}). Requires no additional dependencies.
+	 */
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnMissingBean(ToolIndex.class)
+	@ConditionalOnProperty(prefix = ToolSearchAdvisorProperties.CONFIG_PREFIX, name = "tool-index-type",
+			havingValue = "regex", matchIfMissing = true)
+	static class RegexToolIndexConfiguration {
+
+		@Bean
+		RegexToolIndex regexToolIndex() {
+			return new RegexToolIndex();
+		}
+
+	}
+
+}

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
@@ -16,6 +16,11 @@
 
 package org.springframework.ai.chat.client.advisor.toolsearch.autoconfigure;
 
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.client.advisor.toolsearch.ToolSearchToolCallingAdvisor;
 import org.springframework.ai.model.tool.ToolCallingManager;
@@ -29,6 +34,7 @@ import org.springframework.ai.tool.toolsearch.index.lucene.LuceneToolIndex;
 import org.springframework.ai.tool.toolsearch.index.regex.RegexToolIndex;
 import org.springframework.ai.tool.toolsearch.index.vectorstore.VectorToolIndex;
 import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -72,7 +78,27 @@ import org.springframework.util.StringUtils;
 @ConditionalOnClass(ToolSearchToolCallingAdvisor.class)
 @EnableConfigurationProperties(ToolSearchAdvisorProperties.class)
 @ConditionalOnProperty(prefix = ToolSearchAdvisorProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")
-public class ToolSearchAdvisorAutoConfiguration {
+public class ToolSearchAdvisorAutoConfiguration implements InitializingBean {
+
+	private static final Log logger = LogFactory.getLog(ToolSearchAdvisorAutoConfiguration.class);
+
+	private static final Set<String> KNOWN_TOOL_INDEX_TYPES = Set.of("regex", "lucene", "vector");
+
+	private final ToolSearchAdvisorProperties properties;
+
+	public ToolSearchAdvisorAutoConfiguration(ToolSearchAdvisorProperties properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		String type = this.properties.getToolIndexType();
+		if (type != null && !KNOWN_TOOL_INDEX_TYPES.contains(type.toLowerCase())) {
+			logger.warn("Unknown 'spring.ai.chat.client.tool-search-advisor.tool-index-type' value: '" + type
+					+ "'. Known built-in values are: " + KNOWN_TOOL_INDEX_TYPES
+					+ ". If this is intentional, ensure a matching ToolIndex bean is declared in the application context.");
+		}
+	}
 
 	/**
 	 * Registers a {@link ToolSearchToolCallingAdvisor.Builder} typed as
@@ -119,20 +145,26 @@ public class ToolSearchAdvisorAutoConfiguration {
 	/**
 	 * Registers a {@link VectorToolIndex}.
 	 * <p>
-	 * Activated only when {@code tool-index-type=vector} is set explicitly. Also requires
-	 * {@code VectorToolIndex} on the classpath and a {@link VectorStore} bean in the
-	 * context.
+	 * Activated only when {@code tool-index-type=vector} is set explicitly. Fails fast
+	 * with a descriptive error if no {@link VectorStore} bean is present in the context.
 	 */
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(VectorToolIndex.class)
-	@ConditionalOnBean(VectorStore.class)
 	@ConditionalOnMissingBean(ToolIndex.class)
 	@ConditionalOnProperty(prefix = ToolSearchAdvisorProperties.CONFIG_PREFIX, name = "tool-index-type",
 			havingValue = "vector", matchIfMissing = false)
 	static class VectorToolIndexConfiguration {
 
 		@Bean
-		VectorToolIndex vectorToolIndex(VectorStore vectorStore) {
+		VectorToolIndex vectorToolIndex(ObjectProvider<VectorStore> vectorStoreProvider) {
+			VectorStore vectorStore = vectorStoreProvider.getIfAvailable();
+			if (vectorStore == null) {
+				throw new IllegalStateException(
+						"'spring.ai.chat.client.tool-search-advisor.tool-index-type=vector' requires a VectorStore "
+								+ "bean in the application context, but none was found. Add a VectorStore "
+								+ "implementation (e.g. spring-ai-starter-vector-store-pgvector) to your "
+								+ "dependencies.");
+			}
 			return new VectorToolIndex(vectorStore);
 		}
 

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorProperties.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorProperties.java
@@ -22,7 +22,9 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.tool.toolsearch.ToolIndex;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.Assert;
 
 /**
  * Configuration properties for {@link ToolSearchAdvisorAutoConfiguration}.
@@ -57,7 +59,7 @@ public class ToolSearchAdvisorProperties {
 	 * </ul>
 	 * When not set, {@code regex} is used as the default.
 	 */
-	@Nullable private String toolIndexType;
+	private String toolIndexType = "regex";
 
 	/**
 	 * Maximum number of tool references returned per tool-search call. When {@code null},
@@ -112,11 +114,12 @@ public class ToolSearchAdvisorProperties {
 		this.enabled = enabled;
 	}
 
-	public @Nullable String getToolIndexType() {
+	public String getToolIndexType() {
 		return this.toolIndexType;
 	}
 
-	public void setToolIndexType(@Nullable String toolIndexType) {
+	public void setToolIndexType(String toolIndexType) {
+		Assert.hasText(toolIndexType, "toolIndexType must not be empty");
 		this.toolIndexType = toolIndexType;
 	}
 

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorProperties.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorProperties.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.toolsearch.autoconfigure;
+
+import java.time.Duration;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for {@link ToolSearchAdvisorAutoConfiguration}.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+@ConfigurationProperties(ToolSearchAdvisorProperties.CONFIG_PREFIX)
+public class ToolSearchAdvisorProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.chat.client.tool-search-advisor";
+
+	/**
+	 * Enable the {@code ToolSearchToolCallingAdvisor} as a replacement for the default
+	 * {@code ToolCallingAdvisor}. When {@code true}, the advisor is registered in the
+	 * {@code ChatClient} builder and the default advisor is suppressed via
+	 * {@code @ConditionalOnMissingBean}.
+	 */
+	private boolean enabled = false;
+
+	/**
+	 * {@link ToolIndex} implementation to use for tool search.
+	 * <p>
+	 * Supported values:
+	 * <ul>
+	 * <li>{@code regex} — lightweight regex/keyword pattern matching; no additional
+	 * dependencies needed (default when this property is not set).</li>
+	 * <li>{@code lucene} — Apache Lucene keyword search; requires
+	 * {@code org.apache.lucene:lucene-core} on the classpath.</li>
+	 * <li>{@code vector} — embedding-based semantic search; requires a
+	 * {@code VectorStore} bean and {@code spring-ai-vector-store} on the classpath.</li>
+	 * </ul>
+	 * When not set, {@code regex} is used as the default.
+	 */
+	@Nullable private String toolIndexType;
+
+	/**
+	 * Maximum number of tool references returned per tool-search call. When {@code null},
+	 * the {@code ToolSearchTool} uses its own built-in default.
+	 */
+	@Nullable private Integer maxResults;
+
+	/**
+	 * Key name in the advisor context map that carries the conversation/session ID. Must
+	 * match the key used by whatever provides it (e.g. a memory advisor). Defaults to
+	 * {@link ChatMemory#CONVERSATION_ID}.
+	 */
+	private String sessionIdKeyName = ChatMemory.CONVERSATION_ID;
+
+	/**
+	 * When {@code true} (default), tool references discovered across all tool-search tool
+	 * responses in a turn are accumulated. When {@code false}, only the last response is
+	 * used to determine which tools to inject.
+	 */
+	private boolean referenceToolNameAccumulation = true;
+
+	/**
+	 * Custom system-message suffix injected at the start of each conversation to instruct
+	 * the model on how to use the tool-search tool. When {@code null} (default), the
+	 * built-in {@code classpath:/DEFAULT_SYSTEM_PROMPT_SUFFIX.md} resource is loaded.
+	 */
+	@Nullable private String systemMessageSuffix;
+
+	/**
+	 * Order of the advisor in the advisor chain. Controls which advisors participate in
+	 * each tool-call iteration. Mirrors the semantics of
+	 * {@code spring.ai.chat.client.tool-calling.advisor-order}.
+	 */
+	private int advisorOrder = ToolCallingAdvisor.DEFAULT_ORDER;
+
+	/**
+	 * Whether intermediate tool-call responses are streamed back to the caller during a
+	 * {@code stream()} invocation. When {@code false} (default), only the final answer is
+	 * streamed.
+	 */
+	private boolean streamToolCallResponses = false;
+
+	private final Eviction eviction = new Eviction();
+
+	private final Lucene lucene = new Lucene();
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public @Nullable String getToolIndexType() {
+		return this.toolIndexType;
+	}
+
+	public void setToolIndexType(@Nullable String toolIndexType) {
+		this.toolIndexType = toolIndexType;
+	}
+
+	public @Nullable Integer getMaxResults() {
+		return this.maxResults;
+	}
+
+	public void setMaxResults(@Nullable Integer maxResults) {
+		this.maxResults = maxResults;
+	}
+
+	public String getSessionIdKeyName() {
+		return this.sessionIdKeyName;
+	}
+
+	public void setSessionIdKeyName(String sessionIdKeyName) {
+		this.sessionIdKeyName = sessionIdKeyName;
+	}
+
+	public boolean isReferenceToolNameAccumulation() {
+		return this.referenceToolNameAccumulation;
+	}
+
+	public void setReferenceToolNameAccumulation(boolean referenceToolNameAccumulation) {
+		this.referenceToolNameAccumulation = referenceToolNameAccumulation;
+	}
+
+	public @Nullable String getSystemMessageSuffix() {
+		return this.systemMessageSuffix;
+	}
+
+	public void setSystemMessageSuffix(@Nullable String systemMessageSuffix) {
+		this.systemMessageSuffix = systemMessageSuffix;
+	}
+
+	public int getAdvisorOrder() {
+		return this.advisorOrder;
+	}
+
+	public void setAdvisorOrder(int advisorOrder) {
+		this.advisorOrder = advisorOrder;
+	}
+
+	public boolean isStreamToolCallResponses() {
+		return this.streamToolCallResponses;
+	}
+
+	public void setStreamToolCallResponses(boolean streamToolCallResponses) {
+		this.streamToolCallResponses = streamToolCallResponses;
+	}
+
+	public Eviction getEviction() {
+		return this.eviction;
+	}
+
+	public Lucene getLucene() {
+		return this.lucene;
+	}
+
+	/**
+	 * Eviction strategy settings for the per-session tool-index cache.
+	 */
+	public static class Eviction {
+
+		/**
+		 * Maximum number of concurrently active sessions to keep in the index cache. The
+		 * least-recently-used session is evicted when the cap is exceeded.
+		 */
+		private int lruMaxSessions = 1000;
+
+		/**
+		 * Time-to-live for idle sessions. When set, a composite LRU+TTL strategy is used
+		 * so that sessions idle longer than this duration are also evicted. When
+		 * {@code null} (default), only LRU eviction applies.
+		 */
+		@Nullable private Duration ttl;
+
+		public int getLruMaxSessions() {
+			return this.lruMaxSessions;
+		}
+
+		public void setLruMaxSessions(int lruMaxSessions) {
+			this.lruMaxSessions = lruMaxSessions;
+		}
+
+		public @Nullable Duration getTtl() {
+			return this.ttl;
+		}
+
+		public void setTtl(@Nullable Duration ttl) {
+			this.ttl = ttl;
+		}
+
+	}
+
+	/**
+	 * Settings specific to the Lucene-backed {@code ToolIndex}. Applies only when a
+	 * {@link org.springframework.ai.tool.toolsearch.index.lucene.LuceneToolIndex} bean is
+	 * auto-configured.
+	 */
+	public static class Lucene {
+
+		/**
+		 * Minimum Lucene score for a tool-search hit to be included in results. Hits
+		 * below this threshold are silently dropped.
+		 */
+		private float minScoreThreshold = 0.25f;
+
+		public float getMinScoreThreshold() {
+			return this.minScoreThreshold;
+		}
+
+		public void setMinScoreThreshold(float minScoreThreshold) {
+			this.minScoreThreshold = minScoreThreshold;
+		}
+
+	}
+
+}

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/package-info.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.chat.client.advisor.toolsearch.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2023-present the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.springframework.ai.chat.client.advisor.toolsearch.autoconfigure.ToolSearchAdvisorAutoConfiguration

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfigurationTests.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfigurationTests.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.toolsearch.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.chat.client.advisor.toolsearch.ToolSearchToolCallingAdvisor;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
+import org.springframework.ai.tool.toolsearch.ToolIndex;
+import org.springframework.ai.tool.toolsearch.eviction.CompositeEvictionStrategy;
+import org.springframework.ai.tool.toolsearch.eviction.LruEvictionStrategy;
+import org.springframework.ai.tool.toolsearch.index.lucene.LuceneToolIndex;
+import org.springframework.ai.tool.toolsearch.index.regex.RegexToolIndex;
+import org.springframework.ai.tool.toolsearch.index.vectorstore.VectorToolIndex;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link ToolSearchAdvisorAutoConfiguration}.
+ *
+ * @author Christian Tzolov
+ */
+class ToolSearchAdvisorAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(ToolSearchAdvisorAutoConfiguration.class))
+		.withBean(ToolCallingManager.class, () -> mock(ToolCallingManager.class));
+
+	// --- Enabled guard ---
+
+	@Test
+	void notActivatedByDefault() {
+		this.contextRunner.run(context -> {
+			assertThat(context).doesNotHaveBean(ToolIndex.class);
+			assertThat(context).doesNotHaveBean(ToolCallingAdvisor.Builder.class);
+		});
+	}
+
+	// --- ToolIndex selection ---
+
+	@Test
+	void regexToolIndexIsRegisteredByDefault() {
+		this.contextRunner.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true").run(context -> {
+			assertThat(context).hasSingleBean(ToolIndex.class);
+			assertThat(context.getBean(ToolIndex.class)).isInstanceOf(RegexToolIndex.class);
+		});
+	}
+
+	@Test
+	void regexToolIndexIsRegisteredWhenExplicitlySet() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.tool-index-type=regex")
+			.run(context -> assertThat(context.getBean(ToolIndex.class)).isInstanceOf(RegexToolIndex.class));
+	}
+
+	@Test
+	void luceneToolIndexIsRegisteredWhenPropertySet() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.tool-index-type=lucene")
+			.run(context -> assertThat(context.getBean(ToolIndex.class)).isInstanceOf(LuceneToolIndex.class));
+	}
+
+	@Test
+	void vectorToolIndexIsRegisteredWhenPropertySetAndVectorStoreBeanPresent() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.tool-index-type=vector")
+			.withBean(VectorStore.class, () -> mock(VectorStore.class))
+			.run(context -> assertThat(context.getBean(ToolIndex.class)).isInstanceOf(VectorToolIndex.class));
+	}
+
+	@Test
+	void vectorToolIndexIsNotRegisteredWithoutVectorStoreBean() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.tool-index-type=vector")
+			.run(context -> assertThat(context).doesNotHaveBean(ToolIndex.class));
+	}
+
+	@Test
+	void customToolIndexBeanSuppressesAutoConfiguration() {
+		ToolIndex customIndex = mock(ToolIndex.class);
+		this.contextRunner.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true")
+			.withBean(ToolIndex.class, () -> customIndex)
+			.run(context -> assertThat(context.getBean(ToolIndex.class)).isSameAs(customIndex));
+	}
+
+	// --- Advisor builder ---
+
+	@Test
+	void toolSearchAdvisorBuilderIsRegistered() {
+		this.contextRunner.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true").run(context -> {
+			assertThat(context).hasSingleBean(ToolCallingAdvisor.Builder.class);
+			assertThat(context.getBean(ToolCallingAdvisor.Builder.class))
+				.isInstanceOf(ToolSearchToolCallingAdvisor.Builder.class);
+		});
+	}
+
+	@Test
+	void advisorOrderPropertyIsApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.advisor-order=42")
+			.run(context -> {
+				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
+				assertThat(builder.getAdvisorOrder()).isEqualTo(42);
+			});
+	}
+
+	@Test
+	void maxResultsPropertyIsApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.max-results=5")
+			.run(context -> {
+				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
+				assertThat(ReflectionTestUtils.getField(builder, "maxResults")).isEqualTo(5);
+			});
+	}
+
+	@Test
+	void sessionIdKeyNamePropertyIsApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.session-id-key-name=mySessionId")
+			.run(context -> {
+				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
+				assertThat(ReflectionTestUtils.getField(builder, "sessionIdKeyName")).isEqualTo("mySessionId");
+			});
+	}
+
+	@Test
+	void toolExecutionEligibilityCheckerIsWiredWhenPresent() {
+		ToolExecutionEligibilityChecker checker = chatResponse -> false;
+		this.contextRunner.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true")
+			.withBean(ToolExecutionEligibilityChecker.class, () -> checker)
+			.run(context -> {
+				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
+				assertThat(ReflectionTestUtils.getField(builder, "toolExecutionEligibilityChecker")).isSameAs(checker);
+			});
+	}
+
+	// --- Remaining builder properties ---
+
+	@Test
+	void streamToolCallResponsesPropertyIsApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.stream-tool-call-responses=true")
+			.run(context -> {
+				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
+				assertThat(ReflectionTestUtils.getField(builder, "streamToolCallResponses")).isEqualTo(true);
+			});
+	}
+
+	@Test
+	void referenceToolNameAccumulationPropertyIsApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.reference-tool-name-accumulation=false")
+			.run(context -> {
+				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
+				assertThat(ReflectionTestUtils.getField(builder, "referenceToolNameAccumulation")).isEqualTo(false);
+			});
+	}
+
+	@Test
+	void systemMessageSuffixPropertyIsApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.system-message-suffix=Use the search tool.")
+			.run(context -> {
+				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
+				assertThat(ReflectionTestUtils.getField(builder, "systemMessageSuffix"))
+					.isEqualTo("Use the search tool.");
+			});
+	}
+
+	@Test
+	void luceneMinScoreThresholdPropertyIsApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.tool-index-type=lucene",
+					"spring.ai.chat.client.tool-search-advisor.lucene.min-score-threshold=0.5")
+			.run(context -> {
+				var index = context.getBean(ToolIndex.class);
+				assertThat(index).isInstanceOf(LuceneToolIndex.class);
+				assertThat(ReflectionTestUtils.getField(index, "minScoreThreshold")).isEqualTo(0.5f);
+			});
+	}
+
+	// --- Eviction strategy ---
+
+	@Test
+	void defaultEvictionStrategyIsLru() {
+		this.contextRunner.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true").run(context -> {
+			var builder = context.getBean(ToolCallingAdvisor.Builder.class);
+			assertThat(ReflectionTestUtils.getField(builder, "evictionStrategy"))
+				.isInstanceOf(LruEvictionStrategy.class);
+		});
+	}
+
+	@Test
+	void ttlPropertyProducesCompositeEvictionStrategy() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.eviction.ttl=10m")
+			.run(context -> {
+				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
+				assertThat(ReflectionTestUtils.getField(builder, "evictionStrategy"))
+					.isInstanceOf(CompositeEvictionStrategy.class);
+			});
+	}
+
+}

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfigurationTests.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfigurationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.chat.client.advisor.toolsearch.autoconfigure;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.client.advisor.toolsearch.ToolSearchToolCallingAdvisor;
@@ -31,6 +32,8 @@ import org.springframework.ai.tool.toolsearch.index.vectorstore.VectorToolIndex;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +44,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Christian Tzolov
  */
+@ExtendWith(OutputCaptureExtension.class)
 class ToolSearchAdvisorAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -93,11 +97,27 @@ class ToolSearchAdvisorAutoConfigurationTests {
 	}
 
 	@Test
-	void vectorToolIndexIsNotRegisteredWithoutVectorStoreBean() {
+	void vectorToolIndexFailsWithClearMessageWhenNoVectorStoreBeanPresent() {
 		this.contextRunner
 			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
 					"spring.ai.chat.client.tool-search-advisor.tool-index-type=vector")
-			.run(context -> assertThat(context).doesNotHaveBean(ToolIndex.class));
+			.run(context -> assertThat(context).hasFailed()
+				.getFailure()
+				.rootCause()
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("tool-index-type=vector")
+				.hasMessageContaining("VectorStore"));
+	}
+
+	@Test
+	void unknownToolIndexTypeLogsWarning(CapturedOutput output) {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
+					"spring.ai.chat.client.tool-search-advisor.tool-index-type=custom-index")
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				assertThat(output).contains("custom-index").contains("tool-index-type");
+			});
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,6 @@
 		<module>starters/spring-ai-starter-mcp-server-webflux</module>
 		<module>starters/spring-ai-starter-mcp-server-webmvc</module>
 
-		<module>starters/spring-ai-starter-tool-search-advisor</module>
-
 		<module>starters/spring-ai-starter-model-anthropic</module>
 		<module>starters/spring-ai-starter-model-bedrock</module>
 		<module>starters/spring-ai-starter-model-bedrock-converse</module>
@@ -165,6 +163,8 @@
 		<module>starters/spring-ai-starter-model-stability-ai</module>
 		<module>starters/spring-ai-starter-model-transformers</module>
 		<module>starters/spring-ai-starter-model-vertex-ai-embedding</module>
+
+		<module>starters/spring-ai-starter-tool-search-advisor</module>
 
 		<module>starters/spring-ai-starter-vector-store-aws-opensearch</module>
 		<module>starters/spring-ai-starter-vector-store-azure</module>
@@ -370,18 +370,26 @@
 								</requireMavenVersion>
 
 								<bannedDependencies>
-									<!-- Spring AI should NOT depend on boot. There are only 4 exceptions to this: -->
-									<!-- 1. test code can currently depend on boot (includes element below)-->
-									<!-- 2. auto-configurations module CAN depend on boot, but should use optional=true on all deps. This enforcer rule sadly can't see those dependencies, so no particular config here -->
-									<!-- 3. starters obviously depend on boot. There is a special profile below in this pom that relaxes the following rule, see further below. -->
-									<!-- 4. docker-compose and testcontainers projects depend on boot and have an override in their respective poms. -->
+									<!-- Spring AI should NOT depend on boot. There are only 4
+									exceptions to this: -->
+									<!-- 1. test code can currently depend on boot (includes element
+									below)-->
+									<!-- 2. auto-configurations module CAN depend on boot, but
+									should use optional=true on all deps. This enforcer rule sadly
+									can't see those dependencies, so no particular config here -->
+									<!-- 3. starters obviously depend on boot. There is a special
+									profile below in this pom that relaxes the following rule, see
+									further below. -->
+									<!-- 4. docker-compose and testcontainers projects depend on
+									boot and have an override in their respective poms. -->
 									<excludes>
 										<exclude>org.springframework.boot</exclude>
 									</excludes>
 									<includes>
 										<include>org.springframework.boot:*:*:jar:test</include>
 									</includes>
-									<message>Spring AI code should NOT depend on Spring boot. The only exception to this is autoconfigure and starter modules.</message>
+									<message>Spring AI code should NOT depend on Spring boot. The
+										only exception to this is autoconfigure and starter modules.</message>
 								</bannedDependencies>
 							</rules>
 						</configuration>
@@ -483,7 +491,9 @@
 								<!-- The following arg won't be necessary with JDK25+ -->
 								<arg>-XDaddTypeAnnotationsToSymbol=true</arg>
 								<arg>--should-stop=ifError=FLOW</arg>
-								<arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked -XepOpt:NullAway:JSpecifyMode=true</arg>
+								<arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR
+									-XepOpt:NullAway:OnlyNullMarked
+									-XepOpt:NullAway:JSpecifyMode=true</arg>
 							</compilerArgs>
 						</configuration>
 					</execution>
@@ -579,21 +589,21 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven-javadoc-plugin.version}</version>
-			<configuration>
-				<overview>
-					${maven.multiModuleProjectDirectory}/spring-ai-docs/src/main/javadoc/overview.html</overview>
-				<detectJavaApiLink>false</detectJavaApiLink>
-				<doclint>none</doclint>
-			</configuration>
-			<executions>
-				<execution>
-					<id>package-javadocs</id>
-					<phase>package</phase>
-					<goals>
-						<goal>jar</goal>
-					</goals>
-				</execution>
-			</executions>
+				<configuration>
+					<overview>
+						${maven.multiModuleProjectDirectory}/spring-ai-docs/src/main/javadoc/overview.html</overview>
+					<detectJavaApiLink>false</detectJavaApiLink>
+					<doclint>none</doclint>
+				</configuration>
+				<executions>
+					<execution>
+						<id>package-javadocs</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 
 		</plugins>
@@ -691,9 +701,11 @@
 								<inherited>true</inherited>
 								<configuration>
 									<skip>${disable.checks}</skip>
-									<configLocation>${maven.multiModuleProjectDirectory}/src/checkstyle/checkstyle.xml
+									<configLocation>
+										${maven.multiModuleProjectDirectory}/src/checkstyle/checkstyle.xml
 									</configLocation>
-									<headerLocation>${maven.multiModuleProjectDirectory}/src/checkstyle/checkstyle-header.txt
+									<headerLocation>
+										${maven.multiModuleProjectDirectory}/src/checkstyle/checkstyle-header.txt
 									</headerLocation>
 									<includeTestSourceDirectory>true
 									</includeTestSourceDirectory>
@@ -716,11 +728,14 @@
 		</profile>
 		<profile>
 			<id>starter-banned-dependency-relaxation</id>
-			<!-- This profile relaxes the enforcer rule that prohibits code to depend on boot, for starters/ only. -->
+			<!-- This profile relaxes the enforcer rule that prohibits code to depend on boot, for
+			starters/ only. -->
 			<activation>
 				<file>
-					<!-- Trick: since profiles can't be activated via properties in children projects, -->
-					<!-- this profile leverages the fact that starters are the only project type that -->
+					<!-- Trick: since profiles can't be activated via properties in children
+					projects, -->
+					<!-- this profile leverages the fact that starters are the only project type
+					that -->
 					<!-- do not contain source files. -->
 					<missing>src/main</missing>
 				</file>
@@ -751,7 +766,8 @@
 		</profile>
 		<profile>
 			<id>auto-configuration-all-optional</id>
-			<!-- This profile tightens the enforcer rule bannedDependencies to make sure all non-test -->
+			<!-- This profile tightens the enforcer rule bannedDependencies to make sure all
+			non-test -->
 			<!-- deps are optional for auto-configuration modules. -->
 			<activation>
 				<file>
@@ -771,18 +787,24 @@
 									<rules>
 										<bannedDependencies>
 											<excludes>
-												<!-- Since this rule doesn't "see" optional deps, we pretend that autoconfs should depend on NOTHING, -->
+												<!-- Since this rule doesn't "see" optional deps, we
+												pretend that autoconfs should depend on NOTHING, -->
 												<!-- except tests (and the weird netty hiccup) -->
 												<exclude>*:*</exclude>
 											</excludes>
 											<includes>
 												<include>*:*:*:*:test:*</include>
-												<include>org.springframework.ai:spring-ai-autoconfigure-*</include>
-												<!-- for some reason, which likely has to do with classifiers, without this include, the rule fails -->
-												<!-- with a false positive on spring-ai-autoconfigure-mcp-server-webflux. Did not find a better way to fix. -->
+												<include>
+													org.springframework.ai:spring-ai-autoconfigure-*</include>
+												<!-- for some reason, which likely has to do with
+												classifiers, without this include, the rule fails -->
+												<!-- with a false positive on
+												spring-ai-autoconfigure-mcp-server-webflux. Did not
+												find a better way to fix. -->
 												<include>io.netty:netty-*</include>
 											</includes>
-											<message>auto-configuration modules should have all their dependencies declared as optional</message>
+											<message>auto-configuration modules should have all
+												their dependencies declared as optional</message>
 										</bannedDependencies>
 									</rules>
 								</configuration>
@@ -844,7 +866,8 @@
 								<exclude>org.springframework.ai.bedrock.converse/**/*IT.java</exclude>
 								<exclude>org.springframework.ai.elevenlabs/**/*IT.java</exclude>
 								<exclude>org.springframework.ai.mistralai/**/*IT.java</exclude>
-								<exclude>org.springframework.ai.ollama/**/*IT.java</exclude>								<!-- <exclude>org.springframework.ai.openai/**/*IT.java</exclude> -->
+								<exclude>org.springframework.ai.ollama/**/*IT.java</exclude>								<!--
+								<exclude>org.springframework.ai.openai/**/*IT.java</exclude> -->
 								<exclude>org.springframework.ai.openaisdk/**/*IT.java</exclude>
 								<exclude>org.springframework.ai.postgresml/**/*IT.java</exclude>
 								<exclude>org.springframework.ai.stabilityai/**/*IT.java</exclude>
@@ -856,7 +879,8 @@
 								<exclude>org.springframework.ai.vectorstore.azure/**IT.java</exclude>
 								<exclude>org.springframework.ai.vectorstore**/Cassandra**IT.java</exclude>
 								<exclude>org.springframework.ai.chroma/**IT.java</exclude>
-								<!-- <exclude>org.springframework.ai.vectorstore/**/**Chroma**IT.java</exclude> -->
+								<!--
+								<exclude>org.springframework.ai.vectorstore/**/**Chroma**IT.java</exclude> -->
 								<exclude>org.springframework.ai.vectorstore**/Coherence**IT.java</exclude>
 								<exclude>org.springframework.ai.vectorstore**/Elasticsearch**IT.java</exclude>
 								<exclude>org.springframework.ai.vectorstore**/GemFire**IT.java</exclude>
@@ -866,7 +890,8 @@
 								<exclude>org.springframework.ai.vectorstore**/Neo4j**IT.java</exclude>
 								<exclude>org.springframework.ai.vectorstore**/OpenSearch**IT.java</exclude>
 								<exclude>org.springframework.ai.vectorstore**/Oracle**IT.java</exclude>
-								<!-- <exclude>org.springframework.ai.vectorstore**/PgVector**IT.java</exclude> -->
+								<!--
+								<exclude>org.springframework.ai.vectorstore**/PgVector**IT.java</exclude> -->
 								<exclude>org.springframework.ai.vectorstore**/Pinecone**IT.java</exclude>
 								<exclude>org.springframework.ai.vectorstore.qdrant/**/**IT.java</exclude>
 								<exclude>org.springframework.ai.vectorstore**/Qdrant**IT.java</exclude>
@@ -876,41 +901,49 @@
 
 								<!-- Auto-configurations-->
 
-								 <!-- <exclude>org.springframework.ai.autoconfigure/**/**IT.java</exclude> -->
+								<!--
+								<exclude>org.springframework.ai.autoconfigure/**/**IT.java</exclude> -->
 
-								 <exclude>org.springframework.ai.autoconfigure.anthropic/**/**IT.java</exclude>
-								 <exclude>org.springframework.ai.autoconfigure.azure/**/**IT.java</exclude>
-								 <exclude>org.springframework.ai.autoconfigure.bedrock/**/**IT.java</exclude>
-								 <exclude>org.springframework.ai.autoconfigure.huggingface/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.anthropic/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.azure/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.bedrock/**/**IT.java</exclude>
+								<exclude>
+									org.springframework.ai.autoconfigure.huggingface/**/**IT.java</exclude>
 
-								 <exclude>org.springframework.ai.autoconfigure.chat/**/**IT.java</exclude>
-								 <exclude>org.springframework.ai.autoconfigure.elevenlabs/**/**IT.java</exclude>
-								 <exclude>org.springframework.ai.autoconfigure.embedding/**/**IT.java</exclude>
-								 <exclude>org.springframework.ai.autoconfigure.image/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.chat/**/**IT.java</exclude>
+								<exclude>
+									org.springframework.ai.autoconfigure.elevenlabs/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.embedding/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.image/**/**IT.java</exclude>
 
 
-								 <exclude>org.springframework.ai.autoconfigure.mistralai/**/**IT.java</exclude>
-								 <exclude>org.springframework.ai.autoconfigure.ollama/**/**IT.java</exclude>
-								 <!-- <exclude>org.springframework.ai.autoconfigure.openai/**/**IT.java</exclude> -->
-								 <exclude>org.springframework.ai.autoconfigure.postgresml/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.mistralai/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.ollama/**/**IT.java</exclude>
+								<!--
+								<exclude>org.springframework.ai.autoconfigure.openai/**/**IT.java</exclude> -->
+								<exclude>
+									org.springframework.ai.autoconfigure.postgresml/**/**IT.java</exclude>
 
-								 <exclude>org.springframework.ai.autoconfigure.retry/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.retry/**/**IT.java</exclude>
 
-								 <exclude>org.springframework.ai.autoconfigure.stabilityai/**/**IT.java</exclude>
-								 <exclude>org.springframework.ai.autoconfigure.transformers/**/**IT.java</exclude>
+								<exclude>
+									org.springframework.ai.autoconfigure.stabilityai/**/**IT.java</exclude>
+								<exclude>
+									org.springframework.ai.autoconfigure.transformers/**/**IT.java</exclude>
 
-								 <exclude>org.springframework.ai.autoconfigure.vectorstore/**/**IT.java</exclude>
+								<exclude>
+									org.springframework.ai.autoconfigure.vectorstore/**/**IT.java</exclude>
 
-								 <exclude>org.springframework.ai.autoconfigure.vertexai/**/**IT.java</exclude>
+								<exclude>org.springframework.ai.autoconfigure.vertexai/**/**IT.java</exclude>
 
-								 <!-- Test Containers -->
-								 <exclude>org.springframework.ai.testcontainers/**/**IT.java</exclude>
+								<!-- Test Containers -->
+								<exclude>org.springframework.ai.testcontainers/**/**IT.java</exclude>
 
-								 <!-- Test Docker Compose -->
-								 <exclude>org.springframework.ai.docker.compose/**/**IT.java</exclude>
+								<!-- Test Docker Compose -->
+								<exclude>org.springframework.ai.docker.compose/**/**IT.java</exclude>
 
-								 <!-- AI Evaluation -->
-								 <exclude>org.springframework.ai.integration.tests/**/**IT.java</exclude>
+								<!-- AI Evaluation -->
+								<exclude>org.springframework.ai.integration.tests/**/**IT.java</exclude>
 							</excludes>
 
 							<!-- <includes>
@@ -984,42 +1017,42 @@
 			</distributionManagement>
 		</profile>
 		<profile>
-		<id>sonatype</id>
-		<properties>
-			<maven.test.skip>true</maven.test.skip>
-		</properties>
-		<build>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-gpg-plugin</artifactId>
-					<version>${maven-gpg-plugin.version}</version>
-					<executions>
-						<execution>
-							<id>sign-artifacts</id>
-							<phase>verify</phase>
-							<goals>
-								<goal>sign</goal>
-							</goals>
-						</execution>
-					</executions>
-					<configuration>
-						<!-- Passphrase consumed from MAVEN_GPG_PASSPHRASE environment variable. -->
-					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.sonatype.central</groupId>
-					<artifactId>central-publishing-maven-plugin</artifactId>
-					<extensions>true</extensions>
-					<configuration>
-						<publishingServerId>central</publishingServerId>
-						<autoPublish>true</autoPublish>
-						<excludeArtifacts>spring-ai-integration-tests</excludeArtifacts>
-					</configuration>
-				</plugin>
-			</plugins>
-		</build>
-	</profile>
+			<id>sonatype</id>
+			<properties>
+				<maven.test.skip>true</maven.test.skip>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>${maven-gpg-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<!-- Passphrase consumed from MAVEN_GPG_PASSPHRASE environment variable. -->
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<extensions>true</extensions>
+						<configuration>
+							<publishingServerId>central</publishingServerId>
+							<autoPublish>true</autoPublish>
+							<excludeArtifacts>spring-ai-integration-tests</excludeArtifacts>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
 
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
 		<module>advisors/spring-ai-tool-search-advisor</module>
 		<module>advisors/spring-ai-vector-store-advisor</module>
 
+		<module>auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor</module>
+
 		<module>auto-configurations/common/spring-ai-autoconfigure-retry</module>
 
 		<module>auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common</module>
@@ -140,6 +142,8 @@
 		<module>starters/spring-ai-starter-mcp-server</module>
 		<module>starters/spring-ai-starter-mcp-server-webflux</module>
 		<module>starters/spring-ai-starter-mcp-server-webmvc</module>
+
+		<module>starters/spring-ai-starter-tool-search-advisor</module>
 
 		<module>starters/spring-ai-starter-model-anthropic</module>
 		<module>starters/spring-ai-starter-model-bedrock</module>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1438,6 +1438,32 @@ The flow at runtime is:
 
 === Installation
 
+Use the Spring Boot starter for the simplest setup (includes Lucene and auto-configuration):
+
+[tabs]
+======
+Maven::
++
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-tool-search-advisor</artifactId>
+</dependency>
+----
+
+Gradle::
++
+[source,gradle]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-starter-tool-search-advisor'
+}
+----
+======
+
+Or use the library directly for manual configuration:
+
 [source,xml]
 ----
 <dependency>
@@ -1558,7 +1584,7 @@ The following options are available on `ToolSearchToolCallingAdvisor.Builder`:
 
 | `sessionIdKeyName(String)`
 | Context key used to look up the conversation/session ID. Change this when your app stores the conversation ID under a custom key.
-| `"conversationId"`
+| `"chat_memory_conversation_id"` (`ChatMemory.CONVERSATION_ID`)
 
 | `evictionStrategy(ToolIndexEvictionStrategy)`
 | Determines when session tool indexes are freed. See xref:_index_eviction[Index Eviction] below.
@@ -1666,3 +1692,108 @@ Eviction is evaluated lazily on each request — no background thread is require
 * Small tool library (fewer than 10 tools).
 * All tools are frequently used in every session.
 * Tool definitions are very compact.
+
+=== Spring Boot Auto-configuration
+
+The `spring-ai-starter-tool-search-advisor` starter provides zero-boilerplate setup.
+Enable it with a single property:
+
+[source,properties]
+----
+spring.ai.chat.client.tool-search-advisor.enabled=true
+----
+
+When enabled, the auto-configuration registers a `ToolSearchToolCallingAdvisor.Builder` bean that transparently replaces the default `ToolCallingAdvisor` — no code changes needed.
+It also auto-registers a `ToolIndex` bean unless the application declares one explicitly.
+
+==== ToolIndex Auto-selection
+
+Set `spring.ai.chat.client.tool-search-advisor.tool-index-type` to select the implementation:
+
+[cols="1,2,2", options="header"]
+|===
+| Value | Implementation | Requirements
+
+| `regex` (**default**)
+| `RegexToolIndex`
+| No additional dependencies
+
+| `lucene`
+| `LuceneToolIndex`
+| `org.apache.lucene:lucene-core` on the classpath (included in the starter)
+
+| `vector`
+| `VectorToolIndex`
+| A `VectorStore` bean in the application context
+|===
+
+A custom `ToolIndex` bean declared by the application always takes precedence.
+
+==== Configuration Properties Reference
+
+[cols="2,3,1", options="header"]
+|===
+| Property | Description | Default
+
+| `spring.ai.chat.client.tool-search-advisor.enabled`
+| Enable the advisor. Replaces the default `ToolCallingAdvisor` when `true`.
+| `false`
+
+| `spring.ai.chat.client.tool-search-advisor.tool-index-type`
+| `ToolIndex` implementation to use: `regex`, `lucene`, or `vector`.
+| `regex`
+
+| `spring.ai.chat.client.tool-search-advisor.max-results`
+| Maximum tool references returned per search call. `null` uses the built-in default.
+| `null`
+
+| `spring.ai.chat.client.tool-search-advisor.system-message-suffix`
+| Custom prompt suffix appended to the system message. `null` uses the built-in template.
+| `null`
+
+| `spring.ai.chat.client.tool-search-advisor.reference-tool-name-accumulation`
+| Accumulate tool names discovered across all search calls in a single turn.
+| `true`
+
+| `spring.ai.chat.client.tool-search-advisor.session-id-key-name`
+| Advisor context key that carries the conversation/session ID.
+| `"chat_memory_conversation_id"`
+
+| `spring.ai.chat.client.tool-search-advisor.advisor-order`
+| Position of this advisor in the advisor chain.
+| `HIGHEST_PRECEDENCE + 300`
+
+| `spring.ai.chat.client.tool-search-advisor.stream-tool-call-responses`
+| Stream intermediate tool-call responses during `stream()` invocations.
+| `false`
+
+| `spring.ai.chat.client.tool-search-advisor.eviction.lru-max-sessions`
+| Maximum active sessions retained by the LRU eviction strategy.
+| `1000`
+
+| `spring.ai.chat.client.tool-search-advisor.eviction.ttl`
+| Time-to-live for idle sessions. When set, a composite LRU+TTL strategy is used. Accepts a `java.time.Duration` string (e.g. `30m`, `1h`).
+| `null`
+
+| `spring.ai.chat.client.tool-search-advisor.lucene.min-score-threshold`
+| Minimum Lucene score for a hit to be included. Applies when `tool-index-type=lucene`.
+| `0.25`
+|===
+
+Example — Lucene with custom threshold:
+
+[source,properties]
+----
+spring.ai.chat.client.tool-search-advisor.enabled=true
+spring.ai.chat.client.tool-search-advisor.tool-index-type=lucene
+spring.ai.chat.client.tool-search-advisor.lucene.min-score-threshold=0.4
+spring.ai.chat.client.tool-search-advisor.eviction.ttl=30m
+----
+
+Example — vector search (requires a `VectorStore` bean, e.g. from `spring-ai-starter-vector-store-pgvector`):
+
+[source,properties]
+----
+spring.ai.chat.client.tool-search-advisor.enabled=true
+spring.ai.chat.client.tool-search-advisor.tool-index-type=vector
+----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/guides/dynamic-tool-search.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/guides/dynamic-tool-search.adoc
@@ -27,7 +27,40 @@ The blog post covers the complete implementation details, performance benchmarks
 
 === Dependencies
 
-Add the Tool Search Tool dependency to your project:
+Use the Spring Boot starter for the simplest setup (includes Lucene and auto-configuration):
+
+[tabs]
+======
+Maven::
++
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-tool-search-advisor</artifactId>
+</dependency>
+----
+
+Gradle::
++
+[source,gradle]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-starter-tool-search-advisor'
+}
+----
+======
+
+With the starter, enable the advisor in `application.properties` — no Java configuration needed:
+
+[source,properties]
+----
+spring.ai.chat.client.tool-search-advisor.enabled=true
+----
+
+See xref:api/tools.adoc#tool-search-tool[Tool Search Tool auto-configuration] for the full list of configuration properties and ToolIndex selection options.
+
+Alternatively, add only the library for manual `@Bean` configuration:
 
 [tabs]
 ======

--- a/spring-ai-tool-search-tool/src/main/java/org/springframework/ai/tool/toolsearch/index/vectorstore/VectorToolIndex.java
+++ b/spring-ai-tool-search-tool/src/main/java/org/springframework/ai/tool/toolsearch/index/vectorstore/VectorToolIndex.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -38,6 +38,7 @@ import org.springframework.ai.tool.toolsearch.ToolSearchResponse.SearchMetadata;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+import org.springframework.util.Assert;
 
 /**
  * Vector-based tool searcher for semantic search of tool descriptions.
@@ -67,9 +68,17 @@ public class VectorToolIndex implements Closeable, ToolIndex {
 
 	private final VectorStore vectorStore;
 
-	private final AtomicInteger counter = new AtomicInteger(0);
-
 	private final ConcurrentHashMap<String, List<String>> sessionToolIds = new ConcurrentHashMap<>();
+
+	/**
+	 * Creates a new VectorToolIndex with the given vector store.
+	 * @param vectorStore the vector store to use for storing and searching tool
+	 * embeddings
+	 */
+	public VectorToolIndex(VectorStore vectorStore) {
+		Assert.notNull(vectorStore, "VectorStore must not be null");
+		this.vectorStore = vectorStore;
+	}
 
 	@Override
 	public void clearIndex(String sessionId) {
@@ -88,24 +97,9 @@ public class VectorToolIndex implements Closeable, ToolIndex {
 		}
 	}
 
-	/**
-	 * Creates a new VectorToolIndex with the given vector store.
-	 * @param vectorStore the vector store to use for storing and searching tool
-	 * embeddings
-	 */
-	public VectorToolIndex(VectorStore vectorStore) {
-		this.vectorStore = vectorStore;
-	}
-
 	@Override
 	public void indexTool(String sessionId, ToolReference toolReference) {
-		String id = String.valueOf(this.counter.getAndIncrement());
-		this.add(sessionId, id, toolReference.toolName(), toolReference.summary());
-		this.sessionToolIds.compute(sessionId, (k, existing) -> {
-			List<String> list = existing != null ? new ArrayList<>(existing) : new ArrayList<>();
-			list.add(id);
-			return list;
-		});
+		this.indexTools(sessionId, List.of(toolReference));
 	}
 
 	@Override
@@ -114,7 +108,7 @@ public class VectorToolIndex implements Closeable, ToolIndex {
 			return;
 		}
 
-		List<String> ids = toolReferences.stream().map(ref -> String.valueOf(this.counter.getAndIncrement())).toList();
+		List<String> ids = toolReferences.stream().map(ref -> UUID.randomUUID().toString()).toList();
 
 		List<Document> documents = new ArrayList<>(toolReferences.size());
 		for (int i = 0; i < toolReferences.size(); i++) {
@@ -137,6 +131,10 @@ public class VectorToolIndex implements Closeable, ToolIndex {
 
 	@Override
 	public ToolSearchResponse search(ToolSearchRequest toolSearchRequest) {
+		if (toolSearchRequest.categoryFilter() != null && logger.isWarnEnabled()) {
+			logger.warn("VectorToolIndex does not support categoryFilter — '" + toolSearchRequest.categoryFilter()
+					+ "' will be ignored and results will not be narrowed by category.");
+		}
 		int maxResults = toolSearchRequest.maxResults() != null ? toolSearchRequest.maxResults() : DEFAULT_MAX_RESULTS;
 
 		List<Document> docs = this.doSearch(toolSearchRequest.query(), toolSearchRequest.sessionId(), maxResults,
@@ -145,7 +143,7 @@ public class VectorToolIndex implements Closeable, ToolIndex {
 		List<ToolReference> toolReferences = docs.stream()
 			.map(doc -> ToolReference.builder()
 				.toolName((String) Objects.requireNonNull(doc.getMetadata().get(METADATA_TOOL_NAME)))
-				.relevanceScore(Objects.requireNonNull(doc.getScore()))
+				.relevanceScore(Objects.requireNonNullElse(doc.getScore(), 0.0))
 				.summary((String) Objects.requireNonNull(doc.getMetadata().get(METADATA_TOOL_DESCRIPTION)))
 				.build())
 			.toList();
@@ -161,39 +159,6 @@ public class VectorToolIndex implements Closeable, ToolIndex {
 	}
 
 	/**
-	 * Adds a single tool to the vector index.
-	 * @param sessionId the session ID associated with the tool
-	 * @param id unique identifier for the tool
-	 * @param toolName name of the tool
-	 * @param toolDescription description of the tool (used for embedding)
-	 */
-	public void add(String sessionId, String id, String toolName, String toolDescription) {
-		Document document = new Document(id, toolDescription, Map.of(METADATA_SESSION_ID, sessionId, METADATA_ID, id,
-				METADATA_TOOL_NAME, toolName, METADATA_TOOL_DESCRIPTION, toolDescription));
-		this.vectorStore.add(List.of(document));
-	}
-
-	/**
-	 * Searches for tools matching the query string using semantic similarity.
-	 * @param queryString the search query
-	 * @return list of matching documents sorted by similarity
-	 */
-	public List<Document> doSearch(String queryString) {
-		return doSearch(queryString, DEFAULT_MAX_RESULTS, DEFAULT_SIMILARITY_THRESHOLD);
-	}
-
-	/**
-	 * Searches for tools matching the query string with custom parameters.
-	 * @param queryString the search query
-	 * @param maxResults maximum number of results to return
-	 * @param similarityThreshold minimum similarity threshold (0.0 to 1.0)
-	 * @return list of matching documents sorted by similarity
-	 */
-	public List<Document> doSearch(String queryString, int maxResults, double similarityThreshold) {
-		return doSearch(queryString, null, maxResults, similarityThreshold);
-	}
-
-	/**
 	 * Searches the vector store with full control over parameters.
 	 * @param queryString the search query
 	 * @param sessionId if non-null, restricts results to this session's indexed tools
@@ -201,7 +166,7 @@ public class VectorToolIndex implements Closeable, ToolIndex {
 	 * @param similarityThreshold minimum similarity score (0.0–1.0)
 	 * @return matching documents sorted by descending similarity score
 	 */
-	public List<Document> doSearch(String queryString, @Nullable String sessionId, int maxResults,
+	private List<Document> doSearch(String queryString, @Nullable String sessionId, int maxResults,
 			double similarityThreshold) {
 		var b = new FilterExpressionBuilder();
 		SearchRequest searchRequest = SearchRequest.builder()
@@ -214,52 +179,9 @@ public class VectorToolIndex implements Closeable, ToolIndex {
 		return this.vectorStore.similaritySearch(searchRequest);
 	}
 
-	/**
-	 * Deletes a tool from the index by its ID.
-	 * @param id the tool ID to delete
-	 */
-	public void delete(String id) {
-		this.vectorStore.delete(List.of(id));
-	}
-
-	/**
-	 * Deletes multiple tools from the index.
-	 * @param ids list of tool IDs to delete
-	 */
-	public void deleteAll(List<String> ids) {
-		this.vectorStore.delete(ids);
-	}
-
 	@Override
 	public void close() throws IOException {
 		// Vector store lifecycle is managed externally; no cleanup needed here.
-	}
-
-	/**
-	 * Gets the tool name from a search result document.
-	 * @param document the search result document
-	 * @return the tool name
-	 */
-	public static String getToolName(Document document) {
-		return (String) Objects.requireNonNull(document.getMetadata().get(METADATA_TOOL_NAME));
-	}
-
-	/**
-	 * Gets the tool ID from a search result document.
-	 * @param document the search result document
-	 * @return the tool ID
-	 */
-	public static String getToolId(Document document) {
-		return (String) Objects.requireNonNull(document.getMetadata().get(METADATA_ID));
-	}
-
-	/**
-	 * Gets the tool description (content) from a search result document.
-	 * @param document the search result document
-	 * @return the tool description
-	 */
-	public static String getToolDescription(Document document) {
-		return (String) Objects.requireNonNull(document.getMetadata().get(METADATA_TOOL_DESCRIPTION));
 	}
 
 }

--- a/starters/spring-ai-starter-tool-search-advisor/pom.xml
+++ b/starters/spring-ai-starter-tool-search-advisor/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-starter-tool-search-advisor</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Starter - Tool Search Advisor</name>
+	<description>Spring AI Starter for the Tool Search Advisor, enabling dynamic tool discovery via a search index</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-tool-search-advisor</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-tool-search-advisor</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- Lucene is the default ToolIndex when no VectorStore bean is present.
+		     Add spring-ai-vector-store + a VectorStore bean to switch to VectorToolIndex. -->
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-core</artifactId>
+			<version>${lucene.version}</version>
+		</dependency>
+
+	</dependencies>
+
+</project>


### PR DESCRIPTION
- Add spring-ai-autoconfigure-tool-search-advisor module with ToolSearchAdvisorAutoConfiguration and ToolSearchAdvisorProperties
- RegexToolIndex is the default; switch via tool-index-type property to lucene or vector
- Add spring-ai-starter-tool-search-advisor (includes lucene-core)
- Fix VectorToolIndex: UUID IDs, private add(), categoryFilter warning, nullable score fallback
- Add autoconfigure tests and update reference documentation
