### PR TITLE
Filter unsupported tool messages in `MongoChatMemoryRepository`

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
@@ -28,6 +28,7 @@ import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -61,19 +62,27 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 		var messages = this.mongoTemplate.query(Conversation.class)
 			.matching(Query.query(Criteria.where("conversationId").is(conversationId))
 				.with(Sort.by("timestamp").ascending()));
-		return messages.stream().map(MongoChatMemoryRepository::mapMessage).toList();
+		return messages.stream().map(MongoChatMemoryRepository::mapMessage).filter(Objects::nonNull).toList();
 	}
 
 	@Override
 	public void saveAll(String conversationId, List<Message> messages) {
+		List<Message> persistableMessages = messages.stream()
+			.filter(m -> !(m instanceof ToolResponseMessage)
+					&& !(m instanceof AssistantMessage am && am.hasToolCalls()))
+			.toList();
+		if (logger.isWarnEnabled() && persistableMessages.size() < messages.size()) {
+			logger.warn(
+					"MongoChatMemoryRepository does not support tool call messages. Some messages were filtered out for conversation: "
+							+ conversationId);
+		}
 		deleteByConversationId(conversationId);
-		var conversations = messages.stream()
+		var conversations = persistableMessages.stream()
 			.map(message -> new Conversation(conversationId,
 					new Conversation.Message(message.getText(), message.getMessageType().name(), message.getMetadata()),
 					Instant.now()))
 			.toList();
 		this.mongoTemplate.insert(conversations, Conversation.class);
-
 	}
 
 	@Override
@@ -81,13 +90,16 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 		this.mongoTemplate.remove(Query.query(Criteria.where("conversationId").is(conversationId)), Conversation.class);
 	}
 
-	public static Message mapMessage(Conversation conversation) {
+	public static @Nullable Message mapMessage(Conversation conversation) {
 		final String content = Objects.requireNonNullElse(conversation.message().content(), "");
 		return switch (conversation.message().type()) {
 			case "USER" -> UserMessage.builder().text(content).metadata(conversation.message().metadata()).build();
 			case "ASSISTANT" ->
 				AssistantMessage.builder().content(content).properties(conversation.message().metadata()).build();
 			case "SYSTEM" -> SystemMessage.builder().text(content).metadata(conversation.message().metadata()).build();
+			// this implementation doesn't support tool calls message persistence, so
+			// TOOL rows are filtered out by the caller
+			case "TOOL" -> null;
 			default -> {
 				if (logger.isWarnEnabled()) {
 					logger.warn("Unsupported message type: " + conversation.message().type());

--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/test/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/test/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepositoryIT.java
@@ -30,6 +30,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
@@ -135,6 +136,37 @@ public class MongoChatMemoryRepositoryIT {
 
 		var results = this.chatMemoryRepository.findByConversationId(conversationId);
 		assertThat(results).isEqualTo(messages);
+	}
+
+	@Test
+	void toolResponseMessagesAreFilteredOnSave() {
+		var conversationId = UUID.randomUUID().toString();
+		var user = new UserMessage("Hello");
+		var toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id1", "myTool", "result")))
+			.build();
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of(user, toolResponse));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getText()).isEqualTo("Hello");
+	}
+
+	@Test
+	void assistantMessagesWithToolCallsAreFilteredOnSave() {
+		var conversationId = UUID.randomUUID().toString();
+		var user = new UserMessage("What is the weather?");
+		var toolCallAssistant = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}")))
+			.build();
+		var plainAssistant = new AssistantMessage("It is sunny.");
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of(user, toolCallAssistant, plainAssistant));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results).hasSize(2);
+		assertThat(results).extracting(Message::getText).containsExactly("What is the weather?", "It is sunny.");
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -363,6 +363,13 @@ The Neo4j repository will automatically ensure that indexes are created for conv
 
 Messages are retrieved in ascending timestamp order (oldest-to-newest), which is the expected format for LLM conversation history. This ordering is consistent across all chat memory repository implementations.
 
+[WARNING]
+====
+*`MongoChatMemoryRepository` does not support tool call messages.*
+`AssistantMessage` instances containing tool calls and `ToolResponseMessage` instances are silently filtered out on save and will not appear in the retrieved conversation history.
+If your application uses tool calling, consider the https://spring-ai-community.github.io/spring-ai-session/latest/[Spring AI Session] project and the https://spring-ai-community.github.io/spring-ai-session/latest/session-jdbc/[JDBC session store], which properly persist all message types.
+====
+
 First, add the following dependency to your project:
 
 [tabs]


### PR DESCRIPTION
Previously, ToolResponseMessage and AssistantMessage instances with tool calls were silently saved with corrupted data and read back as empty stubs, polluting the LLM conversation context.

This commit explicitly filters out those message types on save to prevent corrupted messages from being injected into the LLM context. A WARN log is emitted when messages are filtered. Legacy TOOL documents already in the database are skipped on read. A warning note is added to the reference documentation.