### PR TITLE
Add Google Vertex AI backend support for Anthropic Claude

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/pom.xml
@@ -40,6 +40,15 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 
+		<!-- Anthropic SDK Vertex AI backend (optional, only needed for
+		     spring.ai.anthropic.backend=vertex-ai) -->
+		<dependency>
+			<groupId>com.anthropic</groupId>
+			<artifactId>anthropic-java-vertex</artifactId>
+			<version>${anthropic-sdk.version}</version>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicBackendType.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicBackendType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.anthropic.autoconfigure;
+
+/**
+ * Enumeration of supported Anthropic API backends.
+ *
+ * @author dragonfsky
+ * @since 2.0.0
+ */
+public enum AnthropicBackendType {
+
+	/**
+	 * Direct Anthropic API ({@code api.anthropic.com}) using an API key.
+	 */
+	ANTHROPIC,
+
+	/**
+	 * Anthropic Claude models hosted on Google Cloud Vertex AI, accessed via GCP
+	 * credentials and project configuration.
+	 */
+	VERTEX_AI
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfiguration.java
@@ -50,6 +50,8 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnClass(AnthropicClient.class)
 @ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.ANTHROPIC,
 		matchIfMissing = true)
+@ConditionalOnProperty(prefix = AnthropicConnectionProperties.CONFIG_PREFIX, name = "backend",
+		havingValue = "anthropic", matchIfMissing = true)
 public class AnthropicChatAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicConnectionProperties.java
@@ -24,12 +24,14 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
 
 /**
  * Anthropic connection properties.
  *
  * @author Soby Chacko
  * @author Sebastien Deleuze
+ * @author dragonfsky
  * @since 2.0.0
  */
 @ConfigurationProperties(AnthropicConnectionProperties.CONFIG_PREFIX)
