### PR TITLE
Refine BaseChatMemoryAdvisor and ToolSearchToolCallingAdvisor

### DIFF
--- a/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
+++ b/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
@@ -71,6 +71,7 @@ import org.springframework.util.StringUtils;
  * {@link ToolIndexEvictionStrategy}.
  *
  * @author Christian Tzolov
+ * @author Yanming Zhou
  * @since 2.0.0
  */
 public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
@@ -322,11 +323,10 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 
 	private String getSessionId(Map<String, @Nullable Object> context) {
 		Assert.notNull(context, "context cannot be null");
-		Assert.noNullElements(context.keySet().toArray(), "context cannot contain null keys");
-		Assert.notNull(context.get(this.sessionIdKeyName),
-				"context must contain a non-null value for '" + this.sessionIdKeyName + "'");
+		Object sessionIdKey = context.get(this.sessionIdKeyName);
+		Assert.notNull(sessionIdKey, "context must contain a non-null value for '" + this.sessionIdKeyName + "'");
 
-		return context.get(this.sessionIdKeyName).toString();
+		return sessionIdKey.toString();
 	}
 
 	/**

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/BaseChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/BaseChatMemoryAdvisor.java
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Pollack
  * @author Thomas Vitale
+ * @author Yanming Zhou
  * @since 1.0
  */
 public interface BaseChatMemoryAdvisor extends BaseAdvisor, MemoryAdvisor {
@@ -37,9 +38,9 @@ public interface BaseChatMemoryAdvisor extends BaseAdvisor, MemoryAdvisor {
 	 */
 	default String getConversationId(Map<String, @Nullable Object> context) {
 		Assert.notNull(context, "context cannot be null");
-		Assert.noNullElements(context.keySet().toArray(), "context cannot contain null keys");
-		Assert.notNull(context.get(ChatMemory.CONVERSATION_ID), "conversationId cannot be null");
-		return context.get(ChatMemory.CONVERSATION_ID).toString();
+		Object conversationId = context.get(ChatMemory.CONVERSATION_ID);
+		Assert.notNull(conversationId, "conversationId cannot be null");
+		return conversationId.toString();
 	}
 
 }


### PR DESCRIPTION
1. Eliminate warning `Method invocation 'toString' may produce 'NullPointerException'`
2. Remove unrelated assertion
