### PR TITLE
Make `buildRequestPrompt` private

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -1455,7 +1455,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
 	 * prompt as is.
 	 */
-	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+	private Prompt buildRequestPrompt(Prompt prompt) {
 		if (prompt.getOptions() == null) {
 			return prompt.mutate().chatOptions(this.getOptions()).build();
 		}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
@@ -248,8 +248,7 @@ class AnthropicChatModelTests {
 
 		AnthropicChatOptions runtimeOptions = AnthropicChatOptions.builder().cacheOptions(cacheOptions).build();
 
-		Prompt originalPrompt = new Prompt("Test", runtimeOptions);
-		Prompt requestPrompt = model.buildRequestPrompt(originalPrompt);
+		Prompt requestPrompt = new Prompt("Test", runtimeOptions);
 
 		AnthropicChatOptions mergedOptions = (AnthropicChatOptions) requestPrompt.getOptions();
 		assertThat(mergedOptions.getCacheOptions()).isNotNull();

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -798,7 +798,7 @@ public class BedrockProxyChatModel implements ChatModel {
 	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
 	 * prompt as is.
 	 */
-	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+	private Prompt buildRequestPrompt(Prompt prompt) {
 		if (prompt.getOptions() == null) {
 			return prompt.mutate().chatOptions(this.getOptions()).build();
 		}

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -455,7 +455,7 @@ public class DeepSeekChatModel implements ChatModel {
 	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
 	 * prompt as is.
 	 */
-	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+	private Prompt buildRequestPrompt(Prompt prompt) {
 		if (prompt.getOptions() == null) {
 			return prompt.mutate().chatOptions(this.getOptions()).build();
 		}

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
@@ -37,8 +37,8 @@ public class DeepSeekChatCompletionRequestTests {
 
 		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
 
-		var prompt = client.buildRequestPrompt(new Prompt("Test message content",
-				DeepSeekChatOptions.builder().model("DEFAULT_MODEL").temperature(66.6).build()));
+		var prompt = new Prompt("Test message content",
+				DeepSeekChatOptions.builder().model("DEFAULT_MODEL").temperature(66.6).build());
 
 		var request = client.createRequest(prompt, false);
 
@@ -67,8 +67,8 @@ public class DeepSeekChatCompletionRequestTests {
 			.reasoningContent("Let me think about this step by step...")
 			.build();
 
-		var prompt = client.buildRequestPrompt(new Prompt(List.of(assistantMessage),
-				DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+		var prompt = new Prompt(List.of(assistantMessage),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build());
 
 		var request = client.createRequest(prompt, false);
 
@@ -87,8 +87,8 @@ public class DeepSeekChatCompletionRequestTests {
 			.content("The answer is 42")
 			.build();
 
-		var prompt = client.buildRequestPrompt(new Prompt(List.of(assistantMessage),
-				DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+		var prompt = new Prompt(List.of(assistantMessage),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build());
 
 		var request = client.createRequest(prompt, false);
 
@@ -105,8 +105,8 @@ public class DeepSeekChatCompletionRequestTests {
 
 		AssistantMessage assistantMessage = new AssistantMessage("The answer is 42");
 
-		var prompt = client.buildRequestPrompt(new Prompt(List.of(assistantMessage),
-				DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+		var prompt = new Prompt(List.of(assistantMessage),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build());
 
 		var request = client.createRequest(prompt, false);
 
@@ -127,8 +127,8 @@ public class DeepSeekChatCompletionRequestTests {
 			.prefix(true)
 			.build();
 
-		var prompt = client.buildRequestPrompt(new Prompt(List.of(assistantMessage),
-				DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+		var prompt = new Prompt(List.of(assistantMessage),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build());
 
 		var request = client.createRequest(prompt, false);
 

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -954,7 +954,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	 * {@link org.springframework.ai.chat.model.ChatModel#getOptions() options}.
 	 * Otherwise, use the prompt as is.
 	 */
-	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+	private Prompt buildRequestPrompt(Prompt prompt) {
 		if (prompt.getOptions() == null) {
 			return prompt.mutate().chatOptions(this.getOptions()).build();
 		}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.google.genai;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 import com.google.genai.Client;
 import com.google.genai.types.Content;
@@ -58,46 +59,16 @@ public class CreateGeminiRequestTests {
 	Client genAiClient;
 
 	@Test
-	public void createRequestWithChatOptions() {
-
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").temperature(66.6).build())
-			.build();
-
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
-
-		assertThat(request.contents()).hasSize(1);
-
-		assertThat(request.config().systemInstruction()).isNotPresent();
-		assertThat(request.modelName()).isEqualTo("DEFAULT_MODEL");
-		assertThat(request.config().temperature().orElse(0f)).isEqualTo(66.6f);
-
-		request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
-				GoogleGenAiChatOptions.builder().model("PROMPT_MODEL").temperature(99.9).build())));
-
-		assertThat(request.contents()).hasSize(1);
-
-		assertThat(request.config().systemInstruction()).isNotPresent();
-		assertThat(request.modelName()).isEqualTo("PROMPT_MODEL");
-		assertThat(request.config().temperature().orElse(0f)).isEqualTo(99.9f);
-	}
-
-	@Test
 	public void createRequestWithFrequencyAndPresencePenalty() {
 
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("DEFAULT_MODEL")
-				.frequencyPenalty(.25)
-				.presencePenalty(.75)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("DEFAULT_MODEL")
+			.frequencyPenalty(.25)
+			.presencePenalty(.75)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.contents()).hasSize(1);
 
@@ -116,13 +87,10 @@ public class CreateGeminiRequestTests {
 				.of(Media.builder().mimeType(MimeTypeUtils.IMAGE_PNG).data(URI.create("http://example.com")).build()))
 			.build();
 
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").temperature(66.6).build())
-			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt(List.of(systemMessage, userMessage))));
+		GeminiRequest request = client.createGeminiRequest(new Prompt(List.of(systemMessage, userMessage),
+				GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").temperature(66.6).build()));
 
 		assertThat(request.modelName()).isEqualTo("DEFAULT_MODEL");
 		assertThat(request.config().temperature().orElse(0f)).isEqualTo(66.6f);
@@ -158,14 +126,14 @@ public class CreateGeminiRequestTests {
 			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
 			.build();
 
-		var requestPrompt = client.buildRequestPrompt(new Prompt("Test message content",
+		var requestPrompt = new Prompt("Test message content",
 				GoogleGenAiChatOptions.builder()
 					.model("PROMPT_MODEL")
 					.toolCallbacks(List.of(FunctionToolCallback.builder(TOOL_FUNCTION_NAME, new MockWeatherService())
 						.description("Get the weather in location")
 						.inputType(MockWeatherService.Request.class)
 						.build()))
-					.build()));
+					.build());
 
 		var request = client.createGeminiRequest(requestPrompt);
 
@@ -190,22 +158,19 @@ public class CreateGeminiRequestTests {
 	@Test
 	public void createRequestWithGenerationConfigOptions() {
 
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("DEFAULT_MODEL")
-				.temperature(66.6)
-				.maxOutputTokens(100)
-				.topK(10)
-				.topP(5.0)
-				.stopSequences(List.of("stop1", "stop2"))
-				.candidateCount(1)
-				.responseMimeType("application/json")
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("DEFAULT_MODEL")
+			.temperature(66.6)
+			.maxOutputTokens(100)
+			.topK(10)
+			.topP(5.0)
+			.stopSequences(List.of("stop1", "stop2"))
+			.candidateCount(1)
+			.responseMimeType("application/json")
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.contents()).hasSize(1);
 
@@ -223,13 +188,10 @@ public class CreateGeminiRequestTests {
 	@Test
 	public void createRequestWithThinkingBudget() {
 
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").thinkingBudget(12853).build())
-			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").thinkingBudget(12853).build()));
 
 		assertThat(request.contents()).hasSize(1);
 		assertThat(request.modelName()).isEqualTo("DEFAULT_MODEL");
@@ -249,8 +211,8 @@ public class CreateGeminiRequestTests {
 			.build();
 
 		// Override default thinkingBudget with prompt-specific value
-		GeminiRequest request = client.createGeminiRequest(client.buildRequestPrompt(
-				new Prompt("Test message content", GoogleGenAiChatOptions.builder().thinkingBudget(25000).build())));
+		GeminiRequest request = client.createGeminiRequest(
+				new Prompt("Test message content", GoogleGenAiChatOptions.builder().thinkingBudget(25000).build()));
 
 		assertThat(request.contents()).hasSize(1);
 		assertThat(request.modelName())
@@ -264,13 +226,10 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithNullThinkingBudget() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").thinkingBudget(null).build())
-			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").thinkingBudget(null).build()));
 
 		assertThat(request.contents()).hasSize(1);
 		assertThat(request.modelName()).isEqualTo("DEFAULT_MODEL");
@@ -281,13 +240,10 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithZeroThinkingBudget() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").thinkingBudget(0).build())
-			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").thinkingBudget(0).build()));
 
 		assertThat(request.config().thinkingConfig()).isPresent();
 		assertThat(request.config().thinkingConfig().get().thinkingBudget()).isPresent();
@@ -296,12 +252,10 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithNoMessages() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
-			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt(List.of())));
+		GeminiRequest request = client.createGeminiRequest(
+				new Prompt(List.of(), GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build()));
 
 		assertThat(request.contents()).isEmpty();
 	}
@@ -310,13 +264,10 @@ public class CreateGeminiRequestTests {
 	public void createRequestWithOnlySystemMessage() {
 		var systemMessage = new SystemMessage("System Message Only");
 
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
-			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt(List.of(systemMessage))));
+		GeminiRequest request = client.createGeminiRequest(
+				new Prompt(List.of(systemMessage), GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build()));
 
 		assertThat(request.config().systemInstruction()).isPresent();
 		assertThat(request.contents()).isEmpty();
@@ -324,16 +275,13 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithLabels() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("DEFAULT_MODEL")
-				.labels(java.util.Map.of("org", "my-org", "env", "test"))
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("DEFAULT_MODEL")
+			.labels(Map.of("org", "my-org", "env", "test"))
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.config().labels()).isPresent();
 		assertThat(request.config().labels().get()).containsEntry("org", "my-org");
@@ -342,16 +290,13 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithThinkingLevel() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("DEFAULT_MODEL")
-				.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("DEFAULT_MODEL")
+			.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).options(options).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.contents()).hasSize(1);
 		assertThat(request.modelName()).isEqualTo("DEFAULT_MODEL");
@@ -373,8 +318,8 @@ public class CreateGeminiRequestTests {
 			.build();
 
 		// Override default thinkingLevel with prompt-specific value
-		GeminiRequest request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
-				GoogleGenAiChatOptions.builder().thinkingLevel(GoogleGenAiThinkingLevel.HIGH).build())));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder().thinkingLevel(GoogleGenAiThinkingLevel.HIGH).build()));
 
 		assertThat(request.config().thinkingConfig()).isPresent();
 		assertThat(request.config().thinkingConfig().get().thinkingLevel()).isPresent();
@@ -383,18 +328,15 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithThinkingLevelAndBudgetCombined() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("DEFAULT_MODEL")
-				.thinkingBudget(8192)
-				.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
-				.includeThoughts(true)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("DEFAULT_MODEL")
+			.thinkingBudget(8192)
+			.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+			.includeThoughts(true)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.config().thinkingConfig()).isPresent();
 		var thinkingConfig = request.config().thinkingConfig().get();
@@ -408,13 +350,10 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithNullThinkingLevel() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").thinkingLevel(null).build())
-			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").thinkingLevel(null).build()));
 
 		// Verify thinkingConfig is not present when only thinkingLevel is null
 		assertThat(request.config().thinkingConfig()).isEmpty();
@@ -422,16 +361,13 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithOnlyThinkingLevel() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("DEFAULT_MODEL")
-				.thinkingLevel(GoogleGenAiThinkingLevel.LOW)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("DEFAULT_MODEL")
+			.thinkingLevel(GoogleGenAiThinkingLevel.LOW)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		// Verify thinkingConfig is present when only thinkingLevel is set
 		assertThat(request.config().thinkingConfig()).isPresent();
@@ -443,16 +379,13 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithThinkingLevelMinimal() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("gemini-3-flash-preview")
-				.thinkingLevel(GoogleGenAiThinkingLevel.MINIMAL)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("gemini-3-flash-preview")
+			.thinkingLevel(GoogleGenAiThinkingLevel.MINIMAL)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.config().thinkingConfig()).isPresent();
 		assertThat(request.config().thinkingConfig().get().thinkingLevel()).isPresent();
@@ -461,16 +394,13 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithThinkingLevelMedium() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("gemini-3-flash-preview")
-				.thinkingLevel(GoogleGenAiThinkingLevel.MEDIUM)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("gemini-3-flash-preview")
+			.thinkingLevel(GoogleGenAiThinkingLevel.MEDIUM)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.config().thinkingConfig()).isPresent();
 		assertThat(request.config().thinkingConfig().get().thinkingLevel()).isPresent();
@@ -479,16 +409,13 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithThinkingLevelMinimalOnProModelThrows() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("gemini-3-pro-preview")
-				.thinkingLevel(GoogleGenAiThinkingLevel.MINIMAL)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("gemini-3-pro-preview")
+			.thinkingLevel(GoogleGenAiThinkingLevel.MINIMAL)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		assertThatThrownBy(
-				() -> client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content"))))
+		assertThatThrownBy(() -> client.createGeminiRequest(new Prompt("Test message content", options)))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("MINIMAL")
 			.hasMessageContaining("not supported")
@@ -497,16 +424,13 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithThinkingLevelMediumOnProModelThrows() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("gemini-3-pro-preview")
-				.thinkingLevel(GoogleGenAiThinkingLevel.MEDIUM)
-				.build())
-			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		assertThatThrownBy(
-				() -> client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content"))))
+		assertThatThrownBy(() -> client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.model("gemini-3-pro-preview")
+					.thinkingLevel(GoogleGenAiThinkingLevel.MEDIUM)
+					.build())))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("MEDIUM")
 			.hasMessageContaining("not supported")
@@ -515,16 +439,13 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithThinkingLevelLowOnProModel() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("gemini-3-pro-preview")
-				.thinkingLevel(GoogleGenAiThinkingLevel.LOW)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("gemini-3-pro-preview")
+			.thinkingLevel(GoogleGenAiThinkingLevel.LOW)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.config().thinkingConfig()).isPresent();
 		assertThat(request.config().thinkingConfig().get().thinkingLevel()).isPresent();
@@ -533,16 +454,13 @@ public class CreateGeminiRequestTests {
 
 	@Test
 	public void createRequestWithThinkingLevelHighOnProModel() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("gemini-3-pro-preview")
-				.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
-				.build())
-			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.model("gemini-3-pro-preview")
+					.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+					.build()));
 
 		assertThat(request.config().thinkingConfig()).isPresent();
 		assertThat(request.config().thinkingConfig().get().thinkingLevel()).isPresent();
@@ -553,13 +471,10 @@ public class CreateGeminiRequestTests {
 	public void createRequestWithAllThinkingLevelsOnFlashModel() {
 		for (GoogleGenAiThinkingLevel level : List.of(GoogleGenAiThinkingLevel.MINIMAL, GoogleGenAiThinkingLevel.LOW,
 				GoogleGenAiThinkingLevel.MEDIUM, GoogleGenAiThinkingLevel.HIGH)) {
-			var client = GoogleGenAiChatModel.builder()
-				.genAiClient(this.genAiClient)
-				.options(GoogleGenAiChatOptions.builder().model("gemini-3-flash-preview").thinkingLevel(level).build())
-				.build();
+			var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-			GeminiRequest request = client
-				.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+			GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+					GoogleGenAiChatOptions.builder().model("gemini-3-flash-preview").thinkingLevel(level).build()));
 
 			assertThat(request.config().thinkingConfig()).isPresent();
 			assertThat(request.config().thinkingConfig().get().thinkingLevel()).isPresent();
@@ -580,11 +495,11 @@ public class CreateGeminiRequestTests {
 			.build();
 
 		// Runtime override with unsupported level should throw
-		assertThatThrownBy(() -> client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
+		assertThatThrownBy(() -> client.createGeminiRequest(new Prompt("Test message content",
 				GoogleGenAiChatOptions.builder()
 					.model("gemini-3-pro-preview")
 					.thinkingLevel(GoogleGenAiThinkingLevel.MINIMAL)
-					.build()))))
+					.build())))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("MINIMAL")
 			.hasMessageContaining("not supported");
@@ -593,16 +508,13 @@ public class CreateGeminiRequestTests {
 	@Test
 	public void createRequestWithThinkingLevelUnspecifiedOnProModel() {
 		// THINKING_LEVEL_UNSPECIFIED should be allowed on Pro models
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("gemini-3-pro-preview")
-				.thinkingLevel(GoogleGenAiThinkingLevel.THINKING_LEVEL_UNSPECIFIED)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("gemini-3-pro-preview")
+			.thinkingLevel(GoogleGenAiThinkingLevel.THINKING_LEVEL_UNSPECIFIED)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.config().thinkingConfig()).isPresent();
 		assertThat(request.config().thinkingConfig().get().thinkingLevel()).isPresent();
@@ -611,16 +523,13 @@ public class CreateGeminiRequestTests {
 	@Test
 	public void createRequestWithProModelInCustomPath() {
 		// Test custom paths like "projects/.../gemini-3-pro-preview"
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("projects/my-project/locations/us-central1/publishers/google/models/gemini-3-pro-preview")
-				.thinkingLevel(GoogleGenAiThinkingLevel.MINIMAL)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("projects/my-project/locations/us-central1/publishers/google/models/gemini-3-pro-preview")
+			.thinkingLevel(GoogleGenAiThinkingLevel.MINIMAL)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		assertThatThrownBy(
-				() -> client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content"))))
+		assertThatThrownBy(() -> client.createGeminiRequest(new Prompt("Test message content", options)))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("MINIMAL")
 			.hasMessageContaining("not supported");
@@ -633,11 +542,11 @@ public class CreateGeminiRequestTests {
 			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
 			.build();
 
-		GeminiRequest request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
 				GoogleGenAiChatOptions.builder()
 					.googleSearchRetrieval(true)
 					.includeServerSideToolInvocations(true)
-					.build())));
+					.build()));
 
 		assertThat(request.config().toolConfig()).isPresent();
 		assertThat(request.config().toolConfig().get().includeServerSideToolInvocations()).isPresent();
@@ -652,70 +561,42 @@ public class CreateGeminiRequestTests {
 			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
 			.build();
 
-		GeminiRequest request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
 				GoogleGenAiChatOptions.builder()
 					.googleSearchRetrieval(true)
 					.includeServerSideToolInvocations(false)
-					.build())));
+					.build()));
 
 		assertThat(request.config().toolConfig()).isNotPresent();
 	}
 
 	@Test
 	public void createRequestWithIncludeServerSideToolInvocationsDefault() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").googleSearchRetrieval(true).build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("DEFAULT_MODEL")
+			.googleSearchRetrieval(true)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		// Default is false, so no ToolConfig should be set
 		assertThat(request.config().toolConfig()).isNotPresent();
 	}
 
 	@Test
