### PR TITLE
Add support for 1-hour cache TTL in Bedrock Converse

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockCacheProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockCacheProperties.java
@@ -20,10 +20,13 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.bedrock.converse.api.BedrockCacheOptions;
 import org.springframework.ai.bedrock.converse.api.BedrockCacheStrategy;
+import org.springframework.ai.bedrock.converse.api.BedrockCacheTtl;
 
 public class BedrockCacheProperties {
 
 	private @Nullable BedrockCacheStrategy strategy;
+
+	private @Nullable BedrockCacheTtl ttl;
 
 	public @Nullable BedrockCacheStrategy getStrategy() {
 		return this.strategy;
@@ -33,8 +36,16 @@ public class BedrockCacheProperties {
 		this.strategy = strategy;
 	}
 
+	public @Nullable BedrockCacheTtl getTtl() {
+		return this.ttl;
+	}
+
+	public void setTtl(@Nullable BedrockCacheTtl ttl) {
+		this.ttl = ttl;
+	}
+
 	public BedrockCacheOptions toOptions() {
-		return BedrockCacheOptions.builder().strategy(this.strategy).build();
+		return BedrockCacheOptions.builder().strategy(this.strategy).ttl(this.ttl).build();
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
@@ -19,6 +19,8 @@ package org.springframework.ai.model.bedrock.converse.autoconfigure;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.bedrock.converse.BedrockProxyChatModel;
+import org.springframework.ai.bedrock.converse.api.BedrockCacheStrategy;
+import org.springframework.ai.bedrock.converse.api.BedrockCacheTtl;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -90,6 +92,24 @@ public class BedrockConverseProxyChatPropertiesTests {
 			.run(context -> {
 				assertThat(context.getBeansOfType(BedrockConverseProxyChatProperties.class)).isEmpty();
 				assertThat(context.getBeansOfType(BedrockProxyChatModel.class)).isEmpty();
+			});
+	}
+
+	@Test
+	public void cacheOptionsTest() {
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.ai.bedrock.converse.chat.cache-options.strategy=SYSTEM_ONLY",
+					"spring.ai.bedrock.converse.chat.cache-options.ttl=ONE_HOUR")
+			.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class,
+					ToolCallingAutoConfiguration.class))
+			.run(context -> {
+				var chatProperties = context.getBean(BedrockConverseProxyChatProperties.class);
+				assertThat(chatProperties.getCacheOptions().getStrategy()).isEqualTo(BedrockCacheStrategy.SYSTEM_ONLY);
+				assertThat(chatProperties.getCacheOptions().getTtl()).isEqualTo(BedrockCacheTtl.ONE_HOUR);
+
+				var options = chatProperties.toOptions();
+				assertThat(options.getCacheOptions().getStrategy()).isEqualTo(BedrockCacheStrategy.SYSTEM_ONLY);
+				assertThat(options.getCacheOptions().getTtl()).isEqualTo(BedrockCacheTtl.ONE_HOUR);
 			});
 	}
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -300,7 +300,11 @@ public class BedrockProxyChatModel implements ChatModel {
 
 				// Apply cache point if this is the last user message
 				if (shouldApplyCachePoint) {
-					CachePointBlock cachePoint = CachePointBlock.builder().type("default").build();
+					CachePointBlock.Builder cachePointBuilder = CachePointBlock.builder().type("default");
+					if (cacheOptions != null && cacheOptions.getTtl() != null) {
+						cachePointBuilder.ttl(cacheOptions.getTtl().getValue());
+					}
+					CachePointBlock cachePoint = cachePointBuilder.build();
 					contents.add(ContentBlock.fromCachePoint(cachePoint));
 					logger.debug("Applied cache point on last user message (conversation history caching)");
 				}
@@ -378,7 +382,11 @@ public class BedrockProxyChatModel implements ChatModel {
 
 			// SystemContentBlock is a union: text and cachePoint must be separate blocks.
 			if (i == cacheBoundaryIndex && shouldCacheSystem) {
-				CachePointBlock cachePoint = CachePointBlock.builder().type("default").build();
+				CachePointBlock.Builder cachePointBuilder = CachePointBlock.builder().type("default");
+				if (cacheOptions != null && cacheOptions.getTtl() != null) {
+					cachePointBuilder.ttl(cacheOptions.getTtl().getValue());
+				}
+				CachePointBlock cachePoint = cachePointBuilder.build();
 				SystemContentBlock cachePointBlock = SystemContentBlock.builder().cachePoint(cachePoint).build();
 				systemMessages.add(cachePointBlock);
 			}
@@ -418,7 +426,11 @@ public class BedrockProxyChatModel implements ChatModel {
 				// Tool is a UNION type - toolSpec and cachePoint must be separate objects
 				boolean isLastTool = (i == toolDefinitions.size() - 1);
 				if (isLastTool && shouldCacheTools) {
-					CachePointBlock cachePoint = CachePointBlock.builder().type("default").build();
+					CachePointBlock.Builder cachePointBuilder = CachePointBlock.builder().type("default");
+					if (cacheOptions != null && cacheOptions.getTtl() != null) {
+						cachePointBuilder.ttl(cacheOptions.getTtl().getValue());
+					}
+					CachePointBlock cachePoint = cachePointBuilder.build();
 					Tool cachePointTool = Tool.builder().cachePoint(cachePoint).build();
 					bedrockTools.add(cachePointTool);
 					logger.debug("Applied cache point after tool definitions");

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptions.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptions.java
@@ -56,9 +56,18 @@ public class BedrockCacheOptions {
 
 	private final boolean multiBlockSystemCaching;
 
+	private final @Nullable BedrockCacheTtl ttl;
+
+	@Deprecated
 	protected BedrockCacheOptions(@Nullable BedrockCacheStrategy strategy, boolean multiBlockSystemCaching) {
+		this(strategy, multiBlockSystemCaching, null);
+	}
+
+	protected BedrockCacheOptions(@Nullable BedrockCacheStrategy strategy, boolean multiBlockSystemCaching,
+			@Nullable BedrockCacheTtl ttl) {
 		this.strategy = (strategy != null ? strategy : BedrockCacheStrategy.NONE);
 		this.multiBlockSystemCaching = multiBlockSystemCaching;
+		this.ttl = ttl;
 	}
 
 	/**
@@ -94,6 +103,14 @@ public class BedrockCacheOptions {
 	}
 
 	/**
+	 * Gets the cache TTL.
+	 * @return the configured BedrockCacheTtl
+	 */
+	public @Nullable BedrockCacheTtl getTtl() {
+		return this.ttl;
+	}
+
+	/**
 	 * Builder for constructing BedrockCacheOptions instances.
 	 */
 	public static class Builder {
@@ -101,6 +118,8 @@ public class BedrockCacheOptions {
 		private @Nullable BedrockCacheStrategy strategy;
 
 		private boolean multiBlockSystemCaching = false;
+
+		private @Nullable BedrockCacheTtl ttl;
 
 		/**
 		 * Sets the caching strategy.
@@ -128,11 +147,21 @@ public class BedrockCacheOptions {
 		}
 
 		/**
+		 * Sets the cache TTL (Time To Live).
+		 * @param ttl the BedrockCacheTtl to use
+		 * @return this Builder instance
+		 */
+		public Builder ttl(@Nullable BedrockCacheTtl ttl) {
+			this.ttl = ttl;
+			return this;
+		}
+
+		/**
 		 * Builds the BedrockCacheOptions instance.
 		 * @return the configured BedrockCacheOptions
 		 */
 		public BedrockCacheOptions build() {
-			return new BedrockCacheOptions(this.strategy, this.multiBlockSystemCaching);
+			return new BedrockCacheOptions(this.strategy, this.multiBlockSystemCaching, this.ttl);
 		}
 
 	}

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/BedrockCacheTtl.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/BedrockCacheTtl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse.api;
+
+/**
+ * AWS Bedrock cache TTL options for specifying how long cached prompts remain valid.
+ *
+ * @author Yash Rawal
+ * @since 1.2.0
+ * @see <a href=
+ * "https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html">AWS Bedrock
+ * Prompt Caching</a>
+ */
+public enum BedrockCacheTtl {
+
+	FIVE_MINUTES("5m"),
+
+	ONE_HOUR("1h");
+
+	private final String value;
+
+	BedrockCacheTtl(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+}

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
 
 import org.springframework.ai.bedrock.converse.api.BedrockCacheOptions;
 import org.springframework.ai.bedrock.converse.api.BedrockCacheStrategy;
+import org.springframework.ai.bedrock.converse.api.BedrockCacheTtl;
 import org.springframework.ai.bedrock.converse.api.MediaFetcher;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -327,6 +328,30 @@ class BedrockProxyChatModelTest {
 		assertThat(system).hasSize(2);
 		assertThat(system.get(0).cachePoint()).isNull();
 		assertThat(system.get(1).cachePoint()).isNull();
+	}
+
+	@Test
+	void shouldApplyCacheTtlOnCachePointBlock() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(BedrockCacheOptions.builder()
+				.strategy(BedrockCacheStrategy.SYSTEM_ONLY)
+				.ttl(BedrockCacheTtl.ONE_HOUR)
+				.build())
+			.build();
+
+		Prompt prompt = new Prompt(List.of(new SystemMessage("Only system message."), new UserMessage("Question?")),
+				options);
+
+		ConverseRequest request = model.createRequest(prompt);
+		List<SystemContentBlock> system = request.system();
+
+		assertThat(system).hasSize(2);
+		assertThat(system.get(0).text()).isEqualTo("Only system message.");
+		assertThat(system.get(1).cachePoint()).isNotNull();
+		assertThat(system.get(1).cachePoint().typeAsString()).isEqualTo("default");
+		assertThat(system.get(1).cachePoint().ttlAsString()).isEqualTo("1h");
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -301,6 +301,7 @@ The `multiBlockSystemCaching` option solves this by placing the cache point *aft
 BedrockCacheOptions cacheOptions = BedrockCacheOptions.builder()
     .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
     .multiBlockSystemCaching(true)
+    .ttl(BedrockCacheTtl.ONE_HOUR)
     .build();
 
 BedrockChatOptions chatOptions = BedrockChatOptions.builder()
@@ -672,8 +673,9 @@ Even small changes will require a new cache entry.
 
 5. **Strategic Cache Placement**: The implementation automatically places cache breakpoints at optimal locations based on your chosen strategy, ensuring compliance with AWS Bedrock's 4-breakpoint limit.
 
-6. **Cache Lifetime**: AWS Bedrock caches have a fixed 5-minute TTL (Time To Live).
+6. **Cache Lifetime**: AWS Bedrock caches have a default 5-minute TTL (Time To Live), but they also support a 1-hour TTL duration.
 Each cache access resets the timer.
+This can be configured using `BedrockCacheTtl` on `BedrockCacheOptions` or via the `spring.ai.bedrock.converse.chat.cache-options.ttl` property.
 
 7. **Model Compatibility**: Be aware of model-specific limitations:
    - **Claude models**: Support all caching strategies


### PR DESCRIPTION
Add BedrockCacheTtl enum and support configuring ONE_HOUR (1h) and FIVE_MINUTES (5m) caching durations. Propagate the TTL selection to the CachePointBlock in BedrockProxyChatModel and expose the configuration as a spring.ai.bedrock.converse.chat.cache-options.ttl property.

Fixes #5604

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc