### PR TITLE
Strip orphan `tool_calls` from chat memory in streaming tool-call turns

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -18,7 +18,9 @@ package org.springframework.ai.chat.client.advisor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -32,6 +34,7 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.client.advisor.api.BaseChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.util.Assert;
@@ -42,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Mark Pollack
  * @author Thomas Vitale
+ * @author Jewoo Shin
  * @since 1.0.0
  */
 public final class MessageChatMemoryAdvisor implements BaseChatMemoryAdvisor {
@@ -140,11 +144,49 @@ public final class MessageChatMemoryAdvisor implements BaseChatMemoryAdvisor {
 			assistantMessages = chatClientResponse.chatResponse()
 				.getResults()
 				.stream()
-				.map(g -> (Message) g.getOutput())
+				.map(g -> sanitizeForMemory(g.getOutput()))
+				.filter(Objects::nonNull)
 				.toList();
 		}
 		this.chatMemory.add(this.getConversationId(chatClientResponse.context()), assistantMessages);
 		return chatClientResponse;
+	}
+
+	/**
+	 * Strip the tool-call round-trip from an assistant message before it is persisted as
+	 * cross-turn history.
+	 * <p>
+	 * The pairing of {@code AssistantMessage(tool_calls=[...])} with its following
+	 * {@link org.springframework.ai.chat.messages.ToolResponseMessage} is intra-turn
+	 * structure managed by the tool-calling loop, not long-term conversation history.
+	 * When {@code stream()} is combined with
+	 * {@code ToolCallingAdvisor.streamToolCallResponses(true)} the
+	 * {@link org.springframework.ai.chat.model.MessageAggregator} folds the tool-call
+	 * round and the recursive text round into a single
+	 * {@code AssistantMessage(text + tool_calls)}; persisting that orphan (there is no
+	 * following tool response in memory) makes the next turn's replay fail on
+	 * OpenAI-compatible backends with HTTP 400
+	 * ({@code "An assistant message with 'tool_calls' must be followed by tool messages"}).
+	 * Keep the assistant's text and drop the {@code tool_calls}; if the frame was a pure
+	 * intermediate tool call with no text, drop it entirely.
+	 * @param assistantMessage the assistant message about to be persisted
+	 * @return the message to persist, or {@code null} if it should be dropped
+	 * @see <a href=
+	 * "https://github.com/spring-projects/spring-ai/issues/6340">spring-ai#6340</a>
+	 */
+	private static @Nullable Message sanitizeForMemory(AssistantMessage assistantMessage) {
+		if (!assistantMessage.hasToolCalls()) {
+			return assistantMessage;
+		}
+		String text = assistantMessage.getText();
+		if (text == null || text.isEmpty()) {
+			return null;
+		}
+		return AssistantMessage.builder()
+			.content(text)
+			.properties(assistantMessage.getMetadata())
+			.media(assistantMessage.getMedia())
+			.build();
 	}
 
 	@Override

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisorTests.java
@@ -16,34 +16,46 @@
 
 package org.springframework.ai.chat.client.advisor;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link MessageChatMemoryAdvisor}.
  *
  * @author Mark Pollack
  * @author Thomas Vitale
