### PR TITLE
Fix `reasoningContent` always `null` on `OpenAiChatModel` call path

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -105,6 +105,7 @@ import org.springframework.util.StringUtils;
  * @author Alexandros Pappas
  * @author Soby Chacko
  * @author Jonghoon Park
+ * @author Jewoo Shin
  * @see ChatModel
  * @see StreamingChatModel
  * @see OpenAiApi
@@ -219,7 +220,8 @@ public class OpenAiChatModel implements ChatModel {
 							"index", choice.index() != null ? choice.index() : 0,
 							"finishReason", getFinishReasonJson(choice.finishReason()),
 							"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "",
-							"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of(Map.of()));
+							"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of(Map.of()),
+							"reasoningContent", choice.message().reasoningContent() != null ? choice.message().reasoningContent() : "");
 					return buildGeneration(choice, metadata, request);
 				}).toList();
 				// @formatter:on

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelWithChatResponseMetadataTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelWithChatResponseMetadataTests.java
@@ -53,6 +53,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 /**
  * @author John Blum
  * @author Christian Tzolov
+ * @author Jewoo Shin
  * @since 0.7.0
  */
 @RestClientTest(OpenAiChatModelWithChatResponseMetadataTests.Config.class)
@@ -142,6 +143,46 @@ public class OpenAiChatModelWithChatResponseMetadataTests {
 
 		var logprobs = response.getResult().getMetadata().get("logprobs");
 		assertThat(logprobs).isNotNull().isInstanceOf(OpenAiApi.LogProbs.class);
+	}
+
+	@Test
+	void aiResponseContainsReasoningContentMetadata() {
+
+		String json = """
+				   {
+				      "id": "chatcmpl-123",
+				      "object": "chat.completion",
+				      "created": 1677652288,
+				      "model": "deepseek-reasoner",
+				      "choices": [{
+				      "index": 0,
+				      "message": {
+				         "role": "assistant",
+				         "content": "I surrender!",
+				         "reasoning_content": "The user demands surrender, so complying is the safest option."
+				      },
+				      "finish_reason": "stop"
+				      }],
+				      "usage": {
+				      "prompt_tokens": 9,
+				      "completion_tokens": 12,
+				      "total_tokens": 21
+				      }
+				   }
+				""";
+
+		this.server.expect(requestTo(StringContains.containsString("/v1/chat/completions")))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer " + TEST_API_KEY))
+			.andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+		Prompt prompt = new Prompt("Reach for the sky.");
+
+		ChatResponse response = this.openAiChatClient.call(prompt);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getResult().getOutput().getMetadata()).containsEntry("reasoningContent",
+				"The user demands surrender, so complying is the safest option.");
 	}
 
 	private void prepareMock(boolean includeLogprobs) {


### PR DESCRIPTION
On the 1.1.x line, `OpenAiChatModel` already exposes `reasoningContent` metadata for streaming responses, but the blocking `call()` path omits the same entry from its generation metadata map. This leaves OpenAI-compatible reasoning responses with `message.getMetadata().get("reasoningContent") == null` even when the wire payload contains `reasoning_content`.

This PR mirrors the streaming metadata entry on the `call()` path and adds a `MockRestServiceServer` regression test for a `reasoning_content` response.

Verified with `./mvnw package -pl models/spring-ai-openai`.

See #6375