### PR TITLE
Always auto-register `ToolCallingAdvisor` to support runtime-injected tools

### DIFF
--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicToolCallingAdvisorAutoRegistrationIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicToolCallingAdvisorAutoRegistrationIT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.chat;
+
+import com.anthropic.models.messages.Model;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.anthropic.AnthropicTestConfiguration;
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.test.chat.client.advisor.AbstractToolCallingAdvisorAutoRegistrationIT;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Integration test for auto-registration of {@link ToolCallingAdvisor} with Anthropic
+ * chat model.
+ *
+ * @author Christian Tzolov
+ */
+@SpringBootTest(classes = AnthropicTestConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+@ActiveProfiles("logging-test")
+class AnthropicToolCallingAdvisorAutoRegistrationIT extends AbstractToolCallingAdvisorAutoRegistrationIT {
+
+	@Override
+	protected ChatModel getChatModel() {
+		return AnthropicChatModel.builder()
+			.options(AnthropicChatOptions.builder()
+				.apiKey(System.getenv("ANTHROPIC_API_KEY"))
+				.model(Model.CLAUDE_SONNET_4_6.asString())
+				.build())
+			.build();
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+	}
+
+}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/client/GoogleGenAiToolCallingAdvisorAutoRegistrationIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/client/GoogleGenAiToolCallingAdvisorAutoRegistrationIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.client;
+
+import com.google.genai.Client;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.test.chat.client.advisor.AbstractToolCallingAdvisorAutoRegistrationIT;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Integration test for auto-registration of {@link ToolCallingAdvisor} with Google GenAI
+ * chat model.
+ *
+ * @author Christian Tzolov
+ */
+@SpringBootTest(classes = GoogleGenAiToolCallingAdvisorAutoRegistrationIT.TestConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "GOOGLE_CLOUD_PROJECT", matches = ".+")
+@ActiveProfiles("logging-test")
+class GoogleGenAiToolCallingAdvisorAutoRegistrationIT extends AbstractToolCallingAdvisorAutoRegistrationIT {
+
+	@Override
+	protected ChatModel getChatModel() {
+
+		GoogleGenAiChatModel.ChatModel model = GoogleGenAiChatModel.ChatModel.GEMINI_3_PRO_PREVIEW;
+
+		String projectId = System.getenv("GOOGLE_CLOUD_PROJECT");
+		String location = "global";
+		var genAiClient = Client.builder().project(projectId).location(location).vertexAI(true).build();
+
+		return GoogleGenAiChatModel.builder()
+			.genAiClient(genAiClient)
+			.options(GoogleGenAiChatOptions.builder().model(model).build())
+			.build();
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+	}
+
+}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/AdvisorParams.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/AdvisorParams.java
@@ -38,10 +38,11 @@ public final class AdvisorParams {
 	/**
 	 * Controls whether a
 	 * {@link org.springframework.ai.chat.client.advisor.ToolCallingAdvisor} is
-	 * automatically added to the chain when tools are configured on the
-	 * {@code ChatClient} and no explicit
-	 * {@link org.springframework.ai.chat.client.advisor.api.ToolAdvisor} is already
-	 * present. Auto-registration is enabled by default; pass {@code false} to opt out:
+	 * automatically added to the chain. Auto-registration is enabled by default so that
+	 * tools injected at runtime by another advisor are handled correctly even when no
+	 * static tools are configured. No explicit
+	 * {@link org.springframework.ai.chat.client.advisor.api.ToolAdvisor} must be present.
+	 * Pass {@code false} to opt out:
 	 *
 	 * <pre>{@code
 	 * client.prompt()

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -42,7 +42,6 @@ import org.springframework.ai.chat.client.advisor.StructuredOutputValidationAdvi
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.BaseAdvisorChain;
-import org.springframework.ai.chat.client.advisor.api.BaseChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.api.MemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
@@ -60,7 +59,6 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.converter.StructuredOutputConverter;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.template.TemplateRenderer;
 import org.springframework.ai.template.st.StTemplateRenderer;
@@ -1205,11 +1203,16 @@ public class DefaultChatClient implements ChatClient {
 		}
 
 		/**
-		 * Auto-registers a {@link ToolCallingAdvisor} when tools are configured but no
-		 * {@link ToolAdvisor} is present. Disables the advisor's internal conversation
-		 * history when a {@link BaseChatMemoryAdvisor} with a higher order (i.e.
-		 * downstream in the request direction) is already registered, since that memory
-		 * advisor will handle history for every tool-call iteration.
+		 * Auto-registers a {@link ToolCallingAdvisor} unless auto-registration is
+		 * disabled or a {@link ToolAdvisor} is already present in the chain. The advisor
+		 * is always registered so that tools injected dynamically at runtime (e.g. by
+		 * another advisor) are handled correctly even when no static tools are configured
+		 * on the call.
+		 * <p>
+		 * Disables the advisor's internal conversation history when a
+		 * {@link MemoryAdvisor} with a higher order (i.e. downstream in the request
+		 * direction) is already registered, since that memory advisor will handle history
+		 * for every tool-call iteration.
 		 * <p>
 		 * {@code streamToolCallResponses} must be pre-configured on the
 		 * {@code toolCallingAdvisorBuilder} passed to {@link DefaultChatClient}.
@@ -1219,13 +1222,6 @@ public class DefaultChatClient implements ChatClient {
 			boolean autoRegisterDisabled = Boolean.FALSE
 				.equals(this.advisorParams.get(ChatClientAttributes.TOOL_CALLING_ADVISOR_AUTO_REGISTER.getKey()));
 			if (autoRegisterDisabled) {
-				return;
-			}
-
-			boolean hasTools = !this.toolCallbacks.isEmpty() || !this.toolCallbackProviders.isEmpty()
-					|| hasToolsInChatOptions(this.optionsCustomizer)
-					|| hasToolsInChatOptions(this.chatModel.getOptions());
-			if (!hasTools) {
 				return;
 			}
 
@@ -1242,17 +1238,6 @@ public class DefaultChatClient implements ChatClient {
 			this.advisors.add(this.toolCallingAdvisorBuilder.copy()
 				.conversationHistoryEnabled(!hasDownstreamMemoryAdvisor)
 				.build());
-		}
-
-		private static boolean hasToolsInChatOptions(@Nullable Object options) {
-			ToolCallingChatOptions tco = null;
-			if (options instanceof ToolCallingChatOptions direct) {
-				tco = direct;
-			}
-			else if (options instanceof ToolCallingChatOptions.Builder<?> builder) {
-				tco = (ToolCallingChatOptions) builder.build();
-			}
-			return tco != null && ((tco.getToolCallbacks() != null && !tco.getToolCallbacks().isEmpty()));
 		}
 
 		private void validateSingleToolAdvisor() {

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -51,6 +51,11 @@ import org.springframework.util.Assert;
  * <p>
  * This enables intercepting the tool calling loop by the rest of the advisors next in the
  * chain.
+ * <p>
+ * When the prompt options do not implement
+ * {@link org.springframework.ai.model.tool.ToolCallingChatOptions} (e.g. for models that
+ * don't support tool calling), this advisor passes the request through to the next
+ * advisor without modification.
  *
  * @author Christian Tzolov
  * @since 2.0.0
@@ -121,14 +126,12 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		Assert.notNull(chatClientRequest, "chatClientRequest must not be null");
 
 		ChatOptions options = chatClientRequest.prompt().getOptions();
-		if (!(options instanceof ToolCallingChatOptions)) {
-			throw new IllegalArgumentException(
-					"ToolCall Advisor requires ToolCallingChatOptions to be set in the ChatClientRequest options.");
+		if (!(options instanceof ToolCallingChatOptions toolCallingChatOptions)) {
+			// No tool calling options - skip the tool calling advisor
+			return callAdvisorChain.nextCall(chatClientRequest);
 		}
 
 		chatClientRequest = this.doInitializeLoop(chatClientRequest, callAdvisorChain);
-
-		var optionsCopy = ((ToolCallingChatOptions) options).mutate().build();
 
 		var instructions = chatClientRequest.prompt().getInstructions();
 
@@ -140,7 +143,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 			// Before Call
 			var processedChatClientRequest = ChatClientRequest.builder()
-				.prompt(new Prompt(instructions, optionsCopy))
+				.prompt(new Prompt(instructions, toolCallingChatOptions))
 				.context(chatClientRequest.context())
 				.build();
 
@@ -228,28 +231,26 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		Assert.notNull(streamAdvisorChain, "streamAdvisorChain must not be null");
 		Assert.notNull(chatClientRequest, "chatClientRequest must not be null");
 
-		if (chatClientRequest.prompt().getOptions() == null
-				|| !(chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions)) {
-			throw new IllegalArgumentException(
-					"ToolCall Advisor requires ToolCallingChatOptions to be set in the ChatClientRequest options.");
+		ChatOptions options = chatClientRequest.prompt().getOptions();
+		if (!(options instanceof ToolCallingChatOptions toolCallingChatOptions)) {
+			// No tool calling options - skip the tool calling advisor
+			return streamAdvisorChain.nextStream(chatClientRequest);
 		}
 
 		ChatClientRequest initializedRequest = this.doInitializeLoopStream(chatClientRequest, streamAdvisorChain);
 
-		var optionsCopy = ((ToolCallingChatOptions.Builder<?>) chatClientRequest.prompt().getOptions().mutate())
-			.build();
-
-		return this.internalStream(streamAdvisorChain, initializedRequest, optionsCopy,
+		return this.internalStream(streamAdvisorChain, initializedRequest, toolCallingChatOptions,
 				initializedRequest.prompt().getInstructions());
 	}
 
 	private Flux<ChatClientResponse> internalStream(StreamAdvisorChain streamAdvisorChain,
-			ChatClientRequest originalRequest, ToolCallingChatOptions optionsCopy, List<Message> instructions) {
+			ChatClientRequest originalRequest, ToolCallingChatOptions toolCallingChatOptions,
+			List<Message> instructions) {
 
 		return Flux.deferContextual(contextView -> {
 			// Build request with current instructions
 			var processedRequest = ChatClientRequest.builder()
-				.prompt(new Prompt(instructions, optionsCopy))
+				.prompt(new Prompt(instructions, toolCallingChatOptions))
 				.context(originalRequest.context())
 				.build();
 
@@ -263,7 +264,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
 
 			return streamWithToolCallResponses(responseFlux, finalRequest, streamAdvisorChain, originalRequest,
-					optionsCopy);
+					toolCallingChatOptions);
 		});
 	}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/ToolAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/ToolAdvisor.java
@@ -24,7 +24,7 @@ package org.springframework.ai.chat.client.advisor.api;
  * <p>
  * {@link org.springframework.ai.chat.client.DefaultChatClient} uses this marker to detect
  * whether a tool-call handling advisor is already present in the chain, and to avoid
- * auto-registering a duplicate when tools are configured on the {@code ChatClient}.
+ * auto-registering a duplicate.
  *
  * @author Christian Tzolov
  * @since 2.0.0

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ToolCallingAdvisorAutoRegistrationTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ToolCallingAdvisorAutoRegistrationTests.java
@@ -42,6 +42,7 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
 import org.springframework.ai.model.tool.DefaultToolExecutionResult;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
@@ -207,7 +208,9 @@ class ToolCallingAdvisorAutoRegistrationTests {
 		}
 
 		@Test
-		void doesNotAutoRegisterWhenNoTools() {
+		void singleIterationWhenNoToolsConfigured() {
+			// ToolCallingAdvisor is always registered, but exits after one pass when the
+			// model returns no tool calls.
 			stubSingleCallCycle();
 
 			var counter = new ChainIterationCountingAdvisor();
@@ -215,6 +218,25 @@ class ToolCallingAdvisorAutoRegistrationTests {
 
 			assertThat(counter.getCallCount()).isEqualTo(1);
 			verify(chatModel, times(1)).call(any(Prompt.class));
+		}
+
+		@Test
+		void autoRegistersForDynamicallyInjectedTools() {
+			// Issue #6325: ToolCallingAdvisor must be registered even when no static
+			// tools are configured, so advisors that inject tools at runtime still get
+			// tool-call loop support.
+			stubTwoCallCycle();
+
+			var counter = new ChainIterationCountingAdvisor();
+			ChatClient.create(chatModel)
+				.prompt()
+				.advisors(new DynamicToolInjectingAdvisor(weatherTool), counter)
+				.user("weather?")
+				.call()
+				.content();
+
+			assertThat(counter.getCallCount()).isGreaterThanOrEqualTo(2);
+			verify(chatModel, times(2)).call(any(Prompt.class));
 		}
 
 		@Test
@@ -375,6 +397,24 @@ class ToolCallingAdvisorAutoRegistrationTests {
 			assertThat(counter.getCallCount()).isEqualTo(1);
 		}
 
+		@Test
+		void autoRegistersForDynamicallyInjectedTools() {
+			// Issue #6325: same scenario as the call-path test, but for streaming.
+			stubTwoStreamCallCycle();
+
+			var counter = new ChainIterationCountingAdvisor();
+			ChatClient.create(chatModel)
+				.prompt()
+				.advisors(new DynamicToolInjectingAdvisor(weatherTool), counter)
+				.user("weather?")
+				.stream()
+				.content()
+				.collectList()
+				.block();
+
+			assertThat(counter.getCallCount()).isGreaterThanOrEqualTo(2);
+		}
+
 	}
 
 	// -------------------------------------------------------------------------
@@ -450,6 +490,42 @@ class ToolCallingAdvisorAutoRegistrationTests {
 		@Override
 		public int getOrder() {
 			return ToolCallingAdvisor.DEFAULT_ORDER;
+		}
+
+	}
+
+	/**
+	 * Simulates an advisor that injects tools at runtime (e.g. based on user context),
+	 * without any tools being declared statically on the {@link ChatClient}.
+	 */
+	static class DynamicToolInjectingAdvisor implements BaseAdvisor {
+
+		private final ToolCallback tool;
+
+		DynamicToolInjectingAdvisor(ToolCallback tool) {
+			this.tool = tool;
+		}
+
+		@Override
+		public ChatClientRequest before(ChatClientRequest request, AdvisorChain advisorChain) {
+			if (request.prompt().getOptions() instanceof ToolCallingChatOptions opts) {
+				var newOpts = opts.mutate().toolCallbacks(List.of(this.tool)).build();
+				return ChatClientRequest.builder()
+					.prompt(new Prompt(request.prompt().getInstructions(), newOpts))
+					.context(request.context())
+					.build();
+			}
+			return request;
+		}
+
+		@Override
+		public ChatClientResponse after(ChatClientResponse response, AdvisorChain advisorChain) {
+			return response;
+		}
+
+		@Override
+		public int getOrder() {
+			return ToolCallingAdvisor.DEFAULT_ORDER - 10;
 		}
 
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -229,28 +229,34 @@ public class ToolCallingAdvisorTests {
 	}
 
 	@Test
-	void whenOptionsAreNullThenThrow() {
+	void whenOptionsAreNullThenPassThrough() {
 		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().build();
 
 		Prompt prompt = new Prompt(List.of(new UserMessage("test")));
 		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).build();
+		ChatClientResponse expected = mock(ChatClientResponse.class);
+		when(this.callAdvisorChain.nextCall(request)).thenReturn(expected);
 
-		assertThatThrownBy(() -> advisor.adviseCall(request, this.callAdvisorChain))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("ToolCall Advisor requires ToolCallingChatOptions");
+		ChatClientResponse result = advisor.adviseCall(request, this.callAdvisorChain);
+
+		assertThat(result).isEqualTo(expected);
+		verify(this.callAdvisorChain).nextCall(request);
 	}
 
 	@Test
-	void whenOptionsAreNotToolCallingChatOptionsThenThrow() {
+	void whenOptionsAreNotToolCallingChatOptionsThenPassThrough() {
 		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().build();
 
 		ChatOptions nonToolOptions = mock(ChatOptions.class);
 		Prompt prompt = new Prompt(List.of(new UserMessage("test")), nonToolOptions);
 		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).build();
+		ChatClientResponse expected = mock(ChatClientResponse.class);
+		when(this.callAdvisorChain.nextCall(request)).thenReturn(expected);
 
-		assertThatThrownBy(() -> advisor.adviseCall(request, this.callAdvisorChain))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("ToolCall Advisor requires ToolCallingChatOptions");
+		ChatClientResponse result = advisor.adviseCall(request, this.callAdvisorChain);
+
+		assertThat(result).isEqualTo(expected);
+		verify(this.callAdvisorChain).nextCall(request);
 	}
 
 	@Test
@@ -546,22 +552,19 @@ public class ToolCallingAdvisorTests {
 	}
 
 	@Test
-	void whenStreamOptionsAreNotToolCallingChatOptionsThenThrow() {
+	void whenStreamOptionsAreNotToolCallingChatOptionsThenPassThrough() {
 		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().build();
 
 		ChatOptions nonToolOptions = mock(ChatOptions.class);
 		Prompt prompt = new Prompt(List.of(new UserMessage("test")), nonToolOptions);
 		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).build();
+		ChatClientResponse expected = createMockResponse(false);
+		when(this.streamAdvisorChain.nextStream(request)).thenReturn(Flux.just(expected));
 
-		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor(
-				(req, chain) -> Flux.just(createMockResponse(false)));
-		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
-			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
-			.build();
+		ChatClientResponse result = advisor.adviseStream(request, this.streamAdvisorChain).blockFirst();
 
-		assertThatThrownBy(() -> advisor.adviseStream(request, realChain).blockFirst())
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("ToolCall Advisor requires ToolCallingChatOptions");
+		assertThat(result).isEqualTo(expected);
+		verify(this.streamAdvisorChain).nextStream(request);
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors.adoc
@@ -379,7 +379,7 @@ Based on the article: https://arxiv.org/pdf/2309.06275[Re-Reading Improves Reaso
 ===== Tool Calling Advisor
 * `ToolCallingAdvisor`
 +
-Handles the tool calling loop as part of the advisor chain. When tools are registered on a `ChatClient` call, this advisor is automatically added to the chain. It executes tool calls requested by the model and sends the results back, iterating until no more tool calls are needed. Implements `ToolAdvisor`, which is a marker interface that prevents a second `ToolCallingAdvisor` from being auto-registered.
+Handles the tool calling loop as part of the advisor chain. This advisor is always auto-registered by `ChatClient` (unless explicitly disabled), so tools injected at runtime by another advisor are supported even when no static tools are configured. It executes tool calls requested by the model and sends the results back, iterating until no more tool calls are needed. Implements `ToolAdvisor`, which is a marker interface that prevents a second `ToolCallingAdvisor` from being auto-registered.
 +
 For full documentation, see xref:api/advisors-recursive.adoc#_toolcallingadvisor[Recursive Advisors - ToolCallingAdvisor] and xref:api/chatclient.adoc#_tool_calling[ChatClient - Tool Calling].
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -842,15 +842,15 @@ TIP: Be cautious about logging sensitive information in production environments.
 
 === Tool Calling
 
-When tools are registered on a `ChatClient` call (via `.tools(...)` or defaults set on the builder), the `ChatClient` automatically registers a `ToolCallingAdvisor` in the advisor chain to handle the tool execution lifecycle.
-This means you do not need to add a `ToolCallingAdvisor` manually for the common case.
+The `ChatClient` always auto-registers a `ToolCallingAdvisor` in the advisor chain unless auto-registration is explicitly disabled (see below).
+This ensures that tools injected dynamically at runtime by another advisor are handled correctly, even when no static tools are configured on the call.
 
 [source,java]
 ----
 String response = ChatClient.builder(chatModel)
     .build()
     .prompt("What day is tomorrow?")
-    .tools(new DateTimeTools())   // ToolCallingAdvisor is auto-registered here
+    .tools(new DateTimeTools())   // ToolCallingAdvisor is auto-registered
     .call()
     .content();
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1028,7 +1028,7 @@ Spring AI supports three approaches to tool execution lifecycle management. The 
 
 === Framework-Controlled Tool Execution
 
-When using `ChatClient`, Spring AI automatically handles the entire tool calling lifecycle through the `ToolCallingAdvisor`, which is auto-registered in the advisor chain whenever tools are configured. All of this is done transparently — you provide the tools and ask your question; the framework manages the rest.
+When using `ChatClient`, Spring AI automatically handles the entire tool calling lifecycle through the `ToolCallingAdvisor`, which is always auto-registered in the advisor chain (unless explicitly disabled). This means dynamic tools injected at runtime by another advisor are also supported, not just tools declared statically on the call. All of this is done transparently — you provide the tools and ask your question; the framework manages the rest.
 
 image::tools/framework-manager.jpg[Framework-controlled tool execution lifecycle, width=700, align="center"]
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -454,6 +454,30 @@ import org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails
 import org.springframework.ai.google.genai.embedding.GoogleGenAiEmbeddingConnectionDetails;
 ----
 
+[[upgrading-to-2-0-0-RC2]]
+== Upgrading to 2.0.0-RC2
+
+=== Tool Calling
+
+==== Changed: `ToolCallingAdvisor` Always Auto-Registered
+
+`ChatClient` now always auto-registers a `ToolCallingAdvisor` in the advisor chain (unless explicitly disabled), so tool calls requested by the model are handled automatically regardless of whether tools were configured statically or injected by another advisor at runtime.
+
+Previously (as of 2.0.0-M7), auto-registration only happened when tools were explicitly configured on the call. Starting with 2.0.0-RC2, the advisor is registered unconditionally, ensuring that tools injected at runtime by other advisors are also handled correctly.
+
+===== Impact
+
+No action is required in the common case. If you relied on the absence of `ToolCallingAdvisor` when no tools were configured, add an explicit opt-out:
+
+[source,java]
+----
+chatClient.prompt("...")
+    .advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+    .call().content();
+----
+
+Or disable it globally via `spring.ai.chat.client.tool-calling.enabled=false`.
+
 [[upgrading-to-2-0-0-M7]]
 == Upgrading to 2.0.0-M7
 


### PR DESCRIPTION
- ToolCallingAdvisor is now always auto-registered (unless explicitly disabled via AdvisorParams.toolCallingAdvisorAutoRegister(false) or the spring.ai.chat.client.tool-calling.enabled=false property).
- When the prompt options do not implement ToolCallingChatOptions the advisor passes through gracefully instead of throwing IllegalArgumentException.
- Update related tests and docs
- Add auto-registration ITs for google and anthropic models

Closes #6325
