### PR TITLE
GH-4281: Refresh Bedrock documentation links

### DIFF
--- a/models/spring-ai-bedrock/README.md
+++ b/models/spring-ai-bedrock/README.md
@@ -1,11 +1,7 @@
-[Amazon Bedrock Overview](https://docs.spring.io/spring-ai/reference/api/bedrock-chat.html)
+[Amazon Bedrock Overview](https://docs.spring.io/spring-ai/reference/api/bedrock.html)
 
-- [Anthropic3 Chat Documentation](https://docs.spring.io/spring-ai/reference/api/chat/bedrock/bedrock-anthropic3.html)
-- [Anthropic2 Chat Documentation](https://docs.spring.io/spring-ai/reference/api/chat/bedrock/bedrock-anthropic.html)
-- [Cohere Chat Documentation](https://docs.spring.io/spring-ai/reference/api/chat/bedrock/bedrock-cohere.html)
+Spring AI now documents Amazon Bedrock chat integrations through the unified Bedrock Converse API reference, while embedding integrations remain documented separately.
+
+- [Bedrock Converse Chat Documentation](https://docs.spring.io/spring-ai/reference/api/chat/bedrock-converse.html) for Anthropic Claude, Amazon Nova and Titan, AI21, Cohere Command, Meta Llama, and Mistral AI chat models
 - [Cohere Embedding Documentation](https://docs.spring.io/spring-ai/reference/api/embeddings/bedrock-cohere-embedding.html)
-- [Llama Chat Documentation](https://docs.spring.io/spring-ai/reference/api/chat/bedrock/bedrock-llama.html)
-- [Titan Chat Documentation](https://docs.spring.io/spring-ai/reference/api/chat/bedrock/bedrock-titan.html)
 - [Titan Embedding Documentation](https://docs.spring.io/spring-ai/reference/api/embeddings/bedrock-titan-embedding.html)
-- [Jurassic2 Chat Documentation](https://docs.spring.io/spring-ai/reference/api/chat/bedrock/bedrock-jurassic2.html)
-

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -16,7 +16,7 @@ Currently, the Converse API link:https://docs.aws.amazon.com/bedrock/latest/user
 [NOTE]
 ====
 Following the Bedrock recommendations, Spring AI is transitioning to using Amazon Bedrock's Converse API for all chat conversation implementations in Spring AI.
-While the existing xref:api/bedrock-chat.adoc[InvokeModel API] supports conversation applications, we strongly recommend adopting the Converse API for all Chat conversation models.
+While the existing xref:api/bedrock.adoc[Amazon Bedrock reference documentation] continues to cover the remaining InvokeModel-based support, we strongly recommend adopting the Converse API for all chat conversation models.
 
 The Converse API does not support embedding operations, so these will remain in the current API and the embedding model functionality in the existing `InvokeModel API` will be maintained
 ====
@@ -1018,4 +1018,3 @@ public class ChatController {
     }
 }
 ----
-


### PR DESCRIPTION
## Summary
- replace outdated Bedrock README links with the current Bedrock overview and Converse API references
- keep the embedding links that are still valid and collapse the old provider-specific chat links into the unified Converse page
- fix a stale internal Bedrock Converse xref to the current Bedrock reference page

Closes #4281

## Verification
- ./mvnw -pl spring-ai-docs -DskipTests package