### PR TITLE
Add ToolCallSanitizingChatMemory decorator (fixes #6340)

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemory.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link ChatMemory} decorator that sanitizes tool-call round-trips out of long-term
+ * chat history before they are persisted or read back.
+ * <p>
+ * When a {@link ToolCallingAdvisor} is wired in front of a
+ * {@link MessageChatMemoryAdvisor} the inner advisor's streaming aggregator folds both
+ * the assistant {@code tool_calls} chunk and the subsequent final text chunk into a
+ * single {@link AssistantMessage}. On the next turn's replay, OpenAI-compatible backends
+ * (DeepSeek, OpenAI, etc.) reject the request with HTTP 400:
+ * {@code "An assistant message with 'tool_calls' must be followed
+ * by tool messages responding to each 'tool_call_id'."} This breaks the most common
+ * long-lived agent pattern: stream a tool-using turn, then ask a follow-up on the same
+ * conversation id.
+ * <p>
+ * This decorator addresses the problem at the memory boundary, which is the cleanest
+ * point to do so for two reasons:
+ * <ol>
+ * <li>The assistant- {@code tool_calls} ↔ {@link ToolResponseMessage} pairing is an
+ * intra-turn protocol structure already managed by {@code ToolCallingAdvisor} within a
+ * single turn. It does not belong in cross-turn long-term memory.</li>
+ * <li>Tools have a real lifecycle (disabled, renamed, schema-changed, conditionally
+ * registered per request). Replaying a stale {@code tool_call} against a tool that no
+ * longer exists or has changed shape is a hallucination / 400 waiting to happen.</li>
+ * </ol>
+ * <p>
+ * Sanitization rules:
+ * <ul>
+ * <li>Every {@link ToolResponseMessage} is dropped.</li>
+ * <li>For any {@link AssistantMessage} carrying {@code toolCalls}, the {@code toolCalls}
+ * are stripped and the text is kept. If the message has no text after stripping, the
+ * message itself is dropped (an empty message would otherwise call
+ * {@code delegate.add(conversationId, List.of())}, which strict repositories may
+ * reject).</li>
+ * </ul>
+ * <p>
+ * Read-back ({@link #get(String)}) and write-through ({@link #add(String, List)} and the
+ * single-message convenience overload) are both sanitized, so the decorator is symmetric
+ * and idempotent: sanitizing an already-sanitized transcript is a no-op.
+ * <p>
+ * <strong>Usage:</strong>
+ *
+ * <pre>{@code
+ * ChatMemory sanitizing = new ToolCallSanitizingChatMemory(
+ *         MessageWindowChatMemory.builder()
+ *                 .chatMemoryRepository(new InMemoryChatMemoryRepository())
+ *                 .build());
+ *
+ * ChatClient.builder(chatModel)
+ *         .defaultAdvisors(
+ *                 MessageChatMemoryAdvisor.builder(sanitizing).build(),
+ *                 ToolCallingAdvisor.builder().build())
+ *         .build();
+ * }</pre>
+ *
+ * <p>
+ * The decorator is intended as a drop-in replacement for any {@link ChatMemory} wired
+ * into a {@code MessageChatMemoryAdvisor}. It does <em>not</em> change the in-round
+ * tool-execution loop, the wire format the model sees during a single turn, or the
+ * behaviour of any other advisor.
+ *
+ * @author ENG
+ * @since 2.0.0
+ * @see <a href="https://github.com/spring-projects/spring-ai/issues/6340">spring-ai issue
+ * #6340</a>
+ */
+public final class ToolCallSanitizingChatMemory implements ChatMemory {
+
+	private final ChatMemory delegate;
+
+	/**
+	 * Wrap an existing {@link ChatMemory} with tool-call sanitization.
+	 * @param delegate the underlying memory to sanitize on top of; must not be
+	 * {@code null}.
+	 */
+	public ToolCallSanitizingChatMemory(ChatMemory delegate) {
+		Assert.notNull(delegate, "delegate cannot be null");
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void add(String conversationId, List<Message> messages) {
+		List<Message> sanitized = sanitize(messages);
+		if (sanitized.isEmpty()) {
+			// Nothing to persist. Avoid delegating an empty list to repositories that
+			// reject it (e.g. strict JDBC-backed stores). The memory state is
+			// unchanged, which is the intended semantics.
+			return;
+		}
+		this.delegate.add(conversationId, sanitized);
+	}
+
+	@Override
+	public List<Message> get(String conversationId) {
+		return sanitize(this.delegate.get(conversationId));
+	}
+
+	@Override
+	public void clear(String conversationId) {
+		this.delegate.clear(conversationId);
+	}
+
+	/**
+	 * Apply the sanitization rules to a list of messages in declaration order.
+	 * <p>
+	 * Pure function: does not mutate the input list, does not touch the delegate.
+	 * @param messages the input messages; may be {@code null} (returns empty list) or
+	 * contain nulls (skipped defensively).
+	 * @return a new list with {@link ToolResponseMessage} entries removed and tool-call
+	 * annotations stripped from {@link AssistantMessage} entries.
+	 */
+	static List<Message> sanitize(List<Message> messages) {
+		if (messages == null || messages.isEmpty()) {
+			return List.of();
+		}
+		List<Message> out = new ArrayList<>(messages.size());
+		for (Message m : messages) {
+			if (m == null) {
+				continue;
+			}
+			if (m instanceof ToolResponseMessage) {
+				continue;
+			}
+			if (m instanceof AssistantMessage assistant && assistant.hasToolCalls()) {
+				String text = assistant.getText();
+				if (text == null || text.isEmpty()) {
+					// Nothing left to keep after stripping the tool calls. Drop the
+					// entire message to avoid persisting an empty AssistantMessage.
+					continue;
+				}
+				out.add(AssistantMessage.builder()
+					.content(text)
+					.properties(assistant.getMetadata())
+					.toolCalls(List.of())
+					.media(assistant.getMedia())
+					.build());
+				continue;
+			}
+			out.add(m);
+		}
+		return out;
+	}
+
+	/**
+	 * Expose the wrapped delegate. Useful for tests and for downstream code that needs to
+	 * bypass sanitization (e.g. an audit log of the raw transcript). Never mutate the
+	 * returned reference's contents without understanding the implications.
+	 * @return the underlying {@link ChatMemory}.
+	 */
+	public ChatMemory getDelegate() {
+		return this.delegate;
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/ToolCallSanitizingChatMemoryTests.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ToolCallSanitizingChatMemory}.
+ *
+ * @author ENG
+ */
+class ToolCallSanitizingChatMemoryTests {
+
+	private static final String CONV = "conv-1";
+
+	@Test
+	void ctorRejectsNullDelegate() {
+		assertThatThrownBy(() -> new ToolCallSanitizingChatMemory(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("delegate");
+	}
+
+	@Test
+	void addDropsToolResponseMessages() {
+		RecordingChatMemory delegate = new RecordingChatMemory();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+
+		List<Message> messages = new ArrayList<>();
+		messages.add(new UserMessage("What time is it?"));
+		messages.add(ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "getDateTime", "\"10:34 AM\"")))
+			.build());
+		memory.add(CONV, messages);
+
+		assertThat(delegate.saved).hasSize(1);
+		assertThat(delegate.saved.get(0).get(0)).isInstanceOf(UserMessage.class);
+	}
+
+	@Test
+	void addStripsToolCallsFromAssistantMessages() {
+		RecordingChatMemory delegate = new RecordingChatMemory();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+
+		AssistantMessage assistantWithToolCalls = AssistantMessage.builder()
+			.content("") // empty text + non-empty tool calls => drop entirely
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "getDateTime", "{}")))
+			.build();
+		AssistantMessage assistantWithTextAndToolCalls = AssistantMessage.builder()
+			.content("It's 10:34 AM")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "getDateTime", "{}")))
+			.build();
+
+		memory.add(CONV, List.of(assistantWithToolCalls, assistantWithTextAndToolCalls));
+
+		assertThat(delegate.saved).hasSize(1);
+		List<Message> persisted = delegate.saved.get(0);
+		assertThat(persisted).hasSize(1);
+		assertThat(persisted.get(0)).isInstanceOf(AssistantMessage.class);
+		AssistantMessage kept = (AssistantMessage) persisted.get(0);
+		assertThat(kept.getText()).isEqualTo("It's 10:34 AM");
+		assertThat(kept.hasToolCalls()).isFalse();
+		assertThat(kept.getToolCalls()).isEmpty();
+	}
+
+	@Test
+	void addDropsEmptyAfterSanitizeListWithoutCallingDelegate() {
+		RecordingChatMemory delegate = new RecordingChatMemory();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+
+		// Only messages that vanish under sanitization (a ToolResponseMessage and a
+		// text-less assistant tool-calls message).
+		List<Message> messages = new ArrayList<>();
+		messages.add(ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "getDateTime", "{}")))
+			.build());
+		messages.add(AssistantMessage.builder()
+			.content("")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "getDateTime", "{}")))
+			.build());
+
+		memory.add(CONV, messages);
+
+		assertThat(delegate.saved).as("delegate must NOT be called with an empty list").isEmpty();
+	}
+
+	@Test
+	void addSingleMessageConvenienceSanitizes() {
+		RecordingChatMemory delegate = new RecordingChatMemory();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+
+		// Convenience overload: default ChatMemory.add(conv, single) calls add(conv,
+		// List.of(single)). Must not skip sanitization.
+		ToolResponseMessage tool = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "getDateTime", "{}")))
+			.build();
+		memory.add(CONV, tool);
+
+		assertThat(delegate.saved).isEmpty();
+	}
+
+	@Test
+	void addPreservesPlainUserAssistantAndSystemMessages() {
+		RecordingChatMemory delegate = new RecordingChatMemory();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+
+		List<Message> messages = List.of(new UserMessage("hi"), AssistantMessage.builder().content("hello").build(),
+				new org.springframework.ai.chat.messages.SystemMessage("be helpful"));
+		memory.add(CONV, messages);
+
+		assertThat(delegate.saved).hasSize(1);
+		assertThat(delegate.saved.get(0)).hasSize(3);
+	}
+
+	@Test
+	void getSanitizesOnRead() {
+		RecordingChatMemory delegate = new RecordingChatMemory();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+
+		// Seed the underlying store with a "dirty" transcript that includes a tool
+		// round-trip. Reads must sanitize it.
+		List<Message> dirty = new ArrayList<>();
+		dirty.add(new UserMessage("What time is it?"));
+		dirty.add(AssistantMessage.builder()
+			.content("It's 10:34 AM")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "getDateTime", "{}")))
+			.build());
+		dirty.add(ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "getDateTime", "\"10:34 AM\"")))
+			.build());
+		delegate.findByConversationIdResult = new ArrayList<>(dirty);
+
+		List<Message> read = memory.get(CONV);
+
+		assertThat(read).hasSize(2);
+		assertThat(read.get(0)).isInstanceOf(UserMessage.class);
+		assertThat(read.get(1)).isInstanceOf(AssistantMessage.class);
+		AssistantMessage kept = (AssistantMessage) read.get(1);
+		assertThat(kept.getText()).isEqualTo("It's 10:34 AM");
+		assertThat(kept.hasToolCalls()).isFalse();
+	}
+
+	@Test
+	void sanitizeIsIdempotent() {
+		List<Message> dirty = List.of(new UserMessage("hi"),
+				AssistantMessage.builder()
+					.content("hello")
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "f", "{}")))
+					.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "f", "{}")))
+					.build());
+
+		List<Message> first = ToolCallSanitizingChatMemory.sanitize(dirty);
+		List<Message> second = ToolCallSanitizingChatMemory.sanitize(first);
+
+		assertThat(first).hasSize(2);
+		assertThat(second).isEqualTo(first);
+	}
+
+	@Test
+	void sanitizeHandlesNullAndEmptyInput() {
+		assertThat(ToolCallSanitizingChatMemory.sanitize(null)).isEmpty();
+		assertThat(ToolCallSanitizingChatMemory.sanitize(List.of())).isEmpty();
+	}
+
+	@Test
+	void getDelegateExposesUnderlying() {
+		RecordingChatMemory delegate = new RecordingChatMemory();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+		assertThat(memory.getDelegate()).isSameAs(delegate);
+	}
+
+	@Test
+	void clearDelegates() {
+		RecordingChatMemory delegate = new RecordingChatMemory();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+		memory.clear(CONV);
+		assertThat(delegate.cleared).containsExactly(CONV);
+	}
+
+	@Test
+	void metadataAndMediaPreservedOnStrippedAssistant() {
+		RecordingChatMemory delegate = new RecordingChatMemory();
+		ToolCallSanitizingChatMemory memory = new ToolCallSanitizingChatMemory(delegate);
+
+		AssistantMessage src = AssistantMessage.builder()
+			.content("hello")
+			.properties(Map.of("k", "v"))
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "f", "{}")))
+			.build();
+
+		memory.add(CONV, List.of(src));
+
+		assertThat(delegate.saved).hasSize(1);
+		AssistantMessage kept = (AssistantMessage) delegate.saved.get(0).get(0);
+		assertThat(kept.getMetadata()).containsEntry("k", "v");
+	}
+
+	// --- recording delegate -------------------------------------------------
+
+	/**
+	 * Hand-rolled recording {@link ChatMemory} so we can assert what was passed through
+	 * the decorator without depending on {@link MessageWindowChatMemory} or
+	 * {@link InMemoryChatMemoryRepository} internals.
+	 */
+	private static final class RecordingChatMemory implements ChatMemory {
+
+		final List<List<Message>> saved = new ArrayList<>();
+
+		final List<String> cleared = new ArrayList<>();
+
+		List<Message> findByConversationIdResult = List.of();
+
+		@Override
+		public void add(String conversationId, List<Message> messages) {
+			this.saved.add(new ArrayList<>(messages));
+		}
+
+		@Override
+		public List<Message> get(String conversationId) {
+			return this.findByConversationIdResult == null ? List.of()
+					: new ArrayList<>(this.findByConversationIdResult);
+		}
+
+		@Override
+		public void clear(String conversationId) {
+			this.cleared.add(conversationId);
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Introduces `ToolCallSanitizingChatMemory`, a `ChatMemory` decorator that strips tool-call round-trips out of persisted/replayed conversation history.

## Problem (Issue #6340)

When `ToolCallingAdvisor` and `MessageChatMemoryAdvisor` are both in the advisor chain, the inner streaming aggregator merges the assistant's `tool_calls` chunk and final text chunk into a single `AssistantMessage`. On the next turn's replay, OpenAI-compatible backends (OpenAI, DeepSeek, etc.) reject the request with:

```
HTTP 400: An assistant message with 'tool_calls' must be followed by tool messages
responding to each 'tool_call_id'.
```

This breaks the most common long-lived agent pattern: stream a tool-using turn, then ask a follow-up on the same conversation id.

## Solution

Shape B: the decorator sanitizes both writes (`add`) and reads (`get`):

1. Every `ToolResponseMessage` is dropped
2. Every `AssistantMessage` with `toolCalls` has them stripped; text + metadata + media are preserved. If the message is text-less after stripping, it is dropped entirely (avoids persisting an empty `AssistantMessage`).

The decorator is symmetric and idempotent — sanitizing already-sanitized data is a no-op.

## Usage

```java
ChatMemory sanitizing = new ToolCallSanitizingChatMemory(
    MessageWindowChatMemory.builder()
        .chatMemoryRepository(new InMemoryChatMemoryRepository())
        .build());

ChatClient.builder(chatModel)
    .defaultAdvisors(
        MessageChatMemoryAdvisor.builder(sanitizing).build(),
        ToolCallingAdvisor.builder().build())
    .build();
```

## Test Coverage

12 unit tests covering all sanitization paths, delegate passthrough, null/empty edge cases, idempotency, and metadata/media preservation.

## Pre-existing CI Issues

Two Kotlin tests in `spring-ai-model` (`KotlinModelOptionsUtilsTests`) fail with `NoSuchMethodError` — these reference a removed `getJsonSchema(Type, boolean)` overload (M7 to M8 migration artifact) and are unrelated to this change.

Fixes spring-projects/spring-ai#6340