### PR TITLE
Resolve `@McpProgressToken` parameters from the request in prompt callbacks

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AbstractMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AbstractMcpPromptMethodCallback.java
@@ -210,11 +210,7 @@ public abstract class AbstractMcpPromptMethodCallback {
 		// First, handle @McpProgressToken annotated parameters
 		for (int i = 0; i < parameters.length; i++) {
 			if (parameters[i].isAnnotationPresent(McpProgressToken.class)) {
-				// GetPromptRequest doesn't have a progressToken method in the current
-				// spec
-				// Set to null for now - this would need to be updated when the spec
-				// supports it
-				args[i] = null;
+				args[i] = request != null ? request.progressToken() : null;
 			}
 		}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallbackTests.java
@@ -39,6 +39,7 @@ import reactor.test.StepVerifier;
 
 import org.springframework.ai.mcp.annotation.McpArg;
 import org.springframework.ai.mcp.annotation.McpMeta;
+import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpPrompt;
 import org.springframework.ai.mcp.annotation.context.McpAsyncRequestContext;
 import org.springframework.ai.mcp.annotation.context.McpSyncRequestContext;
@@ -549,6 +550,69 @@ public class AsyncMcpPromptMethodCallbackTests {
 					"Sync complete methods should use McpSyncRequestContext instead of McpAsyncRequestContext parameter");
 	}
 
+	@Test
+	public void testCallbackInjectsProgressTokenFromRequest() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+		Method method = TestPromptProvider.class.getMethod("getPromptWithProgressToken", String.class, String.class);
+
+		Prompt prompt = createTestPrompt("progress-token", "A prompt with progress token");
+
+		BiFunction<McpAsyncServerExchange, GetPromptRequest, Mono<GetPromptResult>> callback = AsyncMcpPromptMethodCallback
+			.builder()
+			.method(method)
+			.bean(provider)
+			.prompt(prompt)
+			.build();
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		Map<String, Object> args = new HashMap<>();
+		args.put("name", "John");
+		GetPromptRequest request = new GetPromptRequest("progress-token", args,
+				Map.of("progressToken", "progress-123"));
+
+		Mono<GetPromptResult> resultMono = callback.apply(exchange, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.description()).isEqualTo("Progress token prompt");
+			assertThat(result.messages()).hasSize(1);
+			PromptMessage message = result.messages().get(0);
+			assertThat(message.role()).isEqualTo(Role.ASSISTANT);
+			assertThat(((TextContent) message.content()).text()).isEqualTo("Hello John (token: progress-123)");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testCallbackWithProgressTokenNull() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+		Method method = TestPromptProvider.class.getMethod("getPromptWithProgressToken", String.class, String.class);
+
+		Prompt prompt = createTestPrompt("progress-token", "A prompt with progress token");
+
+		BiFunction<McpAsyncServerExchange, GetPromptRequest, Mono<GetPromptResult>> callback = AsyncMcpPromptMethodCallback
+			.builder()
+			.method(method)
+			.bean(provider)
+			.prompt(prompt)
+			.build();
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		Map<String, Object> args = new HashMap<>();
+		args.put("name", "John");
+		// No progress token in the request, so the parameter is null
+		GetPromptRequest request = GetPromptRequest.builder("progress-token").arguments(args).build();
+
+		Mono<GetPromptResult> resultMono = callback.apply(exchange, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.messages()).hasSize(1);
+			PromptMessage message = result.messages().get(0);
+			assertThat(message.role()).isEqualTo(Role.ASSISTANT);
+			assertThat(((TextContent) message.content()).text()).isEqualTo("Hello John (no token)");
+		}).verifyComplete();
+	}
+
 	private static class TestPromptProvider {
 
 		@McpPrompt(name = "greeting", description = "A simple greeting prompt")
@@ -597,6 +661,14 @@ public class AsyncMcpPromptMethodCallbackTests {
 									.build())))
 				.description("Mixed arguments prompt")
 				.build();
