### PR TITLE
Add ToolCallSanitizingChatMemory decorator to fix streaming tool-call replay (spring-ai #6340)

### DIFF
--- a/models/spring-ai-deepseek/pom.xml
+++ b/models/spring-ai-deepseek/pom.xml
@@ -59,6 +59,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekToolCallSanitizingMemoryIT.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekToolCallSanitizingMemoryIT.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.deepseek.chat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.chat.memory.ToolCallSanitizingChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.deepseek.api.DeepSeekApi;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.annotation.Tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Integration test reproducing
+ * <a href= "https://github.com/spring-projects/spring-ai/issues/6340">spring-ai#6340</a>
+ * against the live DeepSeek backend. This is the GA release-blocker test: the issue's
+ * exact repro is streamed through a {@link ChatClient} with
+ * {@code ToolCallingAdvisor.streamToolCallResponses(true)} +
+ * {@code MessageChatMemoryAdvisor} wrapped in {@link ToolCallSanitizingChatMemory}, and
+ * we verify that round 1 returns a text reply (via the {@code getDateTime} tool) and
+ * round 2 does NOT throw an HTTP 400 from the DeepSeek API.
+ * <p>
+ * Skipped when {@code DEEPSEEK_API_KEY} is not set in the environment.
+ *
+ * @author redinside-dev
+ */
+@EnabledIfEnvironmentVariable(named = "DEEPSEEK_API_KEY", matches = ".+")
+class DeepSeekToolCallSanitizingMemoryIT {
+
+	@Test
+	void deepSeekStreamingToolCallMemoryTwoRoundReproIsClean() {
+		DeepSeekApi api = DeepSeekApi.builder().apiKey(System.getenv("DEEPSEEK_API_KEY")).build();
+		org.springframework.ai.deepseek.DeepSeekChatModel chatModel = org.springframework.ai.deepseek.DeepSeekChatModel
+			.builder()
+			.deepSeekApi(api)
+			.build();
+		RecordingChatModel model = new RecordingChatModel(chatModel);
+
+		ChatMemory memory = new ToolCallSanitizingChatMemory(
+				MessageWindowChatMemory.builder().chatMemoryRepository(new InMemoryChatMemoryRepository()).build());
+
+		ChatClient client = ChatClient.builder(model)
+			.defaultOptions((ChatOptions.Builder) ToolCallingChatOptions.builder())
+			.defaultAdvisors(ToolCallingAdvisor.builder().streamToolCallResponses(true).build(),
+					MessageChatMemoryAdvisor.builder(memory).build())
+			.defaultTools(new Clock())
+			.build();
+
+		// Round 1: the tool-calling turn. Must stream a text reply and not throw.
+		List<String> round1Texts = client.prompt()
+			.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "c1"))
+			.user("What time is it? Answer in one short sentence.")
+			.stream()
+			.chatResponse()
+			.flatMap(r -> Flux.fromIterable(r.getResults()).flatMap(gen -> {
+				String text = gen.getOutput().getText();
+				return (text == null || text.isBlank()) ? Flux.<String>empty() : Flux.just(text);
+			}))
+			.collectList()
+			.block();
+		assertThat(round1Texts).as("round 1 should produce at least one text chunk").isNotEmpty();
+
+		// Persisted memory must NOT contain a ToolResponseMessage (issue #6340) and
+		// the assistant message must NOT carry orphan tool_calls. (DeepSeek rejects
+		// "assistant message with 'tool_calls' must be followed by tool messages
+		// responding to each 'tool_call_id'" with HTTP 400 — see
+		// https://github.com/spring-projects/spring-ai/issues/6340.)
+		List<Message> persisted = memory.get("c1");
+		assertThat(persisted).extracting(Message::getMessageType).doesNotContain(MessageType.TOOL);
+		assertThat(persisted.stream()
+			.filter(m -> m instanceof AssistantMessage)
+			.map(m -> ((AssistantMessage) m).hasToolCalls())
+			.filter(Boolean::booleanValue)
+			.findAny()).as("no persisted AssistantMessage may carry orphan tool_calls (issue #6340)").isEmpty();
+
+		// Round 2: a follow-up turn. Before the fix this would have raised an HTTP
+		// 400 from DeepSeek. With ToolCallSanitizingChatMemory in place the replay
+		// is clean.
+		assertThatNoException().isThrownBy(() -> client.prompt()
+			.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "c1"))
+			.user("Thanks")
+			.stream()
+			.chatResponse()
+			.blockLast());
+
+		// Multi-round replay assertion (test #2 from the spec): the recorded follow-up
+		// prompt's instructions must not contain a ToolResponseMessage, and the last
+		// assistant message must not carry tool_calls.
+		List<Prompt> recordedPrompts = model.recorded();
+		assertThat(recordedPrompts).isNotEmpty();
+		Prompt followUpPrompt = recordedPrompts.get(recordedPrompts.size() - 1);
+		List<Message> instructions = new java.util.ArrayList<>(followUpPrompt.getInstructions());
+		assertThat(instructions).extracting(Message::getMessageType).doesNotContain(MessageType.TOOL);
+		Message lastAssistant = instructions.stream()
+			.filter(m -> m instanceof AssistantMessage)
+			.reduce((a, b) -> b)
+			.orElseThrow(() -> new AssertionError("expected at least one AssistantMessage in replay prompt"));
+		assertThat(((AssistantMessage) lastAssistant).hasToolCalls())
+			.as("replayed assistant message must not carry tool_calls (issue #6340)")
+			.isFalse();
+	}
+
+	static final class Clock {
+
+		@Tool(name = "getDateTime", description = "ISO-8601 local date-time")
+		String getDateTime() {
+			return LocalDateTime.now().toString();
+		}
+
+	}
+
+	/**
+	 * Recording chat model wrapper used for the multi-round replay assertion.
+	 */
+	static final class RecordingChatModel implements org.springframework.ai.chat.model.ChatModel {
+
+		private final java.util.List<Prompt> prompts = new java.util.ArrayList<>();
+
+		private final org.springframework.ai.chat.model.ChatModel delegate;
+
+		RecordingChatModel(org.springframework.ai.chat.model.ChatModel delegate) {
+			this.delegate = delegate;
+		}
+
+		java.util.List<Prompt> recorded() {
+			return this.prompts;
+		}
+
+		@Override
+		public org.springframework.ai.chat.model.ChatResponse call(Prompt prompt) {
+			this.prompts.add(prompt);
+			return this.delegate.call(prompt);
+		}
+
+		@Override
+		public Flux<org.springframework.ai.chat.model.ChatResponse> stream(Prompt prompt) {
+			this.prompts.add(prompt);
+			return this.delegate.stream(prompt);
+		}
+
+		@Override
+		public ChatOptions getOptions() {
+			return this.delegate.getOptions();
+		}
+
+	}
+
+}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemoryIntegrationTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemoryIntegrationTests.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.annotation.Tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Integration tests for the
+ * {@code stream() + ToolCallingAdvisor.streamToolCallResponses(true)
+ * + MessageChatMemoryAdvisor} scenario from
+ * <a href= "https://github.com/spring-projects/spring-ai/issues/6340">spring-ai#6340</a>.
+ * These tests use a scripted {@link ChatModel} (no OpenAI / DeepSeek API key required)
+ * that emits a deterministic two-round flux, the same shape that produces the 400 in the
+ * issue. The fix under test is the {@link ToolCallSanitizingChatMemory} decorator that
+ * strips the tool round-trip from persisted memory.
+ *
+ * @author redinside-dev
+ */
+class ToolCallSanitizingChatMemoryIntegrationTests {
+
+	/**
+	 * Acceptance test #1 from the spec — no-network repro of the bug. With the
+	 * {@link ToolCallSanitizingChatMemory} decorator wrapping
+	 * {@link MessageWindowChatMemory}, the persisted memory after a tool-calling turn
+	 * must contain a clean transcript — no orphan {@code tool_calls} (which would trigger
+	 * the 400 on the next turn replay against an OpenAI-compatible backend).
+	 * <p>
+	 * Without the sanitizer, the outer {@code ChatClientMessageAggregator} would fold the
+	 * streaming tool-call chunks and the recursive text chunks into a single
+	 * {@code AssistantMessage(text+toolCalls)} and persist it as-is. With the sanitizer,
+	 * the persisted assistant message carries text only, no {@code
+	 * toolCalls}, and never a {@code ToolResponseMessage} (which would have required the
+	 * same backend pairing that just got sanitized away).
+	 */
+	@Test
+	void streamingToolCallMemoryPersistsSanitizedTranscript() {
+		ChatMemory memory = new ToolCallSanitizingChatMemory(
+				MessageWindowChatMemory.builder().chatMemoryRepository(new InMemoryChatMemoryRepository()).build());
+
+		ChatClient client = ChatClient.builder(new FakeScriptedChatModel())
+			.defaultOptions((ChatOptions.Builder) ToolCallingChatOptions.builder())
+			.defaultAdvisors(ToolCallingAdvisor.builder().streamToolCallResponses(true).build(),
+					MessageChatMemoryAdvisor.builder(memory).build())
+			.defaultTools(new Clock())
+			.build();
+
+		List<ChatResponse> chunks = client.prompt()
+			.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "c1"))
+			.user("What time is it?")
+			.stream()
+			.chatResponse()
+			.collectList()
+			.block();
+
+		assertThat(chunks).isNotNull().isNotEmpty();
+
+		// Read the persisted memory: the assistant message in there must NOT carry
+		// tool_calls (they were sanitized away) and there must be NO ToolResponseMessage
+		// (the tool round-trip was stripped, which is the entire point of #6340 Shape B).
+		List<Message> persisted = memory.get("c1");
+		assertThat(persisted).extracting(Message::getMessageType).doesNotContain(MessageType.TOOL);
+
+		AssistantMessage assistant = (AssistantMessage) persisted.stream()
+			.filter(m -> m instanceof AssistantMessage)
+			.reduce((a, b) -> b) // last assistant message
+			.orElseThrow(() -> new AssertionError("expected at least one AssistantMessage in memory"));
+		assertThat(assistant.hasToolCalls()).as("persisted assistant message must not carry tool_calls (issue #6340)")
+			.isFalse();
+	}
+
+	/**
+	 * Acceptance test #1 (second part) — follow-up turn on the same conversation id does
+	 * not raise. Before the fix, the persisted transcript carried an
+	 * {@code AssistantMessage} with orphan {@code tool_calls}, and a follow-up turn
+	 * against an OpenAI-compatible backend would be rejected with HTTP 400. With the
+	 * sanitizer in place, no orphan tool_calls reach the wire and the next turn goes
+	 * through cleanly.
+	 */
+	@Test
+	void followUpTurnAfterStreamingToolCallDoesNotThrow() {
+		ChatMemory memory = new ToolCallSanitizingChatMemory(
+				MessageWindowChatMemory.builder().chatMemoryRepository(new InMemoryChatMemoryRepository()).build());
+
+		ChatClient client = ChatClient.builder(new FakeScriptedChatModel())
+			.defaultOptions((ChatOptions.Builder) ToolCallingChatOptions.builder())
+			.defaultAdvisors(ToolCallingAdvisor.builder().streamToolCallResponses(true).build(),
+					MessageChatMemoryAdvisor.builder(memory).build())
+			.defaultTools(new Clock())
+			.build();
+
+		client.prompt()
+			.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "c1"))
+			.user("What time is it?")
+			.stream()
+			.chatResponse()
+			.blockLast();
+
+		assertThatNoException().isThrownBy(() -> client.prompt()
+			.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "c1"))
+			.user("Thanks")
+			.stream()
+			.chatResponse()
+			.blockLast());
+	}
+
+	/**
+	 * Acceptance test #2 — multi-round replay. After a streaming tool-calling turn, the
+	 * persisted memory snapshot — what would be fed to the next
+	 * {@code ChatModel.stream(...)} request on a follow-up turn — contains no orphan
+	 * {@code tool_calls} and no {@code ToolResponseMessage}. I.e. it is replay-clean and
+	 * would not be rejected by an OpenAI-compatible backend. The follow-up turn is
+	 * replayed through a recording {@link ChatModel} wrapper that captures the actual
+	 * wire prompt and lets us assert on the message list sent to the model.
+	 */
+	@Test
+	void multiRoundReplayMemorySnapshotIsClean() {
+		RecordingChatModel model = new RecordingChatModel();
+
+		ChatMemory memory = new ToolCallSanitizingChatMemory(
+				MessageWindowChatMemory.builder().chatMemoryRepository(new InMemoryChatMemoryRepository()).build());
+
+		ChatClient client = ChatClient.builder(model)
+			.defaultOptions((ChatOptions.Builder) ToolCallingChatOptions.builder())
+			.defaultAdvisors(ToolCallingAdvisor.builder().streamToolCallResponses(true).build(),
+					MessageChatMemoryAdvisor.builder(memory).build())
+			.defaultTools(new Clock())
+			.build();
+
+		// Round 1: the tool-calling turn that triggers the bug.
+		client.prompt()
+			.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "c1"))
+			.user("What time is it?")
+			.stream()
+			.chatResponse()
+			.blockLast();
+
+		// Sanity: the sanitizer should have already produced a clean memory snapshot
+		// after round 1. The follow-up "Thanks" turn replays this snapshot.
+		List<Message> persisted = memory.get("c1");
+		assertThat(persisted).extracting(Message::getMessageType).doesNotContain(MessageType.TOOL);
+		assertThat(persisted.stream()
+			.filter(m -> m instanceof AssistantMessage)
+			.map(m -> ((AssistantMessage) m).hasToolCalls())
+			.filter(Boolean::booleanValue)
+			.findAny()).as("no persisted AssistantMessage may carry tool_calls (issue #6340)").isEmpty();
+
+		// Round 2: a follow-up turn. The recorded last call is the one that would be
+		// sent to the backend.
+		client.prompt()
+			.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "c1"))
+			.user("Thanks")
+			.stream()
+			.chatResponse()
+			.blockLast();
+
+		List<Prompt> recordedPrompts = model.recorded();
+		assertThat(recordedPrompts).isNotEmpty();
+		Prompt followUpPrompt = recordedPrompts.get(recordedPrompts.size() - 1);
+
+		List<Message> instructions = new ArrayList<>(followUpPrompt.getInstructions());
+
+		// Critical assertion for #6340: the follow-up prompt's instructions (the
+		// replayed memory + the new user turn) must not contain any
+		// ToolResponseMessage, and the last assistant message must not carry
+		// tool_calls.
+		assertThat(instructions).extracting(Message::getMessageType).doesNotContain(MessageType.TOOL);
+
+		Message lastAssistant = instructions.stream()
+			.filter(m -> m instanceof AssistantMessage)
+			.reduce((a, b) -> b)
+			.orElseThrow(() -> new AssertionError("expected at least one AssistantMessage in replay prompt"));
+		assertThat(((AssistantMessage) lastAssistant).hasToolCalls())
+			.as("replayed assistant message must not carry tool_calls (issue #6340)")
+			.isFalse();
+	}
+
+	/**
+	 * A trivial one-liner {@code @Tool} that returns the current time, matching the
+	 * issue's repro tool.
+	 */
+	static final class Clock {
+
+		@Tool(name = "getDateTime", description = "ISO-8601 local date-time")
+		String getDateTime() {
+			return LocalDateTime.now().toString();
+		}
+
+	}
+
+	/**
+	 * A no-network {@link ChatModel} that returns a scripted two-round response. The
+	 * script is two calls deep: the first emits a single {@code AssistantMessage} that
+	 * has both text and a {@code getDateTime} tool call (this is the round that
+	 * {@code ToolCallingAdvisor} will execute, then recurse), and the second (recursive)
+	 * emits a plain text reply.
+	 * <p>
+	 * This mimics the wire shape of the bug report: a streaming round 1 produces chunks
+	 * that the outer {@code ChatClientMessageAggregator} folds into a single
+	 * {@code AssistantMessage(text+toolCalls)}, then the recursive round 2 appends to the
+	 * same fold — which is exactly the malformed transcript that the un-sanitized
+	 * {@code MessageChatMemoryAdvisor} would persist.
+	 */
+	static final class FakeScriptedChatModel implements ChatModel {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			int n = this.callCount.incrementAndGet();
+			return new ChatResponse(List.of(new Generation(scripted(n))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			int n = this.callCount.incrementAndGet();
+			AssistantMessage message = scripted(n);
+			return Flux.just(new ChatResponse(List.of(new Generation(message))));
+		}
+
+		@Override
+		public ChatOptions getOptions() {
+			return ToolCallingChatOptions.builder().build();
+		}
+
+		private static AssistantMessage scripted(int n) {
+			if (n == 1) {
+				AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call-date-1", "function",
+						"getDateTime", "{}");
+				// Single AssistantMessage that mirrors what MessageAggregator produces
+				// in the multi-round stream case: it carries both text and a tool call.
+				// This is the malformed transcript shape that, without sanitization,
+				// causes a 400 on the next turn replay.
+				return AssistantMessage.builder()
+					.content("It's 10:34 AM on June 9, 2026.")
+					.toolCalls(List.of(toolCall))
+					.build();
+			}
+			return new AssistantMessage("It's 10:34 AM on June 9, 2026.");
+		}
+
+	}
+
+	/**
+	 * ChatModel wrapper that records every prompt it receives and replies with a scripted
+	 * two-round response (same as {@link FakeScriptedChatModel} but with recording).
+	 */
+	static final class RecordingChatModel implements ChatModel {
+
+		private final List<Prompt> prompts = new ArrayList<>();
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		List<Prompt> recorded() {
+			return this.prompts;
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			this.prompts.add(prompt);
+			int n = this.callCount.incrementAndGet();
+			return new ChatResponse(List.of(new Generation(scripted(n))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			this.prompts.add(prompt);
+			int n = this.callCount.incrementAndGet();
+			AssistantMessage message = scripted(n);
+			return Flux.just(new ChatResponse(List.of(new Generation(message))));
+		}
+
+		@Override
+		public ChatOptions getOptions() {
+			return ToolCallingChatOptions.builder().build();
+		}
+
+		private static AssistantMessage scripted(int n) {
+			if (n == 1) {
+				AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call-date-1", "function",
+						"getDateTime", "{}");
+				return AssistantMessage.builder()
+					.content("It's 10:34 AM on June 9, 2026.")
+					.toolCalls(List.of(toolCall))
+					.build();
+			}
+			return new AssistantMessage("It's 10:34 AM on June 9, 2026.");
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemory.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link ChatMemory} decorator that strips tool round-trips from the conversation
+ * history before they are persisted or replayed.
+ * <p>
+ * The tool-call protocol inside a single turn — the pairing of
+ * {@code AssistantMessage(tool_calls=[...])} with the following
+ * {@link ToolResponseMessage} — is intra-turn structure managed by
+ * {@code ToolCallAdvisor} (or any other tool-calling loop). It is not part of the
+ * cross-turn long-term chat history, and replaying it on the next turn is actively
+ * harmful: OpenAI-compatible backends reject it with HTTP 400
+ * ({@code "An assistant message with 'tool_calls' must be followed by tool messages
+ * responding to each 'tool_call_id'"}), and tools may have been disabled, renamed, or had
+ * their schema changed between turns — replaying a stale {@code tool_call} against a tool
+ * that no longer exists is a hallucination waiting to happen.
+ * <p>
+ * Sanitization rules, applied on every {@code add(...)} and {@code get(...)}:
+ * <ol>
+ * <li>Drop every {@link ToolResponseMessage}.</li>
+ * <li>For any {@link AssistantMessage} carrying {@code toolCalls}, keep only the text
+ * content. The {@code toolCalls} are discarded.</li>
+ * <li>If, after stripping {@code toolCalls}, an {@link AssistantMessage} has no text
+ * content (the common case for a pure tool-call intermediate frame), drop it
+ * entirely.</li>
+ * </ol>
+ * <p>
+ * Typical usage: wrap an existing memory in the sanitizing decorator and pass that to
+ * {@code MessageChatMemoryAdvisor.builder(...)}:
+ *
+ * <pre>{@code
+ * ChatMemory memory = new ToolCallSanitizingChatMemory(
+ *         MessageWindowChatMemory.builder()
+ *                 .chatMemoryRepository(new InMemoryChatMemoryRepository())
+ *                 .build());
+ * }</pre>
+ *
+ * <p>
+ * This addresses the bug described in
+ * <a href= "https://github.com/spring-projects/spring-ai/issues/6340">spring-ai#6340</a>:
+ * {@code stream() + ToolCallAdvisor.streamToolCallResponses(true) +
+ * MessageChatMemoryAdvisor} used to persist a malformed
+ * {@code AssistantMessage(text+tool_calls, no ToolResponseMessage)} to memory, which then
+ * failed with HTTP 400 on the next turn's replay.
+ *
+ * @author redinside-dev
+ * @since 2.0.0
+ */
+public final class ToolCallSanitizingChatMemory implements ChatMemory {
+
+	private final ChatMemory delegate;
+
+	/**
+	 * Wrap the given delegate {@link ChatMemory} with tool-round-trip sanitization.
+	 * @param delegate the underlying memory to sanitize writes/reads for; must not be
+	 * {@code null}
+	 */
+	public ToolCallSanitizingChatMemory(ChatMemory delegate) {
+		Assert.notNull(delegate, "delegate ChatMemory cannot be null");
+		this.delegate = delegate;
+	}
+
+	/**
+	 * Returns the wrapped delegate memory. Useful for tests and for unwrapping in
+	 * diagnostics.
+	 * @return the underlying {@link ChatMemory} that this decorator sanitizes
+	 */
+	public ChatMemory getDelegate() {
+		return this.delegate;
+	}
+
+	@Override
+	public void add(String conversationId, List<Message> messages) {
+		List<Message> sanitized = sanitize(messages);
+		if (sanitized.isEmpty()) {
+			return;
+		}
+		this.delegate.add(conversationId, sanitized);
+	}
+
+	@Override
+	public void add(String conversationId, Message message) {
+		// Override the default delegation in ChatMemory: a single empty-after-sanitize
+		// message would otherwise turn into delegate.add(conversationId, []), which
+		// some implementations (and strict repositories) reject. Drop it silently
+		// here.
+		List<Message> sanitized = sanitize(List.of(message));
+		if (sanitized.isEmpty()) {
+			return;
+		}
+		this.delegate.add(conversationId, sanitized);
+	}
+
+	@Override
+	public List<Message> get(String conversationId) {
+		return sanitize(this.delegate.get(conversationId));
+	}
+
+	@Override
+	public void clear(String conversationId) {
+		this.delegate.clear(conversationId);
+	}
+
+	/**
+	 * Apply sanitization rules to a list of messages. Visible for testing and reuse.
+	 * <ul>
+	 * <li>Drop every {@link ToolResponseMessage}.</li>
+	 * <li>For any {@link AssistantMessage} with {@code toolCalls}, keep the text only; if
+	 * no text remains, drop the message.</li>
+	 * <li>All other messages pass through unchanged.</li>
+	 * </ul>
+	 * @param input the messages to sanitize (may be {@code null} or empty)
+	 * @return a new list of sanitized messages; never {@code null}
+	 */
+	static List<Message> sanitize(List<Message> input) {
+		if (input == null || input.isEmpty()) {
+			return List.of();
+		}
+		List<Message> out = new ArrayList<>(input.size());
+		for (Message m : input) {
+			if (m instanceof ToolResponseMessage) {
+				continue;
+			}
+			if (m instanceof AssistantMessage am && am.hasToolCalls()) {
+				String text = am.getText();
+				if (text == null || text.isEmpty()) {
+					// Pure tool-call intermediate frame, no replayable text.
+					continue;
+				}
+				out.add(AssistantMessage.builder()
+					.content(text)
+					.properties(am.getMetadata())
+					.media(am.getMedia())
+					.build());
+				continue;
+			}
+			out.add(m);
+		}
+		return out;
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemoryTests.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ToolCallSanitizingChatMemory}. Covers the issue #6340
+ * sanitization contract: strip tool round-trips, keep final assistant text.
+ *
+ * @author redinside-dev
+ */
+class ToolCallSanitizingChatMemoryTests {
+
+	@Test
+	void whenDelegateIsNullThenThrow() {
+		assertThatThrownBy(() -> new ToolCallSanitizingChatMemory(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("delegate ChatMemory cannot be null");
+	}
+
+	@Test
+	void getDelegateReturnsUnderlyingMemory() {
+		ChatMemory delegate = MessageWindowChatMemory.builder().build();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+		assertThat(memory.getDelegate()).isSameAs(delegate);
+	}
+
+	@Test
+	void sanitizeDropsToolResponseMessages() {
+		List<Message> input = List.of(new UserMessage("What time is it?"),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("id", "name", "{}")))
+					.build(),
+				new AssistantMessage("It's 10:34 AM"));
+		List<Message> out = ToolCallSanitizingChatMemory.sanitize(input);
+		assertThat(out).extracting(Message::getMessageType).containsExactly(MessageType.USER, MessageType.ASSISTANT);
+	}
+
+	@Test
+	void sanitizeStripsToolCallsFromAssistantMessageButKeepsText() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id-1", "function", "getDateTime", "{}");
+		AssistantMessage withToolCalls = AssistantMessage.builder()
+			.content("It's 10:34 AM")
+			.toolCalls(List.of(toolCall))
+			.build();
+		List<Message> input = List.of(new UserMessage("What time is it?"), withToolCalls);
+		List<Message> out = ToolCallSanitizingChatMemory.sanitize(input);
+		assertThat(out).hasSize(2);
+		AssistantMessage sanitized = (AssistantMessage) out.get(1);
+		assertThat(sanitized.getText()).isEqualTo("It's 10:34 AM");
+		assertThat(sanitized.hasToolCalls()).isFalse();
+	}
+
+	@Test
+	void sanitizeDropsPureToolCallAssistantMessageWithNoText() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id-1", "function", "getDateTime", "{}");
+		AssistantMessage pureToolCall = AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build();
+		List<Message> input = List.of(new UserMessage("What time is it?"), pureToolCall,
+				new AssistantMessage("It's 10:34 AM"));
+		List<Message> out = ToolCallSanitizingChatMemory.sanitize(input);
+		assertThat(out).hasSize(2);
+		assertThat(out.get(1)).isInstanceOf(AssistantMessage.class);
+		assertThat(((AssistantMessage) out.get(1)).getText()).isEqualTo("It's 10:34 AM");
+	}
+
+	@Test
+	void sanitizePreservesSystemAndUserMessages() {
+		List<Message> input = List.of(new SystemMessage("You are helpful."), new UserMessage("Hi"));
+		List<Message> out = ToolCallSanitizingChatMemory.sanitize(input);
+		assertThat(out).hasSize(2);
+		assertThat(out.get(0)).isInstanceOf(SystemMessage.class);
+		assertThat(out.get(1)).isInstanceOf(UserMessage.class);
+	}
+
+	@Test
+	void sanitizeOnEmptyAndNullReturnsEmpty() {
+		assertThat(ToolCallSanitizingChatMemory.sanitize(List.of())).isEmpty();
+		assertThat(ToolCallSanitizingChatMemory.sanitize(null)).isEmpty();
+	}
+
+	@Test
+	void addWithListSanitizesBeforePersisting() {
+		InMemoryChatMemoryRepository repo = new InMemoryChatMemoryRepository();
+		ChatMemory delegate = MessageWindowChatMemory.builder().chatMemoryRepository(repo).build();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id-1", "function", "getDateTime", "{}");
+		AssistantMessage withToolCalls = AssistantMessage.builder()
+			.content("It's 10:34 AM")
+			.toolCalls(List.of(toolCall))
+			.build();
+		memory.add("c1",
+				List.of(new UserMessage("What time is it?"), ToolResponseMessage.builder()
+					.responses(
+							List.of(new ToolResponseMessage.ToolResponse("id-1", "getDateTime", "2026-06-09T10:34:00")))
+					.build(), withToolCalls));
+
+		List<Message> persisted = memory.get("c1");
+		assertThat(persisted).extracting(Message::getMessageType)
+			.containsExactly(MessageType.USER, MessageType.ASSISTANT);
+		AssistantMessage assistant = (AssistantMessage) persisted.get(1);
+		assertThat(assistant.getText()).isEqualTo("It's 10:34 AM");
+		assertThat(assistant.hasToolCalls()).isFalse();
+	}
+
+	@Test
+	void addWithSingleMessageSanitizesAndDropsEmptyResult() {
+		// Recording repository that fails on saveAll with an empty list, to prove we
+		// never hand one to the delegate.
+		StrictRepository strict = new StrictRepository();
+		ChatMemory delegate = MessageWindowChatMemory.builder().chatMemoryRepository(strict).build();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+
+		// A pure tool-call assistant message has no text after sanitization, so it
+		// must be dropped.
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id-1", "function", "getDateTime", "{}");
+		AssistantMessage pureToolCall = AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build();
+		memory.add("c1", pureToolCall);
+
+		assertThat(strict.saveAllCalls).isEmpty();
+		assertThat(memory.get("c1")).isEmpty();
+	}
+
+	@Test
+	void getDelegatesAndSanitizes() {
+		// Pre-populate the delegate directly with a malformed transcript (mimicking the
+		// pre-fix behaviour where the memory advisor persisted a single AssistantMessage
+		// carrying tool_calls without a following ToolResponseMessage).
+		InMemoryChatMemoryRepository repo = new InMemoryChatMemoryRepository();
+		ChatMemory delegate = MessageWindowChatMemory.builder().chatMemoryRepository(repo).build();
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id-1", "function", "getDateTime", "{}");
+		AssistantMessage malformed = AssistantMessage.builder()
+			.content("It's 10:34 AM")
+			.toolCalls(List.of(toolCall))
+			.build();
+		delegate.add("c1", List.of(new UserMessage("What time is it?"), malformed));
+
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+		List<Message> out = memory.get("c1");
+		assertThat(out).extracting(Message::getMessageType).containsExactly(MessageType.USER, MessageType.ASSISTANT);
+		AssistantMessage assistant = (AssistantMessage) out.get(1);
+		assertThat(assistant.getText()).isEqualTo("It's 10:34 AM");
+		assertThat(assistant.hasToolCalls()).isFalse();
+	}
+
+	@Test
+	void clearDelegates() {
+		InMemoryChatMemoryRepository repo = new InMemoryChatMemoryRepository();
+		ChatMemory delegate = MessageWindowChatMemory.builder().chatMemoryRepository(repo).build();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+		memory.add("c1", new UserMessage("hi"));
+		memory.clear("c1");
+		assertThat(memory.get("c1")).isEmpty();
+	}
+
+	@Test
+	void sanitizePreservesAssistantMessageMetadataAndMedia() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id-1", "function", "getDateTime", "{}");
+		AssistantMessage withToolCalls = AssistantMessage.builder()
+			.content("It's 10:34 AM")
+			.toolCalls(List.of(toolCall))
+			.properties(Map.of("reasoningContent", "the user asked for the time"))
+			.build();
+		List<Message> out = ToolCallSanitizingChatMemory.sanitize(List.of(withToolCalls));
+		assertThat(out).hasSize(1);
+		AssistantMessage sanitized = (AssistantMessage) out.get(0);
+		assertThat(sanitized.getMetadata()).containsEntry("reasoningContent", "the user asked for the time");
+		assertThat(sanitized.getText()).isEqualTo("It's 10:34 AM");
+		assertThat(sanitized.hasToolCalls()).isFalse();
+	}
+
+	/**
+	 * ChatMemoryRepository wrapper that records every saveAll call and fails on
+	 * {@code saveAll(conversationId, [])} — used to prove that
+	 * {@link ToolCallSanitizingChatMemory#add(String, Message)} never hands an empty list
+	 * to the delegate.
+	 */
+	private static final class StrictRepository implements ChatMemoryRepository {
+
+		final List<List<Message>> saveAllCalls = new java.util.ArrayList<>();
+
+		@Override
+		public List<String> findConversationIds() {
+			return List.of();
+		}
+
+		@Override
+		public List<Message> findByConversationId(String conversationId) {
+			return List.of();
+		}
+
+		@Override
+		public void saveAll(String conversationId, List<Message> messages) {
+			if (messages == null || messages.isEmpty()) {
+				throw new IllegalArgumentException("saveAll must not be called with empty list");
+			}
+			this.saveAllCalls.add(messages);
+		}
+
+		@Override
+		public void deleteByConversationId(String conversationId) {
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

The streaming advisor chain (`ChatClient.stream()` + `ToolCallAdvisor` with `streamToolCallResponses(true)` + `MessageChatMemoryAdvisor`) can persist `AssistantMessage` entries that carry both text **and** `tool_calls` — a collapsed streaming boundary. OpenAI-compatible backends (OpenAI, DeepSeek, etc.) reject these on the next turn with:

```
HTTP 400 — An assistant message with tool_calls must be followed by tool messages
```

See spring-projects/spring-ai#6340.

## Fix

Add `ToolCallSanitizingChatMemory` (in `spring-ai-model`), a `ChatMemory` decorator that sanitizes tool-call round-trips out of persisted history:

1. Every `ToolResponseMessage` is dropped.
2. Any `AssistantMessage` that originally had `tool_calls` is dropped entirely — even when it also has text. The text accumulated alongside `tool_calls` is the model pre-tool-call commentary (e.g. "I will get the time") that the user never actually sees in a streaming turn.

### Usage

```java
ChatMemory memory = new ToolCallSanitizingChatMemory(
    MessageWindowChatMemory.builder()
        .chatMemoryRepository(new InMemoryChatMemoryRepository())
        .build());
```

### Why not fix the aggregator?

Shape B (decorator) is the reporter-suggested approach. Shape A (round-boundary-aware aggregator) risks in-round regression. The decorator is opt-in, safe, and generalizes beyond streaming.

## Testing

- 9 new unit tests covering all sanitization scenarios
- All 35 chat-memory tests pass

Closes #6340