### PR TITLE
Preserve Bedrock reasoning content on tool replay

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockAssistantMessage.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockAssistantMessage.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.content.Media;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Bedrock-specific {@link AssistantMessage} that carries the signed
+ * {@code reasoningContent} blocks returned alongside an assistant turn so the
+ * tool-calling loop can replay them, unmodified, on the next Bedrock request.
+ * <p>
+ * Amazon Bedrock requires that the assistant turn containing a {@code toolUse} block also
+ * replays the preceding signed {@code reasoningContent} block when the matching
+ * {@code toolResult} is sent. Keeping the reasoning state on the same assistant message
+ * as the tool calls makes that replay invariant explicit: the reasoning is associated
+ * with the same turn that is selected and re-emitted during tool calling.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.1
+ * @see BedrockReasoningContent
+ */
+public class BedrockAssistantMessage extends AssistantMessage {
+
+	private final List<BedrockReasoningContent> reasoningContents;
+
+	protected BedrockAssistantMessage(@Nullable String content, List<BedrockReasoningContent> reasoningContents,
+			Map<String, Object> properties, List<ToolCall> toolCalls, List<Media> media) {
+		super(content, properties, toolCalls, media);
+		this.reasoningContents = reasoningContents;
+	}
+
+	public List<BedrockReasoningContent> getReasoningContents() {
+		return this.reasoningContents;
+	}
+
+	public boolean hasReasoningContents() {
+		return !CollectionUtils.isEmpty(this.reasoningContents);
+	}
+
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof BedrockAssistantMessage that)) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		return Objects.equals(this.reasoningContents, that.reasoningContents);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), this.reasoningContents);
+	}
+
+	@Override
+	public String toString() {
+		return "BedrockAssistantMessage [messageType=" + this.messageType + ", toolCalls=" + super.getToolCalls()
+				+ ", textContent=" + this.textContent + ", reasoningContents=" + this.reasoningContents + ", metadata="
+				+ this.metadata + "]";
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	// Public Builder class exposed to users. Avoids having to deal with noisy generic
+	// parameters.
+	public static class Builder extends AbstractBuilder<Builder> {
+
+	}
+
+	public static class AbstractBuilder<B extends AbstractBuilder<B>> extends AssistantMessage.Builder<B> {
+
+		protected List<BedrockReasoningContent> reasoningContents = List.of();
+
+		public B reasoningContents(List<BedrockReasoningContent> reasoningContents) {
+			this.reasoningContents = reasoningContents;
+			return self();
+		}
+
+		@Override
+		public BedrockAssistantMessage build() {
+			return new BedrockAssistantMessage(this.content, this.reasoningContents, this.properties, this.toolCalls,
+					this.media);
+		}
+
+	}
+
+}

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockAssistantMessage.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockAssistantMessage.java
@@ -27,7 +27,7 @@ import org.springframework.ai.content.Media;
 import org.springframework.util.CollectionUtils;
 
 /**
- * Bedrock-specific {@link AssistantMessage} that carries the signed
+ * Internal Bedrock-specific {@link AssistantMessage} that carries the signed
  * {@code reasoningContent} blocks returned alongside an assistant turn so the
  * tool-calling loop can replay them, unmodified, on the next Bedrock request.
  * <p>
@@ -38,10 +38,9 @@ import org.springframework.util.CollectionUtils;
  * with the same turn that is selected and re-emitted during tool calling.
  *
  * @author Jewoo Shin
- * @since 2.0.1
  * @see BedrockReasoningContent
  */
