### PR TITLE
Accumulate tool calling advisor usage

### DIFF
--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseUsageAggregationTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseUsageAggregationTests.java
@@ -288,19 +288,15 @@ public class BedrockConverseUsageAggregationTests {
 
 		assertThat(result).isNotNull();
 
-		// With external tool calling each chatModel.call() is independent, so only the
-		// last round's usage is reported (no cross-round accumulation).
-		assertThat(result.getMetadata().getUsage().getPromptTokens()).isEqualTo(300);
-		assertThat(result.getMetadata().getUsage().getCompletionTokens()).isEqualTo(30);
-		assertThat(result.getMetadata().getUsage().getTotalTokens()).isEqualTo(330);
+		// ToolCallingAdvisor accumulates usage across framework-controlled tool
+		// calling rounds.
+		assertThat(result.getMetadata().getUsage().getPromptTokens()).isEqualTo(500);
+		assertThat(result.getMetadata().getUsage().getCompletionTokens()).isEqualTo(80);
+		assertThat(result.getMetadata().getUsage().getTotalTokens()).isEqualTo(580);
 
-		// Verify cache metrics in native usage object (last round only)
-		Object nativeUsage = result.getMetadata().getUsage().getNativeUsage();
-		assertThat(nativeUsage).isInstanceOf(TokenUsage.class);
-
-		TokenUsage tokenUsage = (TokenUsage) nativeUsage;
-		assertThat(tokenUsage.cacheReadInputTokens()).isEqualTo(150);
-		assertThat(tokenUsage.cacheWriteInputTokens()).isEqualTo(0);
+		// Verify cache metrics in the accumulated Usage abstraction.
+		assertThat(result.getMetadata().getUsage().getCacheReadInputTokens()).isEqualTo(300L);
+		assertThat(result.getMetadata().getUsage().getCacheWriteInputTokens()).isEqualTo(0L);
 	}
 
 	public record Request(String location, String unit) {

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
@@ -139,7 +139,7 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 
 			// After Call
 			ChatResponse chatResponse = chatClientResponse.chatResponse();
-			usageAccumulator.add(chatResponse);
+			usageAccumulator.addRoundResponse(chatResponse);
 
 			// We should not validate tool call requests, only the content of the final
 			// response.
@@ -175,7 +175,7 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		}
 		while (!isValidationSuccess && repeatCounter <= this.maxRepeatAttempts);
 
-		return usageAccumulator.applyTotalUsage(chatClientResponse);
+		return usageAccumulator.applyAccumulatedUsage(chatClientResponse);
 	}
 
 	@SuppressWarnings("null")

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
@@ -41,6 +41,7 @@ import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.util.JacksonUtils;
 import org.springframework.ai.util.json.schema.JsonSchemaGenerator;
@@ -58,6 +59,7 @@ import org.springframework.util.StringUtils;
  * Streaming responses are not supported.
  *
  * @author Christian Tzolov
+ * @author Jewoo Shin
  */
 public final class StructuredOutputValidationAdvisor implements CallAdvisor, StreamAdvisor {
 
@@ -126,6 +128,8 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 
 		var processedChatClientRequest = chatClientRequest;
 
+		UsageAccumulator usageAccumulator = new UsageAccumulator();
+
 		do {
 			// Before Call
 			repeatCounter++;
@@ -134,10 +138,12 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 			chatClientResponse = callAdvisorChain.copy(this).nextCall(processedChatClientRequest);
 
 			// After Call
+			ChatResponse chatResponse = chatClientResponse.chatResponse();
+			usageAccumulator.add(chatResponse);
 
 			// We should not validate tool call requests, only the content of the final
 			// response.
-			if (chatClientResponse.chatResponse() == null || !chatClientResponse.chatResponse().hasToolCalls()) {
+			if (chatResponse == null || !chatResponse.hasToolCalls()) {
 
 				SchemaValidation validationResponse = validateOutputSchema(chatClientResponse);
 
@@ -169,7 +175,7 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		}
 		while (!isValidationSuccess && repeatCounter <= this.maxRepeatAttempts);
 
-		return chatClientResponse;
+		return usageAccumulator.applyTotalUsage(chatClientResponse);
 	}
 
 	@SuppressWarnings("null")

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -17,10 +17,8 @@
 package org.springframework.ai.chat.client.advisor;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 
@@ -34,8 +32,6 @@ import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
 import org.springframework.ai.chat.messages.Message;
-import org.springframework.ai.chat.metadata.ChatResponseMetadata;
-import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -44,7 +40,6 @@ import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
 import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
-import org.springframework.ai.support.UsageCalculator;
 import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
 
@@ -139,7 +134,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		var instructions = chatClientRequest.prompt().getInstructions();
 
 		ChatClientResponse chatClientResponse = null;
-		ChatResponse accumulatedChatResponse = null;
+		UsageAccumulator usageAccumulator = new UsageAccumulator();
 
 		boolean isToolCall = false;
 
@@ -160,7 +155,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 			// After Call
 			ChatResponse chatResponse = chatClientResponse.chatResponse();
-			accumulatedChatResponse = accumulateUsage(chatResponse, accumulatedChatResponse);
+			usageAccumulator.add(chatResponse);
 			isToolCall = this.toolExecutionEligibilityChecker.isToolCallResponse(chatResponse);
 
 			if (isToolCall) {
@@ -191,84 +186,8 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		}
 		while (isToolCall); // loop until no tool calls are present
 
-		chatClientResponse = withAccumulatedUsage(chatClientResponse, accumulatedChatResponse);
+		chatClientResponse = usageAccumulator.applyTotalUsage(chatClientResponse);
 		return this.doFinalizeLoop(chatClientResponse, callAdvisorChain);
-	}
-
-	private @Nullable ChatResponse accumulateUsage(@Nullable ChatResponse currentChatResponse,
-			@Nullable ChatResponse accumulatedChatResponse) {
-		if (currentChatResponse == null) {
-			return accumulatedChatResponse;
-		}
-
-		Usage currentUsage = currentChatResponse.getMetadata().getUsage();
-		ChatResponse previousChatResponse = UsageCalculator.isEmpty(getUsage(accumulatedChatResponse)) ? null
-				: accumulatedChatResponse;
-		Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
-		if (UsageCalculator.isEmpty(cumulativeUsage)) {
-			return null;
-		}
-
-		return withUsage(currentChatResponse, cumulativeUsage);
-	}
-
-	private ChatClientResponse withAccumulatedUsage(ChatClientResponse chatClientResponse,
-			@Nullable ChatResponse accumulatedChatResponse) {
-		ChatResponse currentChatResponse = chatClientResponse.chatResponse();
-		if (currentChatResponse == null || accumulatedChatResponse == null) {
-			return chatClientResponse;
-		}
-
-		Usage accumulatedUsage = accumulatedChatResponse.getMetadata().getUsage();
-		if (UsageCalculator.isEmpty(accumulatedUsage)
-				|| Objects.equals(currentChatResponse.getMetadata().getUsage(), accumulatedUsage)) {
-			return chatClientResponse;
-		}
-
-		return chatClientResponse.mutate().chatResponse(withUsage(currentChatResponse, accumulatedUsage)).build();
-	}
-
-	private ChatClientResponse withPreviousAccumulatedUsage(ChatClientResponse chatClientResponse,
-			@Nullable ChatResponse accumulatedChatResponse) {
-		ChatResponse currentChatResponse = chatClientResponse.chatResponse();
-		if (currentChatResponse == null || accumulatedChatResponse == null) {
-			return chatClientResponse;
-		}
-
-		Usage currentUsage = currentChatResponse.getMetadata().getUsage();
-		if (UsageCalculator.isEmpty(currentUsage)
-				|| UsageCalculator.isEmpty(accumulatedChatResponse.getMetadata().getUsage())) {
-			return chatClientResponse;
-		}
-
-		Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, accumulatedChatResponse);
-		if (Objects.equals(currentUsage, cumulativeUsage)) {
-			return chatClientResponse;
-		}
-
-		return chatClientResponse.mutate().chatResponse(withUsage(currentChatResponse, cumulativeUsage)).build();
-	}
-
-	private ChatResponse withUsage(ChatResponse chatResponse, Usage usage) {
-		return ChatResponse.builder()
-			.from(chatResponse)
-			.metadata(chatResponseMetadataWithUsage(chatResponse.getMetadata(), usage))
-			.build();
-	}
-
-	private ChatResponseMetadata chatResponseMetadataWithUsage(ChatResponseMetadata metadata, Usage usage) {
-		ChatResponseMetadata.Builder builder = ChatResponseMetadata.builder()
-			.id(metadata.getId())
-			.model(metadata.getModel())
-			.rateLimit(metadata.getRateLimit())
-			.usage(usage)
-			.promptMetadata(metadata.getPromptMetadata());
-		metadata.entrySet().forEach(entry -> builder.keyValue(entry.getKey(), entry.getValue()));
-		return builder.build();
-	}
-
-	private @Nullable Usage getUsage(@Nullable ChatResponse chatResponse) {
-		return chatResponse != null ? chatResponse.getMetadata().getUsage() : null;
 	}
 
 	protected List<Message> doGetNextInstructionsForToolCall(ChatClientRequest chatClientRequest,
@@ -320,15 +239,16 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 		return Flux.defer(() -> {
 			ChatClientRequest initializedRequest = this.doInitializeLoopStream(chatClientRequest, streamAdvisorChain);
-			AtomicReference<@Nullable ChatResponse> accumulatedChatResponseRef = new AtomicReference<>();
+			// Subscription-local accumulator so usage is not shared across subscriptions.
+			UsageAccumulator usageAccumulator = new UsageAccumulator();
 			return this.internalStream(streamAdvisorChain, initializedRequest, toolCallingChatOptions,
-					initializedRequest.prompt().getInstructions(), accumulatedChatResponseRef);
+					initializedRequest.prompt().getInstructions(), usageAccumulator);
 		});
 	}
 
 	private Flux<ChatClientResponse> internalStream(StreamAdvisorChain streamAdvisorChain,
 			ChatClientRequest originalRequest, ToolCallingChatOptions toolCallingChatOptions,
-			List<Message> instructions, AtomicReference<@Nullable ChatResponse> accumulatedChatResponseRef) {
+			List<Message> instructions, UsageAccumulator usageAccumulator) {
 
 		return Flux.deferContextual(contextView -> {
 			// Build request with current instructions
@@ -347,21 +267,22 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
 
 			return streamWithToolCallResponses(responseFlux, finalRequest, streamAdvisorChain, originalRequest,
-					toolCallingChatOptions, accumulatedChatResponseRef);
+					toolCallingChatOptions, usageAccumulator);
 		});
 	}
 
 	private Flux<ChatClientResponse> streamWithToolCallResponses(Flux<ChatClientResponse> responseFlux,
 			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy, AtomicReference<@Nullable ChatResponse> accumulatedChatResponseRef) {
+			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator) {
 
 		AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
-		ChatResponse accumulatedChatResponse = accumulatedChatResponseRef.get();
+		// Snapshot of the usage accumulated from previous rounds (before this round).
+		ChatResponse previousTotal = usageAccumulator.total();
 
 		return CHAT_CLIENT_MESSAGE_AGGREGATOR.aggregateChatClientResponse(responseFlux, aggregatedResponseRef::set)
-			.map(chatClientResponse -> withPreviousAccumulatedUsage(chatClientResponse, accumulatedChatResponse))
+			.map(chatClientResponse -> UsageAccumulator.applyPreviousTotalToChunk(chatClientResponse, previousTotal))
 			.concatWith(Flux.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest,
-					streamAdvisorChain, originalRequest, optionsCopy, accumulatedChatResponseRef)))
+					streamAdvisorChain, originalRequest, optionsCopy, usageAccumulator)))
 			.filter(ccr -> !this.toolExecutionEligibilityChecker.isToolCallResponse(ccr.chatResponse()));
 	}
 
