### PR TITLE
Fix StTemplateRenderer subtemplate variable validation

### DIFF
--- a/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
+++ b/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
@@ -20,15 +20,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.antlr.runtime.Token;
-import org.antlr.runtime.TokenStream;
+import org.antlr.runtime.tree.CommonTree;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.compiler.Compiler;
-import org.stringtemplate.v4.compiler.STLexer;
+import org.stringtemplate.v4.compiler.STParser;
 
 import org.springframework.ai.template.TemplateRenderer;
 import org.springframework.ai.template.ValidationMode;
@@ -52,6 +51,7 @@ import org.springframework.util.Assert;
  *
  * @author Thomas Vitale
  * @author Sun Yuhan
+ * @author Jewoo Shin
  * @since 1.0.0
  */
 public class StTemplateRenderer implements TemplateRenderer {
@@ -59,6 +59,8 @@ public class StTemplateRenderer implements TemplateRenderer {
 	private static final Log logger = LogFactory.getLog(StTemplateRenderer.class);
 
 	private static final String VALIDATION_MESSAGE = "Not all variables were replaced in the template. Missing variable names are: %s.";
+
+	private static final Set<String> PREDEFINED_ANONYMOUS_SUBTEMPLATE_ARGUMENTS = Set.of("i", "i0");
 
 	private static final char DEFAULT_START_DELIMITER_TOKEN = '{';
 
@@ -149,50 +151,88 @@ public class StTemplateRenderer implements TemplateRenderer {
 	}
 
 	private Set<String> getInputVariables(ST st) {
-		TokenStream tokens = st.impl.tokens;
 		Set<String> inputVariables = new HashSet<>();
-		boolean isInsideList = false;
+		collectInputVariables(st.impl.ast, inputVariables, Set.of());
+		return inputVariables;
+	}
 
-		for (int i = 0; i < tokens.size(); i++) {
-			Token token = tokens.get(i);
+	private void collectInputVariables(CommonTree tree, Set<String> inputVariables, Set<String> localVariables) {
+		if (tree == null) {
+			return;
+		}
 
-			// Handle list variables with option (e.g., {items; separator=", "})
-			if (token.getType() == STLexer.LDELIM && i + 1 < tokens.size()
-					&& tokens.get(i + 1).getType() == STLexer.ID) {
-				if (i + 2 < tokens.size() && tokens.get(i + 2).getType() == STLexer.COLON) {
-					String text = tokens.get(i + 1).getText();
-					if (!Compiler.funcs.containsKey(text) || this.validateStFunctions) {
-						inputVariables.add(text);
-						isInsideList = true;
-					}
-				}
+		switch (tree.getType()) {
+			case STParser.ID -> addInputVariable(tree.getText(), inputVariables, localVariables);
+			case STParser.SUBTEMPLATE -> collectSubtemplateInputVariables(tree, inputVariables, localVariables);
+			case STParser.ARGS -> {
+				// Formal arguments are local to the anonymous subtemplate.
 			}
-			else if (token.getType() == STLexer.RDELIM) {
-				isInsideList = false;
-			}
-			// Handle regular variables - only add IDs that are at the start of an
-			// expression
-			else if (!isInsideList && token.getType() == STLexer.ID) {
-				// Check if this ID is a function call
-				boolean isFunctionCall = (i + 1 < tokens.size() && tokens.get(i + 1).getType() == STLexer.LPAREN);
+			case STParser.PROP -> collectChildInputVariables(tree, 0, inputVariables, localVariables);
+			case STParser.PROP_IND -> collectChildrenInputVariables(tree, inputVariables, localVariables);
+			case STParser.EXEC_FUNC, STParser.INCLUDE, STParser.INCLUDE_SUPER, STParser.INCLUDE_REGION,
+					STParser.INCLUDE_SUPER_REGION ->
+				collectChildrenInputVariables(tree, 1, inputVariables, localVariables);
+			case STParser.EQUALS -> collectChildrenInputVariables(tree, 1, inputVariables, localVariables);
+			case STParser.OPTIONS -> collectOptionsInputVariables(tree, inputVariables, localVariables);
+			default -> collectChildrenInputVariables(tree, inputVariables, localVariables);
+		}
+	}
 
-				// Check if this ID is at the beginning of an expression (not a property
-				// access)
-				boolean isAfterDot = (i > 0 && tokens.get(i - 1).getType() == STLexer.DOT);
+	private void collectSubtemplateInputVariables(CommonTree tree, Set<String> inputVariables,
+			Set<String> localVariables) {
+		Set<String> subtemplateLocalVariables = new HashSet<>(localVariables);
+		subtemplateLocalVariables.addAll(PREDEFINED_ANONYMOUS_SUBTEMPLATE_ARGUMENTS);
 
-				// Only add IDs that are:
-				// 1. Not function calls
-				// 2. Not property values (not preceded by a dot)
-				// 3. Either not built-in functions or we're validating functions
-				if (!isFunctionCall && !isAfterDot) {
-					String varName = token.getText();
-					if (!Compiler.funcs.containsKey(varName) || this.validateStFunctions) {
-						inputVariables.add(varName);
-					}
-				}
+		for (int i = 0; i < tree.getChildCount(); i++) {
+			CommonTree child = (CommonTree) tree.getChild(i);
+			if (child.getType() == STParser.ARGS && child.getChildCount() > 0) {
+				subtemplateLocalVariables.add(child.getChild(0).getText());
 			}
 		}
-		return inputVariables;
+
+		for (int i = 0; i < tree.getChildCount(); i++) {
+			CommonTree child = (CommonTree) tree.getChild(i);
+			if (child.getType() != STParser.ARGS) {
+				collectInputVariables(child, inputVariables, subtemplateLocalVariables);
+			}
+		}
+	}
+
+	private void collectOptionsInputVariables(CommonTree tree, Set<String> inputVariables, Set<String> localVariables) {
+		for (int i = 0; i < tree.getChildCount(); i++) {
+			CommonTree child = (CommonTree) tree.getChild(i);
+			if (child.getType() == STParser.EQUALS) {
+				collectInputVariables(child, inputVariables, localVariables);
+			}
+		}
+	}
+
+	private void collectChildrenInputVariables(CommonTree tree, Set<String> inputVariables,
+			Set<String> localVariables) {
+		collectChildrenInputVariables(tree, 0, inputVariables, localVariables);
+	}
+
+	private void collectChildrenInputVariables(CommonTree tree, int start, Set<String> inputVariables,
+			Set<String> localVariables) {
+		for (int i = start; i < tree.getChildCount(); i++) {
+			collectChildInputVariables(tree, i, inputVariables, localVariables);
+		}
+	}
+
+	private void collectChildInputVariables(CommonTree tree, int childIndex, Set<String> inputVariables,
+			Set<String> localVariables) {
+		if (childIndex < tree.getChildCount()) {
+			collectInputVariables((CommonTree) tree.getChild(childIndex), inputVariables, localVariables);
+		}
+	}
+
+	private void addInputVariable(String variableName, Set<String> inputVariables, Set<String> localVariables) {
+		if (localVariables.contains(variableName)) {
+			return;
+		}
+		if (!Compiler.funcs.containsKey(variableName) || this.validateStFunctions) {
+			inputVariables.add(variableName);
+		}
 	}
 
 	public static Builder builder() {

--- a/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererTests.java
+++ b/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererTests.java
@@ -17,6 +17,8 @@
 package org.springframework.ai.template.st;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Unit tests for {@link StTemplateRenderer}.
  *
  * @author Thomas Vitale
+ * @author Jewoo Shin
  */
 class StTemplateRendererTests {
 
@@ -203,13 +206,10 @@ class StTemplateRendererTests {
 
 	/**
 	 * Tests that StringTemplate list variables with separators are correctly handled.
-	 * Note: Uses NONE validation mode because the current implementation of
-	 * getInputVariables incorrectly treats template options like 'separator' as variables
-	 * to be resolved.
 	 */
 	@Test
 	void shouldHandleListVariables() {
-		StTemplateRenderer renderer = StTemplateRenderer.builder().validationMode(ValidationMode.NONE).build();
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
 
 		Map<String, Object> variables = new HashMap<>();
 		variables.put("items", new String[] { "apple", "banana", "cherry" });
@@ -220,14 +220,11 @@ class StTemplateRendererTests {
 	}
 
 	/**
-	 * Tests rendering with StringTemplate options. Note: This uses NONE validation mode
-	 * because the current implementation of getInputVariables incorrectly treats template
-	 * options like 'separator' as variables to be resolved.
+	 * Tests rendering with StringTemplate options.
 	 */
 	@Test
 	void shouldRenderTemplateWithOptions() {
-		// Use NONE validation mode to bypass the issue with option detection
-		StTemplateRenderer renderer = StTemplateRenderer.builder().validationMode(ValidationMode.NONE).build();
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
 
 		Map<String, Object> variables = new HashMap<>();
 		variables.put("fruits", new String[] { "apple", "banana", "cherry" });
@@ -243,6 +240,101 @@ class StTemplateRendererTests {
 		assertThat(result).contains("apple");
 		assertThat(result).contains("banana");
 		assertThat(result).contains("cherry");
+	}
+
+	@Test
+	void shouldNotRequireAnonymousSubtemplateFormalArgumentAsExternalVariable() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> myMap = new LinkedHashMap<>();
+		myMap.put("a", 1);
+		myMap.put("b", 2);
+		myMap.put("c", 3);
+
+		String result = renderer.apply("{myMap:{k | key={k}, value={myMap.(k)}\n}}", Map.of("myMap", myMap));
+
+		assertThat(result).isEqualTo("key=a, value=1\nkey=b, value=2\nkey=c, value=3\n");
+	}
+
+	@Test
+	void shouldNotRequireAnonymousSubtemplateIndexArgumentsAsExternalVariables() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("items", List.of("a", "b"));
+
+		String result = renderer.apply("{items:{item | {i0}:{i}:{item}\n}}", variables);
+
+		assertThat(result).isEqualTo("0:1:a\n1:2:b\n");
+	}
+
+	@Test
+	void shouldRequireItInsideAnonymousSubtemplateWithFormalArgument() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("items", List.of("a"));
+
+		assertThatThrownBy(() -> renderer.apply("{items:{item | rootIt={it}, item={item}}}", variables))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("Not all variables were replaced in the template. Missing variable names are: [it]");
+	}
+
+	@Test
+	void shouldResolveItFromOuterScopeInsideAnonymousSubtemplateWithFormalArgument() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("items", List.of("a", "b"));
+		variables.put("it", "outer");
+
+		String result = renderer.apply("{items:{item | rootIt={it}, item={item}\n}}", variables);
+
+		assertThat(result).isEqualTo("rootIt=outer, item=a\nrootIt=outer, item=b\n");
+	}
+
+	@Test
+	void shouldNotRequireMultipleAnonymousSubtemplateFormalArgumentsAsExternalVariables() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("names", List.of("name1", "name2"));
+		variables.put("phones", List.of("phone1", "phone2"));
+
+		String result = renderer.apply("{names,phones:{n,p | {n}={p}\n}}", variables);
+
+		assertThat(result).isEqualTo("name1=phone1\nname2=phone2\n");
+	}
+
+	@Test
+	void shouldKeepNestedAnonymousSubtemplateScopesSeparate() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> item = new HashMap<>();
+		item.put("name", "item1");
+		item.put("values", List.of("a", "b"));
+
+		String result = renderer.apply("{items:{item | {item.values:{x | {item.name}:{x}\n}}}}",
+				Map.of("items", List.of(item)));
+
+		assertThat(result).isEqualTo("item1:a\nitem1:b\n");
+	}
+
+	@Test
+	void shouldRequireSameVariableNameOutsideAnonymousSubtemplateScope() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("myMap", Map.of("a", 1));
+
+		assertThatThrownBy(() -> renderer.apply("{myMap:{k | key={k}}}{k}", variables))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("Not all variables were replaced in the template. Missing variable names are: [k]");
+	}
+
+	@Test
+	void shouldRequireMissingVariableInsideAnonymousSubtemplateBody() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("items", List.of("a"));
+
+		assertThatThrownBy(() -> renderer.apply("{items:{item | {missing}}}", variables))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining(
+					"Not all variables were replaced in the template. Missing variable names are: [missing]");
 	}
 
 	/**


### PR DESCRIPTION
This updates `StTemplateRenderer` validation to derive required input variables from the StringTemplate AST instead of scanning the token stream. Declared anonymous subtemplate arguments, and ST-provided `i`/`i0`, are now scoped to the subtemplate body while identifiers outside that scope remain required external variables.

This also keeps option names such as `separator` out of the required variable set and adds regression coverage for map subtemplates, multiple subtemplate arguments, nested subtemplate scopes, missing variables, and `it` remaining an external variable unless provided.

Closes #6412