+		}
+
+		@McpPrompt(name = "progress-token", description = "A prompt with progress token")
+		public Mono<GetPromptResult> getPromptWithProgressToken(@McpProgressToken String progressToken,
+				@McpArg(name = "name", description = "The user's name", required = true) String name) {
+			String tokenInfo = progressToken != null ? " (token: " + progressToken + ")" : " (no token)";
+			return Mono.just(new GetPromptResult("Progress token prompt",
+					List.of(new PromptMessage(Role.ASSISTANT, new TextContent("Hello " + name + tokenInfo)))));
 		}
 
 		@McpPrompt(name = "list-messages", description = "A prompt returning a list of messages")

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncStatelessMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncStatelessMcpPromptMethodCallbackTests.java
@@ -39,6 +39,7 @@ import reactor.test.StepVerifier;
 
 import org.springframework.ai.mcp.annotation.McpArg;
 import org.springframework.ai.mcp.annotation.McpMeta;
+import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpPrompt;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -781,6 +782,38 @@ public class AsyncStatelessMcpPromptMethodCallbackTests {
 			.hasMessageContaining("Use McpTransportContext instead");
 	}
 
+	@Test
+	public void testCallbackInjectsProgressTokenFromRequest() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+		Method method = TestPromptProvider.class.getMethod("getPromptWithProgressToken", String.class, String.class);
+
+		Prompt prompt = createTestPrompt("progress-token", "A prompt with progress token");
+
+		BiFunction<McpTransportContext, GetPromptRequest, Mono<GetPromptResult>> callback = AsyncStatelessMcpPromptMethodCallback
+			.builder()
+			.method(method)
+			.bean(provider)
+			.prompt(prompt)
+			.build();
+
+		McpTransportContext context = mock(McpTransportContext.class);
+		Map<String, Object> args = new HashMap<>();
+		args.put("name", "John");
+		GetPromptRequest request = new GetPromptRequest("progress-token", args,
+				Map.of("progressToken", "progress-123"));
+
+		Mono<GetPromptResult> resultMono = callback.apply(context, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.description()).isEqualTo("Progress token prompt");
+			assertThat(result.messages()).hasSize(1);
+			PromptMessage message = result.messages().get(0);
+			assertThat(message.role()).isEqualTo(Role.ASSISTANT);
+			assertThat(((TextContent) message.content()).text()).isEqualTo("Hello John (token: progress-123)");
+		}).verifyComplete();
+	}
+
 	private static class TestPromptProvider {
 
 		@McpPrompt(name = "greeting", description = "A simple greeting prompt")
@@ -799,6 +832,14 @@ public class AsyncStatelessMcpPromptMethodCallbackTests {
 						TextContent.builder("Hello with context from " + request.name()).build())))
 				.description("Greeting with context")
 				.build();
+		}
+
+		@McpPrompt(name = "progress-token", description = "A prompt with progress token")
+		public GetPromptResult getPromptWithProgressToken(@McpProgressToken String progressToken,
+				@McpArg(name = "name", description = "The user's name", required = true) String name) {
+			String tokenInfo = progressToken != null ? " (token: " + progressToken + ")" : " (no token)";
+			return new GetPromptResult("Progress token prompt",
+					List.of(new PromptMessage(Role.ASSISTANT, new TextContent("Hello " + name + tokenInfo))));
 		}
 
 		@McpPrompt(name = "arguments-greeting", description = "A greeting prompt with arguments")

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallbackTests.java
@@ -437,7 +437,7 @@ public class SyncMcpPromptMethodCallbackTests {
 	}
 
 	@Test
