### PR TITLE
Align OpenAI-compatible streaming `reasoning_content` with non-streaming responses

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -119,6 +119,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Vitale
  * @author Eric Bottard
  * @author Taewoong Kim
+ * @author Jewoo Shin
  */
 public final class OpenAiChatModel implements ChatModel {
 
@@ -264,6 +265,7 @@ public final class OpenAiChatModel implements ChatModel {
 		return Flux.deferContextual(contextView -> {
 			ChatCompletionCreateParams request = createRequest(prompt, true);
 			ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
+			ConcurrentHashMap<String, String> reasoningMap = new ConcurrentHashMap<>();
 			final ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(AiProvider.OPENAI.value())
@@ -320,13 +322,19 @@ public final class OpenAiChatModel implements ChatModel {
 					roleMap.putIfAbsent(id, choice.message()._role().asString().isPresent()
 							? choice.message()._role().asStringOrThrow() : "");
 
+					// Accumulate reasoning fragments across the streamed chunks so the
+					// final response of this stream carries the full reasoning content,
+					// surviving last-wins metadata aggregation (e.g. MessageAggregator).
+					String accumulatedReasoning = reasoningMap.merge(id + ":" + choice.index(),
+							getReasoningContent(choice), String::concat);
+
 					Map<String, Object> metadata = Map.of("id", id, //
 							"role", roleMap.getOrDefault(id, ""), //
 							"index", choice.index(), //
 							"finishReason", choice.finishReason().value(), //
 							"refusal", choice.message().refusal().orElse(""), //
 							"annotations", choice.message().annotations().orElseGet(List::of), //
-							REASONING_CONTENT, getReasoningContent(choice) //
+							REASONING_CONTENT, accumulatedReasoning //
 					);
 
 					return buildGeneration(choice, metadata, request);
@@ -1074,7 +1082,20 @@ public final class OpenAiChatModel implements ChatModel {
 				}
 			}).orElse(List.of());
 
-			return left.toBuilder().toolCalls(tcs).build();
+			Delta.Builder deltaBuilder = left.toBuilder().toolCalls(tcs);
+			// Concatenate reasoning fragments (e.g. DeepSeek "reasoning_content") so
+			// they survive the tool-call chunk merge instead of keeping only the first
+			// chunk's value.
+			for (String reasoningKey : List.of("reasoning_content", "reasoning")) {
+				stringProperty(right, reasoningKey).filter(StringUtils::hasLength)
+					.ifPresent(rightFragment -> deltaBuilder.putAdditionalProperty(reasoningKey,
+							JsonValue.from(stringProperty(left, reasoningKey).orElse("") + rightFragment)));
+			}
+			return deltaBuilder.build();
+		}
+
+		private static Optional<String> stringProperty(Delta delta, String key) {
+			return Optional.ofNullable(delta._additionalProperties().get(key)).flatMap(JsonValue::asString);
 		}
 
 		/**
@@ -1105,7 +1126,10 @@ public final class OpenAiChatModel implements ChatModel {
 
 				ChatCompletionMessage.Builder msgBuilder = ChatCompletionMessage.builder()
 					.content(cccc.delta().content())
-					.refusal(cccc.delta().refusal());
+					.refusal(cccc.delta().refusal())
+					// Carry over provider-specific delta fields (e.g. reasoning_content)
+					// so they are readable on the message, as in the non-streaming path.
+					.putAllAdditionalProperties(cccc.delta()._additionalProperties());
 				cccc.delta().toolCalls().ifPresent(ccctcs -> {
 					msgBuilder.toolCalls(ccctcs.stream().map(tc -> {
 						ChatCompletionMessageFunctionToolCall.Builder toolCallBuilder = ChatCompletionMessageFunctionToolCall

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
@@ -47,12 +49,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.util.JsonHelper;
 
@@ -64,6 +69,8 @@ import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link OpenAiChatModel}.
+ *
+ * @author Jewoo Shin
  */
 @ExtendWith(MockitoExtension.class)
 class OpenAiChatModelTests {
@@ -665,6 +672,182 @@ class OpenAiChatModelTests {
 			.orElseThrow();
 		assertThat(assistantParam._additionalProperties()).containsEntry("reasoning_content",
 				JsonValue.from("25 * 4 = 100."));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "reasoning_content", "reasoning" })
+	void streamingReasoningContentSurvivesAggregationWithToolCalls(String reasoningKey) {
+		// DeepSeek-style ("reasoning_content") or OpenRouter-style ("reasoning")
+		// stream: reasoning deltas first, then a tool call split across chunks, then
+		// finish_reason=tool_calls.
+		List<ChatCompletionChunk> chunks = List.of(
+				streamingChunk(delta -> delta.role(ChatCompletionChunk.Choice.Delta.Role.ASSISTANT)
+					.putAdditionalProperty(reasoningKey, JsonValue.from("Think step one. ")), null),
+				streamingChunk(delta -> delta.putAdditionalProperty(reasoningKey, JsonValue.from("Now call the tool.")),
+						null),
+				streamingChunk(delta -> delta.toolCalls(List.of(ChatCompletionChunk.Choice.Delta.ToolCall.builder()
+					.index(0L)
+					.id("call_1")
+					.function(ChatCompletionChunk.Choice.Delta.ToolCall.Function.builder()
+						.name("getWeather")
+						.arguments("{\"city\":")
+						.build())
+					.build())), null),
+				streamingChunk(delta -> delta.toolCalls(List.of(ChatCompletionChunk.Choice.Delta.ToolCall.builder()
+					.index(0L)
+					.function(ChatCompletionChunk.Choice.Delta.ToolCall.Function.builder()
+						.arguments("\"Seoul\"}")
+						.build())
+					.build())).putAdditionalProperty(reasoningKey, JsonValue.from(" One more thought.")), null),
+				streamingChunk(delta -> {
+				}, ChatCompletionChunk.Choice.FinishReason.TOOL_CALLS));
+
+		AssistantMessage aggregated = aggregateStreaming(chunks);
+
+		assertThat(aggregated.getToolCalls()).hasSize(1);
+		assertThat(aggregated.getToolCalls().get(0).name()).isEqualTo("getWeather");
+		assertThat(aggregated.getToolCalls().get(0).arguments()).isEqualTo("{\"city\":\"Seoul\"}");
+		assertThat(aggregated.getMetadata().get("reasoningContent"))
+			.isEqualTo("Think step one. Now call the tool. One more thought.");
+
+		// Replaying the aggregated message on the next turn must re-attach the wire
+		// field that providers like DeepSeek require on assistant tool-call messages.
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("deepseek-reasoner").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+		Prompt replayPrompt = new Prompt(List.of(new UserMessage("What's the weather in Seoul?"), aggregated,
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "getWeather", "{\"temp\":20}")))
+					.build()),
+				options);
+
+		ChatCompletionAssistantMessageParam assistantParam = chatModel.createRequest(replayPrompt, false)
+			.messages()
+			.stream()
+			.filter(ChatCompletionMessageParam::isAssistant)
+			.map(ChatCompletionMessageParam::asAssistant)
+			.findFirst()
+			.orElseThrow();
+		assertThat(assistantParam._additionalProperties()).containsEntry("reasoning_content",
+				JsonValue.from("Think step one. Now call the tool. One more thought."));
+	}
+
+	@Test
+	void streamingReasoningContentSurvivesAggregationWithoutToolCalls() {
+		List<ChatCompletionChunk> chunks = List.of(
+				streamingChunk(delta -> delta.role(ChatCompletionChunk.Choice.Delta.Role.ASSISTANT)
+					.putAdditionalProperty("reasoning_content", JsonValue.from("Quick thought. ")), null),
+				streamingChunk(
+						delta -> delta.putAdditionalProperty("reasoning_content", JsonValue.from("Another thought.")),
+						null),
+				streamingChunk(delta -> delta.content("Hello"), null),
+				streamingChunk(delta -> delta.content("!"), ChatCompletionChunk.Choice.FinishReason.STOP));
+
+		AssistantMessage aggregated = aggregateStreaming(chunks);
+
+		assertThat(aggregated.getText()).isEqualTo("Hello!");
+		assertThat(aggregated.getMetadata().get("reasoningContent")).isEqualTo("Quick thought. Another thought.");
+	}
+
+	@Test
+	void streamingReasoningContentAccumulatesAcrossIntermediateResponses() {
+		List<ChatCompletionChunk> chunks = List.of(
+				streamingChunk(delta -> delta.role(ChatCompletionChunk.Choice.Delta.Role.ASSISTANT)
+					.putAdditionalProperty("reasoning_content", JsonValue.from("Think step one. ")), null),
+				streamingChunk(
+						delta -> delta.putAdditionalProperty("reasoning_content", JsonValue.from("Think step two.")),
+						null),
+				streamingChunk(delta -> delta.content("Hello"), ChatCompletionChunk.Choice.FinishReason.STOP));
+
+		List<ChatResponse> responses = streamResponses(chunks).collectList().block();
+
+		assertThat(responses).hasSize(3);
+		assertThat(responses.get(0).getResult().getOutput().getMetadata().get("reasoningContent"))
+			.isEqualTo("Think step one. ");
+		assertThat(responses.get(1).getResult().getOutput().getMetadata().get("reasoningContent"))
+			.isEqualTo("Think step one. Think step two.");
+		assertThat(responses.get(2).getResult().getOutput().getMetadata().get("reasoningContent"))
+			.isEqualTo("Think step one. Think step two.");
+	}
+
+	private AssistantMessage aggregateStreaming(List<ChatCompletionChunk> chunks) {
+		Flux<ChatResponse> responses = streamResponses(chunks);
+
+		// Aggregate the way ChatClient advisors (e.g. ToolCallingAdvisor) do before
+		// re-injecting the assistant message into the next request.
+		AtomicReference<ChatResponse> aggregatedResponse = new AtomicReference<>();
+		new MessageAggregator().aggregate(responses, aggregatedResponse::set).blockLast();
+
+		assertThat(aggregatedResponse.get()).isNotNull();
+		return aggregatedResponse.get().getResult().getOutput();
+	}
+
+	private Flux<ChatResponse> streamResponses(List<ChatCompletionChunk> chunks) {
+		ChatServiceAsync chatServiceAsync = mock(ChatServiceAsync.class);
+		ChatCompletionServiceAsync chatCompletionServiceAsync = mock(ChatCompletionServiceAsync.class);
+		when(this.openAiClientAsync.chat()).thenReturn(chatServiceAsync);
+		when(chatServiceAsync.completions()).thenReturn(chatCompletionServiceAsync);
+		when(chatCompletionServiceAsync.createStreaming(any(ChatCompletionCreateParams.class)))
+			.thenReturn(asyncStreamResponseOf(chunks));
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("deepseek-reasoner").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		return chatModel.stream(new Prompt("Preserve reasoning metadata while streaming", options));
+	}
+
+	private static ChatCompletionChunk streamingChunk(
+			Consumer<ChatCompletionChunk.Choice.Delta.Builder> deltaCustomizer,
+			ChatCompletionChunk.Choice.FinishReason finishReason) {
+		ChatCompletionChunk.Choice.Delta.Builder deltaBuilder = ChatCompletionChunk.Choice.Delta.builder();
+		deltaCustomizer.accept(deltaBuilder);
+		return ChatCompletionChunk.builder()
+			.id("chatcmpl-123")
+			.created(1777799928L)
+			.model("deepseek-reasoner")
+			.addChoice(ChatCompletionChunk.Choice.builder()
+				.index(0L)
+				.delta(deltaBuilder.build())
+				.finishReason(finishReason)
+				.build())
+			.build();
+	}
+
+	private static AsyncStreamResponse<ChatCompletionChunk> asyncStreamResponseOf(List<ChatCompletionChunk> chunks) {
+		CompletableFuture<Void> onComplete = new CompletableFuture<>();
+		return new AsyncStreamResponse<>() {
+
+			@Override
+			public AsyncStreamResponse<ChatCompletionChunk> subscribe(Handler<? super ChatCompletionChunk> handler) {
+				chunks.forEach(handler::onNext);
+				handler.onComplete(Optional.empty());
+				onComplete.complete(null);
+				return this;
+			}
+
+			@Override
+			public AsyncStreamResponse<ChatCompletionChunk> subscribe(Handler<? super ChatCompletionChunk> handler,
+					Executor executor) {
+				return subscribe(handler);
+			}
+
+			@Override
+			public CompletableFuture<Void> onCompleteFuture() {
+				return onComplete;
+			}
+
+			@Override
+			public void close() {
+			}
+
+		};
 	}
 
 	@Test


