### PR TITLE
Fix #5239: tolerate non-SSE 200 OK on streamable-http GET /mcp probe

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransport.java
@@ -273,6 +273,19 @@ public final class WebClientStreamableHttpTransport implements McpClientTranspor
 						logger.debug("The server does not support SSE streams, using request-response mode.");
 						return Flux.empty();
 					}
+					else if (isStatelessOk(response)) {
+						// Per the MCP spec, the server MUST return either
+						// Content-Type: text/event-stream or HTTP 405 Method Not Allowed
+						// on the GET probe. Some servers (e.g. ModelScope Model API MCP)
+						// return 200 OK with a non-SSE content type (typically
+						// application/json) as a no-stream endpoint. Treat that as
+						// "stateless server that does not stream" — same as 405 — and
+						// fall back to request-response mode rather than failing the
+						// initialization. See spring-ai issue #5239.
+						logger.debug("The server returned a non-SSE 2xx response to the GET probe; "
+								+ "treating as a stateless endpoint and using request-response mode.");
+						return Flux.empty();
+					}
 					else if (isNotFound(response)) {
 						if (transportSession.sessionId().isPresent()) {
 							String sessionIdRepresentation = sessionIdOrPlaceholder(transportSession);
@@ -503,6 +516,35 @@ public final class WebClientStreamableHttpTransport implements McpClientTranspor
 	private static boolean isEventStream(ClientResponse response) {
 		return response.statusCode().is2xxSuccessful() && response.headers().contentType().isPresent()
 				&& response.headers().contentType().get().isCompatibleWith(MediaType.TEXT_EVENT_STREAM);
+	}
+
+	/**
+	 * Detects the case where the GET probe returns a successful response that is not an
+	 * SSE stream. Per the MCP streamable-http spec, the server is required to return
+	 * either {@code Content-Type: text/event-stream} or {@code 405 Method Not Allowed} on
+	 * the GET probe. Some servers instead return a plain {@code 200 OK} with a non-SSE
+	 * content type (e.g. {@code application/json} or no {@code Content-Type} header at
+	 * all) to signal that they do not offer a server-initiated stream at this endpoint.
+	 * The Spring AI client must treat that as a valid no-stream response and fall back to
+	 * request-response mode rather than failing the initialization with an
+	 * {@code McpTransportException}.
+	 *
+	 * <p>
+	 * See <a href="https://github.com/spring-projects/spring-ai/issues/5239">spring-ai
+	 * issue #5239</a>.
+	 */
+	private static boolean isStatelessOk(ClientResponse response) {
+		if (!response.statusCode().is2xxSuccessful()) {
+			return false;
+		}
+		// A 200 with text/event-stream is handled by isEventStream above.
+		if (response.headers().contentType().isPresent()
+				&& response.headers().contentType().get().isCompatibleWith(MediaType.TEXT_EVENT_STREAM)) {
+			return false;
+		}
+		// Any other 2xx (with or without a non-SSE content type) is treated as a
+		// stateless no-stream endpoint.
+		return true;
 	}
 
 	private static String sessionIdOrPlaceholder(McpTransportSession<?> transportSession) {

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpGetProbeIT.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpGetProbeIT.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.webflux.transport;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import com.sun.net.httpserver.HttpServer;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import reactor.test.StepVerifier;
+
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for
+ * <a href="https://github.com/spring-projects/spring-ai/issues/5239"> issue #5239</a>:
+ * the {@code streamable-http} MCP client must tolerate a {@code GET /mcp} probe that
+ * returns {@code 200 OK} with a non-SSE {@code Content-Type} (e.g.
+ * {@code application/json}) as a no-stream endpoint, and fall back to request-response
+ * mode rather than failing the initialization with an {@code McpTransportException}.
+ *
+ * <p>
+ * The MCP streamable-http spec requires the server to return either
+ * {@code Content-Type: text/event-stream} or {@code 405 Method Not Allowed} on the GET
+ * probe. Some MCP servers (e.g. ModelScope Model API MCP) instead return {@code 200 OK}
+ * with a plain JSON body when they do not offer a server-initiated stream, and that
+ * response must not break the client.
+ */
+@Timeout(15)
+public class WebClientStreamableHttpGetProbeIT {
+
+	private HttpServer server;
+
+	private McpClientTransport transport;
+
+	// Latches that observe which path the test server actually received.
+	private CountDownLatch firstPostLatch = new CountDownLatch(1);
+
+	private CountDownLatch getProbeLatch = new CountDownLatch(1);
+
+	// Per-test config set in @BeforeEach.
+	private String getContentType;
+
+	private int getStatus;
+
+	private boolean hasGetBody;
+
+	private String getBody;
+
+	@BeforeEach
+	void resetLatches() {
+		this.firstPostLatch = new CountDownLatch(1);
+		this.getProbeLatch = new CountDownLatch(1);
+	}
+
+	@AfterEach
+	void stopServer() {
+		if (this.server != null) {
+			this.server.stop(0);
+		}
+		if (this.transport != null) {
+			this.transport.closeGracefully().block(Duration.ofSeconds(2));
+		}
+	}
+
+	/**
+	 * The server returns {@code 200 OK} with {@code Content-Type: application/json} on
+	 * the GET probe (no SSE stream). The client must treat this as a stateless endpoint,
+	 * fall back to request-response mode, and successfully complete the request-response
+	 * flow. The transport's exception handler must not be invoked with an error raised by
+	 * the GET probe.
+	 */
+	@Test
+	void testGetProbeWith200ApplicationJson() throws Exception {
+		configureGetProbe("application/json", 200, true, "{\"info\":\"return 200 for GET /mcp.\"}");
+		startServer();
+		AtomicInteger exceptionCount = installExceptionCounter();
+
+		// The reconnect() lifecycle is triggered by sendMessage() once a session is
+		// established. First connect, then send a message — that establishes the
+		// session via POST, then the background GET probe runs.
+		StepVerifier.create(this.transport.connect(msg -> msg)).verifyComplete();
+		StepVerifier.create(this.transport.sendMessage(buildInitializeRequest())).verifyComplete();
+
+		assertThat(this.firstPostLatch.await(5, TimeUnit.SECONDS)).as("Server should have received the initial POST")
+			.isTrue();
+		assertThat(this.getProbeLatch.await(5, TimeUnit.SECONDS)).as("Server should have received the GET probe")
+			.isTrue();
+		// Give the background reconnect loop a moment to surface any error via the
+		// exception handler. With the bug, this handler would have been invoked
+		// with the McpTransportException from the unexpected 200-without-SSE GET.
+		Thread.sleep(1000);
+		assertThat(exceptionCount.get()).as("Exception handler should not have been invoked for a benign 200 GET probe")
+			.isZero();
+	}
+
+	/**
+	 * The server returns {@code 200 OK} with no {@code Content-Type} header on the GET
+	 * probe. The client must still treat it as a stateless endpoint and must not raise an
+	 * error.
+	 */
+	@Test
+	void testGetProbeWith200NoContentType() throws Exception {
+		configureGetProbe(null, 200, true, "{\"info\":\"return 200 for GET /mcp.\"}");
+		startServer();
+		AtomicInteger exceptionCount = installExceptionCounter();
+
+		StepVerifier.create(this.transport.connect(msg -> msg)).verifyComplete();
+		StepVerifier.create(this.transport.sendMessage(buildInitializeRequest())).verifyComplete();
+
+		assertThat(this.firstPostLatch.await(5, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.getProbeLatch.await(5, TimeUnit.SECONDS)).as("Server should have received the GET probe")
+			.isTrue();
+		Thread.sleep(1000);
+		assertThat(exceptionCount.get()).as("Exception handler should not have been invoked for a benign 200 GET probe")
+			.isZero();
+	}
+
+	/**
+	 * Sanity check: the server returns {@code 405 Method Not Allowed} on the GET probe.
+	 * The client must continue to treat that as a stateless endpoint and successfully
+	 * complete the flow. This is the well-formed case the client has always supported.
+	 */
+	@Test
+	void testGetProbeWith405() throws Exception {
+		configureGetProbe(null, 405, false, null);
+		startServer();
+		AtomicInteger exceptionCount = installExceptionCounter();
+
+		StepVerifier.create(this.transport.connect(msg -> msg)).verifyComplete();
+		StepVerifier.create(this.transport.sendMessage(buildInitializeRequest())).verifyComplete();
+
+		assertThat(this.firstPostLatch.await(5, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.getProbeLatch.await(5, TimeUnit.SECONDS)).as("Server should have received the GET probe")
+			.isTrue();
+		Thread.sleep(1000);
+		assertThat(exceptionCount.get()).as("Exception handler should not have been invoked for a 405 GET probe")
+			.isZero();
+	}
+
+	private AtomicInteger installExceptionCounter() {
+		AtomicInteger counter = new AtomicInteger();
+		this.transport.setExceptionHandler((Consumer<Throwable>) t -> counter.incrementAndGet());
+		return counter;
+	}
+
+	private void configureGetProbe(String contentType, int status, boolean hasBody, String body) {
+		this.getContentType = contentType;
+		this.getStatus = status;
+		this.hasGetBody = hasBody;
+		this.getBody = body;
+	}
+
+	private void startServer() throws IOException {
+		this.server = HttpServer.create(new InetSocketAddress(0), 0);
+		AtomicReference<String> sessionIdToReturn = new AtomicReference<>("test-session-5239");
+		this.server.createContext("/mcp", exchange -> {
+			String method = exchange.getRequestMethod();
+			if ("GET".equals(method)) {
+				this.getProbeLatch.countDown();
+				if (this.getContentType != null) {
+					exchange.getResponseHeaders().set("Content-Type", this.getContentType);
+				}
+				if (this.hasGetBody) {
+					byte[] body = this.getBody.getBytes();
+					exchange.sendResponseHeaders(this.getStatus, body.length);
+					exchange.getResponseBody().write(body);
+				}
+				else {
+					exchange.sendResponseHeaders(this.getStatus, 0);
+				}
+				exchange.close();
+				return;
+			}
+			if ("POST".equals(method)) {
+				this.firstPostLatch.countDown();
+				// Respond with a minimal JSON-RPC success carrying a session id so
+				// the client establishes a session and the background GET probe runs.
+				exchange.getResponseHeaders().set("Content-Type", "application/json");
+				exchange.getResponseHeaders().set("Mcp-Session-Id", sessionIdToReturn.get());
+				String response = "{\"jsonrpc\":\"2.0\",\"result\":{},\"id\":\"test-id\"}";
+				byte[] body = response.getBytes();
+				exchange.sendResponseHeaders(200, body.length);
+				exchange.getResponseBody().write(body);
+				exchange.close();
+				return;
+			}
+			exchange.sendResponseHeaders(405, 0);
+			exchange.close();
+		});
+		this.server.setExecutor(null);
+		this.server.start();
+		String host = "http://localhost:" + this.server.getAddress().getPort();
+		this.transport = WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(host)).build();
+	}
+
+	private static McpSchema.JSONRPCRequest buildInitializeRequest() {
+		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_03_26,
+				McpSchema.ClientCapabilities.builder().roots(true).build(),
+				new McpSchema.Implementation("Test Client", "1.0.0"));
+		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE, "test-id",
+				initializeRequest);
+	}
+
+}


### PR DESCRIPTION
### Summary

Fix spring-projects/spring-ai#5239.

The `streamable-http` MCP client fails to initialize against MCP servers that return a plain `200 OK` with a non-SSE `Content-Type` (e.g. `application/json`) on the `GET /mcp` probe. The spec requires the server to return either `Content-Type: text/event-stream` or `HTTP 405 Method Not Allowed` on the GET probe, but real-world servers (ModelScope Model API MCP is the canonical example) instead return `200 OK` with a JSON body or no content type to signal that they do not offer a server-initiated stream. The client must treat that as a valid no-stream response and fall back to request-response mode.

### Fix

In `WebClientStreamableHttpTransport.reconnect`'s `exchangeToFlux` handler, add a new branch for "2xx that is not text/event-stream". A new helper `isStatelessOk(ClientResponse)` returns true for any 2xx that isn't an SSE stream (including 200 with `application/json`, 200 with no content type, 204, etc.). The branch returns `Flux.empty()` — the same behavior as the existing 405 path — so the client continues in request-response mode.

```java
else if (isStatelessOk(response)) {
    // Per the MCP spec, the server MUST return either
    // Content-Type: text/event-stream or HTTP 405 Method Not Allowed
    // on the GET probe. Some servers (e.g. ModelScope Model API MCP)
    // return 200 OK with a non-SSE content type (typically
    // application/json) as a no-stream endpoint. Treat that as
    // "stateless server that does not stream" — same as 405 — and
    // fall back to request-response mode rather than failing the
    // initialization. See spring-ai issue #5239.
    logger.debug("The server returned a non-SSE 2xx response to the GET probe; "
            + "treating as a stateless endpoint and using request-response mode.");
    return Flux.empty();
}
```

### Tests

New `WebClientStreamableHttpGetProbeIT` covers three cases against a local `com.sun.net.httpserver.HttpServer`:

- `testGetProbeWith200ApplicationJson` — `200` + `Content-Type: application/json` (**fails on the unmodified code**, passes with the fix)
- `testGetProbeWith200NoContentType` — `200` with no `Content-Type` header (**fails on the unmodified code**, passes with the fix)
- `testGetProbeWith405` — `405` (sanity check; passes before and after)

Each test asserts that (1) the server actually received the GET probe, and (2) the transport's exception handler was **not** invoked. Without the fix, the default `exchangeToFlux` else branch (`response.createError()`) raises an `McpTransportException`, which the background reconnect loop surfaces via the exception handler.

The existing `WebClientStreamableHttpTransportErrorHandlingIT` regression tests continue to pass.

### Notes

- This is a non-breaking change: the new branch only adds a "treat 2xx-without-SSE as stateless" mode that strictly broadens the set of servers the client can talk to. Servers that already returned `text/event-stream` keep going through the original `eventStream` path.
- The `mcp-core` 0.17.1 workaround mentioned in the issue is a different code path (the JDK HTTP-client-based transport uses `ResponseSubscribers$SseLineSubscriber` directly). That variant does not need this fix because it returns its body to the caller as a single `String` and does not require an SSE-shaped response on the GET probe. The fix here covers the WebFlux variant, which is the one that fails per the issue body.