### PR TITLE
Remove `streamToolCallResponses` from advisor builders

### DIFF
--- a/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
+++ b/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
@@ -119,13 +119,11 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 	private final ToolIndexEvictionStrategy evictionStrategy;
 
 	protected ToolSearchToolCallingAdvisor(ToolCallingManager toolCallingManager, int advisorOrder,
-			boolean streamToolCallResponses, ToolExecutionEligibilityChecker toolExecutionEligibilityChecker,
-			ToolIndex toolIndex, String systemMessageSuffix, boolean referenceToolNameAccumulation,
-			@Nullable Integer maxResults, boolean conversationHistoryEnabled, String sessionIdKeyName,
-			ToolIndexEvictionStrategy evictionStrategy) {
+			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, ToolIndex toolIndex,
+			String systemMessageSuffix, boolean referenceToolNameAccumulation, @Nullable Integer maxResults,
+			boolean conversationHistoryEnabled, String sessionIdKeyName, ToolIndexEvictionStrategy evictionStrategy) {
 
-		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled,
-				streamToolCallResponses);
+		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled);
 		this.toolIndex = toolIndex;
 		this.systemMessageSuffix = systemMessageSuffix;
 		this.referenceToolNameAccumulation = referenceToolNameAccumulation;
@@ -481,7 +479,7 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 
 			Assert.notNull(this.toolIndex, "toolIndex is required");
 			return new ToolSearchToolCallingAdvisor(getToolCallingManager(), getAdvisorOrder(),
-					isStreamToolCallResponses(), getToolExecutionEligibilityChecker(), this.toolIndex,
+					getToolExecutionEligibilityChecker(), this.toolIndex,
 					Objects.requireNonNull(this.systemMessageSuffix), this.referenceToolNameAccumulation,
 					this.maxResults, this.isConversationHistoryEnabled(), this.sessionIdKeyName, this.evictionStrategy);
 		}

