### PR TITLE
Remove Scheduler and event loop shutdown from MCP tests

### DIFF
--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseIT.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseIT.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.provider.Arguments;
-import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
 import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
@@ -100,11 +99,9 @@ class WebMvcSseIT extends AbstractMcpClientServerIntegrationTests {
 
 	@AfterEach
 	public void after() {
-		reactor.netty.http.HttpResources.disposeLoopsAndConnections();
 		if (this.mcpServerTransportProvider != null) {
 			this.mcpServerTransportProvider.closeGracefully().block();
 		}
-		Schedulers.shutdownNow();
 		if (this.tomcatServer.appContext() != null) {
 			this.tomcatServer.appContext().close();
 		}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcStatelessIT.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcStatelessIT.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.provider.Arguments;
-import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
 import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStatelessServerTransport;
@@ -106,11 +105,9 @@ class WebMvcStatelessIT extends AbstractStatelessIntegrationTests {
 
 	@AfterEach
 	public void after() {
-		reactor.netty.http.HttpResources.disposeLoopsAndConnections();
 		if (this.mcpServerTransport != null) {
 			this.mcpServerTransport.closeGracefully().block();
 		}
-		Schedulers.shutdownNow();
 		if (this.tomcatServer.appContext() != null) {
 			this.tomcatServer.appContext().close();
 		}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcStreamableIT.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcStreamableIT.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.provider.Arguments;
-import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
 import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider;
@@ -109,11 +108,9 @@ class WebMvcStreamableIT extends AbstractMcpClientServerIntegrationTests {
 
 	@AfterEach
 	public void after() {
-		reactor.netty.http.HttpResources.disposeLoopsAndConnections();
 		if (this.mcpServerTransportProvider != null) {
 			this.mcpServerTransportProvider.closeGracefully().block();
 		}
-		Schedulers.shutdownNow();
 		if (this.tomcatServer.appContext() != null) {
 			this.tomcatServer.appContext().close();
 		}


### PR DESCRIPTION
These could contribute to test flakiness as shutting down Threads for the entire JVM leads to lazy re-creation of them on next use in another test and can trigger failures.