### PR TITLE
GH-6403: Preserve single-line code block content in MarkdownCodeBlockCleaner

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/converter/MarkdownCodeBlockCleaner.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/converter/MarkdownCodeBlockCleaner.java
@@ -48,8 +48,9 @@ public class MarkdownCodeBlockCleaner implements ResponseTextCleaner {
 				// Extract language identifier if present
 				String firstLine = lines[0].trim();
 				if (firstLine.length() > 3) {
-					// Has language identifier like ```json
-					text = lines.length > 1 ? lines[1] : "";
+					// A single-line block has no language line:
+					// strip the leading fence, keeping the content.
+					text = lines.length > 1 ? lines[1] : text.substring(3);
 				}
 				else {
 					// Just ``` without language

--- a/spring-ai-model/src/test/java/org/springframework/ai/converter/MarkdownCodeBlockCleanerTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/converter/MarkdownCodeBlockCleanerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.converter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MarkdownCodeBlockCleaner}.
+ *
+ * @author gaoxiaolei-s59
+ */
+class MarkdownCodeBlockCleanerTest {
+
+	private final MarkdownCodeBlockCleaner cleaner = new MarkdownCodeBlockCleaner();
+
+	@Test
+	void shouldRemoveFencedBlockWithLanguageIdentifier() {
+		String input = """
+				```json
+				{"key": "value"}
+				```""";
+		assertThat(this.cleaner.clean(input)).isEqualTo("{\"key\": \"value\"}");
+	}
+
+	@Test
+	void shouldRemoveFencedBlockWithoutLanguageIdentifier() {
+		String input = """
+				```
+				{"key": "value"}
+				```""";
+		assertThat(this.cleaner.clean(input)).isEqualTo("{\"key\": \"value\"}");
+	}
+
+	@Test
+	void shouldPreserveMultiLineJsonStructure() {
+		String input = """
+				```json
+				{
+					"key": "value"
+				}
+				```""";
+		assertThat(this.cleaner.clean(input)).isEqualTo("{\n\t\"key\": \"value\"\n}");
+	}
+
+	@Test
+	void shouldTrimSurroundingWhitespaceAroundFencedBlock() {
+		String input = "  ```json\n{\"key\": \"value\"}\n```  ";
+		assertThat(this.cleaner.clean(input)).isEqualTo("{\"key\": \"value\"}");
+	}
+
+	@Test
+	void shouldPreserveContentForSingleLineBlockWithoutLanguageIdentifier() {
+		// A fenced block that fits on a single line (e.g. ```{"key":"value"}```) has no
+		// separate language-identifier line: its content must not be discarded.
+		String input = "```{\"key\": \"value\"}```";
+		assertThat(this.cleaner.clean(input)).isEqualTo("{\"key\": \"value\"}");
+	}
+
+	@Test
+	void shouldReturnTextUnchangedWhenNoCodeBlockPresent() {
+		String input = "{\"key\": \"value\"}";
+		assertThat(this.cleaner.clean(input)).isEqualTo("{\"key\": \"value\"}");
+	}
+
+	@Test
+	void shouldReturnNullWhenInputIsNull() {
+		assertThat(this.cleaner.clean(null)).isNull();
+	}
+
+	@Test
+	void shouldReturnEmptyStringWhenInputIsEmpty() {
+		assertThat(this.cleaner.clean("")).isEmpty();
+	}
+
+}


### PR DESCRIPTION
This fixes `MarkdownCodeBlockCleaner` silently discarding the content of a
single-line fenced code block that has no language identifier (for example
`` ```{"key":"value"}``` ``). The cleaner returned an empty string, so the
payload was lost and structured-output parsing through `BeanOutputConverter`'s
default cleaning pipeline failed.

`text.split("\n", 2)` returns a single element for a single-line block, so the
`lines.length > 1 ? lines[1] : ""` branch replaced the content with `""`. A
single-line block has no separate language-identifier line, so only the leading
fence is stripped now. Multi-line blocks are unaffected.

Regression tests are added covering single-line, multi-line, language-tagged,
plain-text, `null` and empty inputs.

Closes gh-6403
