### PR TITLE
Polish MCP integration tests CI

### DIFF
--- a/.github/workflows/mcp-integration-tests.yml
+++ b/.github/workflows/mcp-integration-tests.yml
@@ -1,15 +1,16 @@
 name: MCP Integration Tests
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+  push:
+    branches:
+      - 'main'
+      - '[0-9].[0-9].x'
   workflow_dispatch:
 
 jobs:
-  mcp-common:
-    name: MCP common and annotations integration tests
+  mcp-it:
+    name: MCP integration tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -22,36 +23,17 @@ jobs:
           distribution: 'liberica'
           cache: 'maven'
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup Maven Build-Cache (~/.m2/build-cache)
+        if: ${{ github.event_name != 'schedule' }}
+        uses: actions/cache@v5
         with:
-          node-version: '20'
+          path: ~/.m2/build-cache
+          # See pr-check.yml for an explanation of the key format
+          key: build-cache-${{ runner.os }}-mcp-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
+          restore-keys: |
+            build-cache-${{ runner.os }}-mcp-${{ hashFiles('**/pom.xml') }}-
+            build-cache-${{ runner.os }}-
 
-      - name: Build with Maven and run mcp/common and mcp/mcp-annotations integration tests
+      - name: Build with Maven and run integration tests
         run: |
-          ./mvnw clean verify -am -Pintegration-tests -pl "mcp/common,mcp/mcp-annotations"
-
-  mcp-transport:
-    name: MCP transport integration tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v6
-
-      - name: Set up JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'liberica'
-          cache: 'maven'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
-      - name: Build with Maven and run MCP transport integration tests
-        run: |
-          ./mvnw clean verify -am -Pintegration-tests -pl "mcp/transport/mcp-spring-webflux,mcp/transport/mcp-spring-webmvc"
-
-          
+          ./mvnw --batch-mode -ntp verify -Pintegration-tests -am -pl "mcp/transport/mcp-spring-webflux,mcp/transport/mcp-spring-webmvc"


### PR DESCRIPTION
Before this commit, the WF had two jobs that actually did the same thing (because the first job target actually depended on the secong targets (transports) and there are no integration tests in common nor annotations).

This commit also adds the build cache so that tests do not run if nothing has changed in the codebase.

Lastly, refine WHEN this workflow runs in terms of PRs, continuous integration, etc.)
