### PR TITLE
Add missing `_additionalProperties` to `ChatCompletionMessage` in `OpenAiChatModel` stream mode

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -121,6 +121,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Vitale
  * @author Eric Bottard
  * @author Taewoong Kim
+ * @author guan xu
  */
 public final class OpenAiChatModel implements ChatModel {
 
@@ -1119,7 +1120,8 @@ public final class OpenAiChatModel implements ChatModel {
 
 				ChatCompletionMessage.Builder msgBuilder = ChatCompletionMessage.builder()
 					.content(cccc.delta().content())
-					.refusal(cccc.delta().refusal());
+					.refusal(cccc.delta().refusal())
+					.additionalProperties(cccc.delta()._additionalProperties());
 				cccc.delta().toolCalls().ifPresent(ccctcs -> {
 					msgBuilder.toolCalls(ccctcs.stream().map(tc -> {
 						ChatCompletionMessageFunctionToolCall.Builder toolCallBuilder = ChatCompletionMessageFunctionToolCall

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
@@ -41,6 +42,7 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.chat.messages.AbstractMessage;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -113,7 +115,29 @@ public class OpenAiChatModelIT {
 		var prompt = new Prompt("What is 2+2? Think step by step.", promptOptions);
 		ChatResponse response = this.chatModel.call(prompt);
 
-		assertThat((Object) response.getResult().getOutput().getMetadata().get("reasoningContent")).isNotNull();
+		assertThat(response.getResult().getOutput().getMetadata().get("reasoningContent")).isNotNull();
+	}
+
+	@Test
+	void streamReasoningContentTest() {
+		var promptOptions = OpenAiChatOptions.builder()
+			.model("o3-mini")
+			.reasoningEffort(ReasoningEffort.LOW.toString())
+			.build();
+
+		var prompt = new Prompt("What is 2+2? Think step by step.", promptOptions);
+		String reasoningContent = this.chatModel.stream(prompt)
+			.collectList()
+			.block()
+			.stream()
+			.map(ChatResponse::getResult)
+			.filter(Objects::nonNull)
+			.map(Generation::getOutput)
+			.map(AbstractMessage::getMetadata)
+			.map(metadata -> metadata.get("reasoningContent").toString())
+			.collect(Collectors.joining());
+
+		assertThat(reasoningContent).isNotNull();
 	}
 
 	void roleTest() {


### PR DESCRIPTION
# Summary
The `_additionalProperties` field is missing in `com.openai.models.chat.completions.ChatCompletionMessage`, which prevents the `reasoningContent` property from being retrieved.

# Related issue
Closes: #6375 