@@ -371,7 +292,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 	 */
 	private Flux<ChatClientResponse> handleToolCallRecursion(ChatClientResponse aggregatedResponse,
 			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy, AtomicReference<@Nullable ChatResponse> accumulatedChatResponseRef) {
+			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator) {
 
 		if (aggregatedResponse == null) {
 			return Flux.empty();
@@ -380,13 +301,18 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		aggregatedResponse = this.doAfterStream(aggregatedResponse, streamAdvisorChain);
 
 		ChatResponse chatResponse = aggregatedResponse.chatResponse();
-		ChatResponse accumulatedChatResponse = accumulateUsage(chatResponse, accumulatedChatResponseRef.get());
-		accumulatedChatResponseRef.set(accumulatedChatResponse);
+		ChatResponse accumulatedChatResponse = usageAccumulator.add(chatResponse);
 		boolean isToolCall = this.toolExecutionEligibilityChecker.isToolCallResponse(chatResponse);
 
 		if (!isToolCall) {
-			// No tool call - streaming already happened, nothing more to emit
-			return this.doFinalizeLoopStream(Flux.empty(), streamAdvisorChain);
+			// No tool call: the final round's chunks have already been streamed. If that
+			// round carried no usage of its own, the usage accumulated from previous
+			// rounds was never stamped onto any emitted chunk, so emit a trailing
+			// usage-only response to keep the aggregated stream usage correct. Otherwise
+			// nothing more needs to be emitted.
+			Flux<ChatClientResponse> finalEmissions = UsageAccumulator.usageCorrection(aggregatedResponse, chatResponse,
+					accumulatedChatResponse);
+			return this.doFinalizeLoopStream(finalEmissions, streamAdvisorChain);
 		}
 
 		Assert.notNull(chatResponse, "redundant check that should never fail, but here to help NullAway");
@@ -411,14 +337,14 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 						.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
 						.build())
 					.build();
-				return Flux.just(withAccumulatedUsage(directResponse, accumulatedChatResponseRef.get()));
+				return Flux.just(usageAccumulator.applyTotalUsage(directResponse));
 			}
 			else {
 				// Recursive call with updated conversation history
 				List<Message> nextInstructions = this.doGetNextInstructionsForToolCallStream(finalRequest,
 						finalAggregatedResponse, toolExecutionResult);
 				return this.internalStream(streamAdvisorChain, originalRequest, optionsCopy, nextInstructions,
-						accumulatedChatResponseRef);
+						usageAccumulator);
 			}
 		});
 		return toolCallFlux.subscribeOn(Schedulers.boundedElastic());

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -17,8 +17,10 @@
 package org.springframework.ai.chat.client.advisor;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 
@@ -32,6 +34,8 @@ import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -40,6 +44,7 @@ import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
 import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
+import org.springframework.ai.support.UsageCalculator;
 import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
 
@@ -58,6 +63,7 @@ import org.springframework.util.Assert;
  * advisor without modification.
  *
  * @author Christian Tzolov
+ * @author Jewoo Shin
  * @since 2.0.0
  */
 public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvisor {
@@ -133,6 +139,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		var instructions = chatClientRequest.prompt().getInstructions();
 
 		ChatClientResponse chatClientResponse = null;
+		ChatResponse accumulatedChatResponse = null;
 
 		boolean isToolCall = false;
 
@@ -152,8 +159,8 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			chatClientResponse = this.doAfterCall(chatClientResponse, callAdvisorChain);
 
 			// After Call
-
 			ChatResponse chatResponse = chatClientResponse.chatResponse();
+			accumulatedChatResponse = accumulateUsage(chatResponse, accumulatedChatResponse);
 			isToolCall = this.toolExecutionEligibilityChecker.isToolCallResponse(chatResponse);
 
 			if (isToolCall) {
@@ -184,7 +191,84 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		}
 		while (isToolCall); // loop until no tool calls are present
 
+		chatClientResponse = withAccumulatedUsage(chatClientResponse, accumulatedChatResponse);
 		return this.doFinalizeLoop(chatClientResponse, callAdvisorChain);
+	}
+
+	private @Nullable ChatResponse accumulateUsage(@Nullable ChatResponse currentChatResponse,
+			@Nullable ChatResponse accumulatedChatResponse) {
+		if (currentChatResponse == null) {
+			return accumulatedChatResponse;
+		}
+
+		Usage currentUsage = currentChatResponse.getMetadata().getUsage();
+		ChatResponse previousChatResponse = UsageCalculator.isEmpty(getUsage(accumulatedChatResponse)) ? null
+				: accumulatedChatResponse;
+		Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
+		if (UsageCalculator.isEmpty(cumulativeUsage)) {
+			return null;
+		}
+
+		return withUsage(currentChatResponse, cumulativeUsage);
+	}
+
+	private ChatClientResponse withAccumulatedUsage(ChatClientResponse chatClientResponse,
+			@Nullable ChatResponse accumulatedChatResponse) {
+		ChatResponse currentChatResponse = chatClientResponse.chatResponse();
+		if (currentChatResponse == null || accumulatedChatResponse == null) {
+			return chatClientResponse;
+		}
+
+		Usage accumulatedUsage = accumulatedChatResponse.getMetadata().getUsage();
+		if (UsageCalculator.isEmpty(accumulatedUsage)
+				|| Objects.equals(currentChatResponse.getMetadata().getUsage(), accumulatedUsage)) {
+			return chatClientResponse;
+		}
+
+		return chatClientResponse.mutate().chatResponse(withUsage(currentChatResponse, accumulatedUsage)).build();
+	}
+
+	private ChatClientResponse withPreviousAccumulatedUsage(ChatClientResponse chatClientResponse,
+			@Nullable ChatResponse accumulatedChatResponse) {
+		ChatResponse currentChatResponse = chatClientResponse.chatResponse();
+		if (currentChatResponse == null || accumulatedChatResponse == null) {
+			return chatClientResponse;
+		}
+
+		Usage currentUsage = currentChatResponse.getMetadata().getUsage();
+		if (UsageCalculator.isEmpty(currentUsage)
+				|| UsageCalculator.isEmpty(accumulatedChatResponse.getMetadata().getUsage())) {
+			return chatClientResponse;
+		}
+
+		Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, accumulatedChatResponse);
+		if (Objects.equals(currentUsage, cumulativeUsage)) {
+			return chatClientResponse;
+		}
+
+		return chatClientResponse.mutate().chatResponse(withUsage(currentChatResponse, cumulativeUsage)).build();
+	}
+
+	private ChatResponse withUsage(ChatResponse chatResponse, Usage usage) {
+		return ChatResponse.builder()
+			.from(chatResponse)
+			.metadata(chatResponseMetadataWithUsage(chatResponse.getMetadata(), usage))
+			.build();
+	}
+
+	private ChatResponseMetadata chatResponseMetadataWithUsage(ChatResponseMetadata metadata, Usage usage) {
+		ChatResponseMetadata.Builder builder = ChatResponseMetadata.builder()
+			.id(metadata.getId())
+			.model(metadata.getModel())
+			.rateLimit(metadata.getRateLimit())
+			.usage(usage)
+			.promptMetadata(metadata.getPromptMetadata());
+		metadata.entrySet().forEach(entry -> builder.keyValue(entry.getKey(), entry.getValue()));
+		return builder.build();
+	}
+
+	private @Nullable Usage getUsage(@Nullable ChatResponse chatResponse) {
+		return chatResponse != null ? chatResponse.getMetadata().getUsage() : null;
 	}
 
 	protected List<Message> doGetNextInstructionsForToolCall(ChatClientRequest chatClientRequest,
@@ -234,15 +318,17 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			return streamAdvisorChain.nextStream(chatClientRequest);
 		}
 
-		ChatClientRequest initializedRequest = this.doInitializeLoopStream(chatClientRequest, streamAdvisorChain);
-
-		return this.internalStream(streamAdvisorChain, initializedRequest, toolCallingChatOptions,
-				initializedRequest.prompt().getInstructions());
+		return Flux.defer(() -> {
+			ChatClientRequest initializedRequest = this.doInitializeLoopStream(chatClientRequest, streamAdvisorChain);
+			AtomicReference<@Nullable ChatResponse> accumulatedChatResponseRef = new AtomicReference<>();
+			return this.internalStream(streamAdvisorChain, initializedRequest, toolCallingChatOptions,
+					initializedRequest.prompt().getInstructions(), accumulatedChatResponseRef);
+		});
 	}
 
 	private Flux<ChatClientResponse> internalStream(StreamAdvisorChain streamAdvisorChain,
 			ChatClientRequest originalRequest, ToolCallingChatOptions toolCallingChatOptions,
-			List<Message> instructions) {
+			List<Message> instructions, AtomicReference<@Nullable ChatResponse> accumulatedChatResponseRef) {
 
 		return Flux.deferContextual(contextView -> {
 			// Build request with current instructions
@@ -261,19 +347,21 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
 
 			return streamWithToolCallResponses(responseFlux, finalRequest, streamAdvisorChain, originalRequest,
-					toolCallingChatOptions);
+					toolCallingChatOptions, accumulatedChatResponseRef);
 		});
 	}
 
 	private Flux<ChatClientResponse> streamWithToolCallResponses(Flux<ChatClientResponse> responseFlux,
 			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy) {
+			ToolCallingChatOptions optionsCopy, AtomicReference<@Nullable ChatResponse> accumulatedChatResponseRef) {
 
 		AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
+		ChatResponse accumulatedChatResponse = accumulatedChatResponseRef.get();
 
 		return CHAT_CLIENT_MESSAGE_AGGREGATOR.aggregateChatClientResponse(responseFlux, aggregatedResponseRef::set)
+			.map(chatClientResponse -> withPreviousAccumulatedUsage(chatClientResponse, accumulatedChatResponse))
 			.concatWith(Flux.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest,
-					streamAdvisorChain, originalRequest, optionsCopy)))
+					streamAdvisorChain, originalRequest, optionsCopy, accumulatedChatResponseRef)))
 			.filter(ccr -> !this.toolExecutionEligibilityChecker.isToolCallResponse(ccr.chatResponse()));
 	}
 
@@ -283,7 +371,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 	 */
 	private Flux<ChatClientResponse> handleToolCallRecursion(ChatClientResponse aggregatedResponse,
 			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy) {
+			ToolCallingChatOptions optionsCopy, AtomicReference<@Nullable ChatResponse> accumulatedChatResponseRef) {
 
 		if (aggregatedResponse == null) {
 			return Flux.empty();
@@ -292,6 +380,8 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		aggregatedResponse = this.doAfterStream(aggregatedResponse, streamAdvisorChain);
 
 		ChatResponse chatResponse = aggregatedResponse.chatResponse();
+		ChatResponse accumulatedChatResponse = accumulateUsage(chatResponse, accumulatedChatResponseRef.get());
+		accumulatedChatResponseRef.set(accumulatedChatResponse);
 		boolean isToolCall = this.toolExecutionEligibilityChecker.isToolCallResponse(chatResponse);
 
 		if (!isToolCall) {
@@ -315,18 +405,20 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 			if (toolExecutionResult.returnDirect()) {
 				// Return tool execution result directly to the application client
-				return Flux.just(finalAggregatedResponse.mutate()
+				ChatClientResponse directResponse = finalAggregatedResponse.mutate()
 					.chatResponse(ChatResponse.builder()
 						.from(chatResponse)
 						.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
 						.build())
-					.build());
+					.build();
+				return Flux.just(withAccumulatedUsage(directResponse, accumulatedChatResponseRef.get()));
 			}
 			else {
 				// Recursive call with updated conversation history
 				List<Message> nextInstructions = this.doGetNextInstructionsForToolCallStream(finalRequest,
 						finalAggregatedResponse, toolExecutionResult);
-				return this.internalStream(streamAdvisorChain, originalRequest, optionsCopy, nextInstructions);
+				return this.internalStream(streamAdvisorChain, originalRequest, optionsCopy, nextInstructions,
+						accumulatedChatResponseRef);
 			}
 		});
 		return toolCallFlux.subscribeOn(Schedulers.boundedElastic());

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -155,7 +155,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 			// After Call
 			ChatResponse chatResponse = chatClientResponse.chatResponse();
-			usageAccumulator.add(chatResponse);
+			usageAccumulator.addRoundResponse(chatResponse);
 			isToolCall = this.toolExecutionEligibilityChecker.isToolCallResponse(chatResponse);
 
 			if (isToolCall) {
@@ -186,7 +186,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		}
 		while (isToolCall); // loop until no tool calls are present
 
-		chatClientResponse = usageAccumulator.applyTotalUsage(chatClientResponse);
+		chatClientResponse = usageAccumulator.applyAccumulatedUsage(chatClientResponse);
 		return this.doFinalizeLoop(chatClientResponse, callAdvisorChain);
 	}
 
