### PR TITLE
Skip Kotlin `Continuation` in tool input schema

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
@@ -177,6 +177,13 @@ public final class McpJsonSchemaGenerator {
 				continue;
 			}
 
+			// A Kotlin suspend function carries a synthetic trailing Continuation
+			// parameter that is not part of the tool contract and must not appear in
+			// the generated schema.
+			if (KotlinDetector.isSuspendingFunction(method) && i == method.getParameterCount() - 1) {
+				continue;
+			}
+
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);
 			}

--- a/mcp/mcp-annotations/src/test/kotlin/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorKotlinTests.kt
+++ b/mcp/mcp-annotations/src/test/kotlin/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorKotlinTests.kt
@@ -54,6 +54,19 @@ class McpJsonSchemaGeneratorKotlinTests {
 		assertThat(requestRequired).doesNotContain("filter")
 	}
 
+	@Test
+	fun `suspend functions do not expose the continuation parameter`() {
+		val method = SearchTools::class.java.declaredMethods.first { it.name == "fetch" }
+
+		val schema = McpJsonSchemaGenerator.generateForMethodInput(method)
+		val schemaNode = jsonMapper.readTree(schema)
+		val properties = schemaNode["properties"]
+
+		assertThat(properties["url"]).isNotNull()
+		assertThat(properties["\$completion"]).isNull()
+		assertThat(requiredNames(schemaNode["required"])).containsExactly("url")
+	}
+
 	private fun requiredNames(required: JsonNode?): List<String> {
 		if (required == null || required.isNull) {
 			return emptyList()
@@ -75,6 +88,11 @@ class McpJsonSchemaGeneratorKotlinTests {
 		@McpTool(description = "Mixed")
 		fun mixed(@McpToolParam(required = false) request: SearchRequest? = null): String {
 			return "ok"
+		}
+
+		@McpTool(description = "Fetch")
+		suspend fun fetch(url: String): String {
+			return url
 		}
 
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -152,6 +152,12 @@ public final class JsonSchemaGenerator {
 				// outside the model interaction flow.
 				continue;
 			}
+			// A Kotlin suspend function carries a synthetic trailing Continuation
+			// parameter that is not part of the tool contract and must not appear in
+			// the generated schema.
+			if (KotlinDetector.isSuspendingFunction(method) && i == method.getParameterCount() - 1) {
+				continue;
+			}
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);
 			}

--- a/spring-ai-model/src/test/kotlin/org/springframework/ai/util/json/schema/JsonSchemaGeneratorKotlinTests.kt
+++ b/spring-ai-model/src/test/kotlin/org/springframework/ai/util/json/schema/JsonSchemaGeneratorKotlinTests.kt
@@ -64,6 +64,19 @@ class JsonSchemaGeneratorKotlinTests {
 		assertThat(requestRequired).doesNotContain("filter")
 	}
 
+	@Test
+	fun `suspend functions do not expose the continuation parameter`() {
+		val method = SearchTools::class.java.declaredMethods.first { it.name == "fetch" }
+
+		val schema = JsonSchemaGenerator.generateForMethodInput(method)
+		val schemaNode = jsonMapper.readTree(schema)
+		val properties = schemaNode["properties"]
+
+		assertThat(properties["url"]).isNotNull()
+		assertThat(properties["\$completion"]).isNull()
+		assertThat(requiredNames(schemaNode["required"])).containsExactly("url")
+	}
+
 	private fun requiredNames(required: JsonNode?): List<String> {
 		if (required == null || required.isNull) {
 			return emptyList()
@@ -87,6 +100,11 @@ class JsonSchemaGeneratorKotlinTests {
 		@Tool(description = "Mixed")
 		fun mixed(request: SearchRequest?): String {
 			return "ok"
+		}
+
+		@Tool(description = "Fetch")
+		suspend fun fetch(url: String): String {
+			return url
 		}
 	}
 


### PR DESCRIPTION
Kotlin `suspend` functions exposed as tools currently leak the compiler-generated
`kotlin.coroutines.Continuation` parameter into the generated JSON input schema.

### Problem

A Kotlin `suspend` function is compiled to a JVM method with an extra trailing
`kotlin.coroutines.Continuation` parameter:

```kotlin
suspend fun fetch(url: String): String
```

becomes, at the JVM level:

```text
fetch(url: String, $completion: Continuation)
```

Both `JsonSchemaGenerator#generateForMethodInput` (`@Tool`) and
`McpJsonSchemaGenerator#generateForMethodInput` (`@McpTool`) iterate over all
method parameters and skip the framework-supplied parameter types they recognize
(such as `ToolContext` and the MCP infrastructure types), but not Kotlin's
synthetic `Continuation`. As a result, the generated schema includes an
unexpected required `$completion` property:

```json
{
  "type": "object",
  "properties": {
    "url": { "type": "string" },
    "$completion": { "type": "object" }
  },
  "required": [ "url", "$completion" ]
}
```

`$completion` is not a real tool parameter; it is an artifact of how Kotlin
compiles `suspend` functions to JVM bytecode. Emitting it in the model-facing
input schema — and marking it `required` — exposes an internal implementation
detail as if it were a tool argument the model must provide.

### Fix

Skip the trailing `Continuation` parameter when the method is detected as a Kotlin
suspending function, via `org.springframework.core.KotlinDetector#isSuspendingFunction`.
This is applied to both schema generators, so the same `fetch` tool now produces a
schema with only its declared parameters:

```json
{
  "type": "object",
  "properties": {
    "url": { "type": "string" }
  },
  "required": [ "url" ]
}
```

This change only affects schema generation; broader support for Kotlin `suspend`
functions as tools is a separate concern, requested in #3718.

### Tests

Added tests verifying that a Kotlin `suspend` tool function exposes only its
declared parameters:

- `JsonSchemaGeneratorKotlinTests` — `@Tool` path
- `McpJsonSchemaGeneratorKotlinTests` — `@McpTool` path

### Reproduced on

| Version | `@Tool` | `@McpTool` |
| --- | --- | --- |
| `2.0.1-SNAPSHOT` (main) | reproduced | reproduced |
| `1.1.8` | reproduced | n/a (the `@McpTool` annotation path was added in 2.0.x) |

Standalone reproduction: https://github.com/rea9r/spring-ai-kotlin-suspend-schema-repro