--- a/advisors/spring-ai-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/AbstractToolSearchToolCallingAdvisorIT.java
+++ b/advisors/spring-ai-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/AbstractToolSearchToolCallingAdvisorIT.java
@@ -120,7 +120,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 	class CallTests {
 
 		@ParameterizedTest(name = "[{index}] {0}")
-		@MethodSource("org.springframework.ai.tool.toolsearch.advisor.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		@MethodSource("org.springframework.ai.chat.client.advisor.toolsearch.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
 		void callMultipleToolInvocations(ToolIndex toolIndex) {
 			String response = ChatClient.create(getChatModel())
 				.prompt()
@@ -134,7 +134,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 		}
 
 		@ParameterizedTest(name = "[{index}] {0}")
-		@MethodSource("org.springframework.ai.tool.toolsearch.advisor.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		@MethodSource("org.springframework.ai.chat.client.advisor.toolsearch.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
 		void callMultipleToolInvocationsWithExternalMemory(ToolIndex toolIndex) {
 			String response = ChatClient.create(getChatModel())
 				.prompt()
@@ -150,7 +150,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 		}
 
 		@ParameterizedTest(name = "[{index}] {0}")
-		@MethodSource("org.springframework.ai.tool.toolsearch.advisor.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		@MethodSource("org.springframework.ai.chat.client.advisor.toolsearch.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
 		void callDefaultAdvisorConfiguration(ToolIndex toolIndex) {
 			var chatClient = ChatClient.builder(getChatModel())
 				.defaultAdvisors(createToolSearchToolCallingAdvisor(toolIndex))
@@ -166,7 +166,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 		}
 
 		@ParameterizedTest(name = "[{index}] {0}")
-		@MethodSource("org.springframework.ai.tool.toolsearch.advisor.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		@MethodSource("org.springframework.ai.chat.client.advisor.toolsearch.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
 		void callDefaultAdvisorConfigurationWithExternalMemory(ToolIndex toolIndex) {
 			var chatClient = ChatClient.builder(getChatModel())
 				.defaultAdvisors(createToolSearchToolCallingAdvisorWithExternalMemory(toolIndex),
@@ -188,7 +188,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 	class StreamTests {
 
 		@ParameterizedTest(name = "[{index}] {0}")
-		@MethodSource("org.springframework.ai.tool.toolsearch.advisor.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		@MethodSource("org.springframework.ai.chat.client.advisor.toolsearch.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
 		void streamMultipleToolInvocations(ToolIndex toolIndex) {
 			Flux<String> response = ChatClient.create(getChatModel())
 				.prompt()
@@ -204,7 +204,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 		}
 
 		@ParameterizedTest(name = "[{index}] {0}")
-		@MethodSource("org.springframework.ai.tool.toolsearch.advisor.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		@MethodSource("org.springframework.ai.chat.client.advisor.toolsearch.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
 		void streamMultipleToolInvocationsWithExternalMemory(ToolIndex toolIndex) {
 			Flux<String> response = ChatClient.create(getChatModel())
 				.prompt()
@@ -222,7 +222,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 		}
 
 		@ParameterizedTest(name = "[{index}] {0}")
-		@MethodSource("org.springframework.ai.tool.toolsearch.advisor.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		@MethodSource("org.springframework.ai.chat.client.advisor.toolsearch.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
 		void streamDefaultAdvisorConfiguration(ToolIndex toolIndex) {
 			var chatClient = ChatClient.builder(getChatModel())
 				.defaultAdvisors(createToolSearchToolCallingAdvisor(toolIndex))
@@ -240,7 +240,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 		}
 
 		@ParameterizedTest(name = "[{index}] {0}")
-		@MethodSource("org.springframework.ai.tool.toolsearch.advisor.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		@MethodSource("org.springframework.ai.chat.client.advisor.toolsearch.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
 		void streamDefaultAdvisorConfigurationWithExternalMemory(ToolIndex toolIndex) {
 			var chatClient = ChatClient.builder(getChatModel())
 				.defaultAdvisors(createToolSearchToolCallingAdvisorWithExternalMemory(toolIndex),

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
@@ -117,7 +117,6 @@ public class ToolSearchAdvisorAutoConfiguration implements InitializingBean {
 			.toolCallingManager(toolCallingManager)
 			.toolIndex(toolIndex)
 			.advisorOrder(properties.getAdvisorOrder())
-			.streamToolCallResponses(properties.isStreamToolCallResponses())
 			.referenceToolNameAccumulation(properties.isReferenceToolNameAccumulation())
 			.sessionIdKeyName(properties.getSessionIdKeyName())
 			.evictionStrategy(buildEvictionStrategy(properties.getEviction()));

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorProperties.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorProperties.java
@@ -95,13 +95,6 @@ public class ToolSearchAdvisorProperties {
 	 */
 	private int advisorOrder = ToolCallingAdvisor.DEFAULT_ORDER;
 
-	/**
-	 * Whether intermediate tool-call responses are streamed back to the caller during a
-	 * {@code stream()} invocation. When {@code false} (default), only the final answer is
-	 * streamed.
-	 */
-	private boolean streamToolCallResponses = false;
-
 	private final Eviction eviction = new Eviction();
 
 	private final Lucene lucene = new Lucene();
@@ -161,14 +154,6 @@ public class ToolSearchAdvisorProperties {
 
 	public void setAdvisorOrder(int advisorOrder) {
 		this.advisorOrder = advisorOrder;
-	}
-
-	public boolean isStreamToolCallResponses() {
-		return this.streamToolCallResponses;
-	}
-
-	public void setStreamToolCallResponses(boolean streamToolCallResponses) {
-		this.streamToolCallResponses = streamToolCallResponses;
 	}
 
 	public Eviction getEviction() {

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfigurationTests.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfigurationTests.java
@@ -186,17 +186,6 @@ class ToolSearchAdvisorAutoConfigurationTests {
 	// --- Remaining builder properties ---
 
 	@Test
-	void streamToolCallResponsesPropertyIsApplied() {
-		this.contextRunner
-			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",
-					"spring.ai.chat.client.tool-search-advisor.stream-tool-call-responses=true")
-			.run(context -> {
-				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
-				assertThat(ReflectionTestUtils.getField(builder, "streamToolCallResponses")).isEqualTo(true);
-			});
-	}
-
-	@Test
 	void referenceToolNameAccumulationPropertyIsApplied() {
 		this.contextRunner
 			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true",

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
@@ -102,8 +102,7 @@ public class ChatClientAutoConfiguration {
 			ObjectProvider<ToolExecutionEligibilityChecker> toolExecutionEligibilityChecker) {
 		var builder = ToolCallingAdvisor.builder()
 			.toolCallingManager(toolCallingManager)
-			.advisorOrder(properties.getToolCalling().getAdvisorOrder())
-			.streamToolCallResponses(properties.getToolCalling().isStreamToolCallResponses());
+			.advisorOrder(properties.getToolCalling().getAdvisorOrder());
 
 		toolExecutionEligibilityChecker.ifAvailable(builder::toolExecutionEligibilityChecker);
 

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientBuilderProperties.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientBuilderProperties.java
@@ -77,14 +77,6 @@ public class ChatClientBuilderProperties {
 		 */
 		private int advisorOrder = ToolCallingAdvisor.DEFAULT_ORDER;
 
-		/**
-		 * Whether intermediate tool-call responses are streamed back to the caller during
-		 * a {@code stream()} invocation. When {@code true}, each tool-call iteration
-		 * emits its chunks in real time before the recursive call is made. When
-		 * {@code false} (default), only the final answer is streamed.
-		 */
-		private boolean streamToolCallResponses = false;
-
 		public boolean isEnabled() {
 			return this.enabled;
 		}
@@ -99,14 +91,6 @@ public class ChatClientBuilderProperties {
 
 		public void setAdvisorOrder(int advisorOrder) {
 			this.advisorOrder = advisorOrder;
-		}
-
-		public boolean isStreamToolCallResponses() {
-			return this.streamToolCallResponses;
-		}
-
-		public void setStreamToolCallResponses(boolean streamToolCallResponses) {
-			this.streamToolCallResponses = streamToolCallResponses;
 		}
 
 	}

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfigurationTests.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfigurationTests.java
@@ -111,19 +111,6 @@ class ChatClientAutoConfigurationTests {
 	}
 
 	@Test
-	void streamToolCallResponsesPropertyIsAppliedToToolCallingAdvisorBuilder() {
-		var manager = mock(ToolCallingManager.class);
-
-		this.contextRunner.withBean(ToolCallingManager.class, () -> manager)
-			.withPropertyValues("spring.ai.chat.client.tool-calling.stream-tool-call-responses=true")
-			.run(context -> {
-				assertThat(context).hasNotFailed();
-				var advisorBuilder = context.getBean(ToolCallingAdvisor.Builder.class);
-				assertThat(ReflectionTestUtils.getField(advisorBuilder, "streamToolCallResponses")).isEqualTo(true);
-			});
-	}
-
-	@Test
 	void toolExecutionEligibilityCheckerBeanIsWiredIntoAdvisorBuilder() {
 		var manager = mock(ToolCallingManager.class);
 		ToolExecutionEligibilityChecker customChecker = chatResponse -> false;

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -1213,9 +1213,6 @@ public class DefaultChatClient implements ChatClient {
 		 * {@link MemoryAdvisor} with a higher order (i.e. downstream in the request
 		 * direction) is already registered, since that memory advisor will handle history
 		 * for every tool-call iteration.
-		 * <p>
-		 * {@code streamToolCallResponses} must be pre-configured on the
-		 * {@code toolCallingAdvisorBuilder} passed to {@link DefaultChatClient}.
 		 */
 		private void autoRegisterToolCallingAdvisor() {
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -29,9 +29,8 @@ public class ToolCallAdvisor extends ToolCallingAdvisor {
 
 	protected ToolCallAdvisor(ToolCallingManager toolCallingManager,
 			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, int advisorOrder,
-			boolean conversationHistoryEnabled, boolean streamToolCallResponses) {
-		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled,
-				streamToolCallResponses);
+			boolean conversationHistoryEnabled) {
+		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled);
 	}
 
 	/**
@@ -56,7 +55,7 @@ public class ToolCallAdvisor extends ToolCallingAdvisor {
 		@Override
 		public ToolCallAdvisor build() {
 			return new ToolCallAdvisor(getToolCallingManager(), getToolExecutionEligibilityChecker(), getAdvisorOrder(),
-					isConversationHistoryEnabled(), isStreamToolCallResponses());
+					isConversationHistoryEnabled());
 		}
 
 	}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -90,11 +90,9 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 	private final boolean conversationHistoryEnabled;
 
-	private final boolean streamToolCallResponses;
-
 	protected ToolCallingAdvisor(ToolCallingManager toolCallingManager,
 			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, int advisorOrder,
-			boolean conversationHistoryEnabled, boolean streamToolCallResponses) {
+			boolean conversationHistoryEnabled) {
 		Assert.notNull(toolCallingManager, "toolCallingManager must not be null");
 		Assert.notNull(toolExecutionEligibilityChecker, "toolExecutionEligibilityChecker must not be null");
 		Assert.isTrue(advisorOrder > BaseAdvisor.HIGHEST_PRECEDENCE && advisorOrder < BaseAdvisor.LOWEST_PRECEDENCE,
@@ -104,7 +102,6 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
 		this.advisorOrder = advisorOrder;
 		this.conversationHistoryEnabled = conversationHistoryEnabled;
-		this.streamToolCallResponses = streamToolCallResponses;
 	}
 
 	@Override
@@ -277,8 +274,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		return CHAT_CLIENT_MESSAGE_AGGREGATOR.aggregateChatClientResponse(responseFlux, aggregatedResponseRef::set)
 			.concatWith(Flux.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest,
 					streamAdvisorChain, originalRequest, optionsCopy)))
-			.filter(ccr -> this.streamToolCallResponses
-					|| !this.toolExecutionEligibilityChecker.isToolCallResponse(ccr.chatResponse()));
+			.filter(ccr -> !this.toolExecutionEligibilityChecker.isToolCallResponse(ccr.chatResponse()));
 	}
 
 	/**
@@ -432,8 +428,6 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 		private boolean conversationHistoryEnabled = true;
 
-		private boolean streamToolCallResponses = false;
-
 		protected Builder() {
 		}
 
@@ -503,20 +497,6 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		}
 
 		/**
-		 * Sets whether intermediate tool call responses should be streamed to downstream
-		 * consumers. When enabled (default), all chunks including tool call responses are
-		 * streamed in real-time. When disabled, only the final answer chunks are
-		 * streamed, and intermediate tool call responses are filtered out.
-		 * @param streamToolCallResponses true to stream tool call responses (default),
-		 * false to filter them out
-		 * @return this Builder instance for method chaining
-		 */
-		public T streamToolCallResponses(boolean streamToolCallResponses) {
-			this.streamToolCallResponses = streamToolCallResponses;
-			return self();
-		}
-
-		/**
 		 * Returns the configured ToolCallingManager.
 		 * @return the ToolCallingManager instance
 		 */
@@ -543,8 +523,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		/**
 		 * Creates a shallow copy of this builder with all current settings. The copy can
 		 * be used as a template from which per-call overrides (e.g.
-		 * {@code conversationHistoryEnabled}, {@code streamToolCallResponses}) are
-		 * applied without mutating the original.
+		 * {@code conversationHistoryEnabled}) are applied without mutating the original.
 		 * <p>
 		 * Subclasses must override {@link #newCopy()} to return an instance of their own
 		 * type, and override this method to copy their additional fields into it.
@@ -556,7 +535,6 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			copy.toolExecutionEligibilityChecker = this.toolExecutionEligibilityChecker;
 			copy.advisorOrder = this.advisorOrder;
 			copy.conversationHistoryEnabled = this.conversationHistoryEnabled;
-			copy.streamToolCallResponses = this.streamToolCallResponses;
 			return copy;
 		}
 
@@ -569,14 +547,6 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		 */
 		protected Builder<?> newCopy() {
 			return new Builder<>();
-		}
-
-		/**
-		 * Returns whether tool call responses should be streamed.
-		 * @return true if tool call responses should be streamed
-		 */
-		protected boolean isStreamToolCallResponses() {
-			return this.streamToolCallResponses;
 		}
 
 		/**
@@ -596,7 +566,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		 */
 		public ToolCallingAdvisor build() {
 			return new ToolCallingAdvisor(this.toolCallingManager, this.toolExecutionEligibilityChecker,
-					this.advisorOrder, this.conversationHistoryEnabled, this.streamToolCallResponses);
+					this.advisorOrder, this.conversationHistoryEnabled);
 		}
 
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -192,7 +192,6 @@ public class ToolCallingAdvisorTests {
 		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
 			.toolCallingManager(this.toolCallingManager)
 			.toolExecutionEligibilityChecker(chatResponse -> false)
-			.streamToolCallResponses(true)
 			.build();
 
 		ChatClientRequest request = createMockRequest();
@@ -480,8 +479,8 @@ public class ToolCallingAdvisorTests {
 
 		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
 
-		// With default streamToolCallResponses=false, we only get the final response
-		// (intermediate tool call responses are filtered out)
+		// Intermediate tool call responses are filtered out; only the final response is
+		// emitted
 		assertThat(results).isNotNull().hasSize(1);
 		assertThat(callCount[0]).isEqualTo(2);
 		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
@@ -523,8 +522,8 @@ public class ToolCallingAdvisorTests {
 		// Verify that the tool execution was called only once (no loop continuation)
 		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
 
-		// With default streamToolCallResponses=false, we only get the returnDirect result
-		// (intermediate tool call response is filtered out)
+		// Intermediate tool call response is filtered out; only the returnDirect result
+		// is emitted
 		assertThat(results).isNotNull().hasSize(1);
 		// The result contains the tool execution result
 		assertThat(results.get(0).chatResponse()).isNotNull();
@@ -664,63 +663,6 @@ public class ToolCallingAdvisorTests {
 		assertThat(result).isEqualTo(finalResponse);
 		// With conversationHistoryEnabled=false, only the last message from history is
 		// used
-		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
-	}
-
-	@Test
-	void testStreamToolCallResponsesDefaultValue() {
-		ToolCallingAdvisor.Builder<?> builder = ToolCallingAdvisor.builder();
-
-		// By default, streamToolCallResponses should be false
-		assertThat(builder.isStreamToolCallResponses()).isFalse();
-	}
-
-	@Test
-	void testStreamToolCallResponsesBuilderMethod() {
-		ToolCallingAdvisor.Builder<?> builder = ToolCallingAdvisor.builder().streamToolCallResponses(false);
-
-		assertThat(builder.isStreamToolCallResponses()).isFalse();
-	}
-
-	@Test
-	void testAdviseStreamWithToolCallResponsesEnabled() {
-		// Create advisor with tool call streaming explicitly enabled
-		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
-			.toolCallingManager(this.toolCallingManager)
-			.streamToolCallResponses(true)
-			.build();
-
-		ChatClientRequest request = createMockRequest();
-		ChatClientResponse responseWithToolCall = createMockResponse(true);
-		ChatClientResponse finalResponse = createMockResponse(false);
-
-		// Create a terminal stream advisor that returns responses in sequence
-		int[] callCount = { 0 };
-		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
-			callCount[0]++;
-			return Flux.just(callCount[0] == 1 ? responseWithToolCall : finalResponse);
-		});
-
-		// Create a real chain with both advisors
-		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
-			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
-			.build();
-
-		// Mock tool execution result
-		List<Message> conversationHistory = List.of(new UserMessage("test"),
-				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
-		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
-			.conversationHistory(conversationHistory)
-			.build();
-		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
-			.thenReturn(toolExecutionResult);
-
-		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
-
-		// With streamToolCallResponses(true), we get both the intermediate tool call
-		// response (streamed in real-time) and the final response from recursive call
-		assertThat(results).isNotNull().hasSize(2);
-		assertThat(callCount[0]).isEqualTo(2); // Both iterations still happen
 		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
 	}
 
@@ -994,7 +936,7 @@ public class ToolCallingAdvisorTests {
 		private final int[] hookCallCounts;
 
 		TestableToolCallingAdvisor(ToolCallingManager toolCallingManager, int advisorOrder, int[] hookCallCounts) {
-			super(toolCallingManager, DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER, advisorOrder, true, true);
+			super(toolCallingManager, DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER, advisorOrder, true);
 			this.hookCallCounts = hookCallCounts;
 		}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -95,27 +95,109 @@ var chatClient = ChatClient.builder(chatModel)
     .build();
 ----
 
-==== Streaming Intermediate Tool-Call Responses
+==== User-Controlled Tool Execution
 
-By default, only the final LLM answer is emitted when using `.stream()` — chunks from intermediate tool-call iterations are suppressed until the last iteration finishes.
-Set `streamToolCallResponses(true)` on the builder to stream each iteration's chunks in real time as they arrive:
+By default, `ToolCallingAdvisor` is auto-registered and manages the entire tool-calling loop internally — the caller only receives the final LLM answer.
+When you need full control over the loop (for example, to stream intermediate progress to a UI, add custom observability, or apply conditional logic between iterations), you can opt out of the auto-registered advisor and drive the loop yourself.
+
+Disable the auto-registration on a per-call basis using `AdvisorParams.toolCallingAdvisorAutoRegister(false)`:
 
 [source,java]
 ----
-var toolCallingAdvisor = ToolCallingAdvisor.builder()
-    .toolCallingManager(toolCallingManager)
-    .streamToolCallResponses(true)
+ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+ToolCallback[] tools = ToolCallbacks.from(new WeatherTools());
+ChatOptions chatOptions = ToolCallingChatOptions.builder()
+    .toolCallbacks(tools)
     .build();
+
+String question = "What is the weather in Amsterdam and Paris?";
+
+// ToolCallingAdvisor is disabled — no tool loop runs automatically
+ChatClientResponse response = chatClient.prompt()
+    .user(question)
+    .options(chatOptions)
+    .advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+    .call()
+    .chatClientResponse();
+
+Prompt prompt = new Prompt(List.of(new UserMessage(question)), chatOptions);
+
+// Drive the loop manually — each iteration can be forwarded to a UI as it happens
+while (response.chatResponse() != null && response.chatResponse().hasToolCalls()) {
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, response.chatResponse());
+    prompt = new Prompt(result.conversationHistory(), chatOptions);
+    response = chatClient.prompt()
+        .messages(result.conversationHistory())
+        .options(chatOptions)
+        .advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+        .call()
+        .chatClientResponse();
+}
 ----
 
-When using Spring Boot auto-configuration, set the equivalent property instead:
+For a complete example including the streaming path, see xref:api/tools.adoc#_with_chatclient[User-Controlled Tool Execution — With ChatClient].
 
-[source,properties]
+==== Observing the Tool-Calling Loop
+
+As an alternative to driving the loop manually, you can place a custom advisor _inside_ the `ToolCallingAdvisor` loop by giving it an order value greater than `ToolCallingAdvisor.DEFAULT_ORDER` (e.g. `HIGHEST_PRECEDENCE + 400`).
+Such an advisor is invoked on **every iteration** of the tool-calling loop, not just once at the end, which means it has access to all intermediate messages:
+
+* **In streaming mode** — it receives the model's raw chunk stream for each iteration, including tool-call request chunks, before `ToolCallingAdvisor` filters them out of the outbound stream.
+* **In the call path** — the conversation history passed in each subsequent request includes the `ToolResponseMessage`(s) from the previous iteration, so the advisor observes both tool-call requests and their responses.
+
+This pattern lets you forward intermediate chunks to a side channel (SSE, WebSocket, log) without disrupting the tool-calling loop:
+
+[source,java]
 ----
-spring.ai.chat.client.tool-calling.stream-tool-call-responses=true
+public class ToolCallObservingAdvisor implements CallAdvisor, StreamAdvisor {
+
+    private final Consumer<ChatClientResponse> observer;
+
+    public ToolCallObservingAdvisor(Consumer<ChatClientResponse> observer) {
+        this.observer = observer;
+    }
+
+    @Override
+    public ChatClientResponse aroundCall(ChatClientRequest request, CallAdvisorChain chain) {
+        // Inspect all messages on every iteration — subsequent requests include ToolResponseMessages
+        request.prompt().getInstructions().forEach(msg -> log.debug("Message: {}", msg));
+        ChatClientResponse response = chain.nextCall(request);
+        observer.accept(response);
+        return response;
+    }
+
+    @Override
+    public Flux<ChatClientResponse> aroundStream(ChatClientRequest request, StreamAdvisorChain chain) {
+        // Observe every chunk including tool-call request chunks that ToolCallingAdvisor will suppress upstream
+        return chain.nextStream(request).doOnNext(observer);
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 400; // inside ToolCallingAdvisor (order 300)
+    }
+}
 ----
 
-NOTE: Enabling this option increases the number of chunks the client receives but may interleave tool-call fragments with the final answer depending on how the client processes the stream.
+Register the observing advisor alongside the auto-registered `ToolCallingAdvisor`:
+
+[source,java]
+----
+var chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(new ToolCallObservingAdvisor(chunk -> forwardToSse(chunk)))
+    .build();
+
+String response = chatClient.prompt()
+    .user("What is the weather in Amsterdam and Paris?")
+    .tools(new WeatherTools())
+    .call()
+    .content();
+----
+
+Because `ToolCallObservingAdvisor` is at order `HIGHEST_PRECEDENCE + 400` it is inserted _after_ the auto-registered `ToolCallingAdvisor` (order `HIGHEST_PRECEDENCE + 300`) in the chain, so it participates in every tool-call iteration.
+`ToolCallingAdvisor` still filters tool-call chunks from what it returns to the outer chain, so the main caller receives only the final answer — the observing advisor handles the side-channel emission.
+
+This approach keeps the tool-calling loop fully managed by the framework while still giving you complete visibility into every intermediate step, and it pairs naturally with the `conversationHistoryEnabled` and memory advisor patterns described in xref:_conversation_history_management[].
 
 ==== Return Direct Functionality
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -926,7 +926,6 @@ The `spring.ai.chat.client.tool-calling.*` properties control the auto-configure
 | Property | Default | Description
 | `spring.ai.chat.client.tool-calling.enabled` | `true` | Set to `false` to disable `ToolCallingAdvisor` auto-registration for all calls. Tools are still sent to the model, but tool calls are not executed automatically.
 | `spring.ai.chat.client.tool-calling.advisor-order` | `Ordered.HIGHEST_PRECEDENCE + 300` | Position of the auto-registered `ToolCallingAdvisor` in the advisor chain.
-| `spring.ai.chat.client.tool-calling.stream-tool-call-responses` | `false` | When `true`, intermediate tool-call chunks are streamed in real time during `.stream()` calls.
 |===
 
 ===== Spring Boot: advisor order property
@@ -942,15 +941,10 @@ spring.ai.chat.client.tool-calling.advisor-order=0
 The value must be lower than the order of any advisor that should run _inside_ the tool-call loop (i.e., repeated on every iteration), and higher than any advisor that should run _outside_ it (i.e., executed only once per user request).
 The default is `ToolCallingAdvisor.DEFAULT_ORDER`.
 
-===== Spring Boot: streaming intermediate tool-call responses
+===== Spring Boot: user-controlled tool execution
 
-By default, only the final answer is emitted during a `.stream()` call — intermediate tool-call chunks are suppressed until the last LLM iteration completes.
-Set `spring.ai.chat.client.tool-calling.stream-tool-call-responses=true` to stream each iteration's chunks in real time as they arrive:
-
-[source,properties]
-----
-spring.ai.chat.client.tool-calling.stream-tool-call-responses=true
-----
+To observe each iteration of the tool-calling loop — for example to forward intermediate chunks to a UI — disable the auto-registered advisor per-call and drive the loop yourself using `AdvisorParams.toolCallingAdvisorAutoRegister(false)`.
+See xref:api/tools.adoc#_with_chatclient[User-Controlled Tool Execution — With ChatClient] for a complete example.
 
 ===== Spring Boot: custom `ToolCallingAdvisor.Builder` bean
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1102,7 +1102,6 @@ The `ToolCallingAdvisor.Builder` supports the following configuration options:
 - `toolCallingManager`: The `ToolCallingManager` instance to use for executing tool calls. If not provided, a default instance is used.
 - `advisorOrder`: The order in which the advisor is applied in the chain. Must be between `BaseAdvisor.HIGHEST_PRECEDENCE` and `BaseAdvisor.LOWEST_PRECEDENCE`.
 - `conversationHistoryEnabled`: Controls whether the advisor maintains conversation history internally during tool call iterations. Default is `true`.
-- `streamToolCallResponses`: When `true`, each tool-call iteration streams its chunks in real time during a `.stream()` call. When `false` (default), only the final answer is streamed.
 - `toolExecutionEligibilityChecker`: A `Function<ChatResponse, Boolean>` that decides whether a model response should trigger the next tool-call iteration. The default checks `chatResponse.hasToolCalls()`. Override this to apply provider-specific stop-reason logic (e.g. checking a finish reason field in addition to tool-call presence).
 
 ==== Conversation History Management
@@ -1150,9 +1149,109 @@ For more details about `ToolCallingAdvisor`, see xref:api/advisors-recursive.ado
 
 === User-Controlled Tool Execution
 
-There are cases where you'd rather control the tool execution lifecycle yourself. To do so, invoke the `ChatModel` directly without adding `ToolCallingAdvisor` to the advisor chain.
+There are cases where you'd rather control the tool execution lifecycle yourself — for example, to stream intermediate progress to a UI, add custom observability, or apply conditional logic between iterations.
 
-It's your responsibility to check for tool calls in the `ChatResponse` and execute them using the `ToolCallingManager`.
+Both `ChatClient` and `ChatModel` support user-controlled tool execution.
+In either case you are responsible for detecting tool calls in the `ChatResponse` and executing them with the `ToolCallingManager`.
+
+==== With ChatClient
+
+When using `ChatClient`, disable the auto-registered `ToolCallingAdvisor` for a single call using `AdvisorParams.toolCallingAdvisorAutoRegister(false)`, then drive the tool-call loop yourself.
+
+The following example shows user-controlled tool execution with the `call()` path:
+
+[source,java]
+----
+ChatClient chatClient = ...
+ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+
+ToolCallback[] tools = ToolCallbacks.from(new WeatherTools());
+ChatOptions chatOptions = ToolCallingChatOptions.builder()
+    .toolCallbacks(tools)
+    .build();
+
+String question = "What is the weather in Amsterdam and Paris?";
+
+// ToolCallingAdvisor is disabled — no tool loop runs automatically
+ChatClientResponse response = chatClient.prompt()
+    .user(question)
+    .options(chatOptions)
+    .advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+    .call()
+    .chatClientResponse();
+
+Prompt prompt = new Prompt(List.of(new UserMessage(question)), chatOptions);
+
+// Drive the tool-call loop manually
+while (response.chatResponse() != null && response.chatResponse().hasToolCalls()) {
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, response.chatResponse());
+    prompt = new Prompt(result.conversationHistory(), chatOptions);
+    response = chatClient.prompt()
+        .messages(result.conversationHistory())
+        .options(chatOptions)
+        .advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+        .call()
+        .chatClientResponse();
+}
+
+System.out.println(response.chatResponse().getResult().getOutput().getText());
+----
+
+The same pattern works with the streaming API.
+Because tool calls span multiple stream chunks, each streaming call must be aggregated using `ChatClientMessageAggregator` before checking for tool calls.
+The `Flux` of chunks produced by each iteration can be forwarded to a subscriber (for example an SSE endpoint) while aggregating, giving you full control over what is emitted at each step:
+
+[source,java]
+----
+ChatClient chatClient = ...
+ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+
+ToolCallback[] tools = ToolCallbacks.from(new WeatherTools());
+ChatOptions chatOptions = ToolCallingChatOptions.builder()
+    .toolCallbacks(tools)
+    .build();
+
+String question = "What is the weather in Amsterdam and Paris?";
+Prompt prompt = new Prompt(List.of(new UserMessage(question)), chatOptions);
+
+AtomicReference<ChatClientResponse> ref = new AtomicReference<>();
+new ChatClientMessageAggregator().aggregateChatClientResponse(
+    chatClient.prompt()
+        .messages(prompt.getInstructions())
+        .options(chatOptions)
+        .advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+        .stream()
+        .chatClientResponse(),
+    ref::set
+).blockLast();
+
+ChatClientResponse response = ref.get();
+
+while (response != null && response.chatResponse() != null && response.chatResponse().hasToolCalls()) {
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, response.chatResponse());
+    prompt = new Prompt(result.conversationHistory(), chatOptions);
+
+    ref.set(null);
+    new ChatClientMessageAggregator().aggregateChatClientResponse(
+        chatClient.prompt()
+            .messages(prompt.getInstructions())
+            .options(chatOptions)
+            .advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+            .stream()
+            .chatClientResponse(),
+        ref::set
+    ).blockLast();
+    response = ref.get();
+}
+
+System.out.println(response.chatResponse().getResult().getOutput().getText());
+----
+
+==== With ChatModel
+
+To drive the tool-call loop with `ChatModel`, invoke it directly without a `ToolCallingAdvisor` in the chain and execute tool calls using the `ToolCallingManager`.
+
+NOTE: When choosing the user-controlled tool execution approach, we recommend using a `ToolCallingManager` to manage the tool calling operations. This way, you can benefit from the built-in support provided by Spring AI for tool execution. However, nothing prevents you from implementing your own tool execution logic.
 
 The following example demonstrates a minimal implementation of the user-controlled tool execution approach:
 
@@ -1178,8 +1277,6 @@ while (chatResponse.hasToolCalls()) {
 
 System.out.println(chatResponse.getResult().getOutput().getText());
 ----
-
-NOTE: When choosing the user-controlled tool execution approach, we recommend using a `ToolCallingManager` to manage the tool calling operations. This way, you can benefit from the built-in support provided by Spring AI for tool execution. However, nothing prevents you from implementing your own tool execution logic.
 
 The same pattern works with the streaming API.
 Because tool calls span multiple stream chunks, each streaming call must be aggregated first using `MessageAggregator` before checking for tool calls:
@@ -1762,10 +1859,6 @@ A custom `ToolIndex` bean declared by the application always takes precedence.
 | `spring.ai.chat.client.tool-search-advisor.advisor-order`
 | Position of this advisor in the advisor chain.
 | `HIGHEST_PRECEDENCE + 300`
-
-| `spring.ai.chat.client.tool-search-advisor.stream-tool-call-responses`
-| Stream intermediate tool-call responses during `stream()` invocations.
-| `false`
 
 | `spring.ai.chat.client.tool-search-advisor.eviction.lru-max-sessions`
 | Maximum active sessions retained by the LRU eviction strategy.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -1,6 +1,80 @@
 [[upgrade-notes]]
 = Upgrade Notes
 
+[[upgrading-to-2-0-0-GA]]
+== Upgrading to 2.0.0
+
+=== Tool Calling
+
+==== Removed: `streamToolCallResponses` from Advisor Builders and Auto-Configuration
+
+The `streamToolCallResponses` option has been removed from `ToolCallingAdvisor.Builder`, `ToolCallAdvisor.Builder`, and `ToolSearchToolCallingAdvisor.Builder`, as well as from their corresponding Spring Boot auto-configuration properties:
+
+* `spring.ai.chat.client.tool-calling.stream-tool-call-responses`
+* `spring.ai.chat.client.tool-search-advisor.stream-tool-call-responses`
+
+===== Why
+
+When `streamToolCallResponses=true`, intermediate tool-call request chunks were streamed downstream but the paired `ToolResponseMessage` (sent back to the LLM) was not.
+Any downstream memory advisor that recorded those chunks would receive a tool-call request without the corresponding tool response, producing a corrupted conversation history.
+The design flaw cannot be fixed without introducing a breaking change to `ChatClientResponse`, so the option has been removed entirely.
+
+===== Impact
+
+* Any code that calls `.streamToolCallResponses(true)` or `.streamToolCallResponses(false)` on an advisor builder will fail to compile.
+* Any `application.properties` or `application.yml` entry for the removed properties is silently ignored.
+
+===== Migration
+
+Remove all calls to `.streamToolCallResponses(...)` from your builder chains:
+
+[source,java]
+----
+// Before
+var advisor = ToolCallingAdvisor.builder()
+    .streamToolCallResponses(true)   // <-- remove this line
+    .build();
+
+// After
+var advisor = ToolCallingAdvisor.builder().build();
+----
+
+To gain visibility into each iteration of the tool-calling loop — the use case that `streamToolCallResponses=true` was intended to address — opt out of the auto-registered advisor and drive the loop manually using `AdvisorParams.toolCallingAdvisorAutoRegister(false)`:
+
+[source,java]
+----
+ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+ToolCallback[] tools = ToolCallbacks.from(new WeatherTools());
+ChatOptions chatOptions = ToolCallingChatOptions.builder()
+    .toolCallbacks(tools)
+    .build();
+
+String question = "What is the weather in Amsterdam and Paris?";
+Prompt prompt = new Prompt(List.of(new UserMessage(question)), chatOptions);
+
+ChatClientResponse response = chatClient.prompt()
+    .user(question)
+    .options(chatOptions)
+    .advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+    .call()
+    .chatClientResponse();
+
+while (response.chatResponse() != null && response.chatResponse().hasToolCalls()) {
+    // inspect or forward the tool-call chunk here before executing
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, response.chatResponse());
+    prompt = new Prompt(result.conversationHistory(), chatOptions);
+    response = chatClient.prompt()
+        .messages(result.conversationHistory())
+        .options(chatOptions)
+        .advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+        .call()
+        .chatClientResponse();
+}
+// forward or process the final answer here
+----
+
+For a complete example including the streaming path, see xref:api/tools.adoc#_user_controlled_tool_execution[User-Controlled Tool Execution — With ChatClient].
+
 [[upgrading-to-2-0-0-RC2]]
 == Upgrading to 2.0.0-RC2
 

--- a/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallingAdvisorAutoRegistrationIT.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallingAdvisorAutoRegistrationIT.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Nested;
@@ -30,6 +31,7 @@ import reactor.core.publisher.Flux;
 import org.springframework.ai.chat.client.AdvisorParams;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.ChatClientAttributes;
+import org.springframework.ai.chat.client.ChatClientMessageAggregator;
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
@@ -38,7 +40,13 @@ import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.ai.tool.metadata.ToolMetadata;
@@ -84,6 +92,12 @@ public abstract class AbstractToolCallingAdvisorAutoRegistrationIT {
 
 	private static String collect(Flux<String> flux) {
 		return Objects.requireNonNull(flux.collectList().block()).stream().collect(Collectors.joining());
+	}
+
+	private static ChatClientResponse aggregateStream(Flux<ChatClientResponse> flux) {
+		AtomicReference<ChatClientResponse> ref = new AtomicReference<>();
+		new ChatClientMessageAggregator().aggregateChatClientResponse(flux, ref::set).blockLast();
+		return Objects.requireNonNull(ref.get());
 	}
 
 	// -------------------------------------------------------------------------
@@ -354,6 +368,135 @@ public abstract class AbstractToolCallingAdvisorAutoRegistrationIT {
 				.content();
 
 			assertThat(counter.getCallCount()).isEqualTo(1);
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// User-controlled tool execution (ToolCallingAdvisor disabled)
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class UserControlledToolExecution {
+
+		@Test
+		void callPathManualLoopProducesCorrectAnswer() {
+			ToolCallback weatherTool = createWeatherToolCallback();
+			ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+			ToolCallingChatOptions toolOptions = ToolCallingChatOptions.builder()
+				.toolCallbacks(List.of(weatherTool))
+				.build();
+
+			ChatClient chatClient = ChatClient.create(getChatModel());
+			Prompt currentPrompt = new Prompt(
+					List.of(new UserMessage("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")),
+					toolOptions);
+
+			ChatResponse response = chatClient.prompt()
+				.messages(currentPrompt.getInstructions())
+				.tools(weatherTool)
+				.advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+				.call()
+				.chatResponse();
+
+			while (response != null && response.hasToolCalls()) {
+				ToolExecutionResult result = toolCallingManager.executeToolCalls(currentPrompt, response);
+				currentPrompt = new Prompt(result.conversationHistory(), toolOptions);
+				response = chatClient.prompt()
+					.messages(currentPrompt.getInstructions())
+					.tools(weatherTool)
+					.advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+					.call()
+					.chatResponse();
+			}
+
+			var finalResponse = Objects.requireNonNull(response, "Expected a non-null final ChatResponse");
+			var finalGeneration = Objects.requireNonNull(finalResponse.getResult());
+			assertThat(finalGeneration.getOutput().getText()).contains("30", "10", "15");
+		}
+
+		@Test
+		void callPathManualLoopTraversesChainOncePerIteration() {
+			ToolCallback weatherTool = createWeatherToolCallback();
+			ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+			ToolCallingChatOptions toolOptions = ToolCallingChatOptions.builder()
+				.toolCallbacks(List.of(weatherTool))
+				.build();
+
+			var counter = new ChainIterationCountingAdvisor();
+			ChatClient chatClient = ChatClient.create(getChatModel());
+			Prompt currentPrompt = new Prompt(
+					List.of(new UserMessage("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")),
+					toolOptions);
+
+			int chatClientCallCount = 0;
+			ChatResponse response = chatClient.prompt()
+				.messages(currentPrompt.getInstructions())
+				.tools(weatherTool)
+				.advisors(counter)
+				.advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+				.call()
+				.chatResponse();
+			chatClientCallCount++;
+
+			while (response != null && response.hasToolCalls()) {
+				ToolExecutionResult result = toolCallingManager.executeToolCalls(currentPrompt, response);
+				currentPrompt = new Prompt(result.conversationHistory(), toolOptions);
+				response = chatClient.prompt()
+					.messages(currentPrompt.getInstructions())
+					.tools(weatherTool)
+					.advisors(counter)
+					.advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+					.call()
+					.chatResponse();
+				chatClientCallCount++;
+			}
+
+			// Chain is traversed exactly once per ChatClient call — never looped by
+			// ToolCallingAdvisor
+			assertThat(counter.getCallCount()).isEqualTo(chatClientCallCount);
+			var finalResponse = Objects.requireNonNull(response, "Expected a non-null final ChatResponse");
+			var finalGeneration = Objects.requireNonNull(finalResponse.getResult());
+			assertThat(finalGeneration.getOutput().getText()).contains("30", "10", "15");
+		}
+
+		@Test
+		void streamPathManualLoopProducesCorrectAnswer() {
+			ToolCallback weatherTool = createWeatherToolCallback();
+			ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+			ToolCallingChatOptions toolOptions = ToolCallingChatOptions.builder()
+				.toolCallbacks(List.of(weatherTool))
+				.build();
+
+			ChatClient chatClient = ChatClient.create(getChatModel());
+			Prompt currentPrompt = new Prompt(
+					List.of(new UserMessage("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")),
+					toolOptions);
+
+			// In streaming mode the caller must aggregate chunks before inspecting for
+			// tool calls — the same step ToolCallingAdvisor performs internally.
+			ChatClientResponse aggregated = aggregateStream(chatClient.prompt()
+				.messages(currentPrompt.getInstructions())
+				.tools(weatherTool)
+				.advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+				.stream()
+				.chatClientResponse());
+
+			while (aggregated.chatResponse() != null && aggregated.chatResponse().hasToolCalls()) {
+				ToolExecutionResult result = toolCallingManager.executeToolCalls(currentPrompt,
+						aggregated.chatResponse());
+				currentPrompt = new Prompt(result.conversationHistory(), toolOptions);
+				aggregated = aggregateStream(chatClient.prompt()
+					.messages(currentPrompt.getInstructions())
+					.tools(weatherTool)
+					.advisors(AdvisorParams.toolCallingAdvisorAutoRegister(false))
+					.stream()
+					.chatClientResponse());
+			}
+
+			var finalChatResponse = Objects.requireNonNull(aggregated.chatResponse());
+			var finalGeneration = Objects.requireNonNull(finalChatResponse.getResult());
+			assertThat(finalGeneration.getOutput().getText()).contains("30", "10", "15");
 		}
 
 	}


### PR DESCRIPTION
When streamToolCallResponses=true, tool-call request chunks were streamed downstream without the paired ToolResponseMessage, corrupting any downstream memory advisor's conversation history. The flaw cannot be fixed cleanly, so the option is removed from ToolCallingAdvisor, ToolCallAdvisor, and ToolSearchToolCallingAdvisor builders along with the corresponding auto-configuration properties.
Two replacement patterns are documented:
- Placing a custom advisor inside the tool-call loop (order > `ToolCallingAdvisor.DEFAULT_ORDER) to observe every iteration via a side channel
- Disabling the auto-registered advisor with AdvisorParams.toolCallingAdvisorAutoRegister(false) and driving the loop manually.
Integration tests for the manual pattern are added . Upgrade notes for 2.0.0 GA cover impact and migration steps.