### PR TITLE
GH-4106: Restore contribution guidelines nav link

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -128,7 +128,7 @@
 ** xref:api/chat/prompt-engineering-patterns.adoc[]
 ** xref:api/effective-agents.adoc[Building Effective Agents]
 
-// * xref:contribution-guidelines.adoc[Contribution Guidelines]
+* xref:contribution-guidelines.adoc[Contribution Guidelines]
 
 * xref:upgrade-notes.adoc[]
 ** xref:api/tools-migration.adoc[Migrating FunctionCallback to ToolCallback API]


### PR DESCRIPTION
## Summary
- restore the Contribution Guidelines entry in the Antora navigation
- make the existing contribution guide discoverable from the reference docs menu

Closes #4106

## Verification
- ./mvnw -pl spring-ai-docs -DskipTests package