### PR TITLE
Preserve OpenAI tool call additional properties

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -117,12 +117,15 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  * @author Thomas Vitale
  * @author Eric Bottard
+ * @author Taewoong Kim
  */
 public final class OpenAiChatModel implements ChatModel {
 
 	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();
 
 	private static final String REASONING_CONTENT = "reasoningContent";
+
+	private static final String TOOL_CALL_ADDITIONAL_PROPERTIES_METADATA_KEY = "openai.tool_calls.additional_properties";
 
 	private final Log logger = LogFactory.getLog(OpenAiChatModel.class);
 
@@ -343,6 +346,13 @@ public final class OpenAiChatModel implements ChatModel {
 	private Generation buildGeneration(ChatCompletion.Choice choice, Map<String, Object> metadata,
 			ChatCompletionCreateParams request) {
 		ChatCompletionMessage message = choice.message();
+		Map<String, Object> assistantMessageMetadata = new LinkedHashMap<>(metadata);
+		// Keep unknown tool-call fields, such as Gemini thought signatures, for
+		// replay with tool results.
+		Map<String, Map<String, Object>> toolCallAdditionalProperties = extractToolCallAdditionalProperties(message);
+		if (!toolCallAdditionalProperties.isEmpty()) {
+			assistantMessageMetadata.put(TOOL_CALL_ADDITIONAL_PROPERTIES_METADATA_KEY, toolCallAdditionalProperties);
+		}
 		List<AssistantMessage.ToolCall> toolCalls = message.toolCalls()
 			.map(list -> list.stream().filter(tc -> tc.function().isPresent()).map(tc -> {
 				var opt = tc.function();
@@ -386,11 +396,48 @@ public final class OpenAiChatModel implements ChatModel {
 
 		var assistantMessage = AssistantMessage.builder()
 			.content(textContent)
-			.properties(metadata)
+			.properties(assistantMessageMetadata)
 			.toolCalls(toolCalls)
 			.media(media)
 			.build();
 		return new Generation(assistantMessage, generationMetadataBuilder.build());
+	}
+
+	private Map<String, Map<String, Object>> extractToolCallAdditionalProperties(ChatCompletionMessage message) {
+		Map<String, Map<String, Object>> additionalProperties = new LinkedHashMap<>();
+		message.toolCalls()
+			.ifPresent(toolCalls -> toolCalls.forEach(toolCall -> toolCall.function().ifPresent(functionToolCall -> {
+				Map<String, Object> toolCallProperties = toJavaMap(functionToolCall._additionalProperties());
+				if (!toolCallProperties.isEmpty()) {
+					additionalProperties.put(functionToolCall.id(), toolCallProperties);
+				}
+			})));
+		return additionalProperties;
+	}
+
+	private Map<String, Object> toJavaMap(Map<String, JsonValue> additionalProperties) {
+		if (CollectionUtils.isEmpty(additionalProperties)) {
+			return Map.of();
+		}
+		Map<String, Object> result = new LinkedHashMap<>();
+		additionalProperties.forEach((key, jsonValue) -> {
+			if (jsonValue != null) {
+				result.put(key, toJavaValue(key, jsonValue));
+			}
+		});
+		return result;
+	}
+
+	private Object toJavaValue(String key, JsonValue jsonValue) {
+		try {
+			return JacksonUtils.getDefaultJsonMapper().convertValue(jsonValue, Object.class);
+		}
+		catch (Exception e) {
+			if (logger.isErrorEnabled()) {
+				logger.error("Error parsing JSON value for key '" + key + "': " + jsonValue, e);
+			}
+			return jsonValue;
+		}
 	}
 
 	private ChatResponseMetadata from(ChatCompletion result, Usage usage) {
@@ -563,6 +610,10 @@ public final class OpenAiChatModel implements ChatModel {
 					var assistantMessage = (AssistantMessage) message;
 					ChatCompletionAssistantMessageParam.Builder builder = ChatCompletionAssistantMessageParam.builder()
 						.role(JsonValue.from(MessageType.ASSISTANT.getValue()));
+					// Restore unknown tool-call fields, such as Gemini thought
+					// signatures, when replaying assistant tool calls.
+					Map<String, Map<String, Object>> toolCallAdditionalProperties = toolCallAdditionalPropertiesFromMetadata(
+							assistantMessage);
 
 					if (assistantMessage.getText() != null) {
 						builder.content(ChatCompletionAssistantMessageParam.builder()
@@ -574,14 +625,21 @@ public final class OpenAiChatModel implements ChatModel {
 					if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
 						List<ChatCompletionMessageToolCall> toolCalls = assistantMessage.getToolCalls()
 							.stream()
-							.map(toolCall -> ChatCompletionMessageToolCall
-								.ofFunction(ChatCompletionMessageFunctionToolCall.builder()
+							.map(toolCall -> {
+								ChatCompletionMessageFunctionToolCall.Builder toolCallBuilder = ChatCompletionMessageFunctionToolCall
+									.builder()
 									.id(toolCall.id())
 									.function(ChatCompletionMessageFunctionToolCall.Function.builder()
 										.name(toolCall.name())
 										.arguments(toolCall.arguments())
-										.build())
-									.build()))
+										.build());
+								Map<String, JsonValue> additionalProperties = toJsonValueMap(
+										toolCallAdditionalProperties.get(toolCall.id()));
+								if (!additionalProperties.isEmpty()) {
+									toolCallBuilder.putAllAdditionalProperties(additionalProperties);
+								}
+								return ChatCompletionMessageToolCall.ofFunction(toolCallBuilder.build());
+							})
 							.toList();
 
 						builder.toolCalls(toolCalls);
@@ -833,6 +891,46 @@ public final class OpenAiChatModel implements ChatModel {
 		return builder.build();
 	}
 
+	private Map<String, Map<String, Object>> toolCallAdditionalPropertiesFromMetadata(
+			AssistantMessage assistantMessage) {
+		Object value = assistantMessage.getMetadata().get(TOOL_CALL_ADDITIONAL_PROPERTIES_METADATA_KEY);
+		if (!(value instanceof Map<?, ?> toolCallProperties)) {
+			return Map.of();
+		}
+
+		Map<String, Map<String, Object>> result = new LinkedHashMap<>();
+		toolCallProperties.forEach((toolCallId, additionalProperties) -> {
+			if (toolCallId instanceof String id && additionalProperties instanceof Map<?, ?> rawProperties) {
+				Map<String, Object> properties = new LinkedHashMap<>();
+				rawProperties.forEach((key, propertyValue) -> {
+					if (key instanceof String propertyName && propertyValue != null) {
+						properties.put(propertyName, propertyValue);
+					}
+				});
+				if (!properties.isEmpty()) {
+					result.put(id, properties);
+				}
+			}
+		});
+		return result;
+	}
+
+	private Map<String, JsonValue> toJsonValueMap(@Nullable Map<String, Object> additionalProperties) {
+		if (CollectionUtils.isEmpty(additionalProperties)) {
+			return Map.of();
+		}
+		Map<String, JsonValue> result = new LinkedHashMap<>();
+		additionalProperties.forEach((key, value) -> {
+			if (value instanceof JsonValue jsonValue) {
+				result.put(key, jsonValue);
+			}
+			else if (value != null) {
+				result.put(key, JsonValue.from(value));
+			}
+		});
+		return result;
+	}
+
 	public static ChatCompletionToolChoiceOption parseToolChoice(JsonNode node) {
 		String type = node.get("type").asString();
 		switch (type) {
@@ -1011,6 +1109,7 @@ public final class OpenAiChatModel implements ChatModel {
 					List<ToolCall> result = new ArrayList<>(tcs1);
 					result.set(tcs1.size() - 1,
 							lastFromTc1.toBuilder()
+								.putAllAdditionalProperties(toolCall._additionalProperties())
 								.function(lastFromTc1F.toBuilder().arguments(concatenatedArgs).build())
 								.build());
 					return result;
@@ -1053,6 +1152,7 @@ public final class OpenAiChatModel implements ChatModel {
 					msgBuilder.toolCalls(ccctcs.stream().map(tc -> {
 						ChatCompletionMessageFunctionToolCall.Builder toolCallBuilder = ChatCompletionMessageFunctionToolCall
 							.builder();
+						toolCallBuilder.putAllAdditionalProperties(tc._additionalProperties());
 						toolCallBuilder.id(tc.id().get());
 						toolCallBuilder.function(ChatCompletionMessageFunctionToolCall.Function.builder()
 							.name(tc.function().get().name().get())

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -17,19 +17,28 @@
 package org.springframework.ai.openai;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
+import com.openai.core.http.AsyncStreamResponse;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionAssistantMessageParam;
+import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessage;
+import com.openai.models.chat.completions.ChatCompletionMessageFunctionToolCall;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
+import com.openai.models.chat.completions.ChatCompletionMessageToolCall;
 import com.openai.models.completions.CompletionUsage;
+import com.openai.services.async.ChatServiceAsync;
+import com.openai.services.async.chat.ChatCompletionServiceAsync;
 import com.openai.services.blocking.ChatService;
 import com.openai.services.blocking.chat.ChatCompletionService;
 import org.junit.jupiter.api.Test;
@@ -40,6 +49,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -57,6 +67,8 @@ import static org.mockito.Mockito.when;
  */
 @ExtendWith(MockitoExtension.class)
 class OpenAiChatModelTests {
+
+	private static final String TOOL_CALL_ADDITIONAL_PROPERTIES_METADATA_KEY = "openai.tool_calls.additional_properties";
 
 	@Mock
 	OpenAIClient openAiClient;
@@ -115,6 +127,263 @@ class OpenAiChatModelTests {
 		assertThat((Object) metadata.get("list_field")).isEqualTo(List.of("abc", 123));
 		assertThat(metadata.<Map<String, Object>>get("object_field")).containsEntry("key1", 1).containsEntry("key2", 2);
 		assertThat(metadata.containsKey("null_field")).isFalse();
+	}
+
+	@Test
+	void preserveUnmappedToolCallAdditionalProperties() {
+		ChatService chatService = mock(ChatService.class);
+		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
+		when(this.openAiClient.chat()).thenReturn(chatService);
+		when(chatService.completions()).thenReturn(chatCompletionService);
+		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+			.id("chatcmpl-test")
+			.created(1777799928)
+			.model("gemini-3.5-flash")
+			.usage(CompletionUsage.builder().promptTokens(1).completionTokens(1).totalTokens(2).build())
+			.addChoice(ChatCompletion.Choice.builder()
+				.finishReason(ChatCompletion.Choice.FinishReason.TOOL_CALLS)
+				.index(0)
+				.logprobs(Optional.empty())
+				.message(ChatCompletionMessage.builder()
+					.content("")
+					.refusal(Optional.empty())
+					.role(JsonValue.from("assistant"))
+					.annotations(List.of())
+					.toolCalls(List
+						.of(ChatCompletionMessageToolCall.ofFunction(ChatCompletionMessageFunctionToolCall.builder()
+							.id("call_1")
+							.function(ChatCompletionMessageFunctionToolCall.Function.builder()
+								.name("get_current_weather")
+								.arguments("{\"location\":\"Seoul\"}")
+								.build())
+							.putAdditionalProperty("extra_content",
+									JsonValue.from(Map.of("google", Map.of("thought_signature", "signature-123"))))
+							.build())))
+					.build())
+				.build())
+			.build());
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gemini-3.5-flash").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.call(new Prompt("hi", options));
+
+		AssistantMessage assistantMessage = response.getResult().getOutput();
+		assertThat(assistantMessage.getToolCalls()).singleElement().satisfies(toolCall -> {
+			assertThat(toolCall.id()).isEqualTo("call_1");
+			assertThat(toolCall.name()).isEqualTo("get_current_weather");
+			assertThat(toolCall.arguments()).isEqualTo("{\"location\":\"Seoul\"}");
+		});
+		assertThat(toolCallProperties(assistantMessage, "call_1")).containsEntry("extra_content",
+				Map.of("google", Map.of("thought_signature", "signature-123")));
+	}
+
+	@Test
+	void preserveUnmappedToolCallAdditionalPropertiesFromStream() {
+		ChatServiceAsync chatServiceAsync = mock(ChatServiceAsync.class);
+		ChatCompletionServiceAsync chatCompletionServiceAsync = mock(ChatCompletionServiceAsync.class);
+		when(this.openAiClientAsync.chat()).thenReturn(chatServiceAsync);
+		when(chatServiceAsync.completions()).thenReturn(chatCompletionServiceAsync);
+		when(chatCompletionServiceAsync.createStreaming(any(ChatCompletionCreateParams.class)))
+			.thenReturn(asyncStreamResponse(
+					ChatCompletionChunk.builder()
+						.id("chatcmpl-stream-test")
+						.created(1777799928)
+						.model("gemini-3.5-flash")
+						.addChoice(ChatCompletionChunk.Choice.builder()
+							.index(0)
+							.finishReason(Optional.empty())
+							.delta(ChatCompletionChunk.Choice.Delta.builder()
+								.addToolCall(ChatCompletionChunk.Choice.Delta.ToolCall.builder()
+									.index(0)
+									.id("call_1")
+									.function(ChatCompletionChunk.Choice.Delta.ToolCall.Function.builder()
+										.name("get_current_weather")
+										.arguments("{\"location\"")
+										.build())
+									.build())
+								.build())
+							.build())
+						.build(),
+					ChatCompletionChunk.builder()
+						.id("chatcmpl-stream-test")
+						.created(1777799928)
+						.model("gemini-3.5-flash")
+						.addChoice(ChatCompletionChunk.Choice.builder()
+							.index(0)
+							.finishReason(Optional.empty())
+							.delta(ChatCompletionChunk.Choice.Delta.builder()
+								.addToolCall(ChatCompletionChunk.Choice.Delta.ToolCall.builder()
+									.index(0)
+									.function(ChatCompletionChunk.Choice.Delta.ToolCall.Function.builder()
+										.arguments(":\"Seoul\"}")
+										.build())
+									.putAdditionalProperty("extra_content",
+											JsonValue
+												.from(Map.of("google", Map.of("thought_signature", "signature-123"))))
+									.build())
+								.build())
+							.build())
+						.build(),
+					ChatCompletionChunk.builder()
+						.id("chatcmpl-stream-test")
+						.created(1777799928)
+						.model("gemini-3.5-flash")
+						.addChoice(ChatCompletionChunk.Choice.builder()
+							.index(0)
+							.finishReason(ChatCompletionChunk.Choice.FinishReason.TOOL_CALLS)
+							.delta(ChatCompletionChunk.Choice.Delta.builder().build())
+							.build())
+						.build()));
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gemini-3.5-flash").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.stream(new Prompt("hi", options)).blockLast();
+
+		assertThat(response).isNotNull();
+		AssistantMessage assistantMessage = response.getResult().getOutput();
+		assertThat(assistantMessage.getToolCalls()).singleElement().satisfies(toolCall -> {
+			assertThat(toolCall.id()).isEqualTo("call_1");
+			assertThat(toolCall.name()).isEqualTo("get_current_weather");
+			assertThat(toolCall.arguments()).isEqualTo("{\"location\":\"Seoul\"}");
+		});
+		assertThat(toolCallProperties(assistantMessage, "call_1")).containsEntry("extra_content",
+				Map.of("google", Map.of("thought_signature", "signature-123")));
+	}
+
+	@Test
+	void restoreUnmappedToolCallAdditionalProperties() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gemini-3.5-flash").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("")
+			.properties(Map.of(TOOL_CALL_ADDITIONAL_PROPERTIES_METADATA_KEY,
+					Map.of("call_1",
+							Map.of("extra_content", Map.of("google", Map.of("thought_signature", "signature-123"))))))
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call_1", "function", "get_current_weather",
+					"{\"location\":\"Seoul\"}")))
+			.build();
+
+		ChatCompletionCreateParams request = chatModel
+			.createRequest(new Prompt(List.<Message>of(assistantMessage), options), false);
+
+		ChatCompletionMessageFunctionToolCall toolCall = request.messages()
+			.get(0)
+			.asAssistant()
+			.toolCalls()
+			.orElseThrow()
+			.get(0)
+			.asFunction();
+		@SuppressWarnings("unchecked")
+		Map<String, Object> extraContent = toolCall._additionalProperties().get("extra_content").convert(Map.class);
+		assertThat(extraContent).containsEntry("google", Map.of("thought_signature", "signature-123"));
+	}
+
+	@Test
+	void restoreUnmappedToolCallAdditionalPropertiesByToolCallId() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gemini-3.5-flash").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+		Map<String, Map<String, Object>> additionalProperties = new LinkedHashMap<>();
+		additionalProperties.put("call_2",
+				Map.of("extra_content", Map.of("google", Map.of("thought_signature", "signature-2"))));
+		additionalProperties.put("call_1",
+				Map.of("extra_content", Map.of("google", Map.of("thought_signature", "signature-1"))));
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("")
+			.properties(Map.of(TOOL_CALL_ADDITIONAL_PROPERTIES_METADATA_KEY, additionalProperties))
+			.toolCalls(List.of(
+					new AssistantMessage.ToolCall("call_1", "function", "get_current_weather",
+							"{\"location\":\"Seoul\"}"),
+					new AssistantMessage.ToolCall("call_2", "function", "get_current_time",
+							"{\"timezone\":\"Asia/Seoul\"}")))
+			.build();
+
+		ChatCompletionCreateParams request = chatModel
+			.createRequest(new Prompt(List.<Message>of(assistantMessage), options), false);
+
+		List<ChatCompletionMessageToolCall> toolCalls = request.messages()
+			.get(0)
+			.asAssistant()
+			.toolCalls()
+			.orElseThrow();
+		ChatCompletionMessageFunctionToolCall firstToolCall = toolCalls.get(0).asFunction();
+		ChatCompletionMessageFunctionToolCall secondToolCall = toolCalls.get(1).asFunction();
+		assertThat(firstToolCall.id()).isEqualTo("call_1");
+		assertThat(secondToolCall.id()).isEqualTo("call_2");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> firstExtraContent = firstToolCall._additionalProperties()
+			.get("extra_content")
+			.convert(Map.class);
+		@SuppressWarnings("unchecked")
+		Map<String, Object> secondExtraContent = secondToolCall._additionalProperties()
+			.get("extra_content")
+			.convert(Map.class);
+		assertThat(firstExtraContent).containsEntry("google", Map.of("thought_signature", "signature-1"));
+		assertThat(secondExtraContent).containsEntry("google", Map.of("thought_signature", "signature-2"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> toolCallProperties(AssistantMessage assistantMessage, String toolCallId) {
+		Map<String, Map<String, Object>> toolCallProperties = (Map<String, Map<String, Object>>) assistantMessage
+			.getMetadata()
+			.get(TOOL_CALL_ADDITIONAL_PROPERTIES_METADATA_KEY);
+		return toolCallProperties.get(toolCallId);
+	}
+
+	private AsyncStreamResponse<ChatCompletionChunk> asyncStreamResponse(ChatCompletionChunk... chunks) {
+		return new AsyncStreamResponse<>() {
+			private final CompletableFuture<Void> completion = new CompletableFuture<>();
+
+			@Override
+			public AsyncStreamResponse<ChatCompletionChunk> subscribe(
+					AsyncStreamResponse.Handler<? super ChatCompletionChunk> handler) {
+				try {
+					for (ChatCompletionChunk chunk : chunks) {
+						handler.onNext(chunk);
+					}
+					handler.onComplete(Optional.empty());
+					this.completion.complete(null);
+				}
+				catch (Throwable throwable) {
+					handler.onComplete(Optional.of(throwable));
+					this.completion.completeExceptionally(throwable);
+				}
+				return this;
+			}
+
+			@Override
+			public AsyncStreamResponse<ChatCompletionChunk> subscribe(
+					AsyncStreamResponse.Handler<? super ChatCompletionChunk> handler, Executor executor) {
+				executor.execute(() -> subscribe(handler));
+				return this;
+			}
+
+			@Override
+			public CompletableFuture<Void> onCompleteFuture() {
+				return this.completion;
+			}
+
+			@Override
+			public void close() {
+			}
+		};
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #6364 

`OpenAiChatModel` currently drops additional properties attached to assistant tool calls while converting OpenAI SDK responses into Spring AI `AssistantMessage.ToolCall`s.

That breaks Gemini OpenAI-compatible tool-calling flows for models that require provider metadata such as:

```text
tool_calls[].extra_content.google.thought_signature
```

to be sent back on the follow-up model call after tool execution. Without it, Gemini 3.x models can fail with:

```text
Function call is missing a thought_signature in functionCall parts.
```

The OpenAI Java SDK already keeps these provider fields in `_additionalProperties()`. This PR carries the root tool-call additional properties through `AssistantMessage` metadata and restores them on the OpenAI SDK request object when conversation history is replayed.

I also checked several Gemini OpenAI-compatible response shapes, including `gemini-2.5-flash-lite` and `gemini-3.5-flash`, covering responses with and without `thought_signature`. When no additional properties are present, nothing extra is replayed.

There is no Gemini-specific handling here.
Spring AI only replays additional fields that were already present in the provider response.
