### PR TITLE
Validate PgVectorStore table schema after initialization

### DIFF
--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorSchemaValidator.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorSchemaValidator.java
@@ -33,6 +33,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * @author Muthukumaran Navaneethakrishnan
  * @author Christian Tzolov
  * @author Yanming Zhou
+ * @author Siarhei Dudzin
  * @since 1.0.0
  */
 class PgVectorSchemaValidator {
@@ -78,8 +79,7 @@ class PgVectorSchemaValidator {
 		}
 	}
 
-	void validateTableSchema(String schemaName, String tableName, int dimensions) {
-
+	void validateNames(String schemaName, String tableName) {
 		if (!isValidNameForDatabaseObject(schemaName)) {
 			throw new IllegalArgumentException(
 					"Schema name should only contain alphanumeric characters and underscores");
@@ -88,6 +88,11 @@ class PgVectorSchemaValidator {
 			throw new IllegalArgumentException(
 					"Table name should only contain alphanumeric characters and underscores");
 		}
+	}
+
+	void validateTableSchema(String schemaName, String tableName, int dimensions) {
+
+		validateNames(schemaName, tableName);
 
 		if (!isTableExists(schemaName, tableName)) {
 			throw new IllegalStateException("Table " + tableName + " does not exist in schema " + schemaName);

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
@@ -153,6 +153,7 @@ import org.springframework.util.StringUtils;
  * @author YeongMin Song
  * @author Jonghoon Park
  * @author Yanming Zhou
+ * @author Siarhei Dudzin
  * @since 1.0.0
  */
 public class PgVectorStore extends AbstractObservationVectorStore implements InitializingBean {
@@ -411,14 +412,16 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 			logger.info("vectorTableValidationsEnabled " + this.schemaValidation);
 		}
 
+		// Validate names before any SQL runs, the table structure after initialization
 		if (this.schemaValidation) {
-			this.schemaValidator.validateTableSchema(this.getSchemaName(), this.getVectorTableName(), this.dimensions);
+			this.schemaValidator.validateNames(this.getSchemaName(), this.getVectorTableName());
 		}
 
 		if (!this.initializeSchema) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Skipping the schema initialization for the table: " + this.getFullyQualifiedTableName());
 			}
+			validateTableSchemaIfEnabled();
 			return;
 		}
 
@@ -451,6 +454,14 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 					CREATE INDEX IF NOT EXISTS %s ON %s USING %s (embedding %s)
 					""", this.getVectorIndexName(), this.getFullyQualifiedTableName(), this.createIndexMethod,
 					this.getDistanceType().index));
+		}
+
+		validateTableSchemaIfEnabled();
+	}
+
+	private void validateTableSchemaIfEnabled() {
+		if (this.schemaValidation) {
+			this.schemaValidator.validateTableSchema(this.getSchemaName(), this.getVectorTableName(), this.dimensions);
 		}
 	}
 

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorSchemaValidatorIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorSchemaValidatorIT.java
@@ -21,6 +21,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
+import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -28,8 +29,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Yanming Zhou
@@ -67,6 +70,19 @@ public class PgVectorSchemaValidatorIT {
 			.isThrownBy(() -> this.schemaValidator.validateTableSchema("public", "vector_store", 2048))
 			.withMessageContaining("1024");
 
+	}
+
+	@Test
+	void schemaValidationWithInitializeSchemaSucceedsOnFreshDatabase() {
+		PgVectorStore vectorStore = PgVectorStore.builder(this.jdbcTemplate, mock(EmbeddingModel.class))
+			.vectorTableName("fresh_vector_store")
+			.dimensions(1024)
+			.initializeSchema(true)
+			.vectorTableValidationsEnabled(true)
+			.build();
+
+		assertThatNoException().isThrownBy(vectorStore::afterPropertiesSet);
+		assertThat(this.schemaValidator.isTableExists("public", "fresh_vector_store")).isTrue();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreCustomNamesIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreCustomNamesIT.java
@@ -115,7 +115,7 @@ public class PgVectorStoreCustomNamesIT {
 	}
 
 	@Test
-	public void shouldFailWhenCustomTableIsAbsentAndValidationEnabled() {
+	public void shouldCreateCustomTableWhenAbsentAndValidationEnabled() {
 
 		String tableName = "customvectortable";
 
@@ -125,9 +125,9 @@ public class PgVectorStoreCustomNamesIT {
 
 			.run(context -> {
 
-				assertThat(context).hasFailed();
-				assertThat(context.getStartupFailure()).hasCauseInstanceOf(IllegalStateException.class)
-					.hasMessageContaining(tableName + " does not exist");
+				assertThat(context).hasNotFailed();
+				assertThat(isTableExists(context, tableName)).isTrue();
+				dropTableByName(context, tableName);
 
 			});
 	}

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreTests.java
@@ -35,10 +35,12 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -79,6 +81,23 @@ public class PgVectorStoreTests {
 	})
 	void isValidTable(String tableName, Boolean expected) {
 		assertThat(PgVectorSchemaValidator.isValidNameForDatabaseObject(tableName)).isEqualTo(expected);
+	}
+
+	@Test
+	void invalidTableNameIsRejectedBeforeAnySqlReachesTheDatabase() {
+		var jdbcTemplate = mock(JdbcTemplate.class);
+		var embeddingModel = mock(EmbeddingModel.class);
+
+		// Names are interpolated into the initialization SQL, reject them before it runs
+		var vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel)
+			.vectorTableName("vector_store; DROP TABLE users;")
+			.dimensions(1024)
+			.initializeSchema(true)
+			.vectorTableValidationsEnabled(true)
+			.build();
+
+		assertThatIllegalArgumentException().isThrownBy(vectorStore::afterPropertiesSet);
+		verify(jdbcTemplate, never()).execute(anyString());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #5228

### Problem

`PgVectorStore.afterPropertiesSet()` validated the table schema before the schema initialization had a chance to create the table. With both `schemaValidation` and `initializeSchema` enabled, the first startup against a fresh database failed with:

```
IllegalStateException: Table <name> does not exist in schema <schema>
```

This combination is reasonable. The reference documentation actively recommends enabling schema validation when using a custom schema or table name, without restricting it to pre-initialized databases (see [PGvector / Configuration properties](https://docs.spring.io/spring-ai/reference/api/vectordbs/pgvector.html)):

> TIP: If you configure a custom schema and/or table name, consider enabling schema validation by setting `spring.ai.vectorstore.pgvector.schema-validation=true`. This ensures the correctness of the names and reduces the risk of SQL injection attacks.

### Fix

Split validation into two phases:

* Names (the SQL injection guard) are validated before any SQL is executed, since the schema and table names are interpolated into the initialization statements.
* Table structure (existence, columns, dimensions) is validated after the schema initialization has had a chance to create the table.

Validate-only mode (`initializeSchema=false`) is unchanged: a missing table is still reported.

### Tests

* New IT `schemaValidationWithInitializeSchemaSucceedsOnFreshDatabase` reproduces the reported failure (both flags plus a fresh DB) and passes with the fix.
* New unit test asserts that an invalid table name is rejected before any SQL reaches the database, preserving the injection guard.
* `PgVectorStoreCustomNamesIT` updated: the case that previously asserted startup failure now asserts the table is created, since its configuration enables `initializeSchema`.

Verified with `./mvnw -pl vector-stores/spring-ai-pgvector-store -Pintegration-tests verify` (Testcontainers).
