### PR TITLE
fix(mcp): propagate progress token to elicitation requests

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/context/DefaultMcpAsyncRequestContext.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/context/DefaultMcpAsyncRequestContext.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.annotation.context;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -158,7 +159,24 @@ public final class DefaultMcpAsyncRequestContext implements McpAsyncRequestConte
 
 		Map<String, Object> schema = typeSchemaCache.computeIfAbsent(type, t -> this.generateElicitSchema(t));
 
-		return this.elicit(ElicitRequest.builder().message(message).requestedSchema(schema).meta(meta).build());
+		return this.elicit(ElicitRequest.builder()
+			.message(message)
+			.requestedSchema(schema)
+			.meta(metaWithProgressToken(meta))
+			.build());
+	}
+
+	private Map<String, Object> metaWithProgressToken(Map<String, Object> meta) {
+		Object progressToken = this.request.progressToken();
+		if (progressToken == null) {
+			return meta;
+		}
+		Map<String, Object> requestMeta = new HashMap<>();
+		if (meta != null) {
+			requestMeta.putAll(meta);
+		}
+		requestMeta.put("progressToken", progressToken);
+		return requestMeta;
 	}
 
 	private Map<String, Object> generateElicitSchema(Type type) {

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/context/DefaultMcpSyncRequestContext.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/context/DefaultMcpSyncRequestContext.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.annotation.context;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -205,10 +206,23 @@ public final class DefaultMcpSyncRequestContext implements McpSyncRequestContext
 		ElicitRequest elicitRequest = ElicitRequest.builder()
 			.message(message)
 			.requestedSchema(schema)
-			.meta(meta)
+			.meta(metaWithProgressToken(meta))
 			.build();
 
 		return this.exchange.createElicitation(elicitRequest);
+	}
+
+	private Map<String, Object> metaWithProgressToken(Map<String, Object> meta) {
+		Object progressToken = this.request.progressToken();
+		if (progressToken == null) {
+			return meta;
+		}
+		Map<String, Object> requestMeta = new HashMap<>();
+		if (meta != null) {
+			requestMeta.putAll(meta);
+		}
+		requestMeta.put("progressToken", progressToken);
+		return requestMeta;
 	}
 
 	private Map<String, Object> generateElicitSchema(Type type) {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/context/DefaultMcpAsyncRequestContextTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/context/DefaultMcpAsyncRequestContextTests.java
@@ -177,6 +177,8 @@ public class DefaultMcpAsyncRequestContextTests {
 		ElicitFormRequest capturedRequest = captor.getValue();
 		assertThat(capturedRequest.message()).isEqualTo("Test message");
 		assertThat(capturedRequest.requestedSchema()).isNotNull();
+		assertThat(capturedRequest.meta()).isNullOrEmpty();
+		assertThat(capturedRequest.progressToken()).isNull();
 	}
 
 	@Test
@@ -212,6 +214,48 @@ public class DefaultMcpAsyncRequestContextTests {
 		verify(this.exchange).createElicitation(captor.capture());
 
 		ElicitRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.meta()).containsEntry("key", "value");
+	}
+
+	@Test
+	public void testElicitationWithProgressToken() {
+		ClientCapabilities capabilities = mock(ClientCapabilities.class);
+		ClientCapabilities.Elicitation elicitation = mock(ClientCapabilities.Elicitation.class);
+		when(capabilities.elicitation()).thenReturn(elicitation);
+		when(this.exchange.getClientCapabilities()).thenReturn(capabilities);
+
+		CallToolRequest requestWithToken = CallToolRequest.builder()
+			.name("test-tool")
+			.arguments(Map.of())
+			.progressToken("token-123")
+			.build();
+		McpAsyncRequestContext contextWithToken = DefaultMcpAsyncRequestContext.builder()
+			.request(requestWithToken)
+			.exchange(this.exchange)
+			.build();
+
+		Map<String, Object> contentMap = Map.of("name", "John", "age", 30);
+		ElicitResult expectedResult = mock(ElicitResult.class);
+		when(expectedResult.action()).thenReturn(ElicitResult.Action.ACCEPT);
+		when(expectedResult.content()).thenReturn(contentMap);
+		when(expectedResult.meta()).thenReturn(null);
+		when(this.exchange.createElicitation(any(ElicitRequest.class))).thenReturn(Mono.just(expectedResult));
+
+		Map<String, Object> requestMeta = Map.of("key", "value");
+		Mono<StructuredElicitResult<Map<String, Object>>> result = contextWithToken.elicit(
+				e -> e.message("Test message").meta(requestMeta),
+				new ParameterizedTypeReference<Map<String, Object>>() {
+				});
+
+		StepVerifier.create(result)
+			.assertNext(structuredResult -> assertThat(structuredResult).isNotNull())
+			.verifyComplete();
+
+		ArgumentCaptor<ElicitRequest> captor = ArgumentCaptor.forClass(ElicitRequest.class);
+		verify(this.exchange).createElicitation(captor.capture());
+
+		ElicitRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.progressToken()).isEqualTo("token-123");
 		assertThat(capturedRequest.meta()).containsEntry("key", "value");
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/context/DefaultMcpSyncRequestContextTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/context/DefaultMcpSyncRequestContextTests.java
@@ -222,6 +222,8 @@ public class DefaultMcpSyncRequestContextTests {
 		ElicitFormRequest capturedRequest = captor.getValue();
 		assertThat(capturedRequest.message()).isEqualTo("Test message");
 		assertThat(capturedRequest.requestedSchema()).isNotNull();
+		assertThat(capturedRequest.meta()).isNullOrEmpty();
+		assertThat(capturedRequest.progressToken()).isNull();
 	}
 
 	@Test