### PR DESCRIPTION
The OpenAI-compatible streaming path drops provider reasoning metadata that `call()` already preserves. `ChunkMerger.chunkToChatCompletion` rebuilds streamed messages from `content`/`refusal`/`toolCalls` only, so fields such as DeepSeek's `reasoning_content` and OpenRouter's `reasoning` never reach `getReasoningContent`. On next-turn replay, `createRequest` then has nothing to re-attach, so providers that require reasoning on assistant tool-call messages reject the request as missing `reasoning_content`.

This keeps the fix inside `OpenAiChatModel` and reuses the existing `reasoning_content` / `reasoning` mapping already used by `getReasoningContent` and assistant-message replay:

- Streamed chunks carry delta additional properties into rebuilt messages.
- Merged tool-call chunks concatenate reasoning fragments.
- The streaming pipeline accumulates reasoning per choice so the final response survives `MessageAggregator`-based advisor replay.
- Intermediate streamed responses now expose the reasoning accumulated so far.

Related scope: #6402 was closed as superseded by this PR. #6484 reports the same `ChunkMerger.chunkToChatCompletion(...)` stream-path boundary, and #6483 covers the first delta-to-message additional-properties copy from that report. This PR also covers reasoning fragments merged across tool-call chunks and the final aggregated assistant message used for advisor/chat-memory replay. The confirmed RC2 `stream()` symptom in #6375 maps to the same gap.

Tests cover DeepSeek/OpenRouter reasoning fields with split tool calls, reasoning without tools, and `createRequest` replay. The native DeepSeek starter loses reasoning through a separate `MessageAggregator` flattening path and remains out of scope.

See #5898, #6375, and #6484