@@ -277,10 +277,11 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 		AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
 		// Snapshot of the usage accumulated from previous rounds (before this round).
-		ChatResponse previousTotal = usageAccumulator.total();
+		ChatResponse previousAccumulatedResponse = usageAccumulator.accumulatedResponse();
 
 		return CHAT_CLIENT_MESSAGE_AGGREGATOR.aggregateChatClientResponse(responseFlux, aggregatedResponseRef::set)
-			.map(chatClientResponse -> UsageAccumulator.applyPreviousTotalToChunk(chatClientResponse, previousTotal))
+			.map(chatClientResponse -> UsageAccumulator.applyPreviousAccumulatedUsageToChunk(chatClientResponse,
+					previousAccumulatedResponse))
 			.concatWith(Flux.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest,
 					streamAdvisorChain, originalRequest, optionsCopy, usageAccumulator)))
 			.filter(ccr -> !this.toolExecutionEligibilityChecker.isToolCallResponse(ccr.chatResponse()));
@@ -301,7 +302,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		aggregatedResponse = this.doAfterStream(aggregatedResponse, streamAdvisorChain);
 
 		ChatResponse chatResponse = aggregatedResponse.chatResponse();
-		ChatResponse accumulatedChatResponse = usageAccumulator.add(chatResponse);
+		ChatResponse accumulatedChatResponse = usageAccumulator.addRoundResponse(chatResponse);
 		boolean isToolCall = this.toolExecutionEligibilityChecker.isToolCallResponse(chatResponse);
 
 		if (!isToolCall) {
@@ -310,8 +311,8 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			// rounds was never stamped onto any emitted chunk, so emit a trailing
 			// usage-only response to keep the aggregated stream usage correct. Otherwise
 			// nothing more needs to be emitted.
-			Flux<ChatClientResponse> finalEmissions = UsageAccumulator.usageCorrection(aggregatedResponse, chatResponse,
-					accumulatedChatResponse);
+			Flux<ChatClientResponse> finalEmissions = UsageAccumulator
+				.emitFinalUsageCorrectionIfNecessary(aggregatedResponse, chatResponse, accumulatedChatResponse);
 			return this.doFinalizeLoopStream(finalEmissions, streamAdvisorChain);
 		}
 
@@ -337,7 +338,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 						.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
 						.build())
 					.build();