@@ -48,6 +50,19 @@ public class AnthropicConnectionProperties {
 	private @Nullable Proxy proxy;
 
 	private Map<String, String> customHeaders = new HashMap<>();
+
+	/**
+	 * Backend type for the Anthropic API. Defaults to
+	 * {@link AnthropicBackendType#ANTHROPIC} (direct API). Set to
+	 * {@link AnthropicBackendType#VERTEX_AI} for Google Vertex AI.
+	 */
+	private AnthropicBackendType backend = AnthropicBackendType.ANTHROPIC;
+
+	/**
+	 * Vertex AI specific configuration. Only used when {@link #backend} is
+	 * {@link AnthropicBackendType#VERTEX_AI}.
+	 */
+	private Vertex vertex = new Vertex();
 
 	public @Nullable String getBaseUrl() {
 		return this.baseUrl;
@@ -95,6 +110,70 @@ public class AnthropicConnectionProperties {
 
 	public void setCustomHeaders(Map<String, String> customHeaders) {
 		this.customHeaders = customHeaders;
+	}
+
+	public AnthropicBackendType getBackend() {
+		return this.backend;
+	}
+
+	public void setBackend(AnthropicBackendType backend) {
+		this.backend = backend;
+	}
+
+	public Vertex getVertex() {
+		return this.vertex;
+	}
+
+	public void setVertex(Vertex vertex) {
+		this.vertex = vertex;
+	}
+
+	/**
+	 * Google Cloud Vertex AI configuration for Anthropic Claude models.
+	 */
+	public static class Vertex {
+
+		/**
+		 * Google Cloud project ID.
+		 */
+		private @Nullable String projectId;
+
+		/**
+		 * Vertex AI location. Examples: {@code global}, {@code us}, {@code eu},
+		 * {@code us-east5}.
+		 */
+		private @Nullable String location;
+
+		/**
+		 * Optional URI to a GCP service account JSON credentials file. When not
+		 * configured, Application Default Credentials (ADC) are used.
+		 */
+		private @Nullable Resource credentialsUri;
+
+		public @Nullable String getProjectId() {
+			return this.projectId;
+		}
+
+		public void setProjectId(@Nullable String projectId) {
+			this.projectId = projectId;
+		}
+
+		public @Nullable String getLocation() {
+			return this.location;
+		}
+
+		public void setLocation(@Nullable String location) {
+			this.location = location;
+		}
+
+		public @Nullable Resource getCredentialsUri() {
+			return this.credentialsUri;
+		}
+
+		public void setCredentialsUri(@Nullable Resource credentialsUri) {
+			this.credentialsUri = credentialsUri;
+		}
+
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicVertexChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicVertexChatAutoConfiguration.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.anthropic.autoconfigure;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.anthropic.backends.Backend;
+import com.anthropic.vertex.backends.VertexBackend;
+import com.google.auth.oauth2.GoogleCredentials;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.anthropic.http.okhttp.AnthropicHttpClientBuilderCustomizer;
+import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.Resource;
+
+/**
+ * Auto-configuration for {@link AnthropicChatModel} when using Anthropic Claude models
+ * through Google Cloud Vertex AI.
+ *
+ * <p>
+ * Activates only when:
+ * <ul>
+ * <li>{@link VertexBackend} is on the classpath (requires
+ * {@code com.anthropic:anthropic-java-vertex})</li>
+ * <li>{@code spring.ai.anthropic.backend=vertex-ai} is set</li>
+ * </ul>
+ *
+ * <p>
+ * This configuration builds a {@link VertexBackend} from the
+ * {@link AnthropicConnectionProperties.Vertex} nested properties, then injects it into
+ * {@link AnthropicChatModel} via {@link AnthropicChatModel.Builder#backend(Backend)}. The
+ * existing {@link AnthropicChatAutoConfiguration} handles the default
+ * {@code spring.ai.anthropic.backend=anthropic} path.
+ *
+ * @author dragonfsky
+ * @since 2.0.0
+ */
+@AutoConfiguration
+@ConditionalOnClass(name = { "com.anthropic.client.AnthropicClient", "com.anthropic.vertex.backends.VertexBackend" })
+@ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.ANTHROPIC,
+		matchIfMissing = true)
+@ConditionalOnProperty(prefix = AnthropicConnectionProperties.CONFIG_PREFIX, name = "backend",
+		havingValue = "vertex-ai")
+@EnableConfigurationProperties({ AnthropicConnectionProperties.class, AnthropicChatProperties.class })
+public class AnthropicVertexChatAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	AnthropicChatModel anthropicVertexChatModel(AnthropicConnectionProperties connectionProperties,
+			AnthropicChatProperties chatProperties, ToolCallingManager toolCallingManager,
+			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
+			ObjectProvider<AnthropicHttpClientBuilderCustomizer> httpClientBuilderCustomizers) {
+
+		AnthropicChatOptions.Builder optionsBuilder = chatProperties.toOptions().mutate();
+
+		// Apply connection-level settings (timeout, retries, proxy, custom headers)
+		// but NOT api-key or base-url — those conflict with Vertex.
+		if (connectionProperties.getTimeout() != null) {
+			optionsBuilder.timeout(connectionProperties.getTimeout());
+		}
+		if (connectionProperties.getMaxRetries() != null) {
+			optionsBuilder.maxRetries(connectionProperties.getMaxRetries());
+		}
+		if (connectionProperties.getProxy() != null) {
+			optionsBuilder.proxy(connectionProperties.getProxy());
+		}
+		if (!connectionProperties.getCustomHeaders().isEmpty()) {
+			optionsBuilder.customHeaders(connectionProperties.getCustomHeaders());
+		}
+
+		AnthropicChatOptions options = optionsBuilder.build();
+
+		// Fail-fast: api-key and base-url make no sense with Vertex AI.
+		if (connectionProperties.getApiKey() != null) {
+			throw new IllegalStateException(
+					"spring.ai.anthropic.api-key must not be configured when spring.ai.anthropic.backend=vertex-ai. "
+							+ "Vertex AI uses Google Cloud credentials, not an Anthropic API key.");
+		}
+		if (connectionProperties.getBaseUrl() != null) {
+			throw new IllegalStateException(
+					"spring.ai.anthropic.base-url must not be configured when spring.ai.anthropic.backend=vertex-ai. "
+							+ "The endpoint is derived from the Vertex project and region.");
+		}
+
+		// Reject headers that would interfere with Vertex auth in both
+		// connection-level customHeaders and per-request chat.httpHeaders.
+		assertNoVertexForbiddenHeaders(connectionProperties.getCustomHeaders(), "spring.ai.anthropic.custom-headers");
+		assertNoVertexForbiddenHeaders(chatProperties.getHttpHeaders(), "spring.ai.anthropic.chat.http-headers");
+
+		Backend backend = createVertexBackend(connectionProperties);
+
+		ObservationRegistry obsReg = observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP);
+		MeterRegistry metReg = chatProperties.isConnectionPoolMetricsEnabled() ? meterRegistry.getIfAvailable() : null;
+
+		List<AnthropicHttpClientBuilderCustomizer> customizers = httpClientBuilderCustomizers.orderedStream()
+			.collect(Collectors.toList());
+
+		AnthropicChatModel chatModel = AnthropicChatModel.builder()
+			.options(options)
+			.backend(backend)
+			.toolCallingManager(toolCallingManager)
+			.observationRegistry(obsReg)
+			.meterRegistry(metReg)
+			.httpClientBuilderCustomizers(customizers)
+			.build();
+
+		return chatModel;
+	}
+
+	private static final Log logger = LogFactory.getLog(AnthropicVertexChatAutoConfiguration.class);
+
+	private static void assertNoVertexForbiddenHeaders(Map<String, String> headers, String propertyName) {
+		if (headers == null || headers.isEmpty()) {
+			return;
+		}
+		for (String header : headers.keySet()) {
+			String normalized = header.toLowerCase(java.util.Locale.ROOT);
+			if (normalized.equals("authorization") || normalized.equals("x-api-key")
+					|| normalized.equals("anthropic-version")) {
+				throw new IllegalStateException("'" + propertyName + "." + header + "' must not be configured when "
+						+ "spring.ai.anthropic.backend=vertex-ai. "
+						+ "Vertex AI manages Authorization, x-api-key, and anthropic-version automatically.");
+			}
+		}
+	}
+
+	/**
+	 * Creates a {@link VertexBackend} from the configured properties. Falls back to
+	 * {@link VertexBackend#fromEnv()} when no explicit configuration is provided.
+	 */
+	@SuppressWarnings("NullAway")
+	private static Backend createVertexBackend(AnthropicConnectionProperties properties) {
+		AnthropicConnectionProperties.Vertex vertex = properties.getVertex();
+
+		boolean hasProjectId = hasText(vertex.getProjectId());
+		boolean hasLocation = hasText(vertex.getLocation());
+		boolean hasCredentials = vertex.getCredentialsUri() != null;
+
+		if (!hasProjectId && !hasLocation && !hasCredentials) {
+			logger.debug("No explicit Vertex AI configuration; using VertexBackend.fromEnv()");
+			return VertexBackend.fromEnv();
+		}
+
+		if (!hasProjectId || !hasLocation) {
+			throw new IllegalStateException(
+					"spring.ai.anthropic.vertex.project-id and spring.ai.anthropic.vertex.location "
+							+ "must be set together when any spring.ai.anthropic.vertex.* property is configured. "
+							+ "Alternatively, omit all vertex.* properties to use VertexBackend.fromEnv().");
+		}
+
+		GoogleCredentials credentials = resolveGoogleCredentials(vertex);
+
+		String projectId = vertex.getProjectId();
+		String location = vertex.getLocation();
+		return VertexBackend.builder().project(projectId).region(location).googleCredentials(credentials).build();
+	}
+
+	private static boolean hasText(@Nullable String value) {
+		return value != null && !value.isBlank();
+	}
+
+	private static GoogleCredentials resolveGoogleCredentials(AnthropicConnectionProperties.Vertex vertex) {
+		Resource credentialsResource = vertex.getCredentialsUri();
+		if (credentialsResource != null) {
+			try (InputStream credentialsStream = credentialsResource.getInputStream()) {
+				return GoogleCredentials.fromStream(credentialsStream);
+			}
+			catch (IOException ex) {
+				throw new IllegalStateException(
+						"Failed to read Google credentials from spring.ai.anthropic.vertex.credentials-uri: "
+								+ credentialsResource,
+						ex);
+			}
+		}
+
+		try {
+			return GoogleCredentials.getApplicationDefault();
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException(
+					"Application Default Credentials are required when " + "spring.ai.anthropic.backend=vertex-ai. "
+							+ "Set spring.ai.anthropic.vertex.credentials-uri or configure "
+							+ "GOOGLE_APPLICATION_CREDENTIALS.",
+					ex);
+		}
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/MissingAnthropicVertexDependencyConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/MissingAnthropicVertexDependencyConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.anthropic.autoconfigure;
+
+import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.model.SpringAIModels;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Fail-fast diagnostic when {@code spring.ai.anthropic.backend=vertex-ai} is set but
+ * {@code com.anthropic:anthropic-java-vertex} is missing from the classpath.
+ *
+ * @author dragonfsky
+ * @since 2.0.0
+ */
+@AutoConfiguration
+@ConditionalOnMissingClass("com.anthropic.vertex.backends.VertexBackend")
+@ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.ANTHROPIC,
+		matchIfMissing = true)
+@ConditionalOnProperty(prefix = AnthropicConnectionProperties.CONFIG_PREFIX, name = "backend",
+		havingValue = "vertex-ai")
+public final class MissingAnthropicVertexDependencyConfiguration {
+
+	private MissingAnthropicVertexDependencyConfiguration() {
+	}
+
+	@Bean
+	static BeanFactoryPostProcessor anthropicVertexMissingDependencyFailure() {
+		return new BeanFactoryPostProcessor() {
+			@Override
+			public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+				throw new IllegalStateException(
+						"spring.ai.anthropic.backend=vertex-ai requires com.anthropic:anthropic-java-vertex "
+								+ "on the classpath. Add the dependency to your build, "
+								+ "or use spring-ai-starter-model-anthropic-vertex if available.");
+			}
+		};
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,3 +14,5 @@
 # limitations under the License.
 #
 org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration
+org.springframework.ai.model.anthropic.autoconfigure.AnthropicVertexChatAutoConfiguration
+org.springframework.ai.model.anthropic.autoconfigure.MissingAnthropicVertexDependencyConfiguration

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicVertexChatAutoConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicVertexChatAutoConfigurationTests.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.anthropic.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the Vertex AI backend auto-configuration selection logic.
+ *
+ * @author dragonfsky
+ */
+class AnthropicVertexChatAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(AnthropicChatAutoConfiguration.class,
+				AnthropicVertexChatAutoConfiguration.class, ToolCallingAutoConfiguration.class));
+
+	// --- Happy path: default backend selection ---
+
+	@Test
+	void defaultBackendCreatesDirectModel() {
+		this.contextRunner.withPropertyValues("spring.ai.anthropic.api-key=test-key")
+			.run(context -> assertThat(context).hasSingleBean(AnthropicChatModel.class));
+	}
+
+	@Test
+	void explicitDirectBackendCreatesModel() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.anthropic.backend=anthropic", "spring.ai.anthropic.api-key=test-key")
+			.run(context -> assertThat(context).hasSingleBean(AnthropicChatModel.class));
+	}
+
+	// --- Vertex backend: classpath-conditional ---
+
+	@Test
+	void vertexAutoConfigurationBacksOffWhenVertexClassesAreMissing() {
+		new ApplicationContextRunner().withClassLoader(new FilteredClassLoader("com.anthropic.vertex"))
+			.withConfiguration(AutoConfigurations.of(AnthropicVertexChatAutoConfiguration.class,
+					ToolCallingAutoConfiguration.class))
+			.withPropertyValues("spring.ai.anthropic.backend=vertex-ai",
+					"spring.ai.anthropic.vertex.project-id=test-project", "spring.ai.anthropic.vertex.location=global")
+			.run(context -> assertThat(context).doesNotHaveBean(AnthropicChatModel.class));
+	}
+
+	@Test
+	void vertexBackendWithAnotherChatModelDoesNotCreateModel() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.model.chat=openai", "spring.ai.anthropic.backend=vertex-ai",
+					"spring.ai.anthropic.vertex.project-id=test-project", "spring.ai.anthropic.vertex.location=global")
+			.run(context -> assertThat(context).doesNotHaveBean(AnthropicChatModel.class));
+	}
+
+	// --- Fail-fast: conflicting properties under Vertex ---
+
+	@Test
+	void vertexBackendWithApiKeyFails() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.anthropic.backend=vertex-ai", "spring.ai.anthropic.api-key=test-key")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure()).hasMessageContaining("api-key");
+			});
+	}
+
+	@Test
+	void vertexBackendWithBaseUrlFails() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.anthropic.backend=vertex-ai",
+					"spring.ai.anthropic.base-url=https://example.com")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure()).hasMessageContaining("base-url");
+			});
+	}
+
+	@Test
+	void vertexBackendWithForbiddenAuthorizationHeaderFails() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.anthropic.backend=vertex-ai",
+					"spring.ai.anthropic.custom-headers.Authorization=Bearer xyz")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure()).hasMessageContaining("Authorization");
+			});
+	}
+
+	@Test
+	void vertexBackendWithForbiddenApiKeyHeaderFails() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.anthropic.backend=vertex-ai",
+					"spring.ai.anthropic.custom-headers.x-api-key=sk-test")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure()).hasMessageContaining("x-api-key");
+			});
+	}
+
+	@Test
+	void vertexBackendWithForbiddenAnthropicVersionHeaderFails() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.anthropic.backend=vertex-ai",
+					"spring.ai.anthropic.custom-headers.anthropic-version=2023-06-01")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure()).hasMessageContaining("anthropic-version");
+			});
+	}
+
+	@Test
+	void vertexBackendPartialConfigProjectOnlyFails() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.anthropic.backend=vertex-ai",
+					"spring.ai.anthropic.vertex.project-id=test-project")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure()).hasMessageContaining("together");
+			});
+	}
+
+	@Test
+	void vertexBackendPartialConfigLocationOnlyFails() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.anthropic.backend=vertex-ai", "spring.ai.anthropic.vertex.location=us-east5")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure()).hasMessageContaining("together");
+			});
+	}
+
+	// --- User-provided bean override ---
+
+	@Test
+	void userProvidedBeanBacksOff() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.anthropic.backend=vertex-ai", "spring.ai.anthropic.vertex.project-id=test",
+					"spring.ai.anthropic.vertex.location=global")
+			.withBean(AnthropicChatModel.class, () -> AnthropicChatModel.builder().build())
+			.run(context -> assertThat(context).hasSingleBean(AnthropicChatModel.class));
+	}
+
+	// --- Direct backend: model selector ---
+
+	@Test
+	void directBackendWithOtherModelDoesNotCreateBean() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.model.chat=openai", "spring.ai.anthropic.backend=anthropic",
+					"spring.ai.anthropic.api-key=test-key")
+			.run(context -> assertThat(context).doesNotHaveBean(AnthropicChatModel.class));
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.anthropic.backends.Backend;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.AnthropicClientAsync;
 import com.anthropic.core.JsonValue;