-	public void createRequestWithIncludeServerSideToolInvocationsRuntimeOverride() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("DEFAULT_MODEL")
-				.includeServerSideToolInvocations(false)
-				.build())
-			.build();
-
-		GeminiRequest request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
-				GoogleGenAiChatOptions.builder()
-					.googleSearchRetrieval(true)
-					.includeServerSideToolInvocations(true)
-					.build())));
-
-		assertThat(request.config().toolConfig()).isPresent();
-		assertThat(request.config().toolConfig().get().includeServerSideToolInvocations().get()).isTrue();
-	}
-
-	@Test
 	public void createRequestWithServiceTier() {
-		var client = GoogleGenAiChatModel.builder()
-			.genAiClient(this.genAiClient)
-			.options(GoogleGenAiChatOptions.builder()
-				.model("DEFAULT_MODEL")
-				.serviceTier(GoogleGenAiServiceTier.PRIORITY)
-				.build())
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("DEFAULT_MODEL")
+			.serviceTier(GoogleGenAiServiceTier.PRIORITY)
 			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
 
-		GeminiRequest request = client
-			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
 
 		assertThat(request.config().serviceTier()).isPresent();
 		assertThat(request.config().serviceTier().get().toString()).isEqualTo("priority");
 
-		request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
-				GoogleGenAiChatOptions.builder().serviceTier(GoogleGenAiServiceTier.STANDARD).build())));
-
-		assertThat(request.config().serviceTier()).isPresent();
-		assertThat(request.config().serviceTier().get().toString()).isEqualTo("standard");
 	}
 
 }

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -546,7 +546,7 @@ public class MistralAiChatModel implements ChatModel {
 	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
 	 * prompt as is.
 	 */
-	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+	private Prompt buildRequestPrompt(Prompt prompt) {
 		if (prompt.getOptions() == null) {
 			return prompt.mutate().chatOptions(this.getOptions()).build();
 		}

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTests.java
@@ -59,7 +59,7 @@ class MistralAiChatCompletionRequestTests {
 
 	@Test
 	void chatCompletionDefaultRequestTest() {
-		var prompt = this.chatModel.buildRequestPrompt(new Prompt("test content"));
+		var prompt = new Prompt("test content", MistralAiChatOptions.builder().build());
 		var request = this.chatModel.createRequest(prompt, false);
 
 		assertThat(request.messages()).hasSize(1);
@@ -90,7 +90,7 @@ class MistralAiChatCompletionRequestTests {
 			.toolChoice(MistralAiApi.ChatCompletionRequest.ToolChoice.AUTO)
 			.build();
 
-		var prompt = this.chatModel.buildRequestPrompt(new Prompt("test content", options));
+		var prompt = new Prompt("test content", options);
 		var request = this.chatModel.createRequest(prompt, true);
 
 		assertThat(request.messages()).hasSize(1);
@@ -173,8 +173,7 @@ class MistralAiChatCompletionRequestTests {
 	private Prompt createPrompt(Message message) {
 		var chatOptions = MistralAiChatOptions.builder().temperature(0.7d).build();
 		var prompt = new Prompt(message, chatOptions);
-
-		return this.chatModel.buildRequestPrompt(prompt);
+		return prompt;
 	}
 
 	private static void verifyToolChatCompletionMessage(ChatCompletionMessage chatCompletionMessage,

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -491,7 +491,7 @@ public class OllamaChatModel implements ChatModel {
 	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
 	 * prompt as is.
 	 */
-	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+	private Prompt buildRequestPrompt(Prompt prompt) {
 		if (prompt.getOptions() == null) {
 			return prompt.mutate().chatOptions(this.getOptions()).build();
 		}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
@@ -51,7 +51,8 @@ class OllamaChatRequestTests {
 
 	@Test
 	void createRequestWithOptions() {
-		var prompt = this.chatModel.buildRequestPrompt(new Prompt("Test message content"));
+		var options = OllamaChatOptions.builder().model("MODEL_NAME").topK(99).temperature(66.6).numGPU(1).build();
+		var prompt = new Prompt("Test message content", options);
 
 		var request = this.chatModel.ollamaChatRequest(prompt, false);
 
@@ -74,7 +75,7 @@ class OllamaChatRequestTests {
 			.topP(0.5)
 			.numGPU(2)
 			.build();
-		var prompt = this.chatModel.buildRequestPrompt(new Prompt("Test message content", promptOptions));
+		var prompt = new Prompt("Test message content", promptOptions);
 
 		var request = this.chatModel.ollamaChatRequest(prompt, true);
 
@@ -92,7 +93,7 @@ class OllamaChatRequestTests {
 	public void createRequestWithPromptOptionsModelOverride() {
 		// Ollama runtime options.
 		OllamaChatOptions promptOptions = OllamaChatOptions.builder().model("PROMPT_MODEL").build();
-		var prompt = this.chatModel.buildRequestPrompt(new Prompt("Test message content", promptOptions));
+		var prompt = new Prompt("Test message content", promptOptions);
 
 		var request = this.chatModel.ollamaChatRequest(prompt, true);
 
@@ -100,54 +101,9 @@ class OllamaChatRequestTests {
 	}
 
 	@Test
-	public void createRequestWithOptionsModelOverride() {
-		OllamaChatModel chatModel = OllamaChatModel.builder()
-			.ollamaApi(OllamaApi.builder().build())
-			.options(OllamaChatOptions.builder().model("DEFAULT_OPTIONS_MODEL").build())
-			.retryTemplate(RetryUtils.DEFAULT_RETRY_TEMPLATE)
-			.build();
-
-		var prompt1 = chatModel.buildRequestPrompt(new Prompt("Test message content"));
-
-		var request = chatModel.ollamaChatRequest(prompt1, true);
-
-		assertThat(request.model()).isEqualTo("DEFAULT_OPTIONS_MODEL");
-
-		// Prompt options should override the default options.
-		OllamaChatOptions promptOptions = OllamaChatOptions.builder().model("PROMPT_MODEL").build();
-		var prompt2 = chatModel.buildRequestPrompt(new Prompt("Test message content", promptOptions));
-
-		request = chatModel.ollamaChatRequest(prompt2, true);
-
-		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
-	}
-
-	@Test
-	public void createRequestWithOptionsModelChatOptionsOverride() {
-		OllamaChatModel chatModel = OllamaChatModel.builder()
-			.ollamaApi(OllamaApi.builder().build())
-			.options(OllamaChatOptions.builder().model("DEFAULT_OPTIONS_MODEL").build())
-			.retryTemplate(RetryUtils.DEFAULT_RETRY_TEMPLATE)
-			.build();
-
-		var prompt1 = chatModel.buildRequestPrompt(new Prompt("Test message content"));
-
-		var request = chatModel.ollamaChatRequest(prompt1, true);
-
-		assertThat(request.model()).isEqualTo("DEFAULT_OPTIONS_MODEL");
-
-		// Prompt options should override the default options.
-		OllamaChatOptions promptOptions = OllamaChatOptions.builder().model("PROMPT_MODEL").build();
-		var prompt2 = chatModel.buildRequestPrompt(new Prompt("Test message content", promptOptions));
-
-		request = chatModel.ollamaChatRequest(prompt2, true);
-
-		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
-	}
-
-	@Test
 	void createRequestWithAllMessageTypes() {
-		var prompt = this.chatModel.buildRequestPrompt(new Prompt(createMessagesWithAllMessageTypes()));
+		var prompt = new Prompt(createMessagesWithAllMessageTypes(),
+				OllamaChatOptions.builder().model("PROMPT_MODEL").build());
 
 		var request = this.chatModel.ollamaChatRequest(prompt, false);
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -944,7 +944,7 @@ public final class OpenAiChatModel implements ChatModel {
 	 * prompt using this model {@link ChatModel#getOptions() options}. Otherwise, use the
 	 * prompt as is.
 	 */
-	/* package */ Prompt buildRequestPrompt(Prompt prompt) {
+	private Prompt buildRequestPrompt(Prompt prompt) {
 		if (prompt.getOptions() == null) {
 			return prompt.mutate().chatOptions(this.getOptions()).build();
 		}


### PR DESCRIPTION
As a follow-up to 836d691b5ec24355922d9c6d3482401f070820b0, make buildRequestPrompt() (which has become a very trivial method) private, and change tests that relied on it merging properties to simply accept a manually constructed prompt.

See #5841
