### PR TITLE
Replace deprecated `JsonNode` methods

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-gemfire/src/test/java/org/springframework/ai/vectorstore/gemfire/autoconfigure/GemFireVectorStoreAutoConfigurationAuthenticationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-gemfire/src/test/java/org/springframework/ai/vectorstore/gemfire/autoconfigure/GemFireVectorStoreAutoConfigurationAuthenticationIT.java
@@ -139,7 +139,7 @@ class GemFireVectorStoreAutoConfigurationAuthenticationIT {
 			Map<String, Object> indexDetails = new HashMap<>();
 			if (rootNode.isObject()) {
 				if (rootNode.has("name")) {
-					indexDetails.put("name", rootNode.get("name").asText());
+					indexDetails.put("name", rootNode.get("name").asString());
 				}
 				if (rootNode.has("beam-width")) {
 					indexDetails.put("beam-width", rootNode.get("beam-width").asInt());
@@ -148,7 +148,8 @@ class GemFireVectorStoreAutoConfigurationAuthenticationIT {
 					indexDetails.put("max-connections", rootNode.get("max-connections").asInt());
 				}
 				if (rootNode.has("vector-similarity-function")) {
-					indexDetails.put("vector-similarity-function", rootNode.get("vector-similarity-function").asText());
+					indexDetails.put("vector-similarity-function",
+							rootNode.get("vector-similarity-function").asString());
 				}
 				if (rootNode.has("buckets")) {
 					indexDetails.put("buckets", rootNode.get("buckets").asInt());

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-gemfire/src/test/java/org/springframework/ai/vectorstore/gemfire/autoconfigure/GemFireVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-gemfire/src/test/java/org/springframework/ai/vectorstore/gemfire/autoconfigure/GemFireVectorStoreAutoConfigurationIT.java
@@ -218,7 +218,7 @@ class GemFireVectorStoreAutoConfigurationIT {
 			Map<String, Object> indexDetails = new HashMap<>();
 			if (rootNode.isObject()) {
 				if (rootNode.has("name")) {
-					indexDetails.put("name", rootNode.get("name").asText());
+					indexDetails.put("name", rootNode.get("name").asString());
 				}
 				if (rootNode.has("beam-width")) {
 					indexDetails.put("beam-width", rootNode.get("beam-width").asInt());
@@ -227,7 +227,8 @@ class GemFireVectorStoreAutoConfigurationIT {
 					indexDetails.put("max-connections", rootNode.get("max-connections").asInt());
 				}
 				if (rootNode.has("vector-similarity-function")) {
-					indexDetails.put("vector-similarity-function", rootNode.get("vector-similarity-function").asText());
+					indexDetails.put("vector-similarity-function",
+							rootNode.get("vector-similarity-function").asString());
 				}
 				if (rootNode.has("buckets")) {
 					indexDetails.put("buckets", rootNode.get("buckets").asInt());

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/CallToolRequestSupportTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/CallToolRequestSupportTests.java
@@ -181,7 +181,7 @@ public class CallToolRequestSupportTests {
 
 		// Should have minimal schema with empty properties
 		assertThat(schemaNode.has("type")).isTrue();
-		assertThat(schemaNode.get("type").asText()).isEqualTo("object");
+		assertThat(schemaNode.get("type").asString()).isEqualTo("object");
 		assertThat(schemaNode.has("properties")).isTrue();
 		assertThat(schemaNode.get("properties").size()).isEqualTo(0);
 		assertThat(schemaNode.has("required")).isTrue();
@@ -209,7 +209,7 @@ public class CallToolRequestSupportTests {
 		assertThat(schemaNode.has("required")).isTrue();
 		JsonNode required = schemaNode.get("required");
 		assertThat(required.size()).isEqualTo(1);
-		assertThat(required.get(0).asText()).isEqualTo("requiredParam");
+		assertThat(required.get(0).asString()).isEqualTo("requiredParam");
 	}
 
 	@Test
@@ -411,7 +411,7 @@ public class CallToolRequestSupportTests {
 		assertThat(schemaNode.has("required")).isTrue();
 		JsonNode required = schemaNode.get("required");
 		assertThat(required.size()).isEqualTo(1);
-		assertThat(required.get(0).asText()).isEqualTo("input");
+		assertThat(required.get(0).asString()).isEqualTo("input");
 	}
 
 	@Test
@@ -435,7 +435,7 @@ public class CallToolRequestSupportTests {
 		assertThat(schemaNode.has("required")).isTrue();
 		JsonNode required = schemaNode.get("required");
 		assertThat(required.size()).isEqualTo(1);
-		assertThat(required.get(0).asText()).isEqualTo("regularParam");
+		assertThat(required.get(0).asString()).isEqualTo("regularParam");
 	}
 
 	@Test
@@ -526,7 +526,7 @@ public class CallToolRequestSupportTests {
 		assertThat(schemaNode.has("required")).isTrue();
 		JsonNode required = schemaNode.get("required");
 		assertThat(required.size()).isEqualTo(1);
-		assertThat(required.get(0).asText()).isEqualTo("input");
+		assertThat(required.get(0).asString()).isEqualTo("input");
 	}
 
 	private static class CallToolRequestTestProvider {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
@@ -51,9 +51,9 @@ class McpJsonSchemaGeneratorTests {
 		assertThat(schemaNode.at("/properties/request").has("$defs"))
 			.as("$defs must not remain nested inside the parameter sub-schema")
 			.isFalse();
-		assertThat(schemaNode.at("/properties/request/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/properties/request/properties/filters/items/$ref").asString())
 			.isEqualTo("#/$defs/RecursiveFilter");
-		assertThat(schemaNode.at("/$defs/RecursiveFilter/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/$defs/RecursiveFilter/properties/filters/items/$ref").asString())
 			.isEqualTo("#/$defs/RecursiveFilter");
 	}
 
@@ -71,9 +71,9 @@ class McpJsonSchemaGeneratorTests {
 
 		assertThat(schemaNode.at("/$defs").size()).isEqualTo(1);
 		assertThat(schemaNode.at("/$defs").has("RecursiveFilter")).isTrue();
-		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asString())
 			.isEqualTo("#/$defs/RecursiveFilter");
-		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asString())
 			.isEqualTo("#/$defs/RecursiveFilter");
 	}
 
@@ -95,10 +95,12 @@ class McpJsonSchemaGeneratorTests {
 		assertThat(schemaNode.at("/$defs/Filter_2").has("properties")).isTrue();
 		assertThat(schemaNode.at("/$defs/Filter/properties").has("label")).isTrue();
 		assertThat(schemaNode.at("/$defs/Filter_2/properties").has("code")).isTrue();
-		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asText()).isEqualTo("#/$defs/Filter");
-		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asText()).isEqualTo("#/$defs/Filter_2");
-		assertThat(schemaNode.at("/$defs/Filter/properties/children/items/$ref").asText()).isEqualTo("#/$defs/Filter");
-		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asText())
+		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asString()).isEqualTo("#/$defs/Filter");
+		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asString())
+			.isEqualTo("#/$defs/Filter_2");
+		assertThat(schemaNode.at("/$defs/Filter/properties/children/items/$ref").asString())
+			.isEqualTo("#/$defs/Filter");
+		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asString())
 			.isEqualTo("#/$defs/Filter_2");
 	}
 
@@ -116,10 +118,11 @@ class McpJsonSchemaGeneratorTests {
 		assertThat(schemaNode.at("/$defs/Filter/properties").has("label")).isTrue();
 		assertThat(schemaNode.at("/$defs/Filter_2/properties").has("code")).isTrue();
 		assertThat(schemaNode.at("/$defs/Wrapper").has("properties")).isTrue();
-		assertThat(schemaNode.at("/$defs/Wrapper/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/$defs/Wrapper/properties/filters/items/$ref").asString())
 			.isEqualTo("#/$defs/Filter_2");
-		assertThat(schemaNode.at("/$defs/Wrapper/properties/nested/items/$ref").asText()).isEqualTo("#/$defs/Wrapper");
-		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asText())
+		assertThat(schemaNode.at("/$defs/Wrapper/properties/nested/items/$ref").asString())
+			.isEqualTo("#/$defs/Wrapper");
+		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asString())
 			.isEqualTo("#/$defs/Filter_2");
 	}
 
