### PR TITLE
Filter unsupported tool messages in `CassandraChatMemoryRepository`

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/main/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/main/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepository.java
@@ -32,6 +32,9 @@ import com.datastax.oss.driver.api.querybuilder.insert.InsertInto;
 import com.datastax.oss.driver.api.querybuilder.insert.RegularInsert;
 import com.datastax.oss.driver.api.querybuilder.select.Select;
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -49,6 +52,8 @@ import org.springframework.util.Assert;
  * @since 1.0.0
  */
 public final class CassandraChatMemoryRepository implements ChatMemoryRepository {
+
+	private static final Log logger = LogFactory.getLog(CassandraChatMemoryRepository.class);
 
 	public static final String CONVERSATION_TS = CassandraChatMemoryRepository.class.getSimpleName()
 			+ "_message_timestamp";
@@ -113,7 +118,10 @@ public final class CassandraChatMemoryRepository implements ChatMemoryRepository
 		for (Row r : this.conf.session.execute(builder.build())) {
 			for (UdtValue udt : Objects.requireNonNullElse(r.getList(this.conf.messagesColumn, UdtValue.class),
 					List.<UdtValue>of())) {
-				messages.add(getMessage(udt));
+				Message msg = getMessage(udt);
+				if (msg != null) {
+					messages.add(msg);
+				}
 			}
 		}
 		return messages;
@@ -125,6 +133,16 @@ public final class CassandraChatMemoryRepository implements ChatMemoryRepository
 		Assert.notNull(messages, "messages cannot be null");
 		Assert.noNullElements(messages, "messages cannot contain null elements");
 
+		List<Message> persistableMessages = messages.stream()
+			.filter(m -> !(m instanceof ToolResponseMessage)
+					&& !(m instanceof AssistantMessage am && am.hasToolCalls()))
+			.toList();
+		if (logger.isWarnEnabled() && persistableMessages.size() < messages.size()) {
+			logger.warn(
+					"CassandraChatMemoryRepository does not support tool call messages. Some messages were filtered out for conversation: "
+							+ conversationId);
+		}
+
 		Instant instant = Instant.now();
 		List<Object> primaryKeys = this.conf.primaryKeyTranslator.apply(conversationId);
 		BoundStatementBuilder builder = this.addStmt.boundStatementBuilder();
@@ -135,7 +153,7 @@ public final class CassandraChatMemoryRepository implements ChatMemoryRepository
 		}
 
 		List<UdtValue> msgs = new ArrayList<>();
-		for (Message msg : messages) {
+		for (Message msg : persistableMessages) {
 
 			Preconditions.checkArgument(
 					!msg.getMetadata().containsKey(CONVERSATION_TS)
@@ -207,7 +225,7 @@ public final class CassandraChatMemoryRepository implements ChatMemoryRepository
 		return this.conf.session.prepare(stmt.build());
 	}
 
-	private Message getMessage(UdtValue udt) {
+	private @Nullable Message getMessage(UdtValue udt) {
 		String content = Objects.requireNonNullElse(udt.getString(this.conf.messageUdtContentColumn), "");
 		Map<String, Object> props = Map.of(CONVERSATION_TS, udt.getInstant(this.conf.messageUdtTimestampColumn));
 		String type = udt.getString(this.conf.messageUdtTypeColumn);
@@ -216,9 +234,9 @@ public final class CassandraChatMemoryRepository implements ChatMemoryRepository
 			case ASSISTANT -> AssistantMessage.builder().content(content).properties(props).build();
 			case USER -> UserMessage.builder().text(content).metadata(props).build();
 			case SYSTEM -> SystemMessage.builder().text(content).metadata(props).build();
-			case TOOL ->
-				// todo – persist ToolResponse somehow
-				ToolResponseMessage.builder().responses(List.of()).metadata(props).build();
+			// this implementation doesn't support tool calls message persistence, so
+			// TOOL rows are filtered out by the caller
+			case TOOL -> null;
 			default -> throw new IllegalStateException(String.format("unknown message type %s", type));
 		};
 	}

--- a/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/test/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/test/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryIT.java
@@ -36,6 +36,7 @@ import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -193,6 +194,43 @@ class CassandraChatMemoryRepositoryIT {
 				assertThat(result.getMessageType()).isEqualTo(message.getMessageType());
 				assertThat(result.getText()).isEqualTo(message.getText());
 			}
+		});
+	}
+
+	@Test
+	void toolResponseMessagesAreFilteredOnSave() {
+		this.contextRunner.run(context -> {
+			var chatMemory = context.getBean(ChatMemoryRepository.class);
+			var sessionId = UUID.randomUUID().toString();
+			var user = new UserMessage("Hello");
+			var toolResponse = ToolResponseMessage.builder()
+				.responses(List.of(new ToolResponseMessage.ToolResponse("id1", "myTool", "result")))
+				.build();
+
+			chatMemory.saveAll(sessionId, List.of(user, toolResponse));
+
+			var results = chatMemory.findByConversationId(sessionId);
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getText()).isEqualTo("Hello");
+		});
+	}
+
+	@Test
+	void assistantMessagesWithToolCallsAreFilteredOnSave() {
+		this.contextRunner.run(context -> {
+			var chatMemory = context.getBean(ChatMemoryRepository.class);
+			var sessionId = UUID.randomUUID().toString();
+			var user = new UserMessage("What is the weather?");
+			var toolCallAssistant = AssistantMessage.builder()
+				.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}")))
+				.build();
+			var plainAssistant = new AssistantMessage("It is sunny.");
+
+			chatMemory.saveAll(sessionId, List.of(user, toolCallAssistant, plainAssistant));
+
+			var results = chatMemory.findByConversationId(sessionId);
+			assertThat(results).hasSize(2);
+			assertThat(results).extracting(Message::getText).containsExactly("What is the weather?", "It is sunny.");
 		});
 	}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -290,6 +290,13 @@ The auto-configuration will automatically create the `ai_chat_memory` table.
 
 You can disable the schema initialization by setting the property `spring.ai.chat.memory.repository.cassandra.initialize-schema` to `false`.
 
+[WARNING]
+====
+*`CassandraChatMemoryRepository` does not support tool call messages.*
+`AssistantMessage` instances containing tool calls and `ToolResponseMessage` instances are silently filtered out on save and will not appear in the retrieved conversation history.
+If your application uses tool calling, consider the https://spring-ai-community.github.io/spring-ai-session/latest/[Spring AI Session] project and the https://spring-ai-community.github.io/spring-ai-session/latest/session-jdbc/[JDBC session store], which properly persist all message types.
+====
+
 === Neo4j ChatMemoryRepository
 
 `Neo4jChatMemoryRepository` is a built-in implementation that uses Neo4j to store chat messages as nodes and relationships in a property graph database. It is suitable for applications that want to leverage Neo4j's graph capabilities for chat memory persistence.


### PR DESCRIPTION
Previously, ToolResponseMessage and AssistantMessage instances with tool calls were silently saved with corrupted data and read back as empty stubs, polluting the LLM conversation context.

This commit explicitly filters out those message types on save to prevent corrupted messages from being injected into the LLM context. A WARN log is emitted when messages are filtered. Legacy TOOL rows already in the database are skipped on read. A warning note is added to the reference documentation.