-	public void testCallbackWithProgressToken() throws Exception {
+	public void testCallbackWithProgressTokenNull() throws Exception {
 		TestPromptProvider provider = new TestPromptProvider();
 		Method method = TestPromptProvider.class.getMethod("getPromptWithProgressToken", String.class, String.class);
 
@@ -453,8 +453,7 @@ public class SyncMcpPromptMethodCallbackTests {
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
 		Map<String, Object> args = new HashMap<>();
 		args.put("name", "John");
-		// Note: GetPromptRequest doesn't have progressToken in current spec, so it will
-		// be null
+		// This request carries no progress token, so the parameter resolves to null
 		GetPromptRequest request = GetPromptRequest.builder("progress-token").arguments(args).build();
 
 		GetPromptResult result = callback.apply(exchange, request);
@@ -464,8 +463,38 @@ public class SyncMcpPromptMethodCallbackTests {
 		assertThat(result.messages()).hasSize(1);
 		PromptMessage message = result.messages().get(0);
 		assertThat(message.role()).isEqualTo(Role.ASSISTANT);
-		// Since GetPromptRequest doesn't have progressToken, it should be null
+		// No progress token in the request, so the parameter is null
 		assertThat(((TextContent) message.content()).text()).isEqualTo("Hello John (no token)");
+	}
+
+	@Test
+	public void testCallbackInjectsProgressTokenFromRequest() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+		Method method = TestPromptProvider.class.getMethod("getPromptWithProgressToken", String.class, String.class);
+
+		Prompt prompt = createTestPrompt("progress-token", "A prompt with progress token");
+
+		BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> callback = SyncMcpPromptMethodCallback
+			.builder()
+			.method(method)
+			.bean(provider)
+			.prompt(prompt)
+			.build();
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		Map<String, Object> args = new HashMap<>();
+		args.put("name", "John");
+		GetPromptRequest request = new GetPromptRequest("progress-token", args,
+				Map.of("progressToken", "progress-123"));
+
+		GetPromptResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.description()).isEqualTo("Progress token prompt");
+		assertThat(result.messages()).hasSize(1);
+		PromptMessage message = result.messages().get(0);
+		assertThat(message.role()).isEqualTo(Role.ASSISTANT);
+		assertThat(((TextContent) message.content()).text()).isEqualTo("Hello John (token: progress-123)");
 	}
 
 	@Test
@@ -495,7 +524,7 @@ public class SyncMcpPromptMethodCallbackTests {
 		assertThat(result.messages()).hasSize(1);
 		PromptMessage message = result.messages().get(0);
 		assertThat(message.role()).isEqualTo(Role.ASSISTANT);
-		// Since GetPromptRequest doesn't have progressToken, it should be null
+		// No progress token in the request, so the parameter is null
 		assertThat(((TextContent) message.content()).text())
 			.isEqualTo("Hello John from mixed-with-progress (no token)");
 	}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncStatelessMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncStatelessMcpPromptMethodCallbackTests.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.annotation.McpArg;
 import org.springframework.ai.mcp.annotation.McpMeta;
+import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpPrompt;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -591,6 +592,36 @@ public class SyncStatelessMcpPromptMethodCallbackTests {
 			.hasMessageContaining("Use McpTransportContext instead");
 	}
 
+	@Test
+	public void testCallbackInjectsProgressTokenFromRequest() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+		Method method = TestPromptProvider.class.getMethod("getPromptWithProgressToken", String.class, String.class);
+
+		Prompt prompt = createTestPrompt("progress-token", "A prompt with progress token");
+
+		BiFunction<McpTransportContext, GetPromptRequest, GetPromptResult> callback = SyncStatelessMcpPromptMethodCallback
+			.builder()
+			.method(method)
+			.bean(provider)
+			.prompt(prompt)
+			.build();
+
+		McpTransportContext context = mock(McpTransportContext.class);
+		Map<String, Object> args = new HashMap<>();
+		args.put("name", "John");
+		GetPromptRequest request = new GetPromptRequest("progress-token", args,
+				Map.of("progressToken", "progress-123"));
+
+		GetPromptResult result = callback.apply(context, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.description()).isEqualTo("Progress token prompt");
+		assertThat(result.messages()).hasSize(1);
+		PromptMessage message = result.messages().get(0);
+		assertThat(message.role()).isEqualTo(Role.ASSISTANT);
+		assertThat(((TextContent) message.content()).text()).isEqualTo("Hello John (token: progress-123)");
+	}
+
 	private static class TestPromptProvider {
 
 		@McpPrompt(name = "greeting", description = "A simple greeting prompt")
@@ -609,6 +640,14 @@ public class SyncStatelessMcpPromptMethodCallbackTests {
 						TextContent.builder("Hello with context from " + request.name()).build())))
 				.description("Greeting with context")
 				.build();
