### PR TITLE
Restore options replacing instead of merging in `ChatModel`

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -1451,6 +1451,20 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	}
 
 	/**
+	 * Look at the options of the provided prompt. If none are provided, return a new
+	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
+	 * prompt as is.
+	 */
+	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+		if (prompt.getOptions() == null) {
+			return prompt.mutate().chatOptions(this.getOptions()).build();
+		}
+		else {
+			return prompt;
+		}
+	}
+
+	/**
 	 * Holds state accumulated during streaming for building complete responses. This
 	 * includes message metadata (ID, model, input tokens) and tool call accumulation
 	 * state for streaming tool calling support.

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -793,6 +793,20 @@ public class BedrockProxyChatModel implements ChatModel {
 		return new Builder();
 	}
 
+	/**
+	 * Look at the options of the provided prompt. If none are provided, return a new
+	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
+	 * prompt as is.
+	 */
+	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+		if (prompt.getOptions() == null) {
+			return prompt.mutate().chatOptions(this.getOptions()).build();
+		}
+		else {
+			return prompt;
+		}
+	}
+
 	public static final class Builder {
 
 		private @Nullable AwsCredentialsProvider credentialsProvider;

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -450,6 +450,20 @@ public class DeepSeekChatModel implements ChatModel {
 		return new Builder();
 	}
 
+	/**
+	 * Look at the options of the provided prompt. If none are provided, return a new
+	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
+	 * prompt as is.
+	 */
+	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+		if (prompt.getOptions() == null) {
+			return prompt.mutate().chatOptions(this.getOptions()).build();
+		}
+		else {
+			return prompt;
+		}
+	}
+
 	public static final class Builder {
 
 		private @Nullable DeepSeekApi deepSeekApi;

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -948,6 +948,21 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		return new Builder();
 	}
 
+	/**
+	 * Look at the options of the provided prompt. If none are provided, return a new
+	 * prompt using this model
+	 * {@link org.springframework.ai.chat.model.ChatModel#getOptions() options}.
+	 * Otherwise, use the prompt as is.
+	 */
+	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+		if (prompt.getOptions() == null) {
+			return prompt.mutate().chatOptions(this.getOptions()).build();
+		}
+		else {
+			return prompt;
+		}
+	}
+
 	public static final class Builder {
 
 		@Nullable private Client genAiClient;

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -541,6 +541,20 @@ public class MistralAiChatModel implements ChatModel {
 		return new Builder();
 	}
 
+	/**
+	 * Look at the options of the provided prompt. If none are provided, return a new
+	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
+	 * prompt as is.
+	 */
+	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+		if (prompt.getOptions() == null) {
+			return prompt.mutate().chatOptions(this.getOptions()).build();
+		}
+		else {
+			return prompt;
+		}
+	}
+
 	public static final class Builder {
 
 		private @Nullable MistralAiApi mistralAiApi;

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -483,6 +483,20 @@ public class OllamaChatModel implements ChatModel {
 		this.observationConvention = observationConvention;
 	}
 
+	/**
+	 * Look at the options of the provided prompt. If none are provided, return a new
+	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
+	 * prompt as is.
+	 */
+	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+		if (prompt.getOptions() == null) {
+			return prompt.mutate().chatOptions(this.getOptions()).build();
+		}
+		else {
+			return prompt;
+		}
+	}
+
 	public static final class Builder {
 
 		private @Nullable OllamaApi ollamaApi;

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
@@ -83,7 +83,7 @@ class OllamaChatRequestTests {
 
 		assertThat(request.model()).isEqualTo(OllamaModel.QWEN_2_5_3B.id());
 		assertThat(request.options()).containsEntry("temperature", 0.8);
-		assertThat(request.options()).containsEntry("top_k", 99);
+		assertThat(request.options()).doesNotContainKey("top_k");
 		assertThat(request.options()).containsEntry("num_gpu", 2);
 		assertThat(request.options()).containsEntry("top_p", 0.5);
 	}

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -931,6 +931,20 @@ public final class OpenAiChatModel implements ChatModel {
 		this.observationConvention = observationConvention;
 	}
 
+	/**
+	 * Look at the options of the provided prompt. If none are provided, return a new
+	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
+	 * prompt as is.
+	 */
+	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+		if (prompt.getOptions() == null) {
+			return prompt.mutate().chatOptions(this.getOptions()).build();
+		}
+		else {
+			return prompt;
+		}
+	}
+
 	private static final class ChunkMerger {
 
 		static boolean hasToolCall(ChatCompletionChunk chunk) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ChatModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ChatModel.java
@@ -26,7 +26,6 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.Model;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 
 public interface ChatModel extends Model<Prompt, ChatResponse>, StreamingChatModel {
 
@@ -64,24 +63,6 @@ public interface ChatModel extends Model<Prompt, ChatResponse>, StreamingChatMod
 
 	default Flux<ChatResponse> stream(Prompt prompt) {
 		throw new UnsupportedOperationException("streaming is not supported");
-	}
-
-	default Prompt buildRequestPrompt(Prompt prompt) {
-		var chatOptionsBuilder = getOptions().mutate();
-		var chatOptions = prompt.getOptions();
-
-		if (chatOptions != null) {
-			chatOptionsBuilder.combineWith(chatOptions.mutate());
-		}
-
-		chatOptions = chatOptionsBuilder.build();
-
-		if (chatOptions instanceof ToolCallingChatOptions toolCallingChatOptions) {
-			ToolCallingChatOptions.validateToolCallbacks(toolCallingChatOptions.getToolCallbacks());
-		}
-
-		return new Prompt(prompt.getInstructions(), chatOptions);
-
 	}
 
 }


### PR DESCRIPTION
This PR reverts commit b157b3413d51efce39ec0aa5b073991dd5e745df  which promoted the "wrong" implementation of `ChatModel` options handling: options merging is should no longer be supported at `ChatModel` level (`ChatClient` otoh supports it). The only logic we support should be this:
- if prompt.options is set, use them
- if prompt.options is null, use the ones from the model.

Moreover, the commit being reverted promoting the `buildRequestPrompt` method as public API level, while it was really meant to be private (was package private for testing purposes only, back in the day when it contained complicated logic).