@@ -190,7 +191,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			@Nullable AnthropicClientAsync anthropicClientAsync, @Nullable AnthropicChatOptions options,
 			@Nullable ToolCallingManager toolCallingManager, @Nullable ObservationRegistry observationRegistry,
 			@Nullable MeterRegistry meterRegistry, @Nullable ExecutorService dispatcherExecutor,
-			List<AnthropicHttpClientBuilderCustomizer> httpClientCustomizers) {
+			List<AnthropicHttpClientBuilderCustomizer> httpClientCustomizers, @Nullable Backend backend) {
 
 		if (options == null) {
 			this.options = AnthropicChatOptions.builder().build();
@@ -205,17 +206,32 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		this.meterRegistry = meterRegistry;
 		this.dispatcherExecutor = dispatcherExecutor;
 
-		this.anthropicClient = Objects.requireNonNullElseGet(anthropicClient,
-				() -> AnthropicSetup.setupSyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
-						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(), this.observationRegistry, this.meterRegistry,
-						this.dispatcherExecutor, httpClientCustomizers));
+		if (backend != null) {
+			this.anthropicClient = Objects.requireNonNullElseGet(anthropicClient,
+					() -> AnthropicSetup.setupSyncClient(backend, this.options.getTimeout(),
+							this.options.getMaxRetries(), this.options.getProxy(), this.options.getCustomHeaders(),
+							this.observationRegistry, this.meterRegistry, this.dispatcherExecutor,
+							httpClientCustomizers));
 
-		this.anthropicClientAsync = Objects.requireNonNullElseGet(anthropicClientAsync,
-				() -> AnthropicSetup.setupAsyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
-						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(), this.observationRegistry, this.meterRegistry,
-						this.dispatcherExecutor, httpClientCustomizers));
+			this.anthropicClientAsync = Objects.requireNonNullElseGet(anthropicClientAsync,
+					() -> AnthropicSetup.setupAsyncClient(backend, this.options.getTimeout(),
+							this.options.getMaxRetries(), this.options.getProxy(), this.options.getCustomHeaders(),
+							this.observationRegistry, this.meterRegistry, this.dispatcherExecutor,
+							httpClientCustomizers));
+		}
+		else {
+			this.anthropicClient = Objects.requireNonNullElseGet(anthropicClient,
+					() -> AnthropicSetup.setupSyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
+							this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
+							this.options.getCustomHeaders(), this.observationRegistry, this.meterRegistry,
+							this.dispatcherExecutor, httpClientCustomizers));
+
+			this.anthropicClientAsync = Objects.requireNonNullElseGet(anthropicClientAsync,
+					() -> AnthropicSetup.setupAsyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
+							this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
+							this.options.getCustomHeaders(), this.observationRegistry, this.meterRegistry,
+							this.dispatcherExecutor, httpClientCustomizers));
+		}
 
 		this.toolCallingManager = Objects.requireNonNullElse(toolCallingManager, DEFAULT_TOOL_CALLING_MANAGER);
 	}
