### PR TITLE
Fix MarkdownCodeBlockCleaner discarding content of single-line fenced code blocks

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/converter/MarkdownCodeBlockCleaner.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/converter/MarkdownCodeBlockCleaner.java
@@ -42,14 +42,19 @@ public class MarkdownCodeBlockCleaner implements ResponseTextCleaner {
 
 		// Check for and remove triple backticks
 		if (text.startsWith("```") && text.endsWith("```")) {
-			// Remove the first line if it contains "```json" or similar
 			String[] lines = text.split("\n", 2);
 			if (lines[0].trim().toLowerCase().startsWith("```")) {
 				// Extract language identifier if present
 				String firstLine = lines[0].trim();
-				if (firstLine.length() > 3) {
-					// Has language identifier like ```json
-					text = lines.length > 1 ? lines[1] : "";
+				if (firstLine.length() > 3 && lines.length > 1) {
+					// Has language identifier like ```json and content on following lines
+					text = lines[1];
+				}
+				else if (firstLine.length() > 3 && lines.length == 1) {
+					// Single-line fenced block without line break, e.g.
+					// ```{"key": "value"}```
+					// Strip the opening fence only; the trailing fence is removed below
+					text = firstLine.substring(3);
 				}
 				else {
 					// Just ``` without language

--- a/spring-ai-model/src/test/java/org/springframework/ai/converter/MarkdownCodeBlockCleanerTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/converter/MarkdownCodeBlockCleanerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.converter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MarkdownCodeBlockCleaner}.
+ *
+ * @author MKP999
+ */
+class MarkdownCodeBlockCleanerTest {
+
+	private final MarkdownCodeBlockCleaner cleaner = new MarkdownCodeBlockCleaner();
+
+	@Test
+	void shouldRemoveMultilineCodeBlockWithLanguageIdentifier() {
+		String input = "```json\n{\"key\": \"value\"}\n```";
+		String result = cleaner.clean(input);
+		assertThat(result).isEqualTo("{\"key\": \"value\"}");
+	}
+
+	@Test
+	void shouldRemoveMultilineCodeBlockWithoutLanguageIdentifier() {
+		String input = "```\n{\"key\": \"value\"}\n```";
+		String result = cleaner.clean(input);
+		assertThat(result).isEqualTo("{\"key\": \"value\"}");
+	}
+
+	@Test
+	void shouldRemoveSingleLineCodeBlockWithLanguageIdentifier() {
+		String input = "```json{\"key\": \"value\"}```";
+		String result = cleaner.clean(input);
+		assertThat(result).isEqualTo("{\"key\": \"value\"}");
+	}
+
+	@Test
+	void shouldRemoveSingleLineCodeBlockWithoutLanguageIdentifier() {
+		String input = "```{\"key\": \"value\"}```";
+		String result = cleaner.clean(input);
+		assertThat(result).isEqualTo("{\"key\": \"value\"}");
+	}
+
+	@Test
+	void shouldReturnNullForNullInput() {
+		assertThat(cleaner.clean(null)).isNull();
+	}
+
+	@Test
+	void shouldReturnEmptyForEmptyInput() {
+		assertThat(cleaner.clean("")).isEmpty();
+	}
+
+	@Test
+	void shouldNotModifyTextWithoutCodeBlocks() {
+		String input = "plain text without code blocks";
+		assertThat(cleaner.clean(input)).isEqualTo(input);
+	}
+
+}


### PR DESCRIPTION
## Problem

When a fenced code block fits on a **single line** without a language identifier, `MarkdownCodeBlockCleaner` returns an empty string and silently discards the payload.

**Affected code:** `spring-ai-model/src/main/java/org/springframework/ai/converter/MarkdownCodeBlockCleaner.java`

**Minimal reproducible example:**
```java
String result = new MarkdownCodeBlockCleaner().clean("```{\"key\": \"value\"}```");
// Expected: {"key": "value"}
// Actual: "" (content discarded)
```

## Root Cause

`text.split("\n", 2)` yields a single-element array for a single-line block. When `firstLine.length() > 3` (because the content is included after the opening fence), the code enters the "has language identifier" branch and evaluates `lines.length > 1 ? lines[1] : ""`. Since `lines.length == 1`, it returns `""`.

## Fix

Add an explicit check for `lines.length == 1` in the single-line case. When the block has no line break, strip only the opening fence from `firstLine` instead of returning an empty string. The trailing fence is already removed by the existing code below.

## Test Coverage

Added `MarkdownCodeBlockCleanerTest` with 7 test cases:
- Single-line code block without language identifier (the bug case)
- Single-line code block with language identifier
- Multi-line code block with language identifier
- Multi-line code block without language identifier
- Null input
- Empty input
- Plain text without code blocks

Closes #6403