@@ -135,7 +138,7 @@ class McpJsonSchemaGeneratorTests {
 		String schema = McpJsonSchemaGenerator.generateFromClass(SearchRequest.class);
 		JsonNode schemaNode = jsonHelper.fromJson(schema, JsonNode.class);
 
-		assertThat(schemaNode.get("type").asText()).isEqualTo("object");
+		assertThat(schemaNode.get("type").asString()).isEqualTo("object");
 		assertThat(schemaNode.has("properties")).isTrue();
 	}
 
@@ -144,7 +147,7 @@ class McpJsonSchemaGeneratorTests {
 		String schema = McpJsonSchemaGenerator.generateFromType(SearchRequest.class);
 		JsonNode schemaNode = jsonHelper.fromJson(schema, JsonNode.class);
 
-		assertThat(schemaNode.get("type").asText()).isEqualTo("object");
+		assertThat(schemaNode.get("type").asString()).isEqualTo("object");
 		assertThat(schemaNode.has("properties")).isTrue();
 	}
 

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelIT.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import com.google.genai.Client;
 import io.micrometer.observation.ObservationRegistry;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -60,7 +61,6 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.NonNull;
 import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
 
@@ -131,8 +131,7 @@ class GoogleGenAiChatModelIT {
 		assertThat(response.getResult().getMetadata().getFinishReason()).isEqualTo("SAFETY");
 	}
 