@@ -1609,6 +1625,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 		private List<AnthropicHttpClientBuilderCustomizer> httpClientCustomizers = new ArrayList<>();
 
+		private @Nullable Backend backend;
+
 		private Builder() {
 		}
 
@@ -1728,6 +1746,20 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		}
 
 		/**
+		 * Sets the SDK {@link Backend} for client construction. When provided, clients
+		 * are created from this backend instead of the {@code baseUrl / apiKey} from
+		 * {@link AnthropicChatOptions}.
+		 * @param backend the SDK backend
+		 * @return this builder
+		 * @since 2.0.0
+		 */
+		public Builder backend(Backend backend) {
+			Assert.notNull(backend, "backend must not be null");
+			this.backend = backend;
+			return this;
+		}
+
+		/**
 		 * Builds a new {@link AnthropicChatModel} instance.
 		 * @return the configured chat model
 		 */
@@ -1744,7 +1776,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			}
 			return new AnthropicChatModel(this.anthropicClient, this.anthropicClientAsync, this.options,
 					this.toolCallingManager, this.observationRegistry, this.meterRegistry, this.dispatcherExecutor,
-					this.httpClientCustomizers);
+					this.httpClientCustomizers, this.backend);
 		}
 
 	}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicSetup.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicSetup.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import com.anthropic.backends.AnthropicBackend;
