### PR TITLE
Fix CallToolResult polymorphic deserialization to support EmbeddedResources (#4534)

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -43,6 +43,7 @@ import org.springframework.ai.tool.definition.DefaultToolDefinition;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.util.JsonHelper;
 import org.springframework.ai.util.json.schema.JsonSchemaUtils;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeType;
 
@@ -266,6 +267,14 @@ public final class McpToolUtils {
 						.isError(false)
 						.build();
 				}
+				try {
+					List<McpSchema.Content> contents = deserializeContents(callResult);
+					if (contents != null) {
+						return McpSchema.CallToolResult.builder().content(contents).isError(false).build();
+					}
+				}
+				catch (Exception ignore) {
+				}
 				return McpSchema.CallToolResult.builder()
 					.content(List.of(new McpSchema.TextContent(callResult)))
 					.isError(false)
@@ -278,6 +287,69 @@ public final class McpToolUtils {
 					.build();
 			}
 		});
+	}
+
+	private static @Nullable List<McpSchema.Content> deserializeContents(String callResult) {
+		try {
+			List<Map<String, Object>> list = jsonHelper.fromJson(callResult,
+					new ParameterizedTypeReference<List<Map<String, Object>>>() {
+					});
+			if (list != null && !list.isEmpty()) {
+				java.util.List<McpSchema.Content> contents = new java.util.ArrayList<>();
+				for (Map<String, Object> map : list) {
+					if (map != null) {
+						McpSchema.Content content = deserializeSingleContent(map);
+						if (content != null) {
+							contents.add(content);
+						}
+					}
+				}
+				if (!contents.isEmpty()) {
+					return contents;
+				}
+			}
+		}
+		catch (Exception ignore) {
+		}
+		try {
+			Map<String, Object> map = jsonHelper.fromJsonToMap(callResult);
+			if (map != null && !map.isEmpty()) {
+				McpSchema.Content content = deserializeSingleContent(map);
+				if (content != null) {
+					return List.of(content);
+				}
+			}
+		}
+		catch (Exception ignore) {
+		}
+		return null;
+	}
+
+	private static McpSchema.@Nullable Content deserializeSingleContent(Map<String, Object> map) {
+		java.util.Map<String, Object> mutableMap = new java.util.HashMap<>(map);
+		if (!mutableMap.containsKey("type")) {
+			if (mutableMap.containsKey("resource")) {
+				mutableMap.put("type", "resource");
+			}
+			else if (mutableMap.containsKey("text")) {
+				mutableMap.put("type", "text");
+			}
+			else if (mutableMap.containsKey("data") || mutableMap.containsKey("mimeType")) {
+				mutableMap.put("type", "image");
+			}
+		}
+
+		String type = (String) mutableMap.get("type");
+		if ("resource".equals(type)) {
+			return jsonHelper.convertFromMap(mutableMap, McpSchema.EmbeddedResource.class);
+		}
+		else if ("text".equals(type)) {
+			return jsonHelper.convertFromMap(mutableMap, McpSchema.TextContent.class);
+		}
+		else if ("image".equals(type)) {
+			return jsonHelper.convertFromMap(mutableMap, McpSchema.ImageContent.class);
+		}
+		return null;
 	}
 
 	/**

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.execution.ToolExecutionException;
+import org.springframework.ai.util.JsonHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -41,6 +42,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SyncMcpToolCallbackTests {
+
+	private static final JsonHelper jsonHelper = new JsonHelper();
 
 	@Mock
 	private McpSyncClient mcpClient;
@@ -267,6 +270,84 @@ class SyncMcpToolCallbackTests {
 		assertThatThrownBy(() -> SyncMcpToolCallback.builder().mcpClient(this.mcpClient).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("MCP tool must not be null");
+	}
+
+	@Test
+	void toSyncToolSpecificationShouldNativelySupportEmbeddedResources() {
+		var annotations = new McpSchema.Annotations(List.of(McpSchema.Role.ASSISTANT), null);
+		var textResource = new McpSchema.TextResourceContents("file:///test.txt", "text/plain",
+				"Embedded Resource Content");
+		var embeddedResource = new McpSchema.EmbeddedResource(annotations, textResource);
+
+		var jsonResource = jsonHelper.toJson(embeddedResource);
+
+		org.springframework.ai.tool.ToolCallback toolCallback = new org.springframework.ai.tool.ToolCallback() {
+			@Override
+			public org.springframework.ai.tool.definition.ToolDefinition getToolDefinition() {
+				return org.springframework.ai.tool.definition.DefaultToolDefinition.builder()
+					.name("resourceTool")
+					.description("Returns resource")
+					.inputSchema("{}")
+					.build();
+			}
+
+			@Override
+			public String call(String toolInput) {
+				return jsonResource;
+			}
+		};
+
+		var spec = McpToolUtils.toSyncToolSpecification(toolCallback);
+		var result = spec.callHandler()
+			.apply(mock(io.modelcontextprotocol.server.McpSyncServerExchange.class),
+					new CallToolRequest("resourceTool", Map.of()));
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(McpSchema.EmbeddedResource.class);
+		McpSchema.EmbeddedResource actualResource = (McpSchema.EmbeddedResource) result.content().get(0);
+		assertThat(actualResource.resource()).isInstanceOf(McpSchema.TextResourceContents.class);
+		assertThat(((McpSchema.TextResourceContents) actualResource.resource()).text())
+			.isEqualTo("Embedded Resource Content");
+	}
+
+	@Test
+	void toSyncToolSpecificationShouldNativelySupportContentList() {
+		var annotations = new McpSchema.Annotations(List.of(McpSchema.Role.ASSISTANT), null);
+		var textResource = new McpSchema.TextResourceContents("file:///test.txt", "text/plain",
+				"Embedded Resource Content");
+		var embeddedResource = new McpSchema.EmbeddedResource(annotations, textResource);
+		var textContent = new McpSchema.TextContent("Additional text content");
+
+		var jsonList = jsonHelper.toJson(List.of(embeddedResource, textContent));
+
+		org.springframework.ai.tool.ToolCallback toolCallback = new org.springframework.ai.tool.ToolCallback() {
+			@Override
+			public org.springframework.ai.tool.definition.ToolDefinition getToolDefinition() {
+				return org.springframework.ai.tool.definition.DefaultToolDefinition.builder()
+					.name("resourceListTool")
+					.description("Returns resource list")
+					.inputSchema("{}")
+					.build();
+			}
+
+			@Override
+			public String call(String toolInput) {
+				return jsonList;
+			}
+		};
+
+		var spec = McpToolUtils.toSyncToolSpecification(toolCallback);
+		var result = spec.callHandler()
+			.apply(mock(io.modelcontextprotocol.server.McpSyncServerExchange.class),
+					new CallToolRequest("resourceListTool", Map.of()));
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(2);
+		assertThat(result.content().get(0)).isInstanceOf(McpSchema.EmbeddedResource.class);
+		assertThat(result.content().get(1)).isInstanceOf(McpSchema.TextContent.class);
 	}
 
 }

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -19,6 +19,8 @@ package org.springframework.ai.mcp.annotation.method.tool;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -26,6 +28,7 @@ import java.util.stream.Stream;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Content;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.mcp.annotation.McpMeta;
@@ -167,6 +170,19 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 		// Return the result if it's already a CallToolResult
 		if (result instanceof CallToolResult) {
 			return (CallToolResult) result;
+		}
+
+		if (result instanceof Content) {
+			return CallToolResult.builder().content(List.of((Content) result)).build();
+		}
+		if (result instanceof Content[]) {
+			return CallToolResult.builder().content(List.of((Content[]) result)).build();
+		}
+		if (result instanceof Collection<?>) {
+			Collection<?> col = (Collection<?>) result;
+			if (!col.isEmpty() && col.iterator().next() instanceof Content) {
+				return CallToolResult.builder().content(col.stream().map(c -> (Content) c).toList()).build();
+			}
 		}
 
 		Type returnType = this.toolMethod.getGenericReturnType();

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProviderTests.java
@@ -960,4 +960,74 @@ public class SyncStatelessMcpToolProviderTests {
 		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Only context tool executed");
 	}
 
+	@Test
+	void testGetToolSpecificationsWithEmbeddedResourceReturn() {
+		class EmbeddedResourceTool {
+
+			@McpTool(name = "resource-tool", description = "Tool returning EmbeddedResource")
+			public McpSchema.EmbeddedResource resourceTool(String uri) {
+				var annotations = new McpSchema.Annotations(List.of(McpSchema.Role.ASSISTANT), null);
+				var textResource = new McpSchema.TextResourceContents(uri, "text/plain", "Embedded Resource Content");
+				return new McpSchema.EmbeddedResource(annotations, textResource);
+			}
+
+		}
+
+		EmbeddedResourceTool toolObject = new EmbeddedResourceTool();
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		SyncToolSpecification toolSpec = toolSpecs.get(0);
+
+		McpTransportContext context = mock(McpTransportContext.class);
+		CallToolRequest request = new CallToolRequest("resource-tool", Map.of("uri", "file:///test.txt"));
+		CallToolResult result = toolSpec.callHandler().apply(context, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(McpSchema.EmbeddedResource.class);
+		McpSchema.EmbeddedResource actualResource = (McpSchema.EmbeddedResource) result.content().get(0);
+		assertThat(((McpSchema.TextResourceContents) actualResource.resource()).text())
+			.isEqualTo("Embedded Resource Content");
+	}
+
+	@Test
+	void testGetToolSpecificationsWithContentListReturn() {
+		class ContentListTool {
+
+			@McpTool(name = "content-list-tool", description = "Tool returning List of Content")
+			public List<McpSchema.Content> contentListTool(String text) {
+				var annotations = new McpSchema.Annotations(List.of(McpSchema.Role.ASSISTANT), null);
+				var textResource = new McpSchema.TextResourceContents("file:///test.txt", "text/plain",
+						"Embedded Resource Content");
+				var embeddedResource = new McpSchema.EmbeddedResource(annotations, textResource);
+				var textContent = new McpSchema.TextContent(text);
+				return List.of(embeddedResource, textContent);
+			}
+
+		}
+
+		ContentListTool toolObject = new ContentListTool();
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		SyncToolSpecification toolSpec = toolSpecs.get(0);
+
+		McpTransportContext context = mock(McpTransportContext.class);
+		CallToolRequest request = new CallToolRequest("content-list-tool", Map.of("text", "hello"));
+		CallToolResult result = toolSpec.callHandler().apply(context, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(2);
+		assertThat(result.content().get(0)).isInstanceOf(McpSchema.EmbeddedResource.class);
+		assertThat(result.content().get(1)).isInstanceOf(McpSchema.TextContent.class);
+		assertThat(((McpSchema.TextContent) result.content().get(1)).text()).isEqualTo("hello");
+	}
+
 }


### PR DESCRIPTION
This PR resolves issue #4534. It fixes the polymorphic deserialization error when tools return a list of Content (such as EmbeddedResources and TextContent) where the type property is missing. We manually inject the type field based on the present fields before letting Jackson deserialize them. Additionally, we support returning EmbeddedResources, Content arrays, and Content collections from method callbacks.