### PR TITLE
Fix nested @ToolParam descriptions in tool schemas

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/SpringAiSchemaModule.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/SpringAiSchemaModule.java
@@ -16,10 +16,20 @@
 
 package org.springframework.ai.util.json.schema;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
 import com.github.victools.jsonschema.generator.MemberScope;
+import kotlin.jvm.JvmClassMappingKt;
+import kotlin.reflect.KClass;
+import kotlin.reflect.KFunction;
+import kotlin.reflect.KParameter;
+import kotlin.reflect.full.KClasses;
+import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.core.KotlinDetector;
 import org.springframework.util.StringUtils;
 
 /**
@@ -42,8 +52,40 @@ public final class SpringAiSchemaModule extends AbstractSpringAiSchemaModule {
 	@Override
 	protected @Nullable String resolveToolParamDescription(MemberScope<?, ?> member) {
 		var annotation = member.getAnnotationConsideringFieldAndGetter(ToolParam.class);
+		if (annotation == null && KotlinDetector.isKotlinReflectPresent()) {
+			annotation = findKotlinConstructorParamAnnotation(member);
+		}
 		if (annotation != null && StringUtils.hasText(annotation.description())) {
 			return annotation.description();
+		}
+		return null;
+	}
+
+	@NullUnmarked
+	private @Nullable ToolParam findKotlinConstructorParamAnnotation(MemberScope<?, ?> member) {
+		if (!(member.getRawMember() instanceof Field field)) {
+			return null;
+		}
+		Class<?> declaringClass = member.getDeclaringType().getErasedType();
+		if (!KotlinDetector.isKotlinType(declaringClass)) {
+			return null;
+		}
+		KClass<?> kClass = JvmClassMappingKt.getKotlinClass(declaringClass);
+		KFunction<?> ctor = KClasses.getPrimaryConstructor(kClass);
+		if (ctor == null) {
+			return null;
+		}
+		String fieldName = field.getName();
+		for (KParameter param : ctor.getParameters()) {
+			String paramName = param.getName();
+			if (fieldName.equals(paramName)) {
+				for (Annotation a : param.getAnnotations()) {
+					if (a.annotationType() == ToolParam.class) {
+						return (ToolParam) a;
+					}
+				}
+				break;
+			}
 		}
 		return null;
 	}

--- a/spring-ai-model/src/test/kotlin/org/springframework/ai/util/json/schema/JsonSchemaGeneratorKotlinTests.kt
+++ b/spring-ai-model/src/test/kotlin/org/springframework/ai/util/json/schema/JsonSchemaGeneratorKotlinTests.kt
@@ -19,6 +19,7 @@ package org.springframework.ai.util.json.schema
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.annotation.ToolParam
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.json.JsonMapper
 
@@ -77,11 +78,44 @@ class JsonSchemaGeneratorKotlinTests {
 		assertThat(requiredNames(schemaNode["required"])).containsExactly("url")
 	}
 
+	@Test
+	fun `@ToolParam description on nested Kotlin data class parameter is included in schema`() {
+		val method = WeatherTools::class.java.getMethod("getWeather", Address::class.java)
+		val schema = JsonSchemaGenerator.generateForMethodInput(method)
+		val schemaNode = jsonMapper.readTree(schema)
+
+		val streetNode = schemaNode["properties"]["address"]["properties"]["street"]
+		assertThat(streetNode["description"].asString())
+			.isEqualTo("The street (without number) of the address")
+	}
+
+	@Test
+	fun `unannotated nested Kotlin data class fields have no description in schema`() {
+		val method = WeatherTools::class.java.getMethod("getWeather", Address::class.java)
+		val schema = JsonSchemaGenerator.generateForMethodInput(method)
+		val schemaNode = jsonMapper.readTree(schema)
+
+		val addressProps = schemaNode["properties"]["address"]["properties"]
+		assertThat(addressProps["postalCode"].has("description")).isFalse()
+		assertThat(addressProps["city"].has("description")).isFalse()
+	}
+
 	private fun requiredNames(required: JsonNode?): List<String> {
 		if (required == null || required.isNull) {
 			return emptyList()
 		}
 		return required.iterator().asSequence().map { it.asString() }.toList()
+	}
+
+	private data class Address(
+		@ToolParam(description = "The street (without number) of the address") val street: String,
+		val postalCode: String,
+		val city: String,
+	)
+
+	private class WeatherTools {
+		@Tool(description = "Get the weather at a specific address")
+		fun getWeather(address: Address): String = "sunny"
 	}
 
 	private data class Filter(val name: String?, val ids: List<String>?)


### PR DESCRIPTION
## Summary

Fixes gh-2866.

This PR includes `@ToolParam` descriptions from Kotlin primary constructor parameters when generating JSON schemas for nested tool parameters.

Previously, `@ToolParam(description = "...")` worked for top-level tool parameters, but descriptions on nested Kotlin data class properties were not included in the generated schema.

## Changes

- Add a Kotlin-specific fallback in `SpringAiSchemaModule` to inspect primary constructor parameter annotations when field/getter lookup does not find `@ToolParam`
- Add a regression test for nested Kotlin data class parameter descriptions
- Ensure unannotated nested Kotlin properties do not receive descriptions

## Verification

Ran:

```bash
./mvnw -pl spring-ai-model -Dmaven.build.cache.enabled=false -Dtest=JsonSchemaGeneratorKotlinTests test
./mvnw -pl spring-ai-model -Dmaven.build.cache.enabled=false -Dtest="JsonSchemaGeneratorTests,JsonSchemaGeneratorKotlinTests" test
./mvnw -pl spring-ai-model -Dmaven.build.cache.enabled=false test