+import com.anthropic.backends.Backend;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.AnthropicClientAsync;
 import com.anthropic.client.AnthropicClientAsyncImpl;
@@ -194,8 +195,45 @@ public final class AnthropicSetup {
 			List<AnthropicHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		Assert.notNull(httpClientCustomizers, "httpClientCustomizers must not be null");
-		ClientOptions opts = buildClientOptions(baseUrl, apiKey, timeout, maxRetries, proxy, customHeaders,
-				observationRegistry, meterRegistry, SYNC_CLIENT_TAGS, dispatcherExecutor, httpClientCustomizers);
+		String resolvedBaseUrl = detectBaseUrlFromEnv(baseUrl);
+		String resolvedApiKey = apiKey != null ? apiKey : detectApiKey();
+		AnthropicBackend backend = buildAnthropicBackend(resolvedBaseUrl, resolvedApiKey);
+		ClientOptions opts = buildClientOptions(backend, timeout, maxRetries, proxy, customHeaders, observationRegistry,
+				meterRegistry, SYNC_CLIENT_TAGS, dispatcherExecutor, httpClientCustomizers);
+		return new AnthropicClientImpl(opts);
+	}
+
+	/**
+	 * Creates a synchronous Anthropic client with the specified SDK {@link Backend}. This
+	 * overload supports alternative backends (e.g. Google Vertex AI) while preserving
+	 * Spring AI's OkHttp observability and customizer pipeline.
+	 * @param backend the SDK backend (e.g. {@link AnthropicBackend} or
+	 * {@code VertexBackend})
+	 * @param timeout the request timeout (null to use default of 60 seconds)
+	 * @param maxRetries the maximum number of retries (null to use default of 2)
+	 * @param proxy the proxy to use (null for no proxy)
+	 * @param customHeaders additional HTTP headers to include in requests
+	 * @param observationRegistry the registry the OkHttp observation interceptor reports
+	 * to; pass {@link ObservationRegistry#NOOP} to disable
+	 * @param meterRegistry optional; when supplied, OkHttp connection-pool gauges are
+	 * registered
+	 * @param dispatcherExecutor the OkHttp dispatcher executor; null to use the
+	 * library-managed default
+	 * @param httpClientCustomizers customizers applied to the underlying OkHttp client
+	 * builder after Spring AI's own defaults
+	 * @return a configured Anthropic client
+	 * @since 2.0.0
+	 */
+	public static AnthropicClient setupSyncClient(Backend backend, @Nullable Duration timeout,
+			@Nullable Integer maxRetries, @Nullable Proxy proxy, @Nullable Map<String, String> customHeaders,
+			ObservationRegistry observationRegistry, @Nullable MeterRegistry meterRegistry,
+			@Nullable ExecutorService dispatcherExecutor,
+			List<AnthropicHttpClientBuilderCustomizer> httpClientCustomizers) {
+
+		Assert.notNull(backend, "backend must not be null");
+		Assert.notNull(httpClientCustomizers, "httpClientCustomizers must not be null");
+		ClientOptions opts = buildClientOptions(backend, timeout, maxRetries, proxy, customHeaders, observationRegistry,
+				meterRegistry, SYNC_CLIENT_TAGS, dispatcherExecutor, httpClientCustomizers);
 		return new AnthropicClientImpl(opts);
 	}
 
