### PR TITLE
docs: add RunAPI OpenAI-compatible example

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -879,7 +879,7 @@ For a hosted OpenAI-compatible endpoint such as https://runapi.ai[RunAPI], set t
 [source,properties]
 ----
 spring.ai.openai.api-key=${RUNAPI_API_KEY}
-spring.ai.openai.base-url=https://api.runapi.ai/v1
+spring.ai.openai.base-url=https://runapi.ai/v1
 spring.ai.openai.chat.model=gpt-5.5
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -874,6 +874,15 @@ spring.ai.openai.chat.extra-body.top_k=50
 spring.ai.openai.chat.extra-body.repetition_penalty=1.1
 ----
 
+For a hosted OpenAI-compatible endpoint such as https://runapi.ai[RunAPI], set the base URL and model ID:
+
+[source,properties]
+----
+spring.ai.openai.api-key=${RUNAPI_API_KEY}
+spring.ai.openai.base-url=https://api.runapi.ai/v1
+spring.ai.openai.chat.model=gpt-5.5
+----
+
 This configuration would produce a JSON request like:
 
 [source,json]


### PR DESCRIPTION
Adds a small RunAPI properties example to the OpenAI-compatible server docs.