### PR TITLE
refactor(observation): make image observation package null-marked

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/image/observation/DefaultImageModelObservationConvention.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/image/observation/DefaultImageModelObservationConvention.java
@@ -41,9 +41,9 @@ public class DefaultImageModelObservationConvention implements ImageModelObserva
 
 	@Override
 	public String getContextualName(ImageModelObservationContext context) {
-		if (StringUtils.hasText(context.getRequest().getOptions().getModel())) {
-			return "%s %s".formatted(context.getOperationMetadata().operationType(),
-					context.getRequest().getOptions().getModel());
+		var options = context.getRequest().getOptions();
+		if (options != null && StringUtils.hasText(options.getModel())) {
+			return "%s %s".formatted(context.getOperationMetadata().operationType(), options.getModel());
 		}
 		return context.getOperationMetadata().operationType();
 	}
@@ -64,9 +64,10 @@ public class DefaultImageModelObservationConvention implements ImageModelObserva
 	}
 
 	protected KeyValue requestModel(ImageModelObservationContext context) {
-		if (StringUtils.hasText(context.getRequest().getOptions().getModel())) {
+		var options = context.getRequest().getOptions();
+		if (options != null && StringUtils.hasText(options.getModel())) {
 			return KeyValue.of(ImageModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL,
-					context.getRequest().getOptions().getModel());
+					options.getModel());
 		}
 		return REQUEST_MODEL_NONE;
 	}
@@ -84,30 +85,31 @@ public class DefaultImageModelObservationConvention implements ImageModelObserva
 	// Request
 
 	protected KeyValues requestImageFormat(KeyValues keyValues, ImageModelObservationContext context) {
-		if (StringUtils.hasText(context.getRequest().getOptions().getResponseFormat())) {
+		var options = context.getRequest().getOptions();
+		if (options != null && StringUtils.hasText(options.getResponseFormat())) {
 			return keyValues.and(
 					ImageModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_IMAGE_RESPONSE_FORMAT.asString(),
-					context.getRequest().getOptions().getResponseFormat());
+					options.getResponseFormat());
 		}
 		return keyValues;
 	}
 
 	protected KeyValues requestImageSize(KeyValues keyValues, ImageModelObservationContext context) {
-		if (context.getRequest().getOptions().getWidth() != null
-				&& context.getRequest().getOptions().getHeight() != null) {
+		var options = context.getRequest().getOptions();
+		if (options != null && options.getWidth() != null && options.getHeight() != null) {
 			return keyValues.and(
 					ImageModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_IMAGE_SIZE.asString(),
-					"%sx%s".formatted(context.getRequest().getOptions().getWidth(),
-							context.getRequest().getOptions().getHeight()));
+					"%sx%s".formatted(options.getWidth(), options.getHeight()));
 		}
 		return keyValues;
 	}
 
 	protected KeyValues requestImageStyle(KeyValues keyValues, ImageModelObservationContext context) {
-		if (StringUtils.hasText(context.getRequest().getOptions().getStyle())) {
+		var options = context.getRequest().getOptions();
+		if (options != null && StringUtils.hasText(options.getStyle())) {
 			return keyValues.and(
 					ImageModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_IMAGE_STYLE.asString(),
-					context.getRequest().getOptions().getStyle());
+					options.getStyle());
 		}
 		return keyValues;
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/image/observation/ImageModelObservationContext.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/image/observation/ImageModelObservationContext.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.image.observation;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 import org.springframework.ai.model.observation.ModelObservationContext;
@@ -47,9 +49,9 @@ public class ImageModelObservationContext extends ModelObservationContext<ImageP
 
 	public static final class Builder {
 
-		private ImagePrompt imagePrompt;
+		private @Nullable ImagePrompt imagePrompt;
 
-		private String provider;
+		private @Nullable String provider;
 
 		private Builder() {
 		}
@@ -65,6 +67,8 @@ public class ImageModelObservationContext extends ModelObservationContext<ImageP
 		}
 
 		public ImageModelObservationContext build() {
+			Assert.notNull(this.imagePrompt, "request cannot be null");
+			Assert.notNull(this.provider, "provider cannot be null or empty");
 			return new ImageModelObservationContext(this.imagePrompt, this.provider);
 		}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/image/observation/package-info.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/image/observation/package-info.java
@@ -17,9 +17,7 @@
 /**
  * Provides classes for observing image data.
  */
-@NonNullApi
-@NonNullFields
+@NullMarked
 package org.springframework.ai.image.observation;
 
-import org.springframework.lang.NonNullApi;
-import org.springframework.lang.NonNullFields;
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
This PR transitions the `org.springframework.ai.image.observation` package to JSpecify `@NullMarked`, updating the annotations in `package-info.java`, adding `@Nullable` declarations in the builder, and introducing necessary null-safety checks in the convention and builder to ensure compliance with NullAway rules.