@@ -258,6 +260,46 @@ public class DefaultMcpSyncRequestContextTests {
 		verify(this.exchange).createElicitation(captor.capture());
 
 		ElicitRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.meta()).containsEntry("key", "value");
+	}
+
+	@Test
+	public void testElicitationWithProgressToken() {
+		ClientCapabilities capabilities = mock(ClientCapabilities.class);
+		ClientCapabilities.Elicitation elicitation = mock(ClientCapabilities.Elicitation.class);
+		when(capabilities.elicitation()).thenReturn(elicitation);
+		when(this.exchange.getClientCapabilities()).thenReturn(capabilities);
+
+		CallToolRequest requestWithToken = CallToolRequest.builder()
+			.name("test-tool")
+			.arguments(Map.of())
+			.progressToken("token-123")
+			.build();
+		McpSyncRequestContext contextWithToken = DefaultMcpSyncRequestContext.builder()
+			.request(requestWithToken)
+			.exchange(this.exchange)
+			.build();
+
+		Map<String, Object> contentMap = Map.of("name", "John", "age", 30);
+		ElicitResult expectedResult = mock(ElicitResult.class);
+		when(expectedResult.action()).thenReturn(ElicitResult.Action.ACCEPT);
+		when(expectedResult.content()).thenReturn(contentMap);
+		when(expectedResult.meta()).thenReturn(null);
+		when(this.exchange.createElicitation(any(ElicitRequest.class))).thenReturn(expectedResult);
+
+		Map<String, Object> requestMeta = Map.of("key", "value");
+		StructuredElicitResult<Map<String, Object>> result = contextWithToken.elicit(
+				e -> e.message("Test message").meta(requestMeta),
+				new ParameterizedTypeReference<Map<String, Object>>() {
+				});
+
+		assertThat(result).isNotNull();
+
+		ArgumentCaptor<ElicitRequest> captor = ArgumentCaptor.forClass(ElicitRequest.class);
+		verify(this.exchange).createElicitation(captor.capture());
+
+		ElicitRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.progressToken()).isEqualTo("token-123");
 		assertThat(capturedRequest.meta()).containsEntry("key", "value");
 	}
 


### PR DESCRIPTION
## What changed

Closes #5050.

This propagates the inbound MCP request `progressToken` into typed elicitation requests created from `McpSyncRequestContext` and `McpAsyncRequestContext`.

The implementation builds a fresh request metadata map when a progress token exists, so existing elicitation metadata is preserved without mutating caller-provided maps. Requests without a progress token keep their existing metadata behavior.

## Testing

- `CI=true ./mvnw -Dmaven.build.cache.enabled=false -pl mcp/mcp-annotations -Dtest=DefaultMcpSyncRequestContextTests#testElicitationWithProgressToken,DefaultMcpAsyncRequestContextTests#testElicitationWithProgressToken test`
- `CI=true ./mvnw -Dmaven.build.cache.enabled=false -pl mcp/mcp-annotations -Dtest=DefaultMcpSyncRequestContextTests,DefaultMcpAsyncRequestContextTests test`
- `CI=true ./mvnw -Dmaven.build.cache.enabled=false -pl mcp/mcp-annotations test`
- `git diff --check`