+ * @author Jewoo Shin
  */
 public class MessageChatMemoryAdvisorTests {
 
@@ -282,6 +294,175 @@ public class MessageChatMemoryAdvisorTests {
 		assertThat(processedMessages.get(0)).isInstanceOf(SystemMessage.class);
 		assertThat(processedMessages.get(0).getText()).isEqualTo("You are a helpful assistant");
 		assertThat(processedMessages.get(1)).isInstanceOf(UserMessage.class);
+	}
+
+	// -------------------------------------------------------------------------
+	// after(): tool-call round-trips must not leak into cross-turn memory (gh-6340)
+	// -------------------------------------------------------------------------
+
+	@Test
+	void whenAfterAssistantMessageCarriesTextAndToolCallsThenToolCallsStrippedTextKept() {
+		// Reproduces gh-6340: stream() + ToolCallingAdvisor.streamToolCallResponses(true)
+		// makes the MessageAggregator fold the tool-call round and the recursive text
+		// round into a single AssistantMessage(text + tool_calls). Persisting that orphan
+		// makes the next turn fail with HTTP 400 on OpenAI-compatible backends.
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+		MessageChatMemoryAdvisor advisor = MessageChatMemoryAdvisor.builder(chatMemory).build();
+		AssistantMessage merged = AssistantMessage.builder()
+			.content("It's 10:34 AM.")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "getDateTime", "{}")))
+			.build();
+		ChatClientResponse response = ChatClientResponse.builder()
+			.chatResponse(new ChatResponse(List.of(new Generation(merged))))
+			.context(ChatMemory.CONVERSATION_ID, "test-conversation")
+			.build();
+
+		advisor.after(response, mock(AdvisorChain.class));
+
+		List<Message> messages = chatMemory.get("test-conversation");
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0)).isInstanceOf(AssistantMessage.class);
+		AssistantMessage persisted = (AssistantMessage) messages.get(0);
+		assertThat(persisted.getText()).isEqualTo("It's 10:34 AM.");
+		assertThat(persisted.hasToolCalls()).isFalse();
+	}
+
+	@Test
+	void whenAfterStripsToolCallsThenMetadataAndMediaArePreserved() {
+		// gh-6340: stripping the orphan tool_calls must not drop the rest of the
+		// message. The metadata keys attached by the MessageAggregator (thoughts,
+		// outputWithoutThoughts) and any media must survive; otherwise replayed
+		// history would silently lose reasoning or attachments.
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+		MessageChatMemoryAdvisor advisor = MessageChatMemoryAdvisor.builder(chatMemory).build();
+		Media media = Media.builder()
+			.mimeType(MimeTypeUtils.IMAGE_PNG)
+			.data(URI.create("https://example.com/clock.png"))
+			.build();
+		AssistantMessage merged = AssistantMessage.builder()
+			.content("It's 10:34 AM.")
+			.properties(Map.of("thoughts", "Let me check the clock.", "outputWithoutThoughts", "It's 10:34 AM."))
+			.media(List.of(media))
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "getDateTime", "{}")))
+			.build();
+		ChatClientResponse response = ChatClientResponse.builder()
+			.chatResponse(new ChatResponse(List.of(new Generation(merged))))
+			.context(ChatMemory.CONVERSATION_ID, "test-conversation")
+			.build();
+
+		advisor.after(response, mock(AdvisorChain.class));
+
+		List<Message> messages = chatMemory.get("test-conversation");
+		assertThat(messages).hasSize(1);
+		AssistantMessage persisted = (AssistantMessage) messages.get(0);
+		assertThat(persisted.hasToolCalls()).isFalse();
+		assertThat(persisted.getText()).isEqualTo("It's 10:34 AM.");
+		assertThat(persisted.getMetadata()).containsEntry("thoughts", "Let me check the clock.")
+			.containsEntry("outputWithoutThoughts", "It's 10:34 AM.");
+		assertThat(persisted.getMedia()).containsExactly(media);
+	}
+
+	@Test
+	void whenAfterPureToolCallFrameHasNoTextThenDroppedEvenWithMetadataAndMedia() {
+		// gh-6340: a tool-call frame with no text is an intra-turn artifact and is
+		// dropped even when it still carries metadata or media, because that transient
+		// payload is not cross-turn history (durable output lives on the text round).
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+		MessageChatMemoryAdvisor advisor = MessageChatMemoryAdvisor.builder(chatMemory).build();
+		Media media = Media.builder()
+			.mimeType(MimeTypeUtils.IMAGE_PNG)
+			.data(URI.create("https://example.com/clock.png"))
+			.build();
+		AssistantMessage pureToolCall = AssistantMessage.builder()
+			.content("")
+			.properties(Map.of("thoughts", "Let me check the clock."))
+			.media(List.of(media))
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "getDateTime", "{}")))
+			.build();
+		ChatClientResponse response = ChatClientResponse.builder()
+			.chatResponse(new ChatResponse(List.of(new Generation(pureToolCall))))
+			.context(ChatMemory.CONVERSATION_ID, "test-conversation")
+			.build();
+
+		advisor.after(response, mock(AdvisorChain.class));
+
+		assertThat(chatMemory.get("test-conversation")).isEmpty();
+	}
+
+	@Test
+	void whenAfterAssistantMessageHasNoToolCallsThenStoredUnchanged() {
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+		MessageChatMemoryAdvisor advisor = MessageChatMemoryAdvisor.builder(chatMemory).build();
+		AssistantMessage plain = new AssistantMessage("It's 10:34 AM.");
+		ChatClientResponse response = ChatClientResponse.builder()
+			.chatResponse(new ChatResponse(List.of(new Generation(plain))))
+			.context(ChatMemory.CONVERSATION_ID, "test-conversation")
+			.build();
+
+		advisor.after(response, mock(AdvisorChain.class));
+
+		List<Message> messages = chatMemory.get("test-conversation");
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0)).isInstanceOf(AssistantMessage.class);
+		AssistantMessage persisted = (AssistantMessage) messages.get(0);
+		assertThat(persisted.getText()).isEqualTo("It's 10:34 AM.");
+		assertThat(persisted.hasToolCalls()).isFalse();
+	}
+
+	@Test
+	void whenAdviseStreamFoldsToolCallRoundThenPersistedMemoryIsReplayClean() {
+		// End-to-end reproduction of gh-6340 through the real streaming path
+		// (before -> nextStream -> ChatClientMessageAggregator -> after). The downstream
+		// stream is the two-round shape produced with
+		// ToolCallingAdvisor.streamToolCallResponses(true): a tool-call round
+		// (text + tool_calls) followed by the recursive post-tool text round. The
+		// aggregator folds them into a single AssistantMessage(text + tool_calls); the
+		// advisor must persist it without the orphan tool_calls so the next turn's replay
+		// does not trip an HTTP 400 on OpenAI-compatible backends.
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+		MessageChatMemoryAdvisor advisor = MessageChatMemoryAdvisor.builder(chatMemory)
+			.scheduler(Schedulers.immediate())
+			.build();
+		Prompt prompt = Prompt.builder().messages(new UserMessage("What time is it?")).build();
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.context(ChatMemory.CONVERSATION_ID, "test-conversation")
+			.build();
+
+		AssistantMessage toolCallRound = AssistantMessage.builder()
+			.content("Let me check. ")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "getDateTime", "{}")))
+			.build();
+		AssistantMessage textRound = new AssistantMessage("It's 10:34 AM.");
+		StreamAdvisorChain chain = mock(StreamAdvisorChain.class);
+		when(chain.nextStream(any())).thenReturn(Flux.just(
+				ChatClientResponse.builder()
+					.chatResponse(new ChatResponse(List.of(new Generation(toolCallRound))))
+					.context(ChatMemory.CONVERSATION_ID, "test-conversation")
+					.build(),
+				ChatClientResponse.builder()
+					.chatResponse(new ChatResponse(List.of(new Generation(textRound))))
+					.context(ChatMemory.CONVERSATION_ID, "test-conversation")
+					.build()));
+
+		advisor.adviseStream(request, chain).blockLast();
+
+		List<Message> persisted = chatMemory.get("test-conversation");
+		assertThat(persisted).extracting(Message::getMessageType)
+			.containsExactly(MessageType.USER, MessageType.ASSISTANT);
+		AssistantMessage assistant = (AssistantMessage) persisted.get(1);
+		assertThat(assistant.hasToolCalls()).isFalse();
+		assertThat(assistant.getText()).isEqualTo("Let me check. It's 10:34 AM.");
 	}
 
 }


### PR DESCRIPTION
With `stream()` + `ToolCallingAdvisor.streamToolCallResponses(true)` + `MessageChatMemoryAdvisor`, a streaming tool-call turn can persist an `AssistantMessage` that contains both final text and orphan `tool_calls`. Replaying that memory on the next turn fails on OpenAI-compatible backends with HTTP 400 because assistant `tool_calls` must be followed by tool messages.

This happens because `MessageChatMemoryAdvisor` wraps the tool-calling stream and folds the tool-call response plus the follow-up text response after tool execution through one `ChatClientMessageAggregator`. This change sanitizes assistant messages before persisting them as cross-turn history: text messages keep text, metadata and media while dropping `tool_calls`, and pure tool-call frames are dropped as intra-turn artifacts.

Tests reproduce the two-round aggregation path and cover text/metadata/media preservation plus pure-frame removal.

Closes #6340