+		}
+
+		@McpPrompt(name = "progress-token", description = "A prompt with progress token")
+		public GetPromptResult getPromptWithProgressToken(@McpProgressToken String progressToken,
+				@McpArg(name = "name", description = "The user's name", required = true) String name) {
+			String tokenInfo = progressToken != null ? " (token: " + progressToken + ")" : " (no token)";
+			return new GetPromptResult("Progress token prompt",
+					List.of(new PromptMessage(Role.ASSISTANT, new TextContent("Hello " + name + tokenInfo))));
 		}
 
 		@McpPrompt(name = "arguments-greeting", description = "A greeting prompt with arguments")


### PR DESCRIPTION
## Summary

In `mcp-annotations`, a `@McpProgressToken`-annotated parameter on an `@McpPrompt` method is set to `null` even when the client supplies a progress token in the request `_meta`, so the handler cannot read it.

`AbstractMcpPromptMethodCallback#buildArgs` uses a `null` placeholder for these parameters:

```java
// AbstractMcpPromptMethodCallback#buildArgs (before)
if (parameters[i].isAnnotationPresent(McpProgressToken.class)) {
    // GetPromptRequest doesn't have a progressToken method in the current spec
    // Set to null for now - this would need to be updated when the spec supports it
    args[i] = null;
}
```

That placeholder is now stale: `GetPromptRequest` implements `Request`, whose default `progressToken()` reads `_meta.progressToken`. The resource and complete callbacks already read the token via `request.progressToken()`; this change resolves it in the prompt callbacks too.

## Behavior

Given a prompt handler that declares a `@McpProgressToken` parameter:

```java
@McpPrompt(name = "summarize")
GetPromptResult summarize(@McpProgressToken String token,
        @McpArg(name = "text") String text) {
    // before: token is always null, even when the client sent one in _meta
    // after:  token is the client's request _meta.progressToken
    ...
}
```

| Request | `@McpProgressToken` parameter (before) | (after) |
|---|---|---|
| `_meta.progressToken = "progress-123"` | `null` | `"progress-123"` |
| no progress token | `null` | `null` |

A prompt handler that declares `@McpProgressToken` to correlate progress notifications with the client's token does not currently receive it. After this change, prompt callbacks resolve it consistently with the resource and complete callbacks.

## Change

`AbstractMcpPromptMethodCallback#buildArgs` now resolves the parameter from the request, mirroring the resource callback:

```java
if (parameters[i].isAnnotationPresent(McpProgressToken.class)) {
    args[i] = request != null ? request.progressToken() : null;
}
```

The `request != null` guard matches the adjacent `McpMeta` branch in the same method (`request != null ? new McpMeta(request.meta()) : new McpMeta(null)`).

All four prompt callbacks (sync/async, stateful/stateless) share this base `buildArgs`, so the single change applies to all of them.

## Tests

Added regression coverage across all four prompt callback variants (sync/async, stateful/stateless), matching the resource callback coverage. The tests cover the token-present case across all variants and the no-token case where relevant.

## Context

The prompt, resource, and complete callbacks were introduced together in #5567; this change brings the prompt callbacks' progress-token handling in line with the other two.