### PR TITLE
fix(mcp): fail fast for invalid stateless tools

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/common/McpPredicates.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/common/McpPredicates.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.annotation.common;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -78,14 +79,17 @@ public final class McpPredicates {
 		};
 	}
 
+	private static boolean isBidirectionalParameterType(Class<?> paramType) {
+		return McpSyncRequestContext.class.isAssignableFrom(paramType)
+				|| McpAsyncRequestContext.class.isAssignableFrom(paramType)
+				|| McpSyncServerExchange.class.isAssignableFrom(paramType)
+				|| McpAsyncServerExchange.class.isAssignableFrom(paramType);
+	}
+
 	private static boolean hasBidirectionalParameters(Method method) {
 
 		for (Class<?> paramType : method.getParameterTypes()) {
-			if (McpSyncRequestContext.class.isAssignableFrom(paramType)
-					|| McpAsyncRequestContext.class.isAssignableFrom(paramType)
-					|| McpSyncServerExchange.class.isAssignableFrom(paramType)
-					|| McpAsyncServerExchange.class.isAssignableFrom(paramType)) {
-
+			if (isBidirectionalParameterType(paramType)) {
 				return true;
 			}
 		}
@@ -104,6 +108,24 @@ public final class McpPredicates {
 			}
 			return false;
 		};
+	}
+
+	public static void validateStatelessMethodDoesNotUseBidirectionalParameters(Method method, String methodType) {
+		String unsupportedParameters = Arrays.stream(method.getParameterTypes())
+			.filter(McpPredicates::isBidirectionalParameterType)
+			.map(Class::getSimpleName)
+			.distinct()
+			.sorted()
+			.reduce((left, right) -> left + ", " + right)
+			.orElse("");
+
+		if (!unsupportedParameters.isEmpty()) {
+			throw new IllegalStateException(
+					("Stateless %s method '%s.%s' cannot declare session-scoped parameter(s): %s. "
+							+ "Use McpTransportContext or switch to a stateful server.")
+						.formatted(methodType, method.getDeclaringClass().getSimpleName(), method.getName(),
+								unsupportedParameters));
+		}
 	}
 
 }

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -75,9 +75,9 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 			.map(toolObject -> Stream.of(doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(McpPredicates.filterNonReactiveReturnTypeMethod())
-				.filter(McpPredicates.filterMethodWithBidirectionalParameters())
 				.sorted(Comparator.comparing(Method::getName))
 				.map(mcpToolMethod -> {
+					McpPredicates.validateStatelessMethodDoesNotUseBidirectionalParameters(mcpToolMethod, "tool");
 
 					var toolJavaAnnotation = doGetMcpToolAnnotation(mcpToolMethod);
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
@@ -72,9 +72,9 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 			.map(toolObject -> Stream.of(this.doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(McpPredicates.filterReactiveReturnTypeMethod())
-				.filter(McpPredicates.filterMethodWithBidirectionalParameters())
 				.sorted(Comparator.comparing(Method::getName))
 				.map(mcpToolMethod -> {
+					McpPredicates.validateStatelessMethodDoesNotUseBidirectionalParameters(mcpToolMethod, "tool");
 
 					var toolJavaAnnotation = this.doGetMcpToolAnnotation(mcpToolMethod);
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -31,6 +32,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.context.McpAsyncRequestContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -176,6 +178,48 @@ public class AsyncStatelessMcpToolProviderTests {
 		assertThat(toolSpecs).hasSize(1);
 		assertThat(toolSpecs.get(0).tool().name()).isEqualTo("async-tool");
 		assertThat(toolSpecs.get(0).tool().description()).isEqualTo("Asynchronous tool");
+	}
+
+	@Test
+	void testGetToolSpecificationsFailsFastForAsyncServerExchangeParameter() {
+		class InvalidStatelessTool {
+
+			@McpTool(name = "invalid-tool", description = "Tool requiring stateful exchange")
+			public Mono<String> invalidTool(McpAsyncServerExchange exchange) {
+				return Mono.just("never");
+			}
+
+		}
+
+		AsyncStatelessMcpToolProvider provider = new AsyncStatelessMcpToolProvider(List.of(new InvalidStatelessTool()));
+
+		assertThatThrownBy(provider::getToolSpecifications).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("invalidTool")
+			.hasMessageContaining("McpAsyncServerExchange")
+			.hasMessageContaining("Stateless")
+			.hasMessageContaining("McpTransportContext")
+			.hasMessageContaining("stateful");
+	}
+
+	@Test
+	void testGetToolSpecificationsFailsFastForAsyncRequestContextParameter() {
+		class InvalidStatelessTool {
+
+			@McpTool(name = "invalid-tool", description = "Tool requiring request context")
+			public Mono<String> invalidTool(McpAsyncRequestContext requestContext) {
+				return Mono.just("never");
+			}
+
+		}
+
+		AsyncStatelessMcpToolProvider provider = new AsyncStatelessMcpToolProvider(List.of(new InvalidStatelessTool()));
+
+		assertThatThrownBy(provider::getToolSpecifications).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("invalidTool")
+			.hasMessageContaining("McpAsyncRequestContext")
+			.hasMessageContaining("Stateless")
+			.hasMessageContaining("McpTransportContext")
+			.hasMessageContaining("stateful");
 	}
 
 	@Test

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProviderTests.java
@@ -22,6 +22,7 @@ import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.context.McpSyncRequestContext;
 import org.springframework.ai.util.JsonHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -179,6 +181,48 @@ public class SyncStatelessMcpToolProviderTests {
 		assertThat(toolSpecs).hasSize(1);
 		assertThat(toolSpecs.get(0).tool().name()).isEqualTo("sync-tool");
 		assertThat(toolSpecs.get(0).tool().description()).isEqualTo("Synchronous tool");
+	}
+
+	@Test
+	void testGetToolSpecificationsFailsFastForSyncServerExchangeParameter() {
+		class InvalidStatelessTool {
+
+			@McpTool(name = "invalid-tool", description = "Tool requiring stateful exchange")
+			public String invalidTool(McpSyncServerExchange exchange) {
+				return "never";
+			}
+
+		}
+
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(new InvalidStatelessTool()));
+
+		assertThatThrownBy(provider::getToolSpecifications).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("invalidTool")
+			.hasMessageContaining("McpSyncServerExchange")
+			.hasMessageContaining("Stateless")
+			.hasMessageContaining("McpTransportContext")
+			.hasMessageContaining("stateful");
+	}
+
+	@Test
+	void testGetToolSpecificationsFailsFastForSyncRequestContextParameter() {
+		class InvalidStatelessTool {
+
+			@McpTool(name = "invalid-tool", description = "Tool requiring request context")
+			public String invalidTool(McpSyncRequestContext requestContext) {
+				return "never";
+			}
+
+		}
+
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(new InvalidStatelessTool()));
+
+		assertThatThrownBy(provider::getToolSpecifications).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("invalidTool")
+			.hasMessageContaining("McpSyncRequestContext")
+			.hasMessageContaining("Stateless")
+			.hasMessageContaining("McpTransportContext")
+			.hasMessageContaining("stateful");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- fail fast when stateless MCP tool providers discover session-scoped parameters
- surface an actionable error that points developers to `McpTransportContext` or a stateful server
- cover both sync and async stateless tool providers with regression tests

Fixes #5373

## Testing
- `./mvnw -pl mcp/mcp-annotations -Dtest=McpPredicatesTests,SyncStatelessMcpToolProviderTests,AsyncStatelessMcpToolProviderTests test`