### PR TITLE
Update outdated Pinecone free-tier namespace notes

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pinecone.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pinecone.adoc
@@ -20,7 +20,7 @@ To set up `PineconeVectorStore`, gather the following details from your Pinecone
 [NOTE]
 ====
 This information is available to you in the Pinecone UI portal.
-The namespace support is not available in the Pinecone free tier.
+Namespaces are supported on all current Pinecone plans, including the free Starter plan; the maximum number of namespaces per serverless index depends on your plan.
 ====
 
 == Auto-configuration
@@ -192,7 +192,7 @@ public VectorStore pineconeVectorStore(EmbeddingModel embeddingModel) {
     return PineconeVectorStore.builder(embeddingModel)
             .apiKey(PINECONE_API_KEY)
             .indexName(PINECONE_INDEX_NAME)
-            .namespace(PINECONE_NAMESPACE) // the free tier doesn't support namespaces.
+            .namespace(PINECONE_NAMESPACE)
             .contentFieldName(CUSTOM_CONTENT_FIELD_NAME) // optional field to store the original content. Defaults to `document_content`
             .build();
 }

--- a/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
@@ -370,9 +370,9 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 		}
 
 		/**
-		 * Sets the Pinecone namespace. Note: The free-tier (gcp-starter) doesn't support
-		 * Namespaces.
-		 * @param namespace The namespace to use (leave empty for free tier)
+		 * Sets the Pinecone namespace.
+		 * @param namespace The namespace to use ({@code null} is treated as the default
+		 * namespace)
 		 * @return The builder instance
 		 */
 		public Builder namespace(@Nullable String namespace) {

--- a/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStoreIT.java
+++ b/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStoreIT.java
@@ -65,8 +65,8 @@ public class PineconeVectorStoreIT extends BaseVectorStoreTests {
 
 	private static final String PINECONE_INDEX_NAME = "spring-ai-test-index";
 
-	// Use unique namespace per test run for isolation when env is not set; set
-	// PINECONE_NAMESPACE="" for free tier (no namespaces).
+	// Use a unique namespace per test run for isolation when PINECONE_NAMESPACE is not
+	// set.
 	private static String PINECONE_NAMESPACE;
 
 	private static final String CUSTOM_CONTENT_FIELD_NAME = "article";

--- a/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStoreObservationIT.java
+++ b/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStoreObservationIT.java
@@ -62,8 +62,8 @@ public class PineconeVectorStoreObservationIT {
 
 	private static final String PINECONE_INDEX_NAME = "spring-ai-test-index";
 
-	// Use unique namespace per test run for isolation when env is not set; set
-	// PINECONE_NAMESPACE="" for free tier (no namespaces).
+	// Use a unique namespace per test run for isolation when PINECONE_NAMESPACE is not
+	// set.
 	private static String PINECONE_NAMESPACE;
 
 	private static final String CUSTOM_CONTENT_FIELD_NAME = "article";


### PR DESCRIPTION
Fixes GH-4754 (https://github.com/spring-projects/spring-ai/issues/4754)

The Pinecone reference docs state that namespaces are not available on the Pinecone free tier. That was true, but now all current Pinecone plans support namespaces on serverless indexes - the free Starter plan allows up to 100 namespaces per index (see the "Object limits" table at https://docs.pinecone.io/reference/api/database-limits).

Changes (docs/comments only, no behavior change):

* `pinecone.adoc` — replace the outdated NOTE with current namespace support info and remove the stale `// the free tier doesn't support namespaces.`  comment from the manual-configuration sample
* `PineconeVectorStore` — update the `Builder#namespace` Javadoc, which still referenced `gcp-starter`; document the actual `null` handling instead
* `PineconeVectorStoreIT` / `PineconeVectorStoreObservationIT` — refresh the namespace comments that carried the same outdated claim

Verification: `./mvnw -pl vector-stores/spring-ai-pinecone-store package` and `process-sources -P checkstyle-check` pass; Antora docs build renders the updated note. Note `PineconeVectorStoreIT` already defaults to a unique namespace per run, so any green IT run against a Starter-plan key exercises namespaces on the free tier.