-				return Flux.just(usageAccumulator.applyTotalUsage(directResponse));
+				return Flux.just(usageAccumulator.applyAccumulatedUsage(directResponse));
 			}
 			else {
 				// Recursive call with updated conversation history

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/UsageAccumulator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/UsageAccumulator.java
@@ -37,6 +37,10 @@ import org.springframework.ai.support.UsageCalculator;
  * {@code adviseCall} invocation, or one per stream subscription (inside a
  * {@link Flux#defer}) to keep the accumulated usage subscription-local.
  * <p>
+ * The token arithmetic and {@link ChatResponse} metadata copying are delegated to
+ * {@link UsageCalculator}; this class owns the recursive advisor loop state and the final
+ * response stamping.
+ * <p>
  * Typical non-streaming use:
  *
  * <pre>{@code
@@ -44,11 +48,11 @@ import org.springframework.ai.support.UsageCalculator;
  * ChatClientResponse response;
  * do {
  *     response = chain.nextCall(request);
- *     usage.add(response.chatResponse());
+ *     usage.addRoundResponse(response.chatResponse());
  *     // ... decide whether to loop again ...
  * }
  * while (loopAgain);
- * return usage.applyTotalUsage(response);
+ * return usage.applyAccumulatedUsage(response);
  * }</pre>
  *
  * @author Christian Tzolov
@@ -62,11 +66,11 @@ public final class UsageAccumulator {
 	/**
 	 * Returns the cumulative usage folded in so far, or {@code null} if none. In a
 	 * streaming loop this is the total of the <em>previous</em> rounds, since it is read
-	 * before the in-flight round is {@link #add(ChatResponse) added}.
+	 * before the in-flight round is {@link #addRoundResponse(ChatResponse) added}.
 	 * @return the accumulated chat response carrying the cumulative usage, or
 	 * {@code null}
 	 */
-	public @Nullable ChatResponse total() {
+	public @Nullable ChatResponse accumulatedResponse() {
 		return this.accumulated;
 	}
 
@@ -76,8 +80,8 @@ public final class UsageAccumulator {
 	 * {@code null}
 	 * @return the updated cumulative total, or {@code null} if still empty
 	 */
-	public @Nullable ChatResponse add(@Nullable ChatResponse roundChatResponse) {
-		this.accumulated = UsageCalculator.accumulate(roundChatResponse, this.accumulated);
+	public @Nullable ChatResponse addRoundResponse(@Nullable ChatResponse roundChatResponse) {
+		this.accumulated = UsageCalculator.accumulateResponseUsage(roundChatResponse, this.accumulated);
 		return this.accumulated;
 	}
 
@@ -89,7 +93,7 @@ public final class UsageAccumulator {
 	 * @param chatClientResponse the response to stamp the total onto
 	 * @return the response carrying the accumulated total usage
 	 */
-	public ChatClientResponse applyTotalUsage(ChatClientResponse chatClientResponse) {
+	public ChatClientResponse applyAccumulatedUsage(ChatClientResponse chatClientResponse) {
 		return stampTotalUsage(chatClientResponse, this.accumulated);
 	}
 
@@ -112,23 +116,25 @@ public final class UsageAccumulator {
 	/**
 	 * Adds the previous rounds' accumulated usage onto a single streamed chunk that
 	 * already carries its own usage. Chunks without usage (or when there is no previous
-	 * total) are returned unchanged, so the previous total is reflected only on
-	 * usage-bearing chunks.
+	 * accumulated response) are returned unchanged, so the previous rounds' usage is
+	 * reflected only on usage-bearing chunks.
 	 * @param chunk the streamed chunk
-	 * @param previousTotal the accumulated total of previous rounds, or {@code null}
-	 * @return the chunk with the previous total added to its usage, or unchanged
+	 * @param previousAccumulatedResponse the response carrying the accumulated usage of
+	 * previous rounds, or {@code null}
+	 * @return the chunk with the previous rounds' usage added to its usage, or unchanged
 	 */
-	public static ChatClientResponse applyPreviousTotalToChunk(ChatClientResponse chunk,
-			@Nullable ChatResponse previousTotal) {
+	static ChatClientResponse applyPreviousAccumulatedUsageToChunk(ChatClientResponse chunk,
+			@Nullable ChatResponse previousAccumulatedResponse) {
 		ChatResponse currentChatResponse = chunk.chatResponse();
-		if (currentChatResponse == null || previousTotal == null) {
+		if (currentChatResponse == null || previousAccumulatedResponse == null) {
 			return chunk;
 		}
 		Usage currentUsage = currentChatResponse.getMetadata().getUsage();
-		if (UsageCalculator.isEmpty(currentUsage) || UsageCalculator.isEmpty(previousTotal.getMetadata().getUsage())) {
+		if (UsageCalculator.isEmpty(currentUsage)
+				|| UsageCalculator.isEmpty(previousAccumulatedResponse.getMetadata().getUsage())) {
 			return chunk;
 		}
-		Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousTotal);
+		Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousAccumulatedResponse);
 		if (Objects.equals(currentUsage, cumulativeUsage)) {
 			return chunk;
 		}
@@ -145,10 +151,10 @@ public final class UsageAccumulator {
 	 * preserve).
 	 * @param aggregatedResponse the aggregated response of the final round
 	 * @param roundChatResponse the final round's own response (its own usage)
-	 * @param accumulatedChatResponse the accumulator carrying the cumulative total
+	 * @param accumulatedChatResponse the response carrying the cumulative usage
 	 * @return a single usage-only response, or an empty flux when no correction is needed
 	 */
-	public static Flux<ChatClientResponse> usageCorrection(ChatClientResponse aggregatedResponse,
+	static Flux<ChatClientResponse> emitFinalUsageCorrectionIfNecessary(ChatClientResponse aggregatedResponse,
 			@Nullable ChatResponse roundChatResponse, @Nullable ChatResponse accumulatedChatResponse) {
 		if (accumulatedChatResponse == null) {
 			return Flux.empty();

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/UsageAccumulator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/UsageAccumulator.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.support.UsageCalculator;
+
+/**
+ * Accumulates token {@link Usage} across the iterations of a recursive advisor (for
+ * example a tool-calling loop or a structured-output validation retry loop), so that the
+ * final response reports the cumulative usage of every model call rather than only the
+ * last one.
+ * <p>
+ * An instance is stateful and not thread-safe: create one per non-streaming
+ * {@code adviseCall} invocation, or one per stream subscription (inside a
+ * {@link Flux#defer}) to keep the accumulated usage subscription-local.
+ * <p>
+ * Typical non-streaming use:
+ *
+ * <pre>{@code
+ * UsageAccumulator usage = new UsageAccumulator();
+ * ChatClientResponse response;
+ * do {
+ *     response = chain.nextCall(request);
+ *     usage.add(response.chatResponse());
+ *     // ... decide whether to loop again ...
+ * }
+ * while (loopAgain);
+ * return usage.applyTotalUsage(response);
+ * }</pre>
+ *
+ * @author Christian Tzolov
+ * @author Jewoo Shin
+ * @since 2.0.0
+ */
+public final class UsageAccumulator {
+
+	private @Nullable ChatResponse accumulated;
+
+	/**
+	 * Returns the cumulative usage folded in so far, or {@code null} if none. In a
+	 * streaming loop this is the total of the <em>previous</em> rounds, since it is read
+	 * before the in-flight round is {@link #add(ChatResponse) added}.
+	 * @return the accumulated chat response carrying the cumulative usage, or
+	 * {@code null}
+	 */
+	public @Nullable ChatResponse total() {
+		return this.accumulated;
+	}
+
+	/**
+	 * Folds the usage of the given round response into the running total.
+	 * @param roundChatResponse the response produced by the current round, or
+	 * {@code null}
+	 * @return the updated cumulative total, or {@code null} if still empty
+	 */
+	public @Nullable ChatResponse add(@Nullable ChatResponse roundChatResponse) {
+		this.accumulated = UsageCalculator.accumulate(roundChatResponse, this.accumulated);
+		return this.accumulated;
+	}
+
+	/**
+	 * Stamps the accumulated total usage onto the given response. Used to finalize a
+	 * non-streaming loop or a streaming return-direct result. The response is returned
+	 * unchanged when there is nothing accumulated, or when its usage already equals the
+	 * accumulated total.
+	 * @param chatClientResponse the response to stamp the total onto
+	 * @return the response carrying the accumulated total usage
+	 */
+	public ChatClientResponse applyTotalUsage(ChatClientResponse chatClientResponse) {
+		return stampTotalUsage(chatClientResponse, this.accumulated);
+	}
+
+	private static ChatClientResponse stampTotalUsage(ChatClientResponse chatClientResponse,
+			@Nullable ChatResponse accumulatedChatResponse) {
+		ChatResponse currentChatResponse = chatClientResponse.chatResponse();
+		if (currentChatResponse == null || accumulatedChatResponse == null) {
+			return chatClientResponse;
+		}
+		Usage accumulatedUsage = accumulatedChatResponse.getMetadata().getUsage();
+		if (UsageCalculator.isEmpty(accumulatedUsage)
+				|| Objects.equals(currentChatResponse.getMetadata().getUsage(), accumulatedUsage)) {
+			return chatClientResponse;
+		}
+		return chatClientResponse.mutate()
+			.chatResponse(UsageCalculator.withUsage(currentChatResponse, accumulatedUsage))
+			.build();
+	}
+
+	/**
+	 * Adds the previous rounds' accumulated usage onto a single streamed chunk that
+	 * already carries its own usage. Chunks without usage (or when there is no previous
+	 * total) are returned unchanged, so the previous total is reflected only on
+	 * usage-bearing chunks.
+	 * @param chunk the streamed chunk
+	 * @param previousTotal the accumulated total of previous rounds, or {@code null}
+	 * @return the chunk with the previous total added to its usage, or unchanged
+	 */
+	public static ChatClientResponse applyPreviousTotalToChunk(ChatClientResponse chunk,
+			@Nullable ChatResponse previousTotal) {
+		ChatResponse currentChatResponse = chunk.chatResponse();
+		if (currentChatResponse == null || previousTotal == null) {
+			return chunk;
+		}
+		Usage currentUsage = currentChatResponse.getMetadata().getUsage();
+		if (UsageCalculator.isEmpty(currentUsage) || UsageCalculator.isEmpty(previousTotal.getMetadata().getUsage())) {
+			return chunk;
+		}
+		Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousTotal);
+		if (Objects.equals(currentUsage, cumulativeUsage)) {
+			return chunk;
+		}
+		return chunk.mutate().chatResponse(UsageCalculator.withUsage(currentChatResponse, cumulativeUsage)).build();
+	}
+
+	/**
+	 * Builds the trailing usage-only emission for a streaming loop whose final round
+	 * reported no usage of its own. In that case the accumulated total from previous
+	 * rounds was never stamped onto an emitted chunk, so a usage-only
+	 * {@link ChatClientResponse} (with empty generations, so no content is duplicated)
+	 * carrying the accumulated total is emitted. Returns an empty flux when no correction
+	 * is needed (the round reported its own usage, or there is nothing accumulated to
+	 * preserve).
+	 * @param aggregatedResponse the aggregated response of the final round
+	 * @param roundChatResponse the final round's own response (its own usage)
+	 * @param accumulatedChatResponse the accumulator carrying the cumulative total
+	 * @return a single usage-only response, or an empty flux when no correction is needed
+	 */
+	public static Flux<ChatClientResponse> usageCorrection(ChatClientResponse aggregatedResponse,
+			@Nullable ChatResponse roundChatResponse, @Nullable ChatResponse accumulatedChatResponse) {
+		if (accumulatedChatResponse == null) {
+			return Flux.empty();
+		}
+		Usage accumulatedUsage = accumulatedChatResponse.getMetadata().getUsage();
+		if (!UsageCalculator.isEmpty(getUsage(roundChatResponse)) || UsageCalculator.isEmpty(accumulatedUsage)) {
+			return Flux.empty();
+		}
+		ChatResponse usageOnlyChatResponse = ChatResponse.builder()
+			.from(accumulatedChatResponse)
+			.generations(List.of())
+			.build();
+		return Flux.just(aggregatedResponse.mutate().chatResponse(usageOnlyChatResponse).build());
+	}
+
+	private static @Nullable Usage getUsage(@Nullable ChatResponse chatResponse) {
+		return chatResponse != null ? chatResponse.getMetadata().getUsage() : null;
+	}
+
+}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.chat.client.advisor;
 
 import java.util.List;
+import java.util.function.BiFunction;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,9 @@ import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -48,6 +52,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link StructuredOutputValidationAdvisor}.
  *
  * @author Christian Tzolov
+ * @author Jewoo Shin
  */
 @ExtendWith(MockitoExtension.class)
 public class StructuredOutputValidationAdvisorTests {
@@ -204,23 +209,10 @@ public class StructuredOutputValidationAdvisorTests {
 
 		// Create a terminal advisor that returns the valid response
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -248,23 +240,10 @@ public class StructuredOutputValidationAdvisorTests {
 
 		// Create a terminal advisor that returns invalid response first, then valid
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return callCount[0] == 1 ? invalidResponse : validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? invalidResponse : validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -273,6 +252,70 @@ public class StructuredOutputValidationAdvisorTests {
 		ChatClientResponse result = realChain.nextCall(request);
 
 		assertThat(result).isEqualTo(validResponse);
+		assertThat(callCount[0]).isEqualTo(2);
+	}
+
+	@Test
+	void adviseCallAccumulatesUsageAcrossValidationRetries() {
+		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
+			.outputType(new TypeReference<Person>() {
+			})
+			.maxRepeatAttempts(1)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		String invalidJson = "{\"name\":\"John Doe\"}";
+		String validJson = "{\"name\":\"John Doe\",\"age\":30}";
+		ChatClientResponse invalidResponse = createResponse(invalidJson, new DefaultUsage(10, 20, 30));
+		ChatClientResponse validResponse = createResponse(validJson, new DefaultUsage(1, 2, 3));
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? invalidResponse : validResponse;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		ChatClientResponse result = realChain.nextCall(request);
+
+		assertThat(result.chatResponse()).isNotNull();
+		assertThat(result.chatResponse().getResult().getOutput().getText()).isEqualTo(validJson);
+		assertUsage(result.chatResponse().getMetadata().getUsage(), 11, 22, 33);
+		assertThat(callCount[0]).isEqualTo(2);
+	}
+
+	@Test
+	void adviseCallAppliesAccumulatedUsageWhenValidationRetriesAreExhausted() {
+		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
+			.outputType(new TypeReference<Person>() {
+			})
+			.maxRepeatAttempts(1)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		String invalidJson = "{\"name\":\"John Doe\"}";
+		String invalidRetryJson = "{\"age\":30}";
+		ChatClientResponse invalidResponse = createResponse(invalidJson, new DefaultUsage(10, 20, 30));
+		ChatClientResponse invalidRetryResponse = createResponse(invalidRetryJson, new DefaultUsage(1, 2, 3));
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? invalidResponse : invalidRetryResponse;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		ChatClientResponse result = realChain.nextCall(request);
+
+		assertThat(result.chatResponse()).isNotNull();
+		assertThat(result.chatResponse().getResult().getOutput().getText()).isEqualTo(invalidRetryJson);
+		assertUsage(result.chatResponse().getMetadata().getUsage(), 11, 22, 33);
 		assertThat(callCount[0]).isEqualTo(2);
 	}
 
@@ -290,23 +333,10 @@ public class StructuredOutputValidationAdvisorTests {
 
 		// Create a terminal advisor that always returns invalid response
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return invalidResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return invalidResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -333,23 +363,10 @@ public class StructuredOutputValidationAdvisorTests {
 
 		// Create a terminal advisor
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return invalidResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return invalidResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -379,23 +396,10 @@ public class StructuredOutputValidationAdvisorTests {
 
 		// Create a terminal advisor that returns null response first, then valid
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return callCount[0] == 1 ? nullResponse : validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? nullResponse : validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -418,6 +422,7 @@ public class StructuredOutputValidationAdvisorTests {
 		ChatClientRequest request = createMockRequest();
 		ChatResponse chatResponse = mock(ChatResponse.class);
 		when(chatResponse.getResult()).thenReturn(null);
+		when(chatResponse.getMetadata()).thenReturn(new ChatResponseMetadata());
 		ChatClientResponse nullResultResponse = mock(ChatClientResponse.class);
 		when(nullResultResponse.chatResponse()).thenReturn(chatResponse);
 
@@ -426,23 +431,10 @@ public class StructuredOutputValidationAdvisorTests {
 
 		// Create a terminal advisor
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return callCount[0] == 1 ? nullResultResponse : validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? nullResultResponse : validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -467,22 +459,7 @@ public class StructuredOutputValidationAdvisorTests {
 		ChatClientResponse validResponse = createMockResponse(validJson);
 
 		// Create a terminal advisor
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				return validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> validResponse);
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -549,28 +526,15 @@ public class StructuredOutputValidationAdvisorTests {
 
 		// Create a terminal advisor that cycles through invalid responses
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return switch (callCount[0]) {
-					case 1 -> invalidResponse1;
-					case 2 -> invalidResponse2;
-					case 3 -> invalidResponse3;
-					default -> validResponse;
-				};
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return switch (callCount[0]) {
+				case 1 -> invalidResponse1;
+				case 2 -> invalidResponse2;
+				case 3 -> invalidResponse3;
+				default -> validResponse;
+			};
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -601,24 +565,11 @@ public class StructuredOutputValidationAdvisorTests {
 		ChatClientRequest[] capturedRequests = new ChatClientRequest[2];
 		int[] callCount = { 0 };
 
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				capturedRequests[callCount[0]] = req;
-				callCount[0]++;
-				return callCount[0] == 1 ? invalidResponse : validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			capturedRequests[callCount[0]] = req;
+			callCount[0]++;
+			return callCount[0] == 1 ? invalidResponse : validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -656,23 +607,10 @@ public class StructuredOutputValidationAdvisorTests {
 		ChatClientResponse validResponse = createMockResponse(validJson);
 
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return callCount[0] == 1 ? emptyResponse : validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? emptyResponse : validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -701,23 +639,10 @@ public class StructuredOutputValidationAdvisorTests {
 		ChatClientResponse validResponse = createMockResponse(validJson);
 
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return callCount[0] == 1 ? malformedResponse : validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? malformedResponse : validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -742,22 +667,7 @@ public class StructuredOutputValidationAdvisorTests {
 		String jsonWithExtraFields = "{\"name\":\"John Doe\",\"age\":30,\"extraField\":\"value\"}";
 		ChatClientResponse response = createMockResponse(jsonWithExtraFields);
 
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				return response;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> response);
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -781,22 +691,7 @@ public class StructuredOutputValidationAdvisorTests {
 		String validJson = "{\"name\":\"John Doe\",\"age\":30,\"address\":{\"street\":\"123 Main St\",\"city\":\"Springfield\",\"zipCode\":\"12345\"}}";
 		ChatClientResponse validResponse = createMockResponse(validJson);
 
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				return validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> validResponse);
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -824,23 +719,10 @@ public class StructuredOutputValidationAdvisorTests {
 		ChatClientResponse validResponse = createMockResponse(validJson);
 
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return callCount[0] == 1 ? invalidResponse : validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? invalidResponse : validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -864,22 +746,7 @@ public class StructuredOutputValidationAdvisorTests {
 		String validJson = "[{\"name\":\"John Doe\",\"age\":30},{\"name\":\"Jane Doe\",\"age\":25}]";
 		ChatClientResponse validResponse = createMockResponse(validJson);
 
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				return validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> validResponse);
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -907,23 +774,10 @@ public class StructuredOutputValidationAdvisorTests {
 		ChatClientResponse validResponse = createMockResponse(validJson);
 
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return callCount[0] == 1 ? invalidResponse : validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? invalidResponse : validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -952,23 +806,10 @@ public class StructuredOutputValidationAdvisorTests {
 		ChatClientResponse validResponse = createMockResponse(validJson);
 
 		int[] callCount = { 0 };
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				callCount[0]++;
-				return callCount[0] == 1 ? invalidResponse : validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? invalidResponse : validResponse;
+		});
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(advisor, terminalAdvisor))
@@ -1011,22 +852,7 @@ public class StructuredOutputValidationAdvisorTests {
 			}
 		};
 
-		CallAdvisor terminalAdvisor = new CallAdvisor() {
-			@Override
-			public String getName() {
-				return "terminal";
-			}
-
-			@Override
-			public int getOrder() {
-				return Ordered.LOWEST_PRECEDENCE;
-			}
-
-			@Override
-			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
-				return validResponse;
-			}
-		};
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> validResponse);
 
 		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
 			.pushAll(List.of(otherAdvisor, advisor, terminalAdvisor))
@@ -1064,6 +890,41 @@ public class StructuredOutputValidationAdvisorTests {
 		when(response.chatResponse()).thenReturn(chatResponse);
 
 		return response;
+	}
+
+	private ChatClientResponse createResponse(String jsonOutput, Usage usage) {
+		AssistantMessage assistantMessage = new AssistantMessage(jsonOutput);
+		Generation generation = new Generation(assistantMessage);
+		ChatResponseMetadata metadata = ChatResponseMetadata.builder().usage(usage).build();
+		ChatResponse chatResponse = ChatResponse.builder().generations(List.of(generation)).metadata(metadata).build();
+		return ChatClientResponse.builder().chatResponse(chatResponse).build();
+	}
+
+	private static CallAdvisor terminalAdvisor(
+			BiFunction<ChatClientRequest, CallAdvisorChain, ChatClientResponse> responseFunction) {
+
+		return new CallAdvisor() {
+			@Override
+			public String getName() {
+				return "terminal";
+			}
+
+			@Override
+			public int getOrder() {
+				return Ordered.LOWEST_PRECEDENCE;
+			}
+
+			@Override
+			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
+				return responseFunction.apply(req, chain);
+			}
+		};
+	}
+
+	private void assertUsage(Usage usage, int promptTokens, int completionTokens, int totalTokens) {
+		assertThat(usage.getPromptTokens()).isEqualTo(promptTokens);
+		assertThat(usage.getCompletionTokens()).isEqualTo(completionTokens);
+		assertThat(usage.getTotalTokens()).isEqualTo(totalTokens);
 	}
 
 	// Test DTOs

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -370,6 +370,40 @@ public class ToolCallingAdvisorTests {
 	}
 
 	@Test
+	void adviseCallAccumulatesCacheMetricsAndDropsNativeUsage() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createResponse(true,
+				new DefaultUsage(10, 20, 30, new Object(), 100L, 5L));
+		ChatClientResponse finalResponse = createResponse(false, new DefaultUsage(1, 2, 3, new Object(), 200L, 0L));
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? responseWithToolCall : finalResponse;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false));
+
+		ChatClientResponse result = advisor.adviseCall(request, realChain);
+
+		Usage usage = result.chatResponse().getMetadata().getUsage();
+		assertUsage(usage, 11, 22, 33);
+		assertThat(usage.getCacheReadInputTokens()).isEqualTo(300L);
+		assertThat(usage.getCacheWriteInputTokens()).isEqualTo(5L);
+		// Provider-specific native usage cannot be merged across rounds, so it is dropped
+		// once usage is accumulated.
+		assertThat(usage.getNativeUsage()).isNull();
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
 	void adviseCallKeepsSingleCallUsageWhenNoToolCall() {
 		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
 
@@ -630,6 +664,42 @@ public class ToolCallingAdvisorTests {
 		assertThat(results.get(0).chatResponse().getResult().getOutput().getText()).isEqualTo("Hello ");
 		assertThat(results.get(1).chatResponse().getResult().getOutput().getText()).isEqualTo("world");
 		assertThat(results.get(2).chatResponse().getResult().getOutput().getText()).isEqualTo("!");
+		assertThat(callCount[0]).isEqualTo(2);
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void adviseStreamEmitsAccumulatedUsageWhenFinalRoundReportsNoUsage() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createResponse(true, new DefaultUsage(10, 20, 30));
+		// The final round streams content but reports no usage of its own.
+		ChatClientResponse finalResponse = createResponse(false, new DefaultUsage(0, 0, 0));
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			return Flux.just(callCount[0] == 1 ? responseWithToolCall : finalResponse);
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false));
+
+		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
+
+		// The final round's content chunk is emitted unchanged (no usage), followed by a
+		// trailing usage-only response carrying the accumulated total from previous
+		// rounds.
+		assertThat(results).isNotNull().hasSize(2);
+		assertUsage(results.get(0).chatResponse().getMetadata().getUsage(), 0, 0, 0);
+		assertThat(results.get(0).chatResponse().getResult().getOutput().getText()).isEqualTo("response");
+		assertUsage(results.get(1).chatResponse().getMetadata().getUsage(), 10, 20, 30);
+		assertThat(results.get(1).chatResponse().getResults()).isEmpty();
 		assertThat(callCount[0]).isEqualTo(2);
 		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -43,6 +43,8 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.ChatOptions;
@@ -64,6 +66,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link ToolCallingAdvisor}.
  *
  * @author Christian Tzolov
+ * @author Jewoo Shin
  */
 @ExtendWith(MockitoExtension.class)
 public class ToolCallingAdvisorTests {
@@ -338,6 +341,84 @@ public class ToolCallingAdvisorTests {
 	}
 
 	@Test
+	void adviseCallAccumulatesUsageAcrossToolCallIterations() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createResponse(true, new DefaultUsage(10, 20, 30));
+		ChatClientResponse finalResponse = createResponse(false, new DefaultUsage(1, 2, 3));
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? responseWithToolCall : finalResponse;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false));
+
+		ChatClientResponse result = advisor.adviseCall(request, realChain);
+
+		assertUsage(result.chatResponse().getMetadata().getUsage(), 11, 22, 33);
+		assertThat(result.chatResponse().getResults()).isEqualTo(finalResponse.chatResponse().getResults());
+		assertThat(callCount[0]).isEqualTo(2);
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void adviseCallKeepsSingleCallUsageWhenNoToolCall() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse response = createResponse(false, new DefaultUsage(1, 2, 3));
+
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> response);
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		ChatClientResponse result = advisor.adviseCall(request, realChain);
+
+		assertUsage(result.chatResponse().getMetadata().getUsage(), 1, 2, 3);
+		assertThat(result.chatResponse().getResults()).isEqualTo(response.chatResponse().getResults());
+		verify(this.toolCallingManager, times(0)).executeToolCalls(any(), any());
+	}
+
+	@Test
+	void adviseCallPreservesAccumulatedUsageForReturnDirect() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse firstToolCallResponse = createResponse(true, new DefaultUsage(10, 20, 30));
+		ChatClientResponse secondToolCallResponse = createResponse(true, new DefaultUsage(1, 2, 3));
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? firstToolCallResponse : secondToolCallResponse;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false), createToolExecutionResult(true));
+
+		ChatClientResponse result = advisor.adviseCall(request, realChain);
+
+		assertUsage(result.chatResponse().getMetadata().getUsage(), 11, 22, 33);
+		assertThat(result.chatResponse().getResults()).hasSize(1);
+		assertThat(result.chatResponse().getResults().get(0).getOutput().getText()).isEqualTo("Tool result data");
+		assertThat(callCount[0]).isEqualTo(2);
+		verify(this.toolCallingManager, times(2)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
 	void testAdviseCallWithMultipleToolCallIterations() {
 		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
 
@@ -484,6 +565,139 @@ public class ToolCallingAdvisorTests {
 		assertThat(results).isNotNull().hasSize(1);
 		assertThat(callCount[0]).isEqualTo(2);
 		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void adviseStreamAccumulatesPreviousLoopUsageOnUsageBearingChunk() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createResponse(true, new DefaultUsage(10, 20, 30));
+		ChatClientResponse finalResponse = createResponse(false, new DefaultUsage(1, 2, 3));
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			return Flux.just(callCount[0] == 1 ? responseWithToolCall : finalResponse);
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false));
+
+		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
+
+		assertThat(results).isNotNull().hasSize(1);
+		assertUsage(results.get(0).chatResponse().getMetadata().getUsage(), 11, 22, 33);
+		assertThat(results.get(0).chatResponse().getResults()).isEqualTo(finalResponse.chatResponse().getResults());
+		assertThat(callCount[0]).isEqualTo(2);
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void adviseStreamAccumulatesPreviousLoopUsageOnlyOnUsageBearingChunks() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createResponse(true, new DefaultUsage(10, 20, 30));
+		ChatClientResponse finalResponseChunk = createResponse(false, new DefaultUsage(0, 0, 0), "Hello ");
+		ChatClientResponse finalResponseWithUsage = createResponse(false, new DefaultUsage(1, 2, 3), "world");
+		ChatClientResponse finalResponseTrailingChunk = createResponse(false, new DefaultUsage(0, 0, 0), "!");
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? Flux.just(responseWithToolCall)
+					: Flux.just(finalResponseChunk, finalResponseWithUsage, finalResponseTrailingChunk);
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false));
+
+		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
+
+		assertThat(results).isNotNull().hasSize(3);
+		assertUsage(results.get(0).chatResponse().getMetadata().getUsage(), 0, 0, 0);
+		assertUsage(results.get(1).chatResponse().getMetadata().getUsage(), 11, 22, 33);
+		assertUsage(results.get(2).chatResponse().getMetadata().getUsage(), 0, 0, 0);
+		assertThat(results.get(0).chatResponse().getResult().getOutput().getText()).isEqualTo("Hello ");
+		assertThat(results.get(1).chatResponse().getResult().getOutput().getText()).isEqualTo("world");
+		assertThat(results.get(2).chatResponse().getResult().getOutput().getText()).isEqualTo("!");
+		assertThat(callCount[0]).isEqualTo(2);
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void adviseStreamKeepsAccumulatedUsageSubscriptionLocal() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createResponse(true, new DefaultUsage(10, 20, 30));
+		ChatClientResponse finalResponse = createResponse(false, new DefaultUsage(1, 2, 3));
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			return Flux.just(callCount[0] % 2 == 1 ? responseWithToolCall : finalResponse);
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false));
+
+		Flux<ChatClientResponse> responseFlux = advisor.adviseStream(request, realChain);
+
+		List<ChatClientResponse> firstSubscriptionResults = responseFlux.collectList().block();
+		List<ChatClientResponse> secondSubscriptionResults = responseFlux.collectList().block();
+
+		assertThat(firstSubscriptionResults).isNotNull().hasSize(1);
+		assertThat(secondSubscriptionResults).isNotNull().hasSize(1);
+		assertUsage(firstSubscriptionResults.get(0).chatResponse().getMetadata().getUsage(), 11, 22, 33);
+		assertUsage(secondSubscriptionResults.get(0).chatResponse().getMetadata().getUsage(), 11, 22, 33);
+		assertThat(callCount[0]).isEqualTo(4);
+		verify(this.toolCallingManager, times(2)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void adviseStreamPreservesAccumulatedUsageForReturnDirect() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse firstToolCallResponse = createResponse(true, new DefaultUsage(10, 20, 30));
+		ChatClientResponse secondToolCallResponse = createResponse(true, new DefaultUsage(1, 2, 3));
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			return Flux.just(callCount[0] == 1 ? firstToolCallResponse : secondToolCallResponse);
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false), createToolExecutionResult(true));
+
+		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
+
+		assertThat(results).isNotNull().hasSize(1);
+		assertUsage(results.get(0).chatResponse().getMetadata().getUsage(), 11, 22, 33);
+		assertThat(results.get(0).chatResponse().getResults()).hasSize(1);
+		assertThat(results.get(0).chatResponse().getResults().get(0).getOutput().getText())
+			.isEqualTo("Tool result data");
+		assertThat(callCount[0]).isEqualTo(2);
+		verify(this.toolCallingManager, times(2)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
 	}
 
 	@Test
@@ -834,6 +1048,50 @@ public class ToolCallingAdvisorTests {
 		});
 
 		return mockRequest;
+	}
+
+	private ChatClientResponse createResponse(boolean hasToolCalls, Usage usage) {
+		return createResponse(hasToolCalls, usage, "response");
+	}
+
+	private ChatClientResponse createResponse(boolean hasToolCalls, Usage usage, String content) {
+		AssistantMessage assistantMessage;
+		if (hasToolCalls) {
+			AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("tool-call-1", "function", "testTool",
+					"{}");
+			assistantMessage = AssistantMessage.builder().content(content).toolCalls(List.of(toolCall)).build();
+		}
+		else {
+			assistantMessage = new AssistantMessage(content);
+		}
+
+		ChatResponseMetadata metadata = ChatResponseMetadata.builder().usage(usage).build();
+		ChatResponse chatResponse = ChatResponse.builder()
+			.generations(List.of(new Generation(assistantMessage)))
+			.metadata(metadata)
+			.build();
+
+		return ChatClientResponse.builder().chatResponse(chatResponse).build();
+	}
+
+	private ToolExecutionResult createToolExecutionResult(boolean returnDirect) {
+		ToolResponseMessage.ToolResponse toolResponse = new ToolResponseMessage.ToolResponse("tool-1", "testTool",
+				"Tool result data");
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(toolResponse))
+			.build();
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), toolResponseMessage);
+		return ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.returnDirect(returnDirect)
+			.build();
+	}
+
+	private void assertUsage(Usage usage, int promptTokens, int completionTokens, int totalTokens) {
+		assertThat(usage.getPromptTokens()).isEqualTo(promptTokens);
+		assertThat(usage.getCompletionTokens()).isEqualTo(completionTokens);
+		assertThat(usage.getTotalTokens()).isEqualTo(totalTokens);
 	}
 
 	private ChatClientResponse createMockResponse(boolean hasToolCalls) {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/UsageAccumulatorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/UsageAccumulatorTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link UsageAccumulator}.
+ *
+ * @author Jewoo Shin
+ */
+class UsageAccumulatorTests {
+
+	@Test
+	void totalIsNullBeforeAnyAdd() {
+		assertThat(new UsageAccumulator().total()).isNull();
+	}
+
+	@Test
+	void addFoldsUsageAcrossRounds() {
+		UsageAccumulator accumulator = new UsageAccumulator();
+
+		accumulator.add(responseWith(new DefaultUsage(10, 20, 30)));
+		ChatResponse total = accumulator.add(responseWith(new DefaultUsage(1, 2, 3)));
+
+		assertThat(total).isNotNull();
+		assertUsage(total.getMetadata().getUsage(), 11, 22, 33);
+		assertThat(accumulator.total()).isSameAs(total);
+	}
+
+	@Test
+	void applyTotalUsageStampsAccumulatedTotalOntoResponse() {
+		UsageAccumulator accumulator = new UsageAccumulator();
+		accumulator.add(responseWith(new DefaultUsage(10, 20, 30)));
+		accumulator.add(responseWith(new DefaultUsage(1, 2, 3)));
+
+		ChatClientResponse finalResponse = clientResponseWith(new DefaultUsage(1, 2, 3));
+		ChatClientResponse result = accumulator.applyTotalUsage(finalResponse);
+
+		assertUsage(result.chatResponse().getMetadata().getUsage(), 11, 22, 33);
+	}
+
+	@Test
+	void applyTotalUsageLeavesResponseUnchangedWhenNothingAccumulated() {
+		ChatClientResponse response = clientResponseWith(new DefaultUsage(1, 2, 3));
+
+		ChatClientResponse result = new UsageAccumulator().applyTotalUsage(response);
+
+		assertThat(result).isSameAs(response);
+	}
+
+	@Test
+	void applyPreviousTotalToChunkAddsPreviousTotalToUsageBearingChunk() {
+		ChatResponse previousTotal = responseWith(new DefaultUsage(10, 20, 30));
+		ChatClientResponse chunk = clientResponseWith(new DefaultUsage(1, 2, 3));
+
+		ChatClientResponse result = UsageAccumulator.applyPreviousTotalToChunk(chunk, previousTotal);
+
+		assertUsage(result.chatResponse().getMetadata().getUsage(), 11, 22, 33);
+	}
+
+	@Test
+	void applyPreviousTotalToChunkLeavesUsageFreeChunkUnchanged() {
+		ChatResponse previousTotal = responseWith(new DefaultUsage(10, 20, 30));
+		ChatClientResponse chunk = clientResponseWith(new DefaultUsage(0, 0, 0));
+
+		ChatClientResponse result = UsageAccumulator.applyPreviousTotalToChunk(chunk, previousTotal);
+
+		assertThat(result).isSameAs(chunk);
+	}
+
+	@Test
+	void usageCorrectionEmitsUsageOnlyResponseWhenFinalRoundHasNoUsage() {
+		ChatClientResponse aggregated = clientResponseWith(new DefaultUsage(0, 0, 0));
+		ChatResponse round = responseWith(new DefaultUsage(0, 0, 0));
+		ChatResponse accumulated = responseWith(new DefaultUsage(10, 20, 30));
+
+		List<ChatClientResponse> result = UsageAccumulator.usageCorrection(aggregated, round, accumulated)
+			.collectList()
+			.block();
+
+		assertThat(result).isNotNull().hasSize(1);
+		assertUsage(result.get(0).chatResponse().getMetadata().getUsage(), 10, 20, 30);
+		// Usage-only: no content generations are duplicated.
+		assertThat(result.get(0).chatResponse().getResults()).isEmpty();
+	}
+
+	@Test
+	void usageCorrectionEmitsNothingWhenFinalRoundReportsUsage() {
+		ChatClientResponse aggregated = clientResponseWith(new DefaultUsage(1, 2, 3));
+		ChatResponse round = responseWith(new DefaultUsage(1, 2, 3));
+		ChatResponse accumulated = responseWith(new DefaultUsage(11, 22, 33));
+
+		Flux<ChatClientResponse> result = UsageAccumulator.usageCorrection(aggregated, round, accumulated);
+
+		assertThat(result.collectList().block()).isEmpty();
+	}
+
+	@Test
+	void usageCorrectionEmitsNothingWhenNothingAccumulated() {
+		ChatClientResponse aggregated = clientResponseWith(new DefaultUsage(0, 0, 0));
+		ChatResponse round = responseWith(new DefaultUsage(0, 0, 0));
+
+		Flux<ChatClientResponse> result = UsageAccumulator.usageCorrection(aggregated, round, null);
+
+		assertThat(result.collectList().block()).isEmpty();
+	}
+
+	private ChatResponse responseWith(Usage usage) {
+		ChatResponseMetadata metadata = ChatResponseMetadata.builder().usage(usage).build();
+		return ChatResponse.builder()
+			.generations(List.of(new Generation(new AssistantMessage("response"))))
+			.metadata(metadata)
+			.build();
+	}
+
+	private ChatClientResponse clientResponseWith(Usage usage) {
+		return ChatClientResponse.builder().chatResponse(responseWith(usage)).build();
+	}
+
+	private void assertUsage(Usage usage, int promptTokens, int completionTokens, int totalTokens) {
+		assertThat(usage.getPromptTokens()).isEqualTo(promptTokens);
+		assertThat(usage.getCompletionTokens()).isEqualTo(completionTokens);
+		assertThat(usage.getTotalTokens()).isEqualTo(totalTokens);
+	}
+
+}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/UsageAccumulatorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/UsageAccumulatorTests.java
@@ -39,70 +39,73 @@ import static org.assertj.core.api.Assertions.assertThat;
 class UsageAccumulatorTests {
 
 	@Test
-	void totalIsNullBeforeAnyAdd() {
-		assertThat(new UsageAccumulator().total()).isNull();
+	void accumulatedResponseIsNullBeforeAnyRoundResponse() {
+		assertThat(new UsageAccumulator().accumulatedResponse()).isNull();
 	}
 
 	@Test
-	void addFoldsUsageAcrossRounds() {
+	void addRoundResponseFoldsUsageAcrossRounds() {
 		UsageAccumulator accumulator = new UsageAccumulator();
 
-		accumulator.add(responseWith(new DefaultUsage(10, 20, 30)));
-		ChatResponse total = accumulator.add(responseWith(new DefaultUsage(1, 2, 3)));
+		accumulator.addRoundResponse(responseWith(new DefaultUsage(10, 20, 30)));
+		ChatResponse total = accumulator.addRoundResponse(responseWith(new DefaultUsage(1, 2, 3)));
 
 		assertThat(total).isNotNull();
 		assertUsage(total.getMetadata().getUsage(), 11, 22, 33);
-		assertThat(accumulator.total()).isSameAs(total);
+		assertThat(accumulator.accumulatedResponse()).isSameAs(total);
 	}
 
 	@Test
-	void applyTotalUsageStampsAccumulatedTotalOntoResponse() {
+	void applyAccumulatedUsageStampsAccumulatedTotalOntoResponse() {
 		UsageAccumulator accumulator = new UsageAccumulator();
-		accumulator.add(responseWith(new DefaultUsage(10, 20, 30)));
-		accumulator.add(responseWith(new DefaultUsage(1, 2, 3)));
+		accumulator.addRoundResponse(responseWith(new DefaultUsage(10, 20, 30)));
+		accumulator.addRoundResponse(responseWith(new DefaultUsage(1, 2, 3)));
 
 		ChatClientResponse finalResponse = clientResponseWith(new DefaultUsage(1, 2, 3));
-		ChatClientResponse result = accumulator.applyTotalUsage(finalResponse);
+		ChatClientResponse result = accumulator.applyAccumulatedUsage(finalResponse);
 
 		assertUsage(result.chatResponse().getMetadata().getUsage(), 11, 22, 33);
 	}
 
 	@Test
-	void applyTotalUsageLeavesResponseUnchangedWhenNothingAccumulated() {
+	void applyAccumulatedUsageLeavesResponseUnchangedWhenNothingAccumulated() {
 		ChatClientResponse response = clientResponseWith(new DefaultUsage(1, 2, 3));
 
-		ChatClientResponse result = new UsageAccumulator().applyTotalUsage(response);
+		ChatClientResponse result = new UsageAccumulator().applyAccumulatedUsage(response);
 
 		assertThat(result).isSameAs(response);
 	}
 
 	@Test
-	void applyPreviousTotalToChunkAddsPreviousTotalToUsageBearingChunk() {
-		ChatResponse previousTotal = responseWith(new DefaultUsage(10, 20, 30));
+	void applyPreviousAccumulatedUsageToChunkAddsPreviousUsageToUsageBearingChunk() {
+		ChatResponse previousAccumulatedResponse = responseWith(new DefaultUsage(10, 20, 30));
 		ChatClientResponse chunk = clientResponseWith(new DefaultUsage(1, 2, 3));
 
-		ChatClientResponse result = UsageAccumulator.applyPreviousTotalToChunk(chunk, previousTotal);
+		ChatClientResponse result = UsageAccumulator.applyPreviousAccumulatedUsageToChunk(chunk,
+				previousAccumulatedResponse);
 
 		assertUsage(result.chatResponse().getMetadata().getUsage(), 11, 22, 33);
 	}
 
 	@Test
-	void applyPreviousTotalToChunkLeavesUsageFreeChunkUnchanged() {
-		ChatResponse previousTotal = responseWith(new DefaultUsage(10, 20, 30));
+	void applyPreviousAccumulatedUsageToChunkLeavesUsageFreeChunkUnchanged() {
+		ChatResponse previousAccumulatedResponse = responseWith(new DefaultUsage(10, 20, 30));
 		ChatClientResponse chunk = clientResponseWith(new DefaultUsage(0, 0, 0));
 
-		ChatClientResponse result = UsageAccumulator.applyPreviousTotalToChunk(chunk, previousTotal);
+		ChatClientResponse result = UsageAccumulator.applyPreviousAccumulatedUsageToChunk(chunk,
+				previousAccumulatedResponse);
 
 		assertThat(result).isSameAs(chunk);
 	}
 
 	@Test
-	void usageCorrectionEmitsUsageOnlyResponseWhenFinalRoundHasNoUsage() {
+	void emitFinalUsageCorrectionIfNecessaryEmitsUsageOnlyResponseWhenFinalRoundHasNoUsage() {
 		ChatClientResponse aggregated = clientResponseWith(new DefaultUsage(0, 0, 0));
 		ChatResponse round = responseWith(new DefaultUsage(0, 0, 0));
 		ChatResponse accumulated = responseWith(new DefaultUsage(10, 20, 30));
 
-		List<ChatClientResponse> result = UsageAccumulator.usageCorrection(aggregated, round, accumulated)
+		List<ChatClientResponse> result = UsageAccumulator
+			.emitFinalUsageCorrectionIfNecessary(aggregated, round, accumulated)
 			.collectList()
 			.block();
 
@@ -113,22 +116,23 @@ class UsageAccumulatorTests {
 	}
 
 	@Test
-	void usageCorrectionEmitsNothingWhenFinalRoundReportsUsage() {
+	void emitFinalUsageCorrectionIfNecessaryEmitsNothingWhenFinalRoundReportsUsage() {
 		ChatClientResponse aggregated = clientResponseWith(new DefaultUsage(1, 2, 3));
 		ChatResponse round = responseWith(new DefaultUsage(1, 2, 3));
 		ChatResponse accumulated = responseWith(new DefaultUsage(11, 22, 33));
 
-		Flux<ChatClientResponse> result = UsageAccumulator.usageCorrection(aggregated, round, accumulated);
+		Flux<ChatClientResponse> result = UsageAccumulator.emitFinalUsageCorrectionIfNecessary(aggregated, round,
+				accumulated);
 
 		assertThat(result.collectList().block()).isEmpty();
 	}
 
 	@Test
-	void usageCorrectionEmitsNothingWhenNothingAccumulated() {
+	void emitFinalUsageCorrectionIfNecessaryEmitsNothingWhenNothingAccumulated() {
 		ChatClientResponse aggregated = clientResponseWith(new DefaultUsage(0, 0, 0));
 		ChatResponse round = responseWith(new DefaultUsage(0, 0, 0));
 
-		Flux<ChatClientResponse> result = UsageAccumulator.usageCorrection(aggregated, round, null);
+		Flux<ChatClientResponse> result = UsageAccumulator.emitFinalUsageCorrectionIfNecessary(aggregated, round, null);
 
 		assertThat(result.collectList().block()).isEmpty();
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -38,6 +38,7 @@ Highlights:
 * Uses `callAdvisorChain.copy(this)` to create a sub-chain for recursive calls — other advisors can observe and intercept every iteration.
 * Supports return-direct: when a tool's result has `returnDirect = true`, the advisor breaks the loop and returns the tool result to the caller without sending it back to the LLM.
 * Implements the `ToolAdvisor` marker interface, which `DefaultChatClient` uses to enforce the single-tool-advisor invariant — custom subclasses register transparently as replacements.
+* Accumulates token usage across every iteration of the loop, so the final `ChatResponse` reports the cumulative usage of all model calls rather than only the last one (see xref:api/usage-handling.adoc#_cumulative_usage_across_multi_step_flows[Cumulative Usage Across Multi-Step Flows]).
 
 Short example:
 
@@ -107,3 +108,24 @@ ActorFilms actorFilms = chatClient.prompt()
     .call()
     .entity(ActorFilms.class, spec -> spec.schemaValidation());
 ----
+
+== Accumulating Token Usage in Custom Recursive Advisors
+
+A recursive advisor performs more than one model call per invocation, so it must accumulate the token usage of every call to report a correct cumulative total; otherwise only the last call's usage is visible to the caller.
+Spring AI provides `org.springframework.ai.chat.client.advisor.UsageAccumulator` to make this straightforward.
+Create one instance per `adviseCall` invocation (or per stream subscription, inside a `Flux.defer`, to keep it subscription-local), fold each round's response in with `add(...)`, and stamp the cumulative total onto the final response with `applyTotalUsage(...)`:
+
+[source,java]
+----
+UsageAccumulator usage = new UsageAccumulator();
+ChatClientResponse response;
+do {
+    response = callAdvisorChain.copy(this).nextCall(request);
+    usage.add(response.chatResponse());
+    // ... decide whether to loop again ...
+}
+while (loopAgain);
+return usage.applyTotalUsage(response);
+----
+
+The underlying token math lives in `org.springframework.ai.support.UsageCalculator` (`accumulate` and `withUsage`), which `UsageAccumulator` wraps.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -113,7 +113,7 @@ ActorFilms actorFilms = chatClient.prompt()
 
 A recursive advisor performs more than one model call per invocation, so it must accumulate the token usage of every call to report a correct cumulative total; otherwise only the last call's usage is visible to the caller.
 Spring AI provides `org.springframework.ai.chat.client.advisor.UsageAccumulator` to make this straightforward.
-Create one instance per `adviseCall` invocation (or per stream subscription, inside a `Flux.defer`, to keep it subscription-local), fold each round's response in with `add(...)`, and stamp the cumulative total onto the final response with `applyTotalUsage(...)`:
+Create one instance per `adviseCall` invocation (or per stream subscription, inside a `Flux.defer`, to keep it subscription-local), fold each round's response in with `addRoundResponse(...)`, and stamp the cumulative total onto the final response with `applyAccumulatedUsage(...)`:
 
 [source,java]
 ----
@@ -121,11 +121,11 @@ UsageAccumulator usage = new UsageAccumulator();
 ChatClientResponse response;
 do {
     response = callAdvisorChain.copy(this).nextCall(request);
-    usage.add(response.chatResponse());
+    usage.addRoundResponse(response.chatResponse());
     // ... decide whether to loop again ...
 }
 while (loopAgain);
-return usage.applyTotalUsage(response);
+return usage.applyAccumulatedUsage(response);
 ----
 
-The underlying token math lives in `org.springframework.ai.support.UsageCalculator` (`accumulate` and `withUsage`), which `UsageAccumulator` wraps.
+The underlying token math lives in `org.springframework.ai.support.UsageCalculator` (`accumulateResponseUsage` and `withUsage`), which `UsageAccumulator` wraps.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -72,6 +72,7 @@ Key features:
 * Retries the call when validation fails (default: up to 3 attempts).
 * Augments the prompt with the validation error message on retry attempts to help the model self-correct.
 * Uses `callAdvisorChain.copy(this)` to create a sub-chain for recursive calls.
+* Accumulates token usage across every validation attempt, so the returned `ChatResponse` reports the cumulative usage of all retries rather than only the final attempt (see xref:api/usage-handling.adoc#_cumulative_usage_across_multi_step_flows[Cumulative Usage Across Multi-Step Flows]).
 * Optionally supports a custom `JsonMapper`.
 
 The advisor can be configured via `outputType` (schema derived automatically) or `outputJsonSchema` (pre-supplied schema string); the two options are mutually exclusive.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/usage-handling.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/usage-handling.adoc
@@ -139,6 +139,29 @@ The following table shows prompt cache metrics availability by provider:
 
 NOTE: For detailed provider-specific cache metrics (such as per-modality cache breakdowns in Gemini), use `getNativeUsage()` to access the provider's native usage object.
 
+== Cumulative Usage Across Multi-Step Flows
+
+When a response is produced through a multi-step flow such as a tool-calling loop, `getUsage()` reports the *cumulative* token usage across every model call in that exchange, not just the last call.
+For example, a `ChatClient` conversation that triggers one tool call performs at least two model calls, and the returned `getUsage()` reflects the sum of both.
+
+[source,java]
+----
+ChatResponse response = chatClient.prompt("What is the weather in Paris?")
+        .tools(new WeatherTools())
+        .call()
+        .chatResponse();
+
+// Cumulative across all model calls in the tool-calling loop
+Usage usage = response.getMetadata().getUsage();
+int totalTokens = usage.getTotalTokens();
+----
+
+The cumulative total is computed via `org.springframework.ai.support.UsageCalculator`, which sums the standard token counts and the unified cache metrics (`getCacheReadInputTokens()` / `getCacheWriteInputTokens()`).
+
+WARNING: Provider-specific native usage objects cannot be merged across responses.
+As a result, `getNativeUsage()` returns `null` once usage has been aggregated across more than one model call (for example after a tool-calling loop); it is preserved only for single-call responses.
+If you need the provider's native usage object, read it from an individual `ChatModel` call rather than from a multi-step `ChatClient` exchange.
+
 == Benefits
 
 **Standardization**: Provides a consistent way to handle usage across different AI models

--- a/spring-ai-model/src/main/java/org/springframework/ai/support/UsageCalculator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/support/UsageCalculator.java
@@ -27,6 +27,7 @@ import org.springframework.ai.chat.model.ChatResponse;
  * A utility class to provide support methods handling {@link Usage}.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Jewoo Shin
  */
 public final class UsageCalculator {
 
@@ -105,18 +106,18 @@ public final class UsageCalculator {
 	}
 
 	/**
-	 * Folds the usage of the given current chat response into a running accumulator. The
-	 * returned {@link ChatResponse} carries the cumulative usage (current plus
-	 * accumulated). This is the building block for accumulating usage across the
-	 * iterations of a recursive flow (for example a tool-calling loop or a validation
-	 * retry loop).
+	 * Folds the usage of the current chat response into the previously accumulated
+	 * {@link ChatResponse}. The returned {@link ChatResponse} carries the cumulative
+	 * usage (current plus previously accumulated). This is the building block for
+	 * accumulating usage across the iterations of a recursive flow (for example a
+	 * tool-calling loop or a validation retry loop).
 	 * @param currentChatResponse the chat response produced by the current iteration, or
 	 * {@code null}
-	 * @param accumulatedChatResponse the running accumulator from previous iterations, or
-	 * {@code null} if none yet
-	 * @return a chat response carrying the cumulative usage, the accumulator unchanged
-	 * when the current response is {@code null}, or {@code null} when no usage has been
-	 * reported
+	 * @param accumulatedChatResponse the chat response carrying the cumulative usage from
+	 * previous iterations, or {@code null} if none yet
+	 * @return a chat response carrying the cumulative usage, the previously accumulated
+	 * response unchanged when the current response is {@code null}, or {@code null} when
+	 * no usage has been reported
 	 * @since 2.0.0
 	 */
 	public static @Nullable ChatResponse accumulate(@Nullable ChatResponse currentChatResponse,

--- a/spring-ai-model/src/main/java/org/springframework/ai/support/UsageCalculator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/support/UsageCalculator.java
@@ -18,6 +18,7 @@ package org.springframework.ai.support;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -36,6 +37,13 @@ public final class UsageCalculator {
 	/**
 	 * Accumulate usage tokens from the previous chat response to the current usage
 	 * tokens.
+	 * <p>
+	 * Note: when the two usages are actually summed, the result is a plain
+	 * {@link DefaultUsage} and the provider-specific {@link Usage#getNativeUsage() native
+	 * usage} object is <em>not</em> preserved (it cannot be merged across responses).
+	 * Only the token counts and cache metrics carry over. The original
+	 * {@code currentUsage} (native usage included) is returned unchanged when there is
+	 * nothing to accumulate.
 	 * @param currentUsage the current usage.
 	 * @param previousChatResponse the previous chat response.
 	 * @return accumulated usage.
@@ -78,6 +86,8 @@ public final class UsageCalculator {
 						+ (usageFromPreviousChatResponse.getCacheWriteInputTokens() != null
 								? usageFromPreviousChatResponse.getCacheWriteInputTokens() : 0L);
 			}
+			// Native usage is passed as null: provider-specific objects cannot be merged
+			// across responses, so only token counts and cache metrics are accumulated.
 			return new DefaultUsage(promptTokens, generationTokens, totalTokens, null, cacheRead, cacheWrite);
 		}
 		// When current usage is empty, return the usage from the previous chat response.
@@ -92,6 +102,65 @@ public final class UsageCalculator {
 	 */
 	public static boolean isEmpty(@Nullable Usage usage) {
 		return usage == null || usage.getTotalTokens() == 0L;
+	}
+
+	/**
+	 * Folds the usage of the given current chat response into a running accumulator. The
+	 * returned {@link ChatResponse} carries the cumulative usage (current plus
+	 * accumulated). This is the building block for accumulating usage across the
+	 * iterations of a recursive flow (for example a tool-calling loop or a validation
+	 * retry loop).
+	 * @param currentChatResponse the chat response produced by the current iteration, or
+	 * {@code null}
+	 * @param accumulatedChatResponse the running accumulator from previous iterations, or
+	 * {@code null} if none yet
+	 * @return a chat response carrying the cumulative usage, the accumulator unchanged
+	 * when the current response is {@code null}, or {@code null} when no usage has been
+	 * reported
+	 * @since 2.0.0
+	 */
+	public static @Nullable ChatResponse accumulate(@Nullable ChatResponse currentChatResponse,
+			@Nullable ChatResponse accumulatedChatResponse) {
+		if (currentChatResponse == null) {
+			return accumulatedChatResponse;
+		}
+		Usage currentUsage = currentChatResponse.getMetadata().getUsage();
+		ChatResponse previousChatResponse = isEmpty(getUsage(accumulatedChatResponse)) ? null : accumulatedChatResponse;
+		Usage cumulativeUsage = getCumulativeUsage(currentUsage, previousChatResponse);
+		if (isEmpty(cumulativeUsage)) {
+			return null;
+		}
+		return withUsage(currentChatResponse, cumulativeUsage);
+	}
+
+	/**
+	 * Returns a copy of the given chat response with its usage replaced by the provided
+	 * {@link Usage}, preserving all other response metadata.
+	 * @param chatResponse the chat response to copy
+	 * @param usage the usage to set on the copy
+	 * @return a new chat response carrying the given usage
+	 * @since 2.0.0
+	 */
+	public static ChatResponse withUsage(ChatResponse chatResponse, Usage usage) {
+		return ChatResponse.builder()
+			.from(chatResponse)
+			.metadata(metadataWithUsage(chatResponse.getMetadata(), usage))
+			.build();
+	}
+
+	private static ChatResponseMetadata metadataWithUsage(ChatResponseMetadata metadata, Usage usage) {
+		ChatResponseMetadata.Builder builder = ChatResponseMetadata.builder()
+			.id(metadata.getId())
+			.model(metadata.getModel())
+			.rateLimit(metadata.getRateLimit())
+			.usage(usage)
+			.promptMetadata(metadata.getPromptMetadata());
+		metadata.entrySet().forEach(entry -> builder.keyValue(entry.getKey(), entry.getValue()));
+		return builder.build();
+	}
+
+	private static @Nullable Usage getUsage(@Nullable ChatResponse chatResponse) {
+		return chatResponse != null ? chatResponse.getMetadata().getUsage() : null;
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/support/UsageCalculator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/support/UsageCalculator.java
@@ -120,7 +120,7 @@ public final class UsageCalculator {
 	 * no usage has been reported
 	 * @since 2.0.0
 	 */
-	public static @Nullable ChatResponse accumulate(@Nullable ChatResponse currentChatResponse,
+	public static @Nullable ChatResponse accumulateResponseUsage(@Nullable ChatResponse currentChatResponse,
 			@Nullable ChatResponse accumulatedChatResponse) {
 		if (currentChatResponse == null) {
 			return accumulatedChatResponse;

--- a/spring-ai-model/src/test/java/org/springframework/ai/support/UsageCalculatorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/support/UsageCalculatorTests.java
@@ -140,40 +140,40 @@ class UsageCalculatorTests {
 	}
 
 	@Test
-	void accumulateReturnsAccumulatorWhenCurrentIsNull() {
+	void accumulateResponseUsageReturnsAccumulatedResponseWhenCurrentIsNull() {
 		ChatResponse accumulated = responseWith(new DefaultUsage(1, 2, 3));
 
-		ChatResponse result = UsageCalculator.accumulate(null, accumulated);
+		ChatResponse result = UsageCalculator.accumulateResponseUsage(null, accumulated);
 
 		assertThat(result).isSameAs(accumulated);
 	}
 
 	@Test
-	void accumulateReturnsCumulativeUsageOnTheCurrentResponse() {
+	void accumulateResponseUsageReturnsCumulativeUsageOnTheCurrentResponse() {
 		ChatResponse current = responseWith(new DefaultUsage(10, 20, 30));
 		ChatResponse accumulated = responseWith(new DefaultUsage(1, 2, 3));
 
-		ChatResponse result = UsageCalculator.accumulate(current, accumulated);
+		ChatResponse result = UsageCalculator.accumulateResponseUsage(current, accumulated);
 
 		assertThat(result).isNotNull();
 		assertUsage(result.getMetadata().getUsage(), 11, 22, 33);
 	}
 
 	@Test
-	void accumulateReturnsNullWhenNothingReported() {
+	void accumulateResponseUsageReturnsNullWhenNothingReported() {
 		ChatResponse current = responseWith(new DefaultUsage(0, 0, 0));
 
-		ChatResponse result = UsageCalculator.accumulate(current, null);
+		ChatResponse result = UsageCalculator.accumulateResponseUsage(current, null);
 
 		assertThat(result).isNull();
 	}
 
 	@Test
-	void accumulateKeepsNativeUsageOnFirstNonEmptyResponse() {
+	void accumulateResponseUsageKeepsNativeUsageOnFirstNonEmptyResponse() {
 		Object nativeUsage = new Object();
 		ChatResponse current = responseWith(new DefaultUsage(10, 20, 30, nativeUsage));
 
-		ChatResponse result = UsageCalculator.accumulate(current, null);
+		ChatResponse result = UsageCalculator.accumulateResponseUsage(current, null);
 
 		assertThat(result).isNotNull();
 		assertThat(result.getMetadata().getUsage().getNativeUsage()).isSameAs(nativeUsage);

--- a/spring-ai-model/src/test/java/org/springframework/ai/support/UsageCalculatorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/support/UsageCalculatorTests.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.support;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link UsageCalculator}.
+ *
+ * @author Jewoo Shin
+ */
+class UsageCalculatorTests {
+
+	@Test
+	void getCumulativeUsageReturnsCurrentWhenPreviousChatResponseIsNull() {
+		Usage current = new DefaultUsage(10, 20, 30);
+
+		Usage result = UsageCalculator.getCumulativeUsage(current, null);
+
+		// The current usage is returned unchanged (same instance) when there is nothing
+		// to accumulate.
+		assertThat(result).isSameAs(current);
+	}
+
+	@Test
+	void getCumulativeUsageReturnsCurrentWhenPreviousUsageIsEmpty() {
+		Usage current = new DefaultUsage(10, 20, 30);
+		ChatResponse previous = responseWith(new DefaultUsage(0, 0, 0));
+
+		Usage result = UsageCalculator.getCumulativeUsage(current, previous);
+
+		// Previous contributes nothing, so the current token counts are preserved.
+		assertUsage(result, 10, 20, 30);
+	}
+
+	@Test
+	void getCumulativeUsageReturnsPreviousWhenCurrentIsEmpty() {
+		Usage current = new DefaultUsage(0, 0, 0);
+		Usage previousUsage = new DefaultUsage(1, 2, 3);
+		ChatResponse previous = responseWith(previousUsage);
+
+		Usage result = UsageCalculator.getCumulativeUsage(current, previous);
+
+		// When current is empty the previous usage is returned as-is.
+		assertThat(result).isSameAs(previousUsage);
+	}
+
+	@Test
+	void getCumulativeUsageSumsTokenCounts() {
+		Usage current = new DefaultUsage(10, 20, 30);
+		ChatResponse previous = responseWith(new DefaultUsage(1, 2, 3));
+
+		Usage result = UsageCalculator.getCumulativeUsage(current, previous);
+
+		assertUsage(result, 11, 22, 33);
+	}
+
+	@Test
+	void getCumulativeUsageSumsCacheMetrics() {
+		Usage current = new DefaultUsage(10, 20, 30, null, 100L, 5L);
+		ChatResponse previous = responseWith(new DefaultUsage(1, 2, 3, null, 200L, 7L));
+
+		Usage result = UsageCalculator.getCumulativeUsage(current, previous);
+
+		assertUsage(result, 11, 22, 33);
+		assertThat(result.getCacheReadInputTokens()).isEqualTo(300L);
+		assertThat(result.getCacheWriteInputTokens()).isEqualTo(12L);
+	}
+
+	@Test
+	void getCumulativeUsageTreatsOneSidedCacheMetricAsZero() {
+		Usage current = new DefaultUsage(10, 20, 30, null, 100L, null);
+		ChatResponse previous = responseWith(new DefaultUsage(1, 2, 3, null, null, null));
+
+		Usage result = UsageCalculator.getCumulativeUsage(current, previous);
+
+		// Only one side reports cacheRead, so it carries over; cacheWrite stays null
+		// because neither side reports it.
+		assertThat(result.getCacheReadInputTokens()).isEqualTo(100L);
+		assertThat(result.getCacheWriteInputTokens()).isNull();
+	}
+
+	@Test
+	void getCumulativeUsagePreservesNullCacheMetricsWhenNeitherSideReports() {
+		Usage current = new DefaultUsage(10, 20, 30);
+		ChatResponse previous = responseWith(new DefaultUsage(1, 2, 3));
+
+		Usage result = UsageCalculator.getCumulativeUsage(current, previous);
+
+		assertThat(result.getCacheReadInputTokens()).isNull();
+		assertThat(result.getCacheWriteInputTokens()).isNull();
+	}
+
+	@Test
+	void getCumulativeUsageDropsNativeUsageWhenAccumulating() {
+		Object currentNative = new Object();
+		Object previousNative = new Object();
+		Usage current = new DefaultUsage(10, 20, 30, currentNative);
+		ChatResponse previous = responseWith(new DefaultUsage(1, 2, 3, previousNative));
+
+		Usage result = UsageCalculator.getCumulativeUsage(current, previous);
+
+		// Provider-specific native usage objects cannot be merged across responses,
+		// so the accumulated result drops them.
+		assertThat(result.getNativeUsage()).isNull();
+	}
+
+	@Test
+	void getCumulativeUsageKeepsNativeUsageWhenNothingToAccumulate() {
+		Object currentNative = new Object();
+		Usage current = new DefaultUsage(10, 20, 30, currentNative);
+
+		Usage result = UsageCalculator.getCumulativeUsage(current, null);
+
+		// A single, non-accumulated usage keeps its native usage intact.
+		assertThat(result.getNativeUsage()).isSameAs(currentNative);
+	}
+
+	@Test
+	void accumulateReturnsAccumulatorWhenCurrentIsNull() {
+		ChatResponse accumulated = responseWith(new DefaultUsage(1, 2, 3));
+
+		ChatResponse result = UsageCalculator.accumulate(null, accumulated);
+
+		assertThat(result).isSameAs(accumulated);
+	}
+
+	@Test
+	void accumulateReturnsCumulativeUsageOnTheCurrentResponse() {
+		ChatResponse current = responseWith(new DefaultUsage(10, 20, 30));
+		ChatResponse accumulated = responseWith(new DefaultUsage(1, 2, 3));
+
+		ChatResponse result = UsageCalculator.accumulate(current, accumulated);
+
+		assertThat(result).isNotNull();
+		assertUsage(result.getMetadata().getUsage(), 11, 22, 33);
+	}
+
+	@Test
+	void accumulateReturnsNullWhenNothingReported() {
+		ChatResponse current = responseWith(new DefaultUsage(0, 0, 0));
+
+		ChatResponse result = UsageCalculator.accumulate(current, null);
+
+		assertThat(result).isNull();
+	}
+
+	@Test
+	void accumulateKeepsNativeUsageOnFirstNonEmptyResponse() {
+		Object nativeUsage = new Object();
+		ChatResponse current = responseWith(new DefaultUsage(10, 20, 30, nativeUsage));
+
+		ChatResponse result = UsageCalculator.accumulate(current, null);
+
+		assertThat(result).isNotNull();
+		assertThat(result.getMetadata().getUsage().getNativeUsage()).isSameAs(nativeUsage);
+	}
+
+	@Test
+	void withUsageReplacesUsageAndPreservesOtherMetadata() {
+		ChatResponseMetadata metadata = ChatResponseMetadata.builder()
+			.id("id-1")
+			.model("model-1")
+			.usage(new DefaultUsage(1, 2, 3))
+			.keyValue("custom", "value")
+			.build();
+		ChatResponse chatResponse = ChatResponse.builder().generations(List.of()).metadata(metadata).build();
+
+		ChatResponse result = UsageCalculator.withUsage(chatResponse, new DefaultUsage(10, 20, 30));
+
+		assertUsage(result.getMetadata().getUsage(), 10, 20, 30);
+		assertThat(result.getMetadata().getId()).isEqualTo("id-1");
+		assertThat(result.getMetadata().getModel()).isEqualTo("model-1");
+		assertThat(result.getMetadata().<String>get("custom")).isEqualTo("value");
+	}
+
+	@Test
+	void isEmptyReturnsTrueForNullUsage() {
+		assertThat(UsageCalculator.isEmpty(null)).isTrue();
+	}
+
+	@Test
+	void isEmptyReturnsTrueForZeroTotalTokens() {
+		assertThat(UsageCalculator.isEmpty(new DefaultUsage(0, 0, 0))).isTrue();
+	}
+
+	@Test
+	void isEmptyReturnsFalseForNonZeroTotalTokens() {
+		assertThat(UsageCalculator.isEmpty(new DefaultUsage(1, 2, 3))).isFalse();
+	}
+
+	private ChatResponse responseWith(Usage usage) {
+		ChatResponseMetadata metadata = ChatResponseMetadata.builder().usage(usage).build();
+		return ChatResponse.builder().generations(List.of()).metadata(metadata).build();
+	}
+
+	private void assertUsage(Usage usage, int promptTokens, int completionTokens, int totalTokens) {
+		assertThat(usage.getPromptTokens()).isEqualTo(promptTokens);
+		assertThat(usage.getCompletionTokens()).isEqualTo(completionTokens);
+		assertThat(usage.getTotalTokens()).isEqualTo(totalTokens);
+	}
+
+}


### PR DESCRIPTION
This update makes `ToolCallingAdvisor` carry cumulative usage across framework-controlled tool-calling loop iterations.

Previously, each internal model call returned its own `Usage`, so the final non-streaming `ChatClientResponse` could expose only the usage from the last model call. The advisor now composes usage with the existing `UsageCalculator` semantics before returning the final call response, including `returnDirect` responses where the generation is replaced with the tool result.

For streaming responses, the accumulator is created per subscription and is updated from each streamed iteration's aggregate response. When a later iteration emits chunks, only chunks that already carry usage metadata are rewritten to include the prior loop accumulator; chunks without usage metadata are left unchanged. No state is kept on the advisor instance.

Validation:

```
./mvnw -pl spring-ai-client-chat -am test -Dtest=ToolCallingAdvisorTests,ToolCallingAdvisorSpanHierarchyTests -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.build.cache.enabled=false
./mvnw -pl spring-ai-client-chat -am package -Dmaven.build.cache.enabled=false
```

Closes #6411
