### PR TITLE
Filter unsupported tool messages in `JdbcChatMemoryRepository`

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
@@ -23,6 +23,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.sql.DataSource;
 
@@ -94,7 +95,10 @@ public final class JdbcChatMemoryRepository implements ChatMemoryRepository {
 	@Override
 	public List<Message> findByConversationId(String conversationId) {
 		Assert.hasText(conversationId, "conversationId cannot be null or empty");
-		return this.jdbcTemplate.query(this.dialect.getSelectMessagesSql(), new MessageRowMapper(), conversationId);
+		return this.jdbcTemplate.query(this.dialect.getSelectMessagesSql(), new MessageRowMapper(), conversationId)
+			.stream()
+			.filter(Objects::nonNull)
+			.toList();
 	}
 
 	@Override
@@ -103,10 +107,15 @@ public final class JdbcChatMemoryRepository implements ChatMemoryRepository {
 		Assert.notNull(messages, "messages cannot be null");
 		Assert.noNullElements(messages, "messages cannot contain null elements");
 
+		List<Message> persistableMessages = messages.stream()
+			.filter(m -> !(m instanceof ToolResponseMessage)
+					&& !(m instanceof AssistantMessage am && am.hasToolCalls()))
+			.toList();
+
 		this.transactionTemplate.executeWithoutResult(status -> {
 			deleteByConversationId(conversationId);
 			this.jdbcTemplate.batchUpdate(this.dialect.getInsertMessageSql(),
-					new AddBatchPreparedStatement(conversationId, messages));
+					new AddBatchPreparedStatement(conversationId, persistableMessages));
 		});
 	}
 
@@ -151,6 +160,7 @@ public final class JdbcChatMemoryRepository implements ChatMemoryRepository {
 	private static class MessageRowMapper implements RowMapper<Message> {
 
 		@Override
+		@SuppressWarnings("NullAway") // TOOL rows return null; caller filters them out
 		public Message mapRow(ResultSet rs, int i) throws SQLException {
 			var content = rs.getString(1);
 			var type = MessageType.valueOf(rs.getString(2));
@@ -162,10 +172,9 @@ public final class JdbcChatMemoryRepository implements ChatMemoryRepository {
 				case USER -> UserMessage.builder().text(content).metadata(metadata).build();
 				case ASSISTANT -> AssistantMessage.builder().content(content).properties(metadata).build();
 				case SYSTEM -> SystemMessage.builder().text(content).metadata(metadata).build();
-				// The content is always stored empty for ToolResponseMessages.
-				// If we want to capture the actual content, we need to extend
-				// AddBatchPreparedStatement to support it.
-				case TOOL -> ToolResponseMessage.builder().responses(List.of()).metadata(metadata).build();
+				// this implementation doesn't support tool calls message persistence, so
+				// TOOL rows are filtered out by the caller
+				case TOOL -> null;
 			};
 		}
 

--- a/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/AbstractJdbcChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/AbstractJdbcChatMemoryRepositoryIT.java
@@ -32,6 +32,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -214,6 +215,37 @@ public abstract class AbstractJdbcChatMemoryRepositoryIT {
 		for (int i = 0; i < 50; i++) {
 			assertThat(retrievedMessages.get(i).getText()).isEqualTo("Message " + i);
 		}
+	}
+
+	@Test
+	void toolResponseMessagesAreFilteredOnSave() {
+		var conversationId = UUID.randomUUID().toString();
+		var user = new UserMessage("Hello");
+		var toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id1", "myTool", "result")))
+			.build();
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of(user, toolResponse));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getText()).isEqualTo("Hello");
+	}
+
+	@Test
+	void assistantMessagesWithToolCallsAreFilteredOnSave() {
+		var conversationId = UUID.randomUUID().toString();
+		var user = new UserMessage("What is the weather?");
+		var toolCallAssistant = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}")))
+			.build();
+		var plainAssistant = new AssistantMessage("It is sunny.");
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of(user, toolCallAssistant, plainAssistant));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results).hasSize(2);
+		assertThat(results).extracting(Message::getText).containsExactly("What is the weather?", "It is sunny.");
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -81,6 +81,13 @@ ChatMemoryRepository repository = new InMemoryChatMemoryRepository();
 
 Messages are retrieved in ascending order (oldest-to-newest), which is the expected format for LLM conversation history. Ordering is maintained by a `sequence_id` column that records each message's position within its conversation. Each message also stores a creation `timestamp`, exposed in the message metadata under the `JdbcChatMemoryRepository.CONVERSATION_TS` key as a `java.time.Instant`, so applications can display when a message was created.
 
+[WARNING]
+====
+*`JdbcChatMemoryRepository` does not support tool call messages.*
+`AssistantMessage` instances containing tool calls and `ToolResponseMessage` instances are silently filtered out on save and will not appear in the retrieved conversation history.
+If your application uses tool calling, consider the https://spring-ai-community.github.io/spring-ai-session/latest/[Spring AI Session] project and the https://spring-ai-community.github.io/spring-ai-session/latest/session-jdbc/[JDBC session store], which properly persist all message types.
+====
+
 First, add the following dependency to your project:
 
 [tabs]


### PR DESCRIPTION
Previously, ToolResponseMessage and AssistantMessage instances with tool calls were silently saved with corrupted data and read back as empty stubs, polluting the LLM conversation context.

This commit explicitly filters out those message types on save to prevent corrupted messages from being injected into the LLM context. Legacy TOOL rows already in the database are skipped on read.
