### PR TITLE
feat(tool): allow returnDirect tool calls to bypass serialization

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -517,6 +517,16 @@ public class DefaultChatClient implements ChatClient {
 			}
 
 			var chatResponse = doGetObservableChatClientResponse(this.request, advisorChain).chatResponse();
+			if (chatResponse != null && chatResponse.getResult() != null
+					&& chatResponse.getResult().getOutput() != null) {
+				var assistantMessage = chatResponse.getResult().getOutput();
+				if (assistantMessage.getMetadata().containsKey("tool-output")) {
+					Object toolOutputObj = assistantMessage.getMetadata().get("tool-output");
+					if (toolOutputObj != null) {
+						return new ResponseEntity<>(chatResponse, (T) toolOutputObj);
+					}
+				}
+			}
 			var responseContent = getContentFromChatResponse(chatResponse);
 			if (responseContent == null) {
 				return new ResponseEntity<>(chatResponse, null);
@@ -608,6 +618,17 @@ public class DefaultChatClient implements ChatClient {
 			}
 
 			var chatResponse = doGetObservableChatClientResponse(this.request, advisorChain).chatResponse();
+
+			if (chatResponse != null && chatResponse.getResult() != null
+					&& chatResponse.getResult().getOutput() != null) {
+				var assistantMessage = chatResponse.getResult().getOutput();
+				if (assistantMessage.getMetadata().containsKey("tool-output")) {
+					Object toolOutputObj = assistantMessage.getMetadata().get("tool-output");
+					if (toolOutputObj != null) {
+						return (T) toolOutputObj;
+					}
+				}
+			}
 
 			var stringResponse = getContentFromChatResponse(chatResponse);
 			if (stringResponse == null) {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
@@ -391,6 +391,57 @@ public class ChatClientResponseEntityTests {
 		verify(this.chatModel, times(1)).call(any(Prompt.class));
 	}
 
+	@Test
+	public void responseEntityWithDirectToolOutputTest() {
+		when(this.chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
+
+		MyBean expectedRawObj = new MyBean("JohnDirect", 45);
+
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("serialized-string")
+			.properties(Map.of("tool-output", expectedRawObj))
+			.build();
+
+		ChatResponse chatResponse = new ChatResponse(List.of(new Generation(assistantMessage)));
+
+		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
+
+		ResponseEntity<ChatResponse, MyBean> responseEntity = ChatClient.builder(this.chatModel)
+			.build()
+			.prompt()
+			.user("Execute direct tool")
+			.call()
+			.responseEntity(MyBean.class);
+
+		assertThat(responseEntity.getResponse()).isEqualTo(chatResponse);
+		assertThat(responseEntity.getEntity()).isSameAs(expectedRawObj);
+	}
+
+	@Test
+	public void entityWithDirectToolOutputTest() {
+		when(this.chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
+
+		MyBean expectedRawObj = new MyBean("JohnDirect", 45);
+
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("serialized-string")
+			.properties(Map.of("tool-output", expectedRawObj))
+			.build();
+
+		ChatResponse chatResponse = new ChatResponse(List.of(new Generation(assistantMessage)));
+
+		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
+
+		MyBean entity = ChatClient.builder(this.chatModel)
+			.build()
+			.prompt()
+			.user("Execute direct tool")
+			.call()
+			.entity(MyBean.class);
+
+		assertThat(entity).isSameAs(expectedRawObj);
+	}
+
 	record MyBean(String name, int age) {
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/ToolResponseMessage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/ToolResponseMessage.java
@@ -72,7 +72,28 @@ public class ToolResponseMessage extends AbstractMessage {
 				+ ", metadata=" + this.metadata + '}';
 	}
 
-	public record ToolResponse(String id, String name, String responseData) {
+	public record ToolResponse(String id, String name, String responseData, @Nullable Object responseDataObj) {
+
+		public ToolResponse(String id, String name, String responseData) {
+			this(id, name, responseData, null);
+		}
+
+		@Override
+		public boolean equals(@Nullable Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof ToolResponse that)) {
+				return false;
+			}
+			return Objects.equals(this.id, that.id) && Objects.equals(this.name, that.name)
+					&& Objects.equals(this.responseData, that.responseData);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.id, this.name, this.responseData);
+		}
 
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -48,6 +48,7 @@ import org.springframework.ai.tool.observation.ToolCallingObservationConvention;
 import org.springframework.ai.tool.observation.ToolCallingObservationDocumentation;
 import org.springframework.ai.tool.resolution.DelegatingToolCallbackResolver;
 import org.springframework.ai.tool.resolution.ToolCallbackResolver;
+import org.springframework.ai.util.JsonHelper;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -63,6 +64,8 @@ import org.springframework.util.StringUtils;
 public final class DefaultToolCallingManager implements ToolCallingManager {
 
 	private static final Log logger = LogFactory.getLog(DefaultToolCallingManager.class);
+
+	private static final JsonHelper jsonHelper = new JsonHelper();
 
 	// @formatter:off
 
@@ -224,24 +227,27 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 				.toolCallArguments(finalToolInputArguments)
 				.build();
 
-			String toolCallResult = ToolCallingObservationDocumentation.TOOL_CALL
+			Object toolCallResultObj = ToolCallingObservationDocumentation.TOOL_CALL
 				.observation(this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
 						this.observationRegistry)
 				.parentObservation(parent)
 				.observe(() -> {
-					String toolResult;
+					Object toolResult;
 					try {
-						toolResult = toolCallback.call(finalToolInputArguments, toolContext);
+						toolResult = toolCallback.callDirect(finalToolInputArguments, toolContext);
 					}
 					catch (ToolExecutionException ex) {
 						toolResult = this.toolExecutionExceptionProcessor.process(ex);
 					}
-					observationContext.setToolCallResult(toolResult);
+					String toolResultStr = (toolResult instanceof String str) ? str : jsonHelper.toJson(toolResult);
+					observationContext.setToolCallResult(toolResultStr);
 					return toolResult;
 				});
 
+			String toolCallResultStr = (toolCallResultObj instanceof String str) ? str
+					: (toolCallResultObj != null ? jsonHelper.toJson(toolCallResultObj) : "");
 			toolResponses.add(new ToolResponseMessage.ToolResponse(toolCall.id(), toolName,
-					toolCallResult != null ? toolCallResult : ""));
+					toolCallResultStr != null ? toolCallResultStr : "", toolCallResultObj));
 		}
 
 		return new InternalToolExecutionResult(ToolResponseMessage.builder().responses(toolResponses).build(),

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionResult.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionResult.java
@@ -70,7 +70,14 @@ public interface ToolExecutionResult {
 		if (conversationHistory
 			.get(conversationHistory.size() - 1) instanceof ToolResponseMessage toolResponseMessage) {
 			toolResponseMessage.getResponses().forEach(response -> {
-				AssistantMessage assistantMessage = new AssistantMessage(response.responseData());
+				java.util.Map<String, Object> properties = new java.util.HashMap<>();
+				if (response.responseDataObj() != null) {
+					properties.put("tool-output", response.responseDataObj());
+				}
+				AssistantMessage assistantMessage = AssistantMessage.builder()
+					.content(response.responseData())
+					.properties(properties)
+					.build();
 				Generation generation = new Generation(assistantMessage,
 						ChatGenerationMetadata.builder()
 							.metadata(METADATA_TOOL_ID, response.id())

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/ToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/ToolCallback.java
@@ -67,4 +67,11 @@ public interface ToolCallback {
 		return call(toolInput);
 	}
 
+	/**
+	 * Execute tool with the given input and context, and return the raw result object.
+	 */
+	default @Nullable Object callDirect(String toolInput, @Nullable ToolContext toolContext) {
+		return call(toolInput, toolContext);
+	}
+
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/augment/AugmentedToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/augment/AugmentedToolCallback.java
@@ -112,6 +112,11 @@ public class AugmentedToolCallback<T extends Record> implements ToolCallback {
 		return this.delegate.call(this.handleAugmentedArguments(toolInput), tooContext);
 	}
 
+	@Override
+	public @Nullable Object callDirect(String toolInput, @Nullable ToolContext toolContext) {
+		return this.delegate.callDirect(this.handleAugmentedArguments(toolInput), toolContext);
+	}
+
 	/**
 	 * Handles the augmented arguments in the tool input. It extracts the augmented
 	 * arguments from the tool input, processes them using the provided consumer, and

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/function/FunctionToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/function/FunctionToolCallback.java
@@ -115,6 +115,24 @@ public class FunctionToolCallback<I, O> implements ToolCallback {
 		return this.toolCallResultConverter.convert(response, null);
 	}
 
+	@Override
+	public @Nullable Object callDirect(String toolInput, @Nullable ToolContext toolContext) {
+		Assert.hasText(toolInput, "toolInput cannot be null or empty");
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Starting execution of tool: " + this.toolDefinition.name());
+		}
+
+		I request = jsonHelper.fromJson(toolInput, this.toolInputType);
+		O response = callMethod(request, toolContext);
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Successful execution of tool: " + this.toolDefinition.name());
+		}
+
+		return response;
+	}
+
 	private O callMethod(@Nullable I request, @Nullable ToolContext toolContext) {
 		try {
 			return this.toolFunction.apply(request, toolContext);

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
@@ -122,6 +122,30 @@ public final class MethodToolCallback implements ToolCallback {
 		return this.toolCallResultConverter.convert(result, returnType);
 	}
 
+	@Override
+	public @Nullable Object callDirect(String toolInput, @Nullable ToolContext toolContext) {
+		Assert.hasText(toolInput, "toolInput cannot be null or empty");
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Starting execution of tool: " + this.toolDefinition.name());
+		}
+
+		this.validateToolContextSupport(toolContext);
+
+		Map<String, Object> toolArguments = this.extractToolArguments(toolInput);
+		Assert.state(toolArguments != null, "toolArguments must not be null");
+
+		Object[] methodArguments = this.buildMethodArguments(toolArguments, toolContext);
+
+		Object result = this.callMethod(methodArguments);
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Successful execution of tool: " + this.toolDefinition.name());
+		}
+
+		return result;
+	}
+
 	private void validateToolContextSupport(@Nullable ToolContext toolContext) {
 		var isNonEmptyToolContextProvided = toolContext != null && !CollectionUtils.isEmpty(toolContext.getContext());
 		var isToolContextAcceptedByMethod = Stream.of(this.toolMethod.getParameterTypes())

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTests.java
@@ -21,9 +21,11 @@ import java.util.List;
 import java.util.Map;
 
 import io.micrometer.observation.ObservationRegistry;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage.ToolResponse;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -188,6 +190,81 @@ class DefaultToolCallingManagerTests {
 
 		assertThat(toolExecutionResult.conversationHistory()).contains(expectedToolResponse);
 		assertThat(toolExecutionResult.returnDirect()).isTrue();
+	}
+
+	@Test
+	void whenSingleToolCallWithReturnDirectRawObjectThenExecute() {
+		class CustomTestObject {
+
+			final String message;
+
+			CustomTestObject(String message) {
+				this.message = message;
+			}
+
+		}
+
+		CustomTestObject expectedRawObj = new CustomTestObject("Hello raw object");
+
+		ToolCallback toolCallback = new ToolCallback() {
+			private final ToolDefinition toolDefinition = DefaultToolDefinition.builder()
+				.name("toolA")
+				.inputSchema("{}")
+				.build();
+
+			private final ToolMetadata toolMetadata = ToolMetadata.builder().returnDirect(true).build();
+
+			@Override
+			public ToolDefinition getToolDefinition() {
+				return this.toolDefinition;
+			}
+
+			@Override
+			public ToolMetadata getToolMetadata() {
+				return this.toolMetadata;
+			}
+
+			@Override
+			public String call(String toolInput) {
+				return "serialized-string";
+			}
+
+			@Override
+			public Object callDirect(String toolInput, @Nullable ToolContext toolContext) {
+				return expectedRawObj;
+			}
+		};
+
+		ToolCallbackResolver toolCallbackResolver = new StaticToolCallbackResolver(List.of(toolCallback));
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder()
+			.toolCallbackResolver(toolCallbackResolver)
+			.build();
+
+		Prompt prompt = new Prompt(new UserMessage("Hello"), ToolCallingChatOptions.builder().build());
+		ChatResponse chatResponse = ChatResponse.builder()
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.content("")
+				.properties(Map.of())
+				.toolCalls(List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}")))
+				.build())))
+			.build();
+
+		ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, chatResponse);
+
+		assertThat(toolExecutionResult.returnDirect()).isTrue();
+		List<Message> history = toolExecutionResult.conversationHistory();
+		assertThat(history).isNotEmpty();
+		Message lastMsg = history.get(history.size() - 1);
+		assertThat(lastMsg).isInstanceOf(ToolResponseMessage.class);
+		ToolResponseMessage toolResponseMessage = (ToolResponseMessage) lastMsg;
+		assertThat(toolResponseMessage.getResponses()).hasSize(1);
+		ToolResponse toolResponse = toolResponseMessage.getResponses().get(0);
+		assertThat(toolResponse.responseDataObj()).isSameAs(expectedRawObj);
+
+		List<Generation> gens = ToolExecutionResult.buildGenerations(toolExecutionResult);
+		assertThat(gens).hasSize(1);
+		AssistantMessage assistantMessage = gens.get(0).getOutput();
+		assertThat(assistantMessage.getMetadata().get("tool-output")).isSameAs(expectedRawObj);
 	}
 
 	@Test


### PR DESCRIPTION
Resolves #3191. This PR introduces support for passing raw objects directly from returnDirect tool calls to DefaultChatClient output converters and entity return methods, bypassing the intermediate JSON serialization step.