### PR TITLE
Align `Document` Jackson deserialization with serialized properties

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/document/Document.java
@@ -126,39 +126,50 @@ public class Document {
 	@JsonIgnore
 	private ContentFormatter contentFormatter = DEFAULT_CONTENT_FORMATTER;
 
-	@JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-	public Document(@JsonProperty("content") @Nullable String content) {
-		this(content, new HashMap<>());
+	public Document(@Nullable String text) {
+		this(text, new HashMap<>());
 	}
 
 	public Document(@Nullable String text, Map<String, Object> metadata) {
-		this(new RandomIdGenerator().generateId(), text, null, metadata, null);
+		this(new RandomIdGenerator().generateId(), text, null, metadata, null, false);
 	}
 
 	public Document(String id, @Nullable String text, Map<String, Object> metadata) {
-		this(id, text, null, metadata, null);
+		this(id, text, null, metadata, null, false);
 	}
 
 	public Document(@Nullable Media media, Map<String, Object> metadata) {
-		this(new RandomIdGenerator().generateId(), null, media, metadata, null);
+		this(new RandomIdGenerator().generateId(), null, media, metadata, null, false);
 	}
 
 	public Document(String id, @Nullable Media media, Map<String, Object> metadata) {
-		this(id, null, media, metadata, null);
+		this(id, null, media, metadata, null, false);
 	}
 
-	private Document(String id, @Nullable String text, @Nullable Media media, Map<String, Object> metadata,
-			@Nullable Double score) {
-		Assert.hasText(id, "id cannot be null or empty");
-		Assert.notNull(metadata, "metadata cannot be null");
-		Assert.noNullElements(metadata.keySet(), "metadata cannot have null keys");
-		Assert.noNullElements(metadata.values(), "metadata cannot have null values");
+	@JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+	private Document(@JsonProperty("id") @Nullable String id, @JsonProperty("text") @Nullable String text,
+			@JsonProperty("media") @Nullable Media media,
+			@JsonProperty("metadata") @Nullable Map<String, Object> metadata,
+			@JsonProperty("score") @Nullable Double score) {
+		this(id, text, media, metadata, score, true);
+	}
+
+	private Document(@Nullable String id, @Nullable String text, @Nullable Media media,
+			@Nullable Map<String, Object> metadata, @Nullable Double score, boolean applyJacksonDefaults) {
+		String documentId = applyJacksonDefaults && !StringUtils.hasText(id) ? new RandomIdGenerator().generateId()
+				: id;
+		Map<String, Object> documentMetadata = applyJacksonDefaults && metadata == null ? new HashMap<>() : metadata;
+
+		Assert.hasText(documentId, "id cannot be null or empty");
+		Assert.notNull(documentMetadata, "metadata cannot be null");
+		Assert.noNullElements(documentMetadata.keySet(), "metadata cannot have null keys");
+		Assert.noNullElements(documentMetadata.values(), "metadata cannot have null values");
 		Assert.isTrue(text != null ^ media != null, "exactly one of text or media must be specified");
 
-		this.id = id;
+		this.id = documentId;
 		this.text = text;
 		this.media = media;
-		this.metadata = new HashMap<>(metadata);
+		this.metadata = new HashMap<>(documentMetadata);
 		this.score = score;
 	}
 

--- a/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.content.Media;
 import org.springframework.ai.document.id.IdGenerator;
+import org.springframework.ai.util.JacksonUtils;
 import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -207,6 +208,22 @@ public class DocumentTests {
 			.build();
 
 		assertThat(document.getMetadata()).containsEntry("key1", "value1").containsEntry("key2", "value2");
+	}
+
+	@Test
+	void serializesAndDeserializesTextDocument() throws Exception {
+		Document document = Document.builder()
+			.id("customId")
+			.text("Test content")
+			.metadata("key", "value")
+			.score(0.95)
+			.build();
+
+		var jsonMapper = JacksonUtils.getDefaultJsonMapper();
+		String json = jsonMapper.writeValueAsString(document);
+		Document restored = jsonMapper.readValue(json, Document.class);
+
+		assertThat(restored).usingRecursiveComparison().isEqualTo(document);
 	}
 
 	private static Media getMedia() {


### PR DESCRIPTION
## Summary

Align `Document` Jackson deserialization with the properties emitted
during serialization.

Fixes #6433

## Problem

`Document` serializes text content as `text`, but deserialization used
a Jackson creator that expected `content`. That breaks round-trip
serialization/deserialization and does not align deserialization with
serialized properties such as `id`, `metadata`, and `score`.

## Changes

- replace the Jackson creator with a property-based creator for `id`,
  `text`, `media`, `metadata`, and `score`
- keep Jackson-only defaults for missing `id` and `metadata`
- preserve the existing validation behavior of the public constructors
- add a regression test covering `Document` round-trip serialization
  and deserialization

## Testing

- `./mvnw -pl spring-ai-commons -Dmaven.build.cache.enabled=false test`
- `./mvnw -ntp -B -U -Dmaven.build.cache.enabled=false package`