@@ -285,24 +323,56 @@ public final class AnthropicSetup {
 			List<AnthropicHttpClientBuilderCustomizer> httpClientCustomizers) {
 
 		Assert.notNull(httpClientCustomizers, "httpClientCustomizers must not be null");
-		ClientOptions opts = buildClientOptions(baseUrl, apiKey, timeout, maxRetries, proxy, customHeaders,
-				observationRegistry, meterRegistry, ASYNC_CLIENT_TAGS, dispatcherExecutor, httpClientCustomizers);
+		String resolvedBaseUrl = detectBaseUrlFromEnv(baseUrl);
+		String resolvedApiKey = apiKey != null ? apiKey : detectApiKey();
+		AnthropicBackend backend = buildAnthropicBackend(resolvedBaseUrl, resolvedApiKey);
+		ClientOptions opts = buildClientOptions(backend, timeout, maxRetries, proxy, customHeaders, observationRegistry,
+				meterRegistry, ASYNC_CLIENT_TAGS, dispatcherExecutor, httpClientCustomizers);
 		return new AnthropicClientAsyncImpl(opts);
 	}
 
-	private static ClientOptions buildClientOptions(@Nullable String baseUrl, @Nullable String apiKey,
-			@Nullable Duration timeout, @Nullable Integer maxRetries, @Nullable Proxy proxy,
-			@Nullable Map<String, String> customHeaders, ObservationRegistry observationRegistry,
-			@Nullable MeterRegistry meterRegistry, Iterable<Tag> connectionPoolTags,
+	/**
+	 * Creates an asynchronous Anthropic client with the specified SDK {@link Backend}.
+	 * This overload supports alternative backends (e.g. Google Vertex AI) while
+	 * preserving Spring AI's OkHttp observability and customizer pipeline.
+	 * @param backend the SDK backend (e.g. {@link AnthropicBackend} or
+	 * {@code VertexBackend})
+	 * @param timeout the request timeout (null to use default of 60 seconds)
+	 * @param maxRetries the maximum number of retries (null to use default of 2)
+	 * @param proxy the proxy to use (null for no proxy)
+	 * @param customHeaders additional HTTP headers to include in requests
+	 * @param observationRegistry the registry the OkHttp observation interceptor reports
+	 * to; pass {@link ObservationRegistry#NOOP} to disable
+	 * @param meterRegistry optional; when supplied, OkHttp connection-pool gauges are
+	 * registered
+	 * @param dispatcherExecutor the OkHttp dispatcher executor; null to use the
+	 * library-managed default
+	 * @param httpClientCustomizers customizers applied to the underlying OkHttp client
+	 * builder after Spring AI's own defaults
+	 * @return a configured async Anthropic client
+	 * @since 2.0.0
+	 */
+	public static AnthropicClientAsync setupAsyncClient(Backend backend, @Nullable Duration timeout,
+			@Nullable Integer maxRetries, @Nullable Proxy proxy, @Nullable Map<String, String> customHeaders,
+			ObservationRegistry observationRegistry, @Nullable MeterRegistry meterRegistry,
 			@Nullable ExecutorService dispatcherExecutor,
 			List<AnthropicHttpClientBuilderCustomizer> httpClientCustomizers) {
 
-		String resolvedBaseUrl = detectBaseUrlFromEnv(baseUrl);
-		String resolvedApiKey = apiKey != null ? apiKey : detectApiKey();
+		Assert.notNull(backend, "backend must not be null");
+		Assert.notNull(httpClientCustomizers, "httpClientCustomizers must not be null");
+		ClientOptions opts = buildClientOptions(backend, timeout, maxRetries, proxy, customHeaders, observationRegistry,
+				meterRegistry, ASYNC_CLIENT_TAGS, dispatcherExecutor, httpClientCustomizers);
+		return new AnthropicClientAsyncImpl(opts);
+	}
+
+	private static ClientOptions buildClientOptions(Backend backend, @Nullable Duration timeout,
+			@Nullable Integer maxRetries, @Nullable Proxy proxy, @Nullable Map<String, String> customHeaders,
+			ObservationRegistry observationRegistry, @Nullable MeterRegistry meterRegistry,
+			Iterable<Tag> connectionPoolTags, @Nullable ExecutorService dispatcherExecutor,
+			List<AnthropicHttpClientBuilderCustomizer> httpClientCustomizers) {
+
 		Duration resolvedTimeout = timeout != null ? timeout : DEFAULT_TIMEOUT;
 		int resolvedMaxRetries = maxRetries != null ? maxRetries : DEFAULT_MAX_RETRIES;
-
-		AnthropicBackend backend = buildBackend(resolvedBaseUrl, resolvedApiKey);
 
 		ClientOptions.Builder optsBuilder = ClientOptions.builder()
 			.timeout(resolvedTimeout)
@@ -325,8 +395,7 @@ public final class AnthropicSetup {
 		}
 
 		// Re-apply Spring AI's resolved backend and meterTags after the customizer loop
-		// so
-		// that neither can be inadvertently overridden:
+		// so that neither can be inadvertently overridden:
 		// - backend: applyCredentials() below relies on the same backend instance; a
 		// replacement would misalign WIF credential injection.
 		// - meterTags: SYNC_CLIENT_TAGS / ASYNC_CLIENT_TAGS discriminate the two OkHttp
@@ -338,12 +407,16 @@ public final class AnthropicSetup {
 		SpringAiAnthropicHttpClient rawHttp = rawHttpBuilder.build();
 
 		// No-op when a static apiKey/authToken is set; otherwise fetches WIF credentials.
-		backend.applyCredentials(rawHttp, optsBuilder);
+		// Only applicable to AnthropicBackend (direct API); VertexBackend and other
+		// backends manage credentials independently.
+		if (backend instanceof AnthropicBackend anthropicBackend) {
+			anthropicBackend.applyCredentials(rawHttp, optsBuilder);
+		}
 
 		return optsBuilder.httpClient(rawHttp).build();
 	}
 
-	private static AnthropicBackend buildBackend(@Nullable String baseUrl, @Nullable String apiKey) {
+	private static AnthropicBackend buildAnthropicBackend(@Nullable String baseUrl, @Nullable String apiKey) {
 		AnthropicBackend.Builder b = AnthropicBackend.builder();
 		if (baseUrl != null) {
 			b.baseUrl(baseUrl);

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicVertexBackendRequestShapeTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicVertexBackendRequestShapeTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import java.util.List;
+
+import com.anthropic.backends.AnthropicBackend;
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.AnthropicClientAsync;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the generic SDK {@code Backend} overloads in {@link AnthropicSetup} and
+ * {@link AnthropicChatModel.Builder#backend} work end-to-end.
+ *
+ * @author dragonfsky
+ */
+class AnthropicVertexBackendRequestShapeTests {
+
+	@Test
+	void syncClientCreatedWithAnthropicBackend() {
+		AnthropicBackend backend = AnthropicBackend.builder().apiKey("test-key").build();
+
+		AnthropicClient client = AnthropicSetup.setupSyncClient(backend, null, null, null, null,
+				ObservationRegistry.NOOP, null, null, List.of());
+
+		assertThat(client).isNotNull();
+	}
+
+	@Test
+	void asyncClientCreatedWithAnthropicBackend() {
+		AnthropicBackend backend = AnthropicBackend.builder().apiKey("test-key").build();
+
+		AnthropicClientAsync client = AnthropicSetup.setupAsyncClient(backend, null, null, null, null,
+				ObservationRegistry.NOOP, null, null, List.of());
+
+		assertThat(client).isNotNull();
+	}
+
+	@Test
+	void chatModelBuilderAcceptsBackend() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder().model("claude-sonnet-4-5").maxTokens(100).build();
+		AnthropicBackend backend = AnthropicBackend.builder().apiKey("test-key").build();
+
+		AnthropicChatModel model = AnthropicChatModel.builder().options(options).backend(backend).build();
+
+		assertThat(model).isNotNull();
+		assertThat(model.getOptions().getModel()).isEqualTo("claude-sonnet-4-5");
+	}
+
+}


### PR DESCRIPTION
Adds support for Anthropic Claude models hosted on Google Cloud Vertex AI by wiring the official SDK's VertexBackend into the existing AnthropicChatModel.

## Approach

No new ChatModel class — the backend selector switches transport while reusing all existing message construction, tool calling, streaming, and caching logic.

```yaml
spring.ai.anthropic.backend=vertex-ai
spring.ai.anthropic.vertex.project-id=my-project
spring.ai.anthropic.vertex.location=us-east5
```

## Changes (11 files)

- **AnthropicSetup**: accept generic SDK Backend for client construction
- **AnthropicChatModel**: builder supports Backend injection
- **AnthropicBackendType**: ANTHROPIC / VERTEX_AI enum
- **AnthropicConnectionProperties**: backend selector + vertex config
- **AnthropicVertexChatAutoConfiguration**: conditionally creates VertexBackend with ADC fallback
- **MissingAnthropicVertexDependencyConfiguration**: fail-fast on missing dep
- **AnthropicChatAutoConfiguration**: gated to backend=anthropic for mutual exclusion

## Defensive design

- Fails fast when api-key, base-url, or forbidden headers are set with backend=vertex-ai
- Clear startup error when anthropic-java-vertex is missing
- Mutually exclusive with the existing direct Anthropic auto-config
- Fully backward compatible

## Tests

16 new tests: 13 auto-config condition tests + 3 request-shape tests. All 178 existing tests pass.

Closes gh-1514