-	@NonNull
-	private Prompt createPrompt(GoogleGenAiChatOptions chatOptions) {
+	private @NonNull Prompt createPrompt(GoogleGenAiChatOptions chatOptions) {
 		String request = "Name 3 famous pirates from the Golden Age of Piracy and tell me what they did.";
 		String name = "Bob";
 		String voice = "pirate";

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/schema/JsonSchemaConverterTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/schema/JsonSchemaConverterTests.java
@@ -36,8 +36,8 @@ class JsonSchemaConverterTests {
 		String json = "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}}}";
 		ObjectNode result = JsonSchemaConverter.fromJson(json);
 
-		assertThat(result.get("type").asText()).isEqualTo("object");
-		assertThat(result.get("properties").get("name").get("type").asText()).isEqualTo("string");
+		assertThat(result.get("type").asString()).isEqualTo("object");
+		assertThat(result.get("properties").get("name").get("type").asString()).isEqualTo("string");
 	}
 
 	@Test
@@ -115,9 +115,9 @@ class JsonSchemaConverterTests {
 				""";
 		ObjectNode result = JsonSchemaConverter.convertToOpenApiSchema(JsonSchemaConverter.fromJson(json));
 		assertThat(result.get("enum")).isNotNull();
-		assertThat(result.get("enum").get(0).asText()).isEqualTo("a");
-		assertThat(result.get("enum").get(1).asText()).isEqualTo("b");
-		assertThat(result.get("enum").get(2).asText()).isEqualTo("c");
+		assertThat(result.get("enum").get(0).asString()).isEqualTo("a");
+		assertThat(result.get("enum").get(1).asString()).isEqualTo("b");
+		assertThat(result.get("enum").get(2).asString()).isEqualTo("c");
 	}
 
 	@Test
@@ -135,7 +135,7 @@ class JsonSchemaConverterTests {
 		assertThat(result.get("nullable").asBoolean()).isTrue();
 		assertThat(result.get("readOnly").asBoolean()).isTrue();
 		assertThat(result.get("writeOnly").asBoolean()).isFalse();
-		assertThat(result.get("description").get("propertyName").asText()).isEqualTo("type");
+		assertThat(result.get("description").get("propertyName").asString()).isEqualTo("type");
 	}
 
 	@Nested
@@ -158,11 +158,12 @@ class JsonSchemaConverterTests {
 
 			ObjectNode result = JsonSchemaConverter.convertToOpenApiSchema(JsonSchemaConverter.fromJson(json));
 
-			assertThat(result.get("openapi").asText()).isEqualTo("3.0.0");
-			assertThat(result.get("type").asText()).isEqualTo("object");
-			assertThat(result.get("properties").get("name").get("type").asText()).isEqualTo("string");
-			assertThat(result.get("properties").get("name").get("description").asText()).isEqualTo("The name property");
-			assertThat(result.get("required").get(0).asText()).isEqualTo("name");
+			assertThat(result.get("openapi").asString()).isEqualTo("3.0.0");
+			assertThat(result.get("type").asString()).isEqualTo("object");
+			assertThat(result.get("properties").get("name").get("type").asString()).isEqualTo("string");
+			assertThat(result.get("properties").get("name").get("description").asString())
+				.isEqualTo("The name property");
+			assertThat(result.get("required").get(0).asString()).isEqualTo("name");
 		}
 
 		@Test
@@ -183,8 +184,8 @@ class JsonSchemaConverterTests {
 
 			ObjectNode result = JsonSchemaConverter.convertToOpenApiSchema(JsonSchemaConverter.fromJson(json));
 
-			assertThat(result.get("properties").get("tags").get("type").asText()).isEqualTo("array");
-			assertThat(result.get("properties").get("tags").get("items").get("type").asText()).isEqualTo("string");
+			assertThat(result.get("properties").get("tags").get("type").asString()).isEqualTo("array");
+			assertThat(result.get("properties").get("tags").get("items").get("type").asString()).isEqualTo("string");
 		}
 
 		@Test
@@ -202,7 +203,7 @@ class JsonSchemaConverterTests {
 
 			ObjectNode result = JsonSchemaConverter.convertToOpenApiSchema(JsonSchemaConverter.fromJson(json));
 
-			assertThat(result.get("properties").get("nickname").get("type").asText()).isEqualTo("string");
+			assertThat(result.get("properties").get("nickname").get("type").asString()).isEqualTo("string");
 			assertThat(result.get("properties").get("nickname").get("nullable").asBoolean()).isTrue();
 		}
 
@@ -219,7 +220,7 @@ class JsonSchemaConverterTests {
 
 			ObjectNode result = JsonSchemaConverter.convertToOpenApiSchema(JsonSchemaConverter.fromJson(json));
 
-			assertThat(result.get("additionalProperties").get("type").asText()).isEqualTo("string");
+			assertThat(result.get("additionalProperties").get("type").asString()).isEqualTo("string");
 		}
 
 		@Test
@@ -258,13 +259,13 @@ class JsonSchemaConverterTests {
 
 			ObjectNode result = JsonSchemaConverter.convertToOpenApiSchema(JsonSchemaConverter.fromJson(json));
 
-			assertThat(result.get("type").asText()).isEqualTo("string");
-			assertThat(result.get("format").asText()).isEqualTo("email");
-			assertThat(result.get("description").asText()).isEqualTo("Email address");
+			assertThat(result.get("type").asString()).isEqualTo("string");
+			assertThat(result.get("format").asString()).isEqualTo("email");
+			assertThat(result.get("description").asString()).isEqualTo("Email address");
 			assertThat(result.get("minLength").asInt()).isEqualTo(5);
 			assertThat(result.get("maxLength").asInt()).isEqualTo(100);
-			assertThat(result.get("pattern").asText()).isEqualTo("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
-			assertThat(result.get("example").asText()).isEqualTo("user@example.com");
+			assertThat(result.get("pattern").asString()).isEqualTo("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+			assertThat(result.get("example").asString()).isEqualTo("user@example.com");
 			assertThat(result.get("deprecated").asBoolean()).isFalse();
 		}
 
@@ -299,7 +300,7 @@ class JsonSchemaConverterTests {
 				.get("properties")
 				.get("street")
 				.get("type")
-				.asText()).isEqualTo("string");
+				.asString()).isEqualTo("string");
 			assertThat(result.get("properties")
 				.get("user")
 				.get("properties")
@@ -307,7 +308,7 @@ class JsonSchemaConverterTests {
 				.get("properties")
 				.get("city")
 				.get("type")
-				.asText()).isEqualTo("string");
+				.asString()).isEqualTo("string");
 		}
 
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -320,8 +320,8 @@ public final class JsonSchemaGenerator {
 						}
 					});
 				}
-				else if (value.isTextual() && entry.getKey().equals("type")) {
-					String oldValue = node.get("type").asText();
+				else if (value.isString() && entry.getKey().equals("type")) {
+					String oldValue = node.get("type").asString();
 					node.put("type", oldValue.toUpperCase());
 				}
 			});

--- a/spring-ai-model/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
@@ -177,7 +177,7 @@ class BeanOutputConverterTest {
 		}
 
 		@Test
-		void verifySchemaPropertyOrder() throws Exception {
+		void verifySchemaPropertyOrder() {
 			var converter = new BeanOutputConverter<>(TestClassWithJsonPropertyOrder.class);
 			String jsonSchema = converter.getJsonSchema();
 
@@ -462,7 +462,7 @@ class BeanOutputConverterTest {
 		// @checkstyle:on RegexpSinglelineJavaCheck
 
 		@Test
-		void formatClassTypeWithToolParamAnnotations() throws Exception {
+		void formatClassTypeWithToolParamAnnotations() {
 			var converter = new BeanOutputConverter<>(TestClassWithToolParam.class);
 			String schema = converter.getJsonSchema();
 			JsonNode schemaNode = JsonMapper.shared().readTree(schema);
@@ -470,14 +470,14 @@ class BeanOutputConverterTest {
 			assertThat(schemaNode.get("required").toString()).contains("requiredField");
 			assertThat(schemaNode.get("required").toString()).doesNotContain("optionalField");
 
-			assertThat(schemaNode.get("properties").get("requiredField").get("description").asText())
+			assertThat(schemaNode.get("properties").get("requiredField").get("description").asString())
 				.isEqualTo("A required field");
-			assertThat(schemaNode.get("properties").get("optionalField").get("description").asText())
+			assertThat(schemaNode.get("properties").get("optionalField").get("description").asString())
 				.isEqualTo("An optional field");
 		}
 
 		@Test
-		void formatClassTypeWithNullableAnnotation() throws Exception {
+		void formatClassTypeWithNullableAnnotation() {
 			var converter = new BeanOutputConverter<>(TestClassWithNullable.class);
 			String schema = converter.getJsonSchema();
 			JsonNode schemaNode = JsonMapper.shared().readTree(schema);

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/augment/AugmentedToolCallbackTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/augment/AugmentedToolCallbackTest.java
@@ -220,15 +220,15 @@ class AugmentedToolCallbackTest {
 			assertTrue(schemaNode.get("properties").has("age"));
 
 			// Check descriptions
-			assertEquals("Test name field", schemaNode.get("properties").get("name").get("description").asText());
-			assertEquals("Test age field", schemaNode.get("properties").get("age").get("description").asText());
+			assertEquals("Test name field", schemaNode.get("properties").get("name").get("description").asString());
+			assertEquals("Test age field", schemaNode.get("properties").get("age").get("description").asString());
 
 			// Check required fields
 			JsonNode requiredArray = schemaNode.get("required");
 			boolean foundOriginal = false;
 			boolean foundName = false;
 			for (JsonNode requiredField : requiredArray) {
-				String fieldName = requiredField.asText();
+				String fieldName = requiredField.asString();
 				if ("originalField".equals(fieldName)) {
 					foundOriginal = true;
 				}

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/augment/ToolInputSchemaAugmenterTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/augment/ToolInputSchemaAugmenterTest.java
@@ -224,7 +224,7 @@ class ToolInputSchemaAugmenterTest {
 
 		@Test
 		@DisplayName("Should augment schema with single property")
-		void shouldAugmentSchemaWithSingleProperty() throws Exception {
+		void shouldAugmentSchemaWithSingleProperty() {
 			String augmentedSchema = ToolInputSchemaAugmenter.augmentToolInputSchema(this.baseSchema, "newField",
 					String.class, "A new field", true);
 
@@ -233,14 +233,14 @@ class ToolInputSchemaAugmenterTest {
 			// Check that new property was added
 			assertTrue(schemaNode.get("properties").has("newField"));
 			JsonNode newFieldNode = schemaNode.get("properties").get("newField");
-			assertEquals("A new field", newFieldNode.get("description").asText());
+			assertEquals("A new field", newFieldNode.get("description").asString());
 
 			// Check that required array was updated
 			JsonNode requiredArray = schemaNode.get("required");
 			assertTrue(requiredArray.isArray());
 			boolean foundNewField = false;
 			for (JsonNode requiredField : requiredArray) {
-				if ("newField".equals(requiredField.asText())) {
+				if ("newField".equals(requiredField.asString())) {
 					foundNewField = true;
 					break;
 				}
@@ -253,7 +253,7 @@ class ToolInputSchemaAugmenterTest {
 
 		@Test
 		@DisplayName("Should augment schema with multiple properties")
-		void shouldAugmentSchemaWithMultipleProperties() throws Exception {
+		void shouldAugmentSchemaWithMultipleProperties() {
 			List<AugmentedArgumentType> argumentTypes = List.of(
 					new AugmentedArgumentType("field1", String.class, "First field", true),
 					new AugmentedArgumentType("field2", Integer.class, "Second field", false));
@@ -267,18 +267,18 @@ class ToolInputSchemaAugmenterTest {
 			assertTrue(schemaNode.get("properties").has("field2"));
 
 			// Check descriptions
-			assertEquals("First field", schemaNode.get("properties").get("field1").get("description").asText());
-			assertEquals("Second field", schemaNode.get("properties").get("field2").get("description").asText());
+			assertEquals("First field", schemaNode.get("properties").get("field1").get("description").asString());
+			assertEquals("Second field", schemaNode.get("properties").get("field2").get("description").asString());
 
 			// Check required array - should contain field1 but not field2
 			JsonNode requiredArray = schemaNode.get("required");
 			boolean foundField1 = false;
 			boolean foundField2 = false;
 			for (JsonNode requiredField : requiredArray) {
-				if ("field1".equals(requiredField.asText())) {
+				if ("field1".equals(requiredField.asString())) {
 					foundField1 = true;
 				}
-				else if ("field2".equals(requiredField.asText())) {
+				else if ("field2".equals(requiredField.asString())) {
 					foundField2 = true;
 				}
 			}
@@ -288,7 +288,7 @@ class ToolInputSchemaAugmenterTest {
 
 		@Test
 		@DisplayName("Should handle schema without existing properties")
-		void shouldHandleSchemaWithoutExistingProperties() throws Exception {
+		void shouldHandleSchemaWithoutExistingProperties() {
 			String minimalSchema = """
 					{
 						"$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -310,12 +310,12 @@ class ToolInputSchemaAugmenterTest {
 			assertTrue(schemaNode.has("required"));
 			JsonNode requiredArray = schemaNode.get("required");
 			assertEquals(1, requiredArray.size());
-			assertEquals("newField", requiredArray.get(0).asText());
+			assertEquals("newField", requiredArray.get(0).asString());
 		}
 
 		@Test
 		@DisplayName("Should handle schema without existing required array")
-		void shouldHandleSchemaWithoutExistingRequiredArray() throws Exception {
+		void shouldHandleSchemaWithoutExistingRequiredArray() {
 			String schemaWithoutRequired = """
 					{
 						"$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -338,12 +338,12 @@ class ToolInputSchemaAugmenterTest {
 			assertTrue(schemaNode.has("required"));
 			JsonNode requiredArray = schemaNode.get("required");
 			assertEquals(1, requiredArray.size());
-			assertEquals("newField", requiredArray.get(0).asText());
+			assertEquals("newField", requiredArray.get(0).asString());
 		}
 
 		@Test
 		@DisplayName("Should handle empty description")
-		void shouldHandleEmptyDescription() throws Exception {
+		void shouldHandleEmptyDescription() {
 			String augmentedSchema = ToolInputSchemaAugmenter.augmentToolInputSchema(this.baseSchema, "newField",
 					String.class, "", false);
 
@@ -356,7 +356,7 @@ class ToolInputSchemaAugmenterTest {
 
 		@Test
 		@DisplayName("Should handle null description")
-		void shouldHandleNullDescription() throws Exception {
+		void shouldHandleNullDescription() {
 			String augmentedSchema = ToolInputSchemaAugmenter.augmentToolInputSchema(this.baseSchema, "newField",
 					String.class, null, false);
 
@@ -378,7 +378,7 @@ class ToolInputSchemaAugmenterTest {
 
 		@Test
 		@DisplayName("Should augment schema using record class")
-		void shouldAugmentSchemaUsingRecordClass() throws Exception {
+		void shouldAugmentSchemaUsingRecordClass() {
 			List<AugmentedArgumentType> argumentTypes = ToolInputSchemaAugmenter
 				.toAugmentedArgumentTypes(SimpleRecord.class);
 			String augmentedSchema = ToolInputSchemaAugmenter.augmentToolInputSchema(this.baseSchema, argumentTypes);
@@ -390,18 +390,20 @@ class ToolInputSchemaAugmenterTest {
 			assertTrue(schemaNode.get("properties").has("age"));
 
 			// Check descriptions from annotations
-			assertEquals("A simple string field", schemaNode.get("properties").get("name").get("description").asText());
-			assertEquals("A simple integer field", schemaNode.get("properties").get("age").get("description").asText());
+			assertEquals("A simple string field",
+					schemaNode.get("properties").get("name").get("description").asString());
+			assertEquals("A simple integer field",
+					schemaNode.get("properties").get("age").get("description").asString());
 
 			// Check required array - should contain name but not age
 			JsonNode requiredArray = schemaNode.get("required");
 			boolean foundName = false;
 			boolean foundAge = false;
 			for (JsonNode requiredField : requiredArray) {
-				if ("name".equals(requiredField.asText())) {
+				if ("name".equals(requiredField.asString())) {
 					foundName = true;
 				}
-				else if ("age".equals(requiredField.asText())) {
+				else if ("age".equals(requiredField.asString())) {
 					foundAge = true;
 				}
 			}
@@ -417,7 +419,7 @@ class ToolInputSchemaAugmenterTest {
 
 		@Test
 		@DisplayName("Should handle complete workflow from record to augmented schema")
-		void shouldHandleCompleteWorkflow() throws Exception {
+		void shouldHandleCompleteWorkflow() {
 			// Start with a basic schema
 			String originalSchema = """
 					{
@@ -454,7 +456,7 @@ class ToolInputSchemaAugmenterTest {
 			boolean foundProductId = false;
 			boolean foundName = false;
 			for (JsonNode requiredField : requiredArray) {
-				String fieldName = requiredField.asText();
+				String fieldName = requiredField.asString();
 				if ("productId".equals(fieldName)) {
 					foundProductId = true;
 				}
@@ -468,7 +470,7 @@ class ToolInputSchemaAugmenterTest {
 
 		@Test
 		@DisplayName("Should preserve schema structure and metadata")
-		void shouldPreserveSchemaStructureAndMetadata() throws Exception {
+		void shouldPreserveSchemaStructureAndMetadata() {
 			String complexSchema = """
 					{
 						"$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -494,11 +496,11 @@ class ToolInputSchemaAugmenterTest {
 			JsonNode schemaNode = JsonMapper.shared().readTree(augmentedSchema);
 
 			// Check that metadata is preserved
-			assertEquals("https://json-schema.org/draft/2020-12/schema", schemaNode.get("$schema").asText());
-			assertEquals("https://example.com/product.schema.json", schemaNode.get("$id").asText());
-			assertEquals("Product Schema", schemaNode.get("title").asText());
-			assertEquals("A product from catalog", schemaNode.get("description").asText());
-			assertEquals("object", schemaNode.get("type").asText());
+			assertEquals("https://json-schema.org/draft/2020-12/schema", schemaNode.get("$schema").asString());
+			assertEquals("https://example.com/product.schema.json", schemaNode.get("$id").asString());
+			assertEquals("Product Schema", schemaNode.get("title").asString());
+			assertEquals("A product from catalog", schemaNode.get("description").asString());
+			assertEquals("object", schemaNode.get("type").asString());
 			assertFalse(schemaNode.get("additionalProperties").asBoolean());
 
 			// Check that original property constraints are preserved

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 
@@ -44,7 +45,6 @@ import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.util.JacksonUtils;
 import org.springframework.ai.util.JsonHelper;
 import org.springframework.ai.util.json.schema.JsonSchemaGenerator;
-import org.springframework.lang.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -771,9 +771,9 @@ class JsonSchemaGeneratorTests {
 		assertThat(schemaNode.at("/properties/request").has("$defs"))
 			.as("$defs must not remain nested inside the parameter sub-schema")
 			.isFalse();
-		assertThat(schemaNode.at("/properties/request/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/properties/request/properties/filters/items/$ref").asString())
 			.isEqualTo("#/$defs/RecursiveFilter");
-		assertThat(schemaNode.at("/$defs/RecursiveFilter/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/$defs/RecursiveFilter/properties/filters/items/$ref").asString())
 			.isEqualTo("#/$defs/RecursiveFilter");
 	}
 
@@ -791,9 +791,9 @@ class JsonSchemaGeneratorTests {
 
 		assertThat(schemaNode.at("/$defs").size()).isEqualTo(1);
 		assertThat(schemaNode.at("/$defs").has("RecursiveFilter")).isTrue();
-		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asString())
 			.isEqualTo("#/$defs/RecursiveFilter");
-		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asString())
 			.isEqualTo("#/$defs/RecursiveFilter");
 	}
 
@@ -819,12 +819,13 @@ class JsonSchemaGeneratorTests {
 		assertThat(schemaNode.at("/$defs/Filter_2/properties").has("code"))
 			.as("second colliding entry retains OuterB.Filter shape (code field)")
 			.isTrue();
-		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asText()).isEqualTo("#/$defs/Filter");
-		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asString()).isEqualTo("#/$defs/Filter");
+		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asString())
 			.as("second parameter's $ref must be rewritten to the renamed entry")
 			.isEqualTo("#/$defs/Filter_2");
-		assertThat(schemaNode.at("/$defs/Filter/properties/children/items/$ref").asText()).isEqualTo("#/$defs/Filter");
-		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asText())
+		assertThat(schemaNode.at("/$defs/Filter/properties/children/items/$ref").asString())
+			.isEqualTo("#/$defs/Filter");
+		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asString())
 			.as("self-reference inside the renamed entry must follow the rename")
 			.isEqualTo("#/$defs/Filter_2");
 	}
@@ -847,13 +848,13 @@ class JsonSchemaGeneratorTests {
 			.as("colliding definition is renamed with PeerB shape")
 			.isTrue();
 		assertThat(schemaNode.at("/$defs/Wrapper").has("properties")).isTrue();
-		assertThat(schemaNode.at("/$defs/Wrapper/properties/filters/items/$ref").asText())
+		assertThat(schemaNode.at("/$defs/Wrapper/properties/filters/items/$ref").asString())
 			.as("peer Wrapper's $ref to the colliding name must be rewritten to the renamed entry")
 			.isEqualTo("#/$defs/Filter_2");
-		assertThat(schemaNode.at("/$defs/Wrapper/properties/nested/items/$ref").asText())
+		assertThat(schemaNode.at("/$defs/Wrapper/properties/nested/items/$ref").asString())
 			.as("peer Wrapper's self-reference must be left alone")
 			.isEqualTo("#/$defs/Wrapper");
-		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asText())
+		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asString())
 			.as("renamed entry's self-reference must follow the rename")
 			.isEqualTo("#/$defs/Filter_2");
 	}
@@ -1073,7 +1074,7 @@ class JsonSchemaGeneratorTests {
 
 	}
 
-	record JSpecifyNullablePerson(int id, String name, @org.jspecify.annotations.Nullable String email) {
+	record JSpecifyNullablePerson(int id, String name, @Nullable String email) {
 
 	}
 

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreWithChatMemoryAdvisorIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreWithChatMemoryAdvisorIT.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -45,7 +46,6 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.lang.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
# Summary
- Replace JsonNode.asText() with asString() and isTextual() with isString().