-public class BedrockAssistantMessage extends AssistantMessage {
+class BedrockAssistantMessage extends AssistantMessage {
 
 	private final List<BedrockReasoningContent> reasoningContents;
 
@@ -89,8 +88,6 @@ public class BedrockAssistantMessage extends AssistantMessage {
 		return new Builder();
 	}
 
-	// Public Builder class exposed to users. Avoids having to deal with noisy generic
-	// parameters.
 	public static class Builder extends AbstractBuilder<Builder> {
 
 	}

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -137,6 +137,7 @@ import org.springframework.web.client.RestClientException;
  * @author Sun Yuhan
  * @author Thomas Vitale
  * @author Sebastien Deleuze
+ * @author Jewoo Shin
  * @since 1.0.0
  */
 public class BedrockProxyChatModel implements ChatModel {
@@ -312,6 +313,15 @@ public class BedrockProxyChatModel implements ChatModel {
 				List<ContentBlock> contentBlocks = new ArrayList<>();
 				if (StringUtils.hasText(message.getText())) {
 					contentBlocks.add(ContentBlock.fromText(message.getText()));
+				}
+				// Replay the signed Bedrock reasoning blocks, unmodified, before the
+				// tool-use blocks. Bedrock validates that reasoning comes before its
+				// tool use when the matching tool result is sent back (gh-6413).
+				if (assistantMessage instanceof BedrockAssistantMessage bedrockAssistantMessage
+						&& bedrockAssistantMessage.hasReasoningContents()) {
+					for (BedrockReasoningContent reasoningContent : bedrockAssistantMessage.getReasoningContents()) {
+						contentBlocks.add(reasoningContent.toContentBlock());
+					}
 				}
 				if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
 					for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
@@ -595,29 +605,55 @@ public class BedrockProxyChatModel implements ChatModel {
 
 		Message message = response.output().message();
 
-		List<Generation> generations = message.content()
+		// Preserve Bedrock reasoning blocks (signed reasoning text or redacted content)
+		// so the tool-calling loop can replay them, unmodified, on the next request. See
+		// gh-6413.
+		List<BedrockReasoningContent> reasoningContents = message.content()
 			.stream()
-			.filter(content -> content.type() != ContentBlock.Type.TOOL_USE)
-			.filter(content -> content.text() != null)
-			.map(content -> new Generation(
-					AssistantMessage.builder().content(content.text()).properties(Map.of()).build(),
-					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build()))
+			.filter(content -> content.type() == ContentBlock.Type.REASONING_CONTENT)
+			.map(content -> BedrockReasoningContent.from(content.reasoningContent()))
 			.toList();
-
-		List<Generation> allGenerations = new ArrayList<>(generations);
-
-		if (response.stopReasonAsString() != null && generations.isEmpty()) {
-			Generation generation = new Generation(AssistantMessage.builder().properties(Map.of()).build(),
-					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build());
-			allGenerations.add(generation);
-		}
 
 		List<ContentBlock> toolUseContentBlocks = message.content()
 			.stream()
 			.filter(c -> c.type() == ContentBlock.Type.TOOL_USE)
 			.toList();
+		boolean hasToolUse = !CollectionUtils.isEmpty(toolUseContentBlocks);
 
-		if (!CollectionUtils.isEmpty(toolUseContentBlocks)) {
+		// When the response carries reasoning but no tool use, surface the reasoning on
+		// the final-text assistant message without displacing the text returned by
+		// ChatResponse.getResult().
+		boolean attachReasoningToText = !hasToolUse && !CollectionUtils.isEmpty(reasoningContents);
+
+		List<Generation> generations = new ArrayList<>();
+		for (ContentBlock content : message.content()) {
+			if (content.type() == ContentBlock.Type.TOOL_USE || content.text() == null) {
+				continue;
+			}
+			AssistantMessage assistantMessage = (attachReasoningToText && generations.isEmpty())
+					? BedrockAssistantMessage.builder()
+						.content(content.text())
+						.properties(Map.of())
+						.reasoningContents(reasoningContents)
+						.build()
+					: AssistantMessage.builder().content(content.text()).properties(Map.of()).build();
+			generations.add(new Generation(assistantMessage,
+					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build()));
+		}
+
+		List<Generation> allGenerations = new ArrayList<>(generations);
+
+		if (response.stopReasonAsString() != null && generations.isEmpty()) {
+			AssistantMessage assistantMessage = attachReasoningToText ? BedrockAssistantMessage.builder()
+				.properties(Map.of())
+				.reasoningContents(reasoningContents)
+				.build() : AssistantMessage.builder().properties(Map.of()).build();
+			Generation generation = new Generation(assistantMessage,
+					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build());
+			allGenerations.add(generation);
+		}
+
+		if (hasToolUse) {
 
 			List<AssistantMessage.ToolCall> toolCalls = new ArrayList<>();
 
@@ -631,11 +667,17 @@ public class BedrockProxyChatModel implements ChatModel {
 					.add(new AssistantMessage.ToolCall(functionCallId, "function", functionName, functionArguments));
 			}
 
-			AssistantMessage assistantMessage = AssistantMessage.builder()
-				.content("")
-				.properties(Map.of())
-				.toolCalls(toolCalls)
-				.build();
+			// Attach the signed reasoning to the same assistant turn as the tool calls so
+			// DefaultToolCallingManager carries it into the next request history
+			// (gh-6413).
+			AssistantMessage assistantMessage = CollectionUtils.isEmpty(reasoningContents)
+					? AssistantMessage.builder().content("").properties(Map.of()).toolCalls(toolCalls).build()
+					: BedrockAssistantMessage.builder()
+						.content("")
+						.properties(Map.of())
+						.toolCalls(toolCalls)
+						.reasoningContents(reasoningContents)
+						.build();
 			Generation toolCallGeneration = new Generation(assistantMessage,
 					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build());
 			allGenerations.add(toolCallGeneration);

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockReasoningContent.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockReasoningContent.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.ReasoningTextBlock;
 import org.springframework.util.Assert;
 
 /**
- * Spring AI Bedrock value object that preserves a single Bedrock Converse
+ * Internal Spring AI Bedrock value object that preserves a single Bedrock Converse
  * {@code reasoningContent} block so it can be replayed, unmodified, on a later request.
  * <p>
  * Amazon Bedrock requires that the assistant turn containing a {@code toolUse} block also
@@ -42,10 +42,9 @@ import org.springframework.util.Assert;
  * leak into logs or assertion output.
  *
  * @author Jewoo Shin
- * @since 2.0.1
  * @see BedrockAssistantMessage
  */
-public final class BedrockReasoningContent {
+final class BedrockReasoningContent {
 
 	private final @Nullable String text;
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockReasoningContent.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockReasoningContent.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningTextBlock;
+
+import org.springframework.util.Assert;
+
+/**
+ * Spring AI Bedrock value object that preserves a single Bedrock Converse
+ * {@code reasoningContent} block so it can be replayed, unmodified, on a later request.
+ * <p>
+ * Amazon Bedrock requires that the assistant turn containing a {@code toolUse} block also
+ * replays the preceding signed {@code reasoningContent} block when the matching
+ * {@code toolResult} is sent. To honor that replay invariant this object captures the
+ * reasoning text, its signature and any redacted content without modification and can
+ * convert itself back into an AWS SDK {@link ContentBlock} via {@link #toContentBlock()}.
+ * <p>
+ * The reasoning text and signature are intentionally redacted from {@link #toString()}:
+ * the signature is an opaque token used only for replay verification and has no reason to
+ * leak into logs or assertion output.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.1
+ * @see BedrockAssistantMessage
+ */
+public final class BedrockReasoningContent {
+
+	private final @Nullable String text;
+
+	private final @Nullable String signature;
+
+	private final byte @Nullable [] redactedContent;
+
+	private BedrockReasoningContent(@Nullable String text, @Nullable String signature,
+			byte @Nullable [] redactedContent) {
+		this.text = text;
+		this.signature = signature;
+		this.redactedContent = redactedContent != null ? redactedContent.clone() : null;
+	}
+
+	/**
+	 * Capture a Bedrock {@link ReasoningContentBlock} as a Spring AI value object,
+	 * preserving its union member (reasoning text and signature, or redacted content)
+	 * without modification.
+	 * @param reasoningContentBlock the AWS SDK reasoning content block
+	 * @return a value object that can replay the same reasoning block
+	 */
+	public static BedrockReasoningContent from(ReasoningContentBlock reasoningContentBlock) {
+		Assert.notNull(reasoningContentBlock, "reasoningContentBlock must not be null");
+		SdkBytes redacted = reasoningContentBlock.redactedContent();
+		if (redacted != null) {
+			return new BedrockReasoningContent(null, null, redacted.asByteArray());
+		}
+		ReasoningTextBlock reasoningText = reasoningContentBlock.reasoningText();
+		if (reasoningText != null) {
+			return new BedrockReasoningContent(reasoningText.text(), reasoningText.signature(), null);
+		}
+		return new BedrockReasoningContent(null, null, null);
+	}
+
+	/**
+	 * Convert this value object back into an AWS SDK {@link ContentBlock} carrying a
+	 * {@code reasoningContent} block. The reasoning text and signature are replayed
+	 * unmodified; signatures are never regenerated.
+	 * @return the reasoning content block ready to be added to a Bedrock request
+	 */
+	public ContentBlock toContentBlock() {
+		ReasoningContentBlock.Builder builder = ReasoningContentBlock.builder();
+		if (this.redactedContent != null) {
+			builder.redactedContent(SdkBytes.fromByteArray(this.redactedContent));
+		}
+		else {
+			builder.reasoningText(ReasoningTextBlock.builder().text(this.text).signature(this.signature).build());
+		}
+		return ContentBlock.fromReasoningContent(builder.build());
+	}
+
+	public @Nullable String getText() {
+		return this.text;
+	}
+
+	public @Nullable String getSignature() {
+		return this.signature;
+	}
+
+	public byte @Nullable [] getRedactedContent() {
+		return this.redactedContent != null ? this.redactedContent.clone() : null;
+	}
+
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof BedrockReasoningContent that)) {
+			return false;
+		}
+		return Objects.equals(this.text, that.text) && Objects.equals(this.signature, that.signature)
+				&& Arrays.equals(this.redactedContent, that.redactedContent);
+	}
+
+	@Override
+	public int hashCode() {
+		return 31 * Objects.hash(this.text, this.signature) + Arrays.hashCode(this.redactedContent);
+	}
+
+	@Override
+	public String toString() {
+		return "BedrockReasoningContent [text=" + (this.text != null ? "***redacted***" : "null") + ", signature="
+				+ (this.signature != null ? "***redacted***" : "null") + ", redactedContent="
+				+ (this.redactedContent != null ? this.redactedContent.length + " bytes" : "null") + "]";
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+
+		private @Nullable String text;
+
+		private @Nullable String signature;
+
+		private byte @Nullable [] redactedContent;
+
+		private Builder() {
+		}
+
+		public Builder text(@Nullable String text) {
+			this.text = text;
+			return this;
+		}
+
+		public Builder signature(@Nullable String signature) {
+			this.signature = signature;
+			return this;
+		}
+
+		public Builder redactedContent(byte @Nullable [] redactedContent) {
+			this.redactedContent = redactedContent != null ? redactedContent.clone() : null;
+			return this;
+		}
+
+		public BedrockReasoningContent build() {
+			return new BedrockReasoningContent(this.text, this.signature, this.redactedContent);
+		}
+
+	}
+
+}

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelReasoningTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelReasoningTests.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.document.internal.MapDocument;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ConversationRole;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseMetrics;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.Message;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningTextBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
+import software.amazon.awssdk.services.bedrockruntime.model.ToolUseBlock;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Mapping tests for Bedrock Converse {@code reasoningContent} preservation and replay
+ * through the tool-calling loop. See gh-6413.
+ *
+ * @author Jewoo Shin
+ */
+@ExtendWith(MockitoExtension.class)
+class BedrockProxyChatModelReasoningTests {
+
+	private static final String REASONING_TEXT = "The user wants the weather in Paris. I will call the weather tool.";
+
+	private static final String REASONING_SIGNATURE = "EsoBCkgIBhABGAIiQ-signature-token";
+
+	private @Mock BedrockRuntimeClient bedrockRuntimeClient;
+
+	private @Mock BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient;
+
+	private BedrockProxyChatModel chatModel;
+
+	@BeforeEach
+	void beforeEach() {
+		this.chatModel = BedrockProxyChatModel.builder()
+			.bedrockRuntimeClient(this.bedrockRuntimeClient)
+			.bedrockRuntimeAsyncClient(this.bedrockRuntimeAsyncClient)
+			.build();
+	}
+
+	@Test
+	void toolUseResponseReplaysSignedReasoningContentBeforeToolUse() {
+		ContentBlock reasoningBlock = ContentBlock.fromReasoningContent(ReasoningContentBlock.builder()
+			.reasoningText(ReasoningTextBlock.builder().text(REASONING_TEXT).signature(REASONING_SIGNATURE).build())
+			.build());
+
+		given(this.bedrockRuntimeClient.converse(isA(ConverseRequest.class)))
+			.willReturn(toolUseResponse(reasoningBlock))
+			.willReturn(finalResponse());
+
+		runToolLoop();
+
+		Message assistantMessage = capturedSecondRequestAssistantMessage();
+		List<ContentBlock> content = assistantMessage.content();
+
+		int reasoningIndex = indexOfType(content, ContentBlock.Type.REASONING_CONTENT);
+		int toolUseIndex = indexOfType(content, ContentBlock.Type.TOOL_USE);
+
+		// The signed reasoning block must be replayed, unmodified, and ordered before the
+		// tool-use block it belongs to.
+		assertThat(reasoningIndex).isGreaterThanOrEqualTo(0);
+		assertThat(toolUseIndex).isGreaterThanOrEqualTo(0);
+		assertThat(reasoningIndex).isLessThan(toolUseIndex);
+
+		ReasoningContentBlock replayed = content.get(reasoningIndex).reasoningContent();
+		assertThat(replayed.reasoningText().text()).isEqualTo(REASONING_TEXT);
+		assertThat(replayed.reasoningText().signature()).isEqualTo(REASONING_SIGNATURE);
+		assertThat(content.get(toolUseIndex).toolUse().name()).isEqualTo("getCurrentWeather");
+	}
+
+	@Test
+	void redactedReasoningContentIsPreservedAndReplayed() {
+		byte[] redacted = "redacted-reasoning-bytes".getBytes(StandardCharsets.UTF_8);
+		ContentBlock reasoningBlock = ContentBlock.fromReasoningContent(
+				ReasoningContentBlock.builder().redactedContent(SdkBytes.fromByteArray(redacted)).build());
+
+		given(this.bedrockRuntimeClient.converse(isA(ConverseRequest.class)))
+			.willReturn(toolUseResponse(reasoningBlock))
+			.willReturn(finalResponse());
+
+		runToolLoop();
+
+		Message assistantMessage = capturedSecondRequestAssistantMessage();
+		List<ContentBlock> content = assistantMessage.content();
+
+		int reasoningIndex = indexOfType(content, ContentBlock.Type.REASONING_CONTENT);
+		assertThat(reasoningIndex).isGreaterThanOrEqualTo(0);
+		assertThat(reasoningIndex).isLessThan(indexOfType(content, ContentBlock.Type.TOOL_USE));
+
+		ReasoningContentBlock replayed = content.get(reasoningIndex).reasoningContent();
+		assertThat(replayed.reasoningText()).isNull();
+		assertThat(replayed.redactedContent().asByteArray()).isEqualTo(redacted);
+	}
+
+	@Test
+	void reasoningOnlyResponseExposesReasoningWithoutDisplacingFinalText() {
+		ContentBlock reasoningBlock = ContentBlock.fromReasoningContent(ReasoningContentBlock.builder()
+			.reasoningText(ReasoningTextBlock.builder().text(REASONING_TEXT).signature(REASONING_SIGNATURE).build())
+			.build());
+
+		ConverseResponse response = ConverseResponse.builder()
+			.output(ConverseOutput.builder()
+				.message(Message.builder()
+					.role(ConversationRole.ASSISTANT)
+					.content(reasoningBlock, ContentBlock.fromText("The weather in Paris is 15°C."))
+					.build())
+				.build())
+			.usage(TokenUsage.builder().inputTokens(20).outputTokens(30).totalTokens(50).build())
+			.stopReason(StopReason.END_TURN)
+			.build();
+
+		given(this.bedrockRuntimeClient.converse(isA(ConverseRequest.class))).willReturn(response);
+
+		ChatResponse chatResponse = this.chatModel.call(new Prompt("What is the weather in Paris?"));
+
+		AssistantMessage output = chatResponse.getResult().getOutput();
+		// The final text returned by getResult() must be unchanged.
+		assertThat(output.getText()).isEqualTo("The weather in Paris is 15°C.");
+		// The reasoning state must still be observable on the final assistant message.
+		assertThat(output).isInstanceOf(BedrockAssistantMessage.class);
+		BedrockReasoningContent reasoning = ((BedrockAssistantMessage) output).getReasoningContents().get(0);
+		assertThat(reasoning.getText()).isEqualTo(REASONING_TEXT);
+		assertThat(reasoning.getSignature()).isEqualTo(REASONING_SIGNATURE);
+	}
+
+	@Test
+	void nonReasoningToolUseResponseAddsNoReasoningBlock() {
+		ConverseResponse toolUse = ConverseResponse.builder()
+			.output(ConverseOutput.builder()
+				.message(Message.builder()
+					.role(ConversationRole.ASSISTANT)
+					.content(ContentBlock.fromText("Let me check the weather for you."), toolUseBlock())
+					.build())
+				.build())
+			.usage(TokenUsage.builder().inputTokens(200).outputTokens(50).totalTokens(250).build())
+			.stopReason(StopReason.TOOL_USE)
+			.metrics(ConverseMetrics.builder().latencyMs(1000L).build())
+			.build();
+
+		given(this.bedrockRuntimeClient.converse(isA(ConverseRequest.class))).willReturn(toolUse)
+			.willReturn(finalResponse());
+
+		runToolLoop();
+
+		Message assistantMessage = capturedSecondRequestAssistantMessage();
+		List<ContentBlock> content = assistantMessage.content();
+
+		// Backward compatibility: a normal text + toolUse response must not introduce any
+		// reasoning block on replay.
+		assertThat(indexOfType(content, ContentBlock.Type.REASONING_CONTENT)).isEqualTo(-1);
+		assertThat(indexOfType(content, ContentBlock.Type.TOOL_USE)).isGreaterThanOrEqualTo(0);
+	}
+
+	private void runToolLoop() {
+		ToolCallback toolCallback = FunctionToolCallback.builder("getCurrentWeather", (Request request) -> "15°C")
+			.description("Gets the weather in location")
+			.inputType(Request.class)
+			.build();
+
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+
+		Prompt prompt = new Prompt("What is the weather in Paris?",
+				BedrockChatOptions.builder().toolCallbacks(toolCallback).build());
+
+		ChatResponse result = this.chatModel.call(prompt);
+
+		while (result.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, result);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(),
+					BedrockChatOptions.builder().toolCallbacks(toolCallback).build());
+			result = this.chatModel.call(prompt);
+		}
+	}
+
+	private Message capturedSecondRequestAssistantMessage() {
+		ArgumentCaptor<ConverseRequest> captor = ArgumentCaptor.forClass(ConverseRequest.class);
+		verify(this.bedrockRuntimeClient, times(2)).converse(captor.capture());
+		ConverseRequest secondRequest = captor.getAllValues().get(1);
+		return secondRequest.messages()
+			.stream()
+			.filter(m -> m.role() == ConversationRole.ASSISTANT)
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("No assistant message in the replayed request"));
+	}
+
+	private static ConverseResponse toolUseResponse(ContentBlock reasoningBlock) {
+		return ConverseResponse.builder()
+			.output(ConverseOutput.builder()
+				.message(Message.builder()
+					.role(ConversationRole.ASSISTANT)
+					.content(reasoningBlock, toolUseBlock())
+					.build())
+				.build())
+			.usage(TokenUsage.builder().inputTokens(200).outputTokens(50).totalTokens(250).build())
+			.stopReason(StopReason.TOOL_USE)
+			.metrics(ConverseMetrics.builder().latencyMs(1000L).build())
+			.build();
+	}
+
+	private static ConverseResponse finalResponse() {
+		return ConverseResponse.builder()
+			.output(ConverseOutput.builder()
+				.message(Message.builder()
+					.role(ConversationRole.ASSISTANT)
+					.content(ContentBlock.fromText("The weather in Paris is 15°C."))
+					.build())
+				.build())
+			.usage(TokenUsage.builder().inputTokens(300).outputTokens(30).totalTokens(330).build())
+			.stopReason(StopReason.END_TURN)
+			.metrics(ConverseMetrics.builder().latencyMs(500L).build())
+			.build();
+	}
+
+	private static ContentBlock toolUseBlock() {
+		return ContentBlock.fromToolUse(ToolUseBlock.builder()
+			.toolUseId("tooluse_123")
+			.name("getCurrentWeather")
+			.input(MapDocument.mapBuilder().putString("location", "Paris, France").putString("unit", "C").build())
+			.build());
+	}
+
+	private static int indexOfType(List<ContentBlock> content, ContentBlock.Type type) {
+		for (int i = 0; i < content.size(); i++) {
+			if (content.get(i).type() == type) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	public record Request(String location, String unit) {
+	}
+
+}


### PR DESCRIPTION
Bedrock Converse responses can include signed `reasoningContent` before `toolUse`. The current adapter drops those blocks, so the next request sends the `toolResult` without replaying the signed reasoning block that Bedrock validates for that assistant turn.

This PR keeps the preserved reasoning on a Bedrock-specific assistant message and replays it, unchanged and before `toolUse`, when the tool-calling loop builds the next request. The scope stays Bedrock-specific; it does not add a generic `AssistantMessage` reasoning API.

AWS-free mapping tests cover signed reasoning replay, redacted reasoning replay, reasoning-only responses, and the existing non-reasoning `text` + `toolUse` path.

Fixes #6413
