### PR TITLE
Support page ranges in `PagePdfDocumentReader`

### DIFF
--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/PagePdfDocumentReader.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/PagePdfDocumentReader.java
@@ -20,7 +20,6 @@ import java.awt.Rectangle;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -99,39 +98,70 @@ public class PagePdfDocumentReader implements DocumentReader {
 		try {
 			var pdfTextStripper = new PDFLayoutTextStripperByArea();
 
-			int pageNumber = 1;
-			int startPageNumber = 1;
-
 			List<String> pageTextGroupList = new ArrayList<>();
 
 			PDPageTree pages = this.document.getDocumentCatalog().getPages();
 			int totalPages = pages.getCount();
 			int logFrequency = totalPages > 10 ? totalPages / 10 : 1;
 
-			int pagesPerDocument = getPagesPerDocument(totalPages);
+			// When all pages are grouped into a single Document, never flush mid-stream;
+			// the trailing flush below emits the single Document.
+			int pagesPerDocument = this.config.pagesPerDocument == PdfDocumentReaderConfig.ALL_PAGES ? Integer.MAX_VALUE
+					: this.config.pagesPerDocument;
+
+			int pageNumber = 0;
+			int selectedPageCount = 0;
+			int processedInGroup = 0;
+			int groupStartPage = 0;
+			int groupEndPage = 0;
+			int previousSelectedPage = 0;
 			for (PDPage page : pages) {
-				if ((pageNumber - 1) % logFrequency == 0) {
+				pageNumber++;
+				// Skip pages outside the configured page ranges (if any) while keeping
+				// the
+				// sequential page-tree iteration and the physical page numbering intact.
+				if (!this.config.isPageSelected(pageNumber)) {
+					continue;
+				}
+
+				// With disjoint page ranges, flush the current group before a gap so a
+				// Document never spans excluded pages and its start/end page metadata
+				// stays accurate. As a result pagesPerDocument acts as a maximum across
+				// gaps rather than merging non-contiguous pages.
+				if (processedInGroup > 0 && pageNumber != previousSelectedPage + 1) {
+					flushGroup(readDocuments, pageTextGroupList, groupStartPage, groupEndPage);
+					groupStartPage = 0;
+					processedInGroup = 0;
+				}
+
+				if (selectedPageCount % logFrequency == 0) {
 					if (logger.isInfoEnabled()) {
 						logger.info("Processing PDF page: " + pageNumber);
 					}
 				}
 
-				handleSinglePage(page, pageNumber, pdfTextStripper, pageTextGroupList);
-
-				if (pageNumber % pagesPerDocument == 0 || pageNumber == totalPages) {
-					if (!CollectionUtils.isEmpty(pageTextGroupList)) {
-						readDocuments.add(toDocument(pageTextGroupList.stream().collect(Collectors.joining()),
-								startPageNumber, pageNumber));
-						pageTextGroupList.clear();
-					}
-					startPageNumber = pageNumber + 1;
+				if (groupStartPage == 0) {
+					groupStartPage = pageNumber;
 				}
+				handleSinglePage(page, pageNumber, pdfTextStripper, pageTextGroupList);
+				groupEndPage = pageNumber;
+				processedInGroup++;
+				selectedPageCount++;
+				previousSelectedPage = pageNumber;
 
-				pageNumber++;
+				if (processedInGroup == pagesPerDocument) {
+					flushGroup(readDocuments, pageTextGroupList, groupStartPage, groupEndPage);
+					groupStartPage = 0;
+					processedInGroup = 0;
+				}
 			}
 
+			// Emit any pages left in a partially filled group (also the single Document
+			// produced when all selected pages are grouped together).
+			flushGroup(readDocuments, pageTextGroupList, groupStartPage, groupEndPage);
+
 			if (logger.isInfoEnabled()) {
-				logger.info("Processed total " + totalPages + " pages");
+				logger.info("Processed " + selectedPageCount + " selected pages of " + totalPages + " total");
 			}
 			return readDocuments;
 		}
@@ -159,11 +189,12 @@ public class PagePdfDocumentReader implements DocumentReader {
 		pdfTextStripper.removeRegion(PDF_PAGE_REGION);
 	}
 
-	private int getPagesPerDocument(int totalPages) {
-		if (this.config.pagesPerDocument == PdfDocumentReaderConfig.ALL_PAGES) {
-			return totalPages;
+	private void flushGroup(List<Document> readDocuments, List<String> pageTextGroupList, int startPageNumber,
+			int endPageNumber) {
+		if (!CollectionUtils.isEmpty(pageTextGroupList)) {
+			readDocuments.add(toDocument(String.join("", pageTextGroupList), startPageNumber, endPageNumber));
+			pageTextGroupList.clear();
 		}
-		return this.config.pagesPerDocument;
 	}
 
 	protected Document toDocument(String docText, int startPageNumber, int endPageNumber) {

--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReader.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReader.java
@@ -34,6 +34,7 @@ import org.springframework.ai.reader.pdf.config.PdfDocumentReaderConfig;
 import org.springframework.ai.reader.pdf.layout.PDFLayoutTextStripperByArea;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -102,6 +103,9 @@ public class ParagraphPdfDocumentReader implements DocumentReader {
 	 * @param config The configuration for PDF document processing.
 	 */
 	public ParagraphPdfDocumentReader(Resource pdfResource, PdfDocumentReaderConfig config) {
+
+		Assert.isTrue(!config.hasPageRanges(),
+				"Page ranges are not supported by ParagraphPdfDocumentReader; use PagePdfDocumentReader instead.");
 
 		try {
 			PDFParser pdfParser = new PDFParser(

--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/config/PdfDocumentReaderConfig.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/config/PdfDocumentReaderConfig.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.reader.pdf.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.ai.reader.ExtractedTextFormatter;
 import org.springframework.ai.reader.pdf.PagePdfDocumentReader;
 import org.springframework.ai.reader.pdf.ParagraphPdfDocumentReader;
@@ -41,12 +44,21 @@ public final class PdfDocumentReaderConfig {
 
 	public final ExtractedTextFormatter pageExtractedTextFormatter;
 
+	/**
+	 * Inclusive, one-based page ranges to read, each stored as a {@code {start, end}}
+	 * pair. An empty array means the whole document is read. Currently honored only by
+	 * {@link PagePdfDocumentReader}; readers that do not support page ranges reject a
+	 * configuration that sets them.
+	 */
+	private final int[][] pageRanges;
+
 	private PdfDocumentReaderConfig(PdfDocumentReaderConfig.Builder builder) {
 		this.pagesPerDocument = builder.pagesPerDocument;
 		this.pageBottomMargin = builder.pageBottomMargin;
 		this.pageTopMargin = builder.pageTopMargin;
 		this.pageExtractedTextFormatter = builder.pageExtractedTextFormatter;
 		this.reversedParagraphPosition = builder.reversedParagraphPosition;
+		this.pageRanges = builder.pageRanges.toArray(new int[0][]);
 	}
 
 	/**
@@ -65,6 +77,34 @@ public final class PdfDocumentReaderConfig {
 		return builder().build();
 	}
 
+	/**
+	 * Whether the given one-based page number should be read. When no page ranges are
+	 * configured every page is read; otherwise a page is read when it falls within any of
+	 * the configured inclusive ranges.
+	 * @param pageNumber the one-based page number
+	 * @return {@code true} if the page should be read
+	 */
+	public boolean isPageSelected(int pageNumber) {
+		if (this.pageRanges.length == 0) {
+			return true;
+		}
+		for (int[] range : this.pageRanges) {
+			if (pageNumber >= range[0] && pageNumber <= range[1]) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Whether any page ranges are configured. Readers that do not support page ranges can
+	 * use this to reject such a configuration instead of silently ignoring it.
+	 * @return {@code true} if at least one page range has been configured
+	 */
+	public boolean hasPageRanges() {
+		return this.pageRanges.length > 0;
+	}
+
 	public static final class Builder {
 
 		private int pagesPerDocument = 1;
@@ -76,6 +116,8 @@ public final class PdfDocumentReaderConfig {
 		private ExtractedTextFormatter pageExtractedTextFormatter = ExtractedTextFormatter.defaults();
 
 		private boolean reversedParagraphPosition = false;
+
+		private final List<int[]> pageRanges = new ArrayList<>();
 
 		private Builder() {
 		}
@@ -134,6 +176,29 @@ public final class PdfDocumentReaderConfig {
 		 */
 		public Builder withReversedParagraphPosition(boolean reversedParagraphPosition) {
 			this.reversedParagraphPosition = reversedParagraphPosition;
+			return this;
+		}
+
+		/**
+		 * Restricts reading to only the given inclusive, one-based page range, allowing
+		 * callers to skip pages such as covers, tables of contents or appendices. May be
+		 * called multiple times to read multiple, possibly disjoint, ranges; their union
+		 * is read. A range whose {@code endPage} exceeds the document length is clamped
+		 * to the last page. When no range is added (the default), the whole document is
+		 * read.
+		 * <p>
+		 * Note: page ranges are a coarse, manual filter based on physical page numbers
+		 * and are intended for cases where the caller already knows which pages to
+		 * include. They are currently honored only by {@link PagePdfDocumentReader};
+		 * readers that do not support page ranges reject a configuration that sets them.
+		 * @param startPage the inclusive, one-based first page to read
+		 * @param endPage the inclusive, one-based last page to read
+		 * @return this builder
+		 */
+		public PdfDocumentReaderConfig.Builder addPageRange(int startPage, int endPage) {
+			Assert.isTrue(startPage >= 1, "startPage must be a positive (one-based) value.");
+			Assert.isTrue(endPage >= startPage, "endPage must be greater than or equal to startPage.");
+			this.pageRanges.add(new int[] { startPage, endPage });
 			return this;
 		}
 

--- a/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
@@ -26,6 +26,7 @@ import org.springframework.ai.reader.ExtractedTextFormatter;
 import org.springframework.ai.reader.pdf.config.PdfDocumentReaderConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Christian Tzolov
@@ -109,6 +110,150 @@ class PagePdfDocumentReaderTests {
 			.get();
 
 		assertThat(documents).hasSize(1);
+	}
+
+	@Test
+	void testSinglePageRange() {
+		// The test pdf contains 64 pages. Read only pages 10..12.
+		var documents = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(1)
+					.addPageRange(10, 12)
+					.build())
+			.get();
+
+		assertThat(documents).hasSize(3);
+		assertThat(documents).extracting(doc -> doc.getMetadata().get(PagePdfDocumentReader.METADATA_START_PAGE_NUMBER))
+			.containsExactly(10, 11, 12);
+	}
+
+	@Test
+	void testMultipleDisjointPageRanges() {
+		// The test pdf contains 64 pages. Read pages 1..2 and the last page (64).
+		var documents = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(1)
+					.addPageRange(1, 2)
+					.addPageRange(64, 64)
+					.build())
+			.get();
+
+		assertThat(documents).hasSize(3);
+		assertThat(documents).extracting(doc -> doc.getMetadata().get(PagePdfDocumentReader.METADATA_START_PAGE_NUMBER))
+			.containsExactly(1, 2, 64);
+	}
+
+	@Test
+	void testPageRangeWithAllPagesPerDocument() {
+		// Pages 5..8 grouped into a single document.
+		var documents = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(0) // all selected pages into one document
+					.addPageRange(5, 8)
+					.build())
+			.get();
+
+		assertThat(documents).hasSize(1);
+		assertThat(documents.get(0).getMetadata()).containsEntry(PagePdfDocumentReader.METADATA_START_PAGE_NUMBER, 5)
+			.containsEntry(PagePdfDocumentReader.METADATA_END_PAGE_NUMBER, 8);
+	}
+
+	@Test
+	void testPageRangeUpperBoundClampedToDocument() {
+		// Range end exceeds the 64-page document; it should clamp to the last page.
+		var documents = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(1)
+					.addPageRange(60, 1000)
+					.build())
+			.get();
+
+		assertThat(documents).hasSize(5);
+		assertThat(documents).extracting(doc -> doc.getMetadata().get(PagePdfDocumentReader.METADATA_START_PAGE_NUMBER))
+			.containsExactly(60, 61, 62, 63, 64);
+	}
+
+	@Test
+	void testOverlappingPageRangesAreDeduplicated() {
+		// Overlapping ranges 10..12 and 11..13 should yield the union 10..13.
+		var documents = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(1)
+					.addPageRange(10, 12)
+					.addPageRange(11, 13)
+					.build())
+			.get();
+
+		assertThat(documents).hasSize(4);
+		assertThat(documents).extracting(doc -> doc.getMetadata().get(PagePdfDocumentReader.METADATA_START_PAGE_NUMBER))
+			.containsExactly(10, 11, 12, 13);
+	}
+
+	@Test
+	void testInvalidPageRangesAreRejected() {
+		// startPage below 1
+		assertThatThrownBy(() -> PdfDocumentReaderConfig.builder().addPageRange(0, 5))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		// negative startPage
+		assertThatThrownBy(() -> PdfDocumentReaderConfig.builder().addPageRange(-1, 5))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		// endPage before startPage
+		assertThatThrownBy(() -> PdfDocumentReaderConfig.builder().addPageRange(5, 3))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void testDisjointRangesSplitAtGapWithAllPagesPerDocument() {
+		// Pages 1..2 and 64 with all-pages-per-document must NOT merge across the gap
+		// into one Document; each contiguous run becomes its own Document so the
+		// start/end page metadata stays accurate.
+		var documents = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(0) // all selected pages into one document per
+												// contiguous run
+					.addPageRange(1, 2)
+					.addPageRange(64, 64)
+					.build())
+			.get();
+
+		assertThat(documents).hasSize(2);
+		assertThat(documents.get(0).getMetadata()).containsEntry(PagePdfDocumentReader.METADATA_START_PAGE_NUMBER, 1)
+			.containsEntry(PagePdfDocumentReader.METADATA_END_PAGE_NUMBER, 2);
+		// Single-page run: only the start page number is set (no end_page_number).
+		assertThat(documents.get(1).getMetadata()).containsEntry(PagePdfDocumentReader.METADATA_START_PAGE_NUMBER, 64)
+			.doesNotContainKey(PagePdfDocumentReader.METADATA_END_PAGE_NUMBER);
+	}
+
+	@Test
+	void testFilteredContentMatchesUnfilteredPages() {
+		// Guard against excluded page text leaking into the output: the text of a
+		// range-filtered read must equal the text of the same pages from a full read.
+		var fullDocuments = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(1)
+					.build())
+			.get();
+
+		var rangedDocuments = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(1)
+					.addPageRange(10, 12)
+					.build())
+			.get();
+
+		assertThat(rangedDocuments).extracting(Document::getText)
+			.containsExactly(fullDocuments.get(9).getText(), fullDocuments.get(10).getText(),
+					fullDocuments.get(11).getText());
 	}
 
 }

--- a/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
@@ -68,6 +68,16 @@ public class ParagraphPdfDocumentReaderTests {
 	}
 
 	@Test
+	void testPageRangesAreRejected() {
+		// ParagraphPdfDocumentReader does not support page ranges; it must fail fast
+		// instead of silently ignoring the configuration.
+		assertThatThrownBy(() -> new ParagraphPdfDocumentReader("classpath:/sample3.pdf",
+				PdfDocumentReaderConfig.builder().addPageRange(1, 2).build()))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Page ranges are not supported by ParagraphPdfDocumentReader");
+	}
+
+	@Test
 	void shouldSkipInvalidOutline() throws IOException {
 
 		Resource basePdfResource = new ClassPathResource("sample3.pdf");


### PR DESCRIPTION
Adds an optional page-range filter so you can read only certain pages of a PDF (e.g. skip the cover, TOC, or appendix) instead of always parsing the whole document.

### Why

`PagePdfDocumentReader` always reads every page. `pagesPerDocument` only controls how parsed pages are grouped, not which ones get read, so there's no clean way to skip pages. Subclassing to do it is awkward because the page loop is internal.

This is a coarse, manual filter on physical page numbers, for when you already know which pages you want. It's not meant to replace content-based page classification (per the discussion on the issue).

### What changed

- New `addPageRange(int startPage, int endPage)` on `PdfDocumentReaderConfig.Builder`. Inclusive, 1-based; call it multiple times to read multiple, possibly disjoint, ranges (their union is read).
- Ranges past the end of the document are clamped to the last page; overlapping ranges are deduped so each page is read once.
- Builder validates each range (`startPage >= 1`, `endPage >= startPage`).
- `PagePdfDocumentReader` keeps its single sequential pass over the page tree. Out-of-range pages are skipped, so there's no perf hit and no change in output when no range is set.
- With disjoint ranges, a Document never spans an excluded gap: each contiguous run of selected pages becomes its own Document, so the `page_number`/`end_page_number` metadata stays accurate (`pagesPerDocument` acts as a maximum across gaps).
- The setting lives on the shared `PdfDocumentReaderConfig` but is honored only by `PagePdfDocumentReader`. `ParagraphPdfDocumentReader` does not support page ranges and now fails fast if a config sets them.

### Example

```java
PdfDocumentReaderConfig config = PdfDocumentReaderConfig.builder()
    // read only pages 3-50 and 55-100
    .addPageRange(3, 50)
    .addPageRange(55, 100)
    .withPagesPerDocument(1)
    .build();

List<Document> documents =
    new PagePdfDocumentReader(new FileSystemResource("document.pdf"), config).get();
```

### Tests

Added cases for a single range, disjoint ranges, all-pages grouping with a range, upper-bound clamping, overlap dedupe, disjoint ranges splitting at the gap under all-pages-per-document, a content-level check that filtered output matches the corresponding unfiltered pages, invalid input, and rejection by `ParagraphPdfDocumentReader`. Existing tests are unchanged.

```
./mvnw -pl document-readers/spring-ai-pdf-document-reader clean test \
  io.spring.javaformat:spring-javaformat-maven-plugin:validate
[INFO] You have 0 Checkstyle violations.
[INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

Closes #6353