### PR TITLE
Fix dead JavaDoc link in upgrade notes

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -2610,7 +2610,7 @@ On our march to release 1.0.0 M1 we have made several breaking changes.  Apologi
 
 === ChatClient changes
 
-A major change was made that took the 'old' `ChatClient` and moved the functionality into `ChatModel`.  The 'new' `ChatClient` now takes an instance of `ChatModel`. This was done to support a fluent API for creating and executing prompts in a style similar to other client classes in the Spring ecosystem, such as `RestClient`, `WebClient`, and `JdbcClient`.  Refer to the [JavaDoc](https://docs.spring.io/spring-ai/docs/api) for more information on the Fluent API, proper reference documentation is coming shortly.
+A major change was made that took the 'old' `ChatClient` and moved the functionality into `ChatModel`.  The 'new' `ChatClient` now takes an instance of `ChatModel`. This was done to support a fluent API for creating and executing prompts in a style similar to other client classes in the Spring ecosystem, such as `RestClient`, `WebClient`, and `JdbcClient`.  Refer to the link:https://docs.spring.io/spring-ai/docs/current/api/[JavaDoc] for more information on the Fluent API, proper reference documentation is coming shortly.
 
 We renamed the 'old' `ModelClient` to `Model` and renamed implementing classes, for example `ImageClient` was renamed to `ImageModel`.  The `Model` implementation represents the portability layer that converts between the Spring AI API and the underlying AI Model API.
 


### PR DESCRIPTION
The `ChatClient changes` section under *Upgrading to 1.0.0.M1* contains a JavaDoc reference that has two issues:

1. The URL `https://docs.spring.io/spring-ai/docs/api` returns **HTTP 404**. The current canonical JavaDoc overview is `https://docs.spring.io/spring-ai/docs/current/api/`.
2. The link uses Markdown syntax `[text](url)` inside an `.adoc` file. Asciidoctor does not recognize this syntax, so the literal `[JavaDoc](` and `)` characters render as plain text while the bare URL is auto-linked to the dead page.

This change replaces the URL with the working one and converts the link to AsciiDoc syntax (`link:url[text]`) so it renders correctly.

## Verification
- Old URL → 404 (verified)
- New URL → loads, shows "Spring AI Parent 1.1.8 API" overview (verified)
- Anchor text "JavaDoc" preserved
- Single-line change, no other content modified
