### PR TITLE
Add ContextAwareToolCallback and ToolContextHolder

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/context/ContextAwareToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/context/ContextAwareToolCallback.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.context;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.metadata.ToolMetadata;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link ToolCallback} decorator that publishes the {@link ToolContext} received in
+ * {@link #call(String, ToolContext)} to the current thread's {@link ToolContextHolder}
+ * for the duration of the delegate invocation.
+ *
+ * <p>
+ * This allows {@code @Tool} methods whose signatures do <strong>not</strong> declare a
+ * {@code ToolContext} parameter &mdash; including tools defined in third-party frameworks
+ * whose method signatures cannot be changed &mdash; to access the {@code ToolContext} by
+ * reading it from {@link ToolContextHolder#get()}.
+ * </p>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>{@code
+ * ToolCallback original = MethodToolCallback.builder()...build();
+ * ToolCallback wrapped = new ContextAwareToolCallback(original);
+ *
+ * // Inside the @Tool method, the signature does not declare ToolContext:
+ * &#64;Tool
+ * String myTool(String input) {
+ *     ToolContext ctx = ToolContextHolder.get();
+ *     String userId = ctx != null ? (String) ctx.getContext().get("userId") : null;
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * <p>
+ * The {@link ToolContextHolder} is cleared automatically after the delegate returns or
+ * throws, so callers do not need to manage the thread-local lifecycle themselves.
+ * However, callers that {@link ToolContextHolder#set(ToolContext) set} the holder outside
+ * of this decorator remain responsible for invoking {@link ToolContextHolder#clear()}.
+ * </p>
+ *
+ * @author zz_zhi
+ * @since 2.0.0
+ */
+public class ContextAwareToolCallback implements ToolCallback {
+
+	private final ToolCallback delegate;
+
+	public ContextAwareToolCallback(ToolCallback delegate) {
+		Assert.notNull(delegate, "delegate must not be null");
+		this.delegate = delegate;
+	}
+
+	@Override
+	public ToolDefinition getToolDefinition() {
+		return this.delegate.getToolDefinition();
+	}
+
+	@Override
+	public ToolMetadata getToolMetadata() {
+		return this.delegate.getToolMetadata();
+	}
+
+	@Override
+	public String call(String toolInput) {
+		return call(toolInput, null);
+	}
+
+	@Override
+	public String call(String toolInput, @Nullable ToolContext toolContext) {
+		ToolContextHolder.set(toolContext);
+		try {
+			return this.delegate.call(toolInput, toolContext);
+		}
+		finally {
+			ToolContextHolder.clear();
+		}
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/context/ToolContextHolder.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/context/ToolContextHolder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.context;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.model.ToolContext;
+
+/**
+ * Thread-local holder for the {@link ToolContext} that flows through a tool call
+ * invocation. Used in combination with {@link ContextAwareToolCallback} to expose the
+ * current {@code ToolContext} to {@code @Tool} methods whose signatures do not declare a
+ * {@code ToolContext} parameter, including tools defined in third-party frameworks whose
+ * method signatures cannot be changed.
+ *
+ * <p>
+ * Typical usage inside a {@code @Tool} method:
+ * </p>
+ *
+ * <pre>{@code
+ * &#64;Tool
+ * String myTool(String input) {
+ *     ToolContext ctx = ToolContextHolder.get();
+ *     String userId = ctx != null ? (String) ctx.getContext().get("userId") : null;
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * <p>
+ * The storage is an {@link InheritableThreadLocal}, so the context is visible to child
+ * threads spawned from the current thread. Callers are responsible for invoking
+ * {@link #clear()} when the context is no longer needed, typically in a
+ * {@code try/finally} block, to prevent leakage when threads are reused.
+ * </p>
+ *
+ * @author zz_zhi
+ * @since 2.0.0
+ */
+public final class ToolContextHolder {
+
+	private static final InheritableThreadLocal<@Nullable ToolContext> CONTEXT = new InheritableThreadLocal<>();
+
+	private ToolContextHolder() {
+	}
+
+	/**
+	 * Bind the given {@link ToolContext} to the current thread, replacing any value
+	 * previously set. Passing {@code null} clears any value bound to the current thread.
+	 * @param toolContext the context to bind, or {@code null} to clear
+	 */
+	public static void set(@Nullable ToolContext toolContext) {
+		CONTEXT.set(toolContext);
+	}
+
+	/**
+	 * Return the {@link ToolContext} bound to the current thread, or {@code null} if none
+	 * has been set.
+	 * @return the current context, or {@code null}
+	 */
+	public static @Nullable ToolContext get() {
+		return CONTEXT.get();
+	}
+
+	/**
+	 * Remove the {@link ToolContext} bound to the current thread. Should be invoked when
+	 * the scope that established the context has finished (typically in a {@code finally}
+	 * block) to prevent the context from leaking into subsequently reused threads.
+	 */
+	public static void clear() {
+		CONTEXT.remove();
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/context/package-info.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/context/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.tool.context;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/context/ContextAwareToolCallbackTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/context/ContextAwareToolCallbackTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.context;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link ContextAwareToolCallback} and {@link ToolContextHolder}.
+ */
+class ContextAwareToolCallbackTest {
+
+	@Mock
+	private ToolCallback mockDelegate;
+
+	@Mock
+	private ToolDefinition mockToolDefinition;
+
+	@Mock
+	private ToolContext mockToolContext;
+
+	private AutoCloseable mocks;
+
+	@BeforeEach
+	void setUp() {
+		this.mocks = MockitoAnnotations.openMocks(this);
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		ToolContextHolder.clear();
+		this.mocks.close();
+	}
+
+	@Nested
+	@DisplayName("ToolContextHolder")
+	class ToolContextHolderTests {
+
+		@Test
+		@DisplayName("set then get returns the same context")
+		void setThenGet() {
+			ToolContextHolder.set(mockToolContext);
+			assertThat(ToolContextHolder.get()).isSameAs(mockToolContext);
+		}
+
+		@Test
+		@DisplayName("get returns null when nothing was set")
+		void getReturnsNullWhenUnset() {
+			assertThat(ToolContextHolder.get()).isNull();
+		}
+
+		@Test
+		@DisplayName("clear removes the bound context")
+		void clearRemovesContext() {
+			ToolContextHolder.set(mockToolContext);
+			ToolContextHolder.clear();
+			assertThat(ToolContextHolder.get()).isNull();
+		}
+
+		@Test
+		@DisplayName("set replaces a previously bound context")
+		void setReplacesPrevious() {
+			ToolContext ctx1 = new ToolContext(Map.of("k", "v1"));
+			ToolContext ctx2 = new ToolContext(Map.of("k", "v2"));
+			ToolContextHolder.set(ctx1);
+			ToolContextHolder.set(ctx2);
+			assertThat(ToolContextHolder.get()).isSameAs(ctx2);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Constructor")
+	class ConstructorTests {
+
+		@Test
+		@DisplayName("delegates getToolDefinition to the wrapped callback")
+		void delegatesToolDefinition() {
+			when(mockDelegate.getToolDefinition()).thenReturn(mockToolDefinition);
+			ContextAwareToolCallback callback = new ContextAwareToolCallback(mockDelegate);
+			assertThat(callback.getToolDefinition()).isSameAs(mockToolDefinition);
+		}
+
+		@Test
+		@DisplayName("rejects a null delegate")
+		void rejectsNullDelegate() {
+			org.assertj.core.api.Assertions.assertThatIllegalArgumentException()
+				.isThrownBy(() -> new ContextAwareToolCallback(null));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("call(String)")
+	class SingleArgCallTests {
+
+		@Test
+		@DisplayName("forwards to delegate.call(input, null) and clears holder after")
+		void forwardsAndClears() {
+			ContextAwareToolCallback callback = new ContextAwareToolCallback(mockDelegate);
+			when(mockDelegate.call(eq("input"), any())).thenReturn("ok");
+
+			String result = callback.call("input");
+
+			assertThat(result).isEqualTo("ok");
+			verify(mockDelegate).call("input", null);
+			assertThat(ToolContextHolder.get()).isNull();
+		}
+
+		@Test
+		@DisplayName("clears the holder even when the delegate throws")
+		void clearsOnException() {
+			ContextAwareToolCallback callback = new ContextAwareToolCallback(mockDelegate);
+			when(mockDelegate.call(any(), any())).thenThrow(new RuntimeException("boom"));
+
+			org.assertj.core.api.Assertions.assertThatThrownBy(() -> callback.call("input"))
+				.isInstanceOf(RuntimeException.class)
+				.hasMessage("boom");
+			assertThat(ToolContextHolder.get()).isNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("call(String, ToolContext)")
+	class TwoArgCallTests {
+
+		@Test
+		@DisplayName("publishes the context to the holder, forwards, then clears")
+		void publishesAndForwards() {
+			ContextAwareToolCallback callback = new ContextAwareToolCallback(mockDelegate);
+			when(mockDelegate.call("input", mockToolContext)).thenAnswer(invocation -> {
+				assertThat(ToolContextHolder.get()).isSameAs(mockToolContext);
+				return "ok";
+			});
+
+			String result = callback.call("input", mockToolContext);
+
+			assertThat(result).isEqualTo("ok");
+			verify(mockDelegate).call("input", mockToolContext);
+			assertThat(ToolContextHolder.get()).isNull();
+		}
+
+		@Test
+		@DisplayName("publishes null context to the holder when called with null")
+		void publishesNullWhenNull() {
+			ContextAwareToolCallback callback = new ContextAwareToolCallback(mockDelegate);
+			when(mockDelegate.call("input", null)).thenAnswer(invocation -> {
+				assertThat(ToolContextHolder.get()).isNull();
+				return "ok";
+			});
+
+			String result = callback.call("input", null);
+
+			assertThat(result).isEqualTo("ok");
+			assertThat(ToolContextHolder.get()).isNull();
+		}
+
+		@Test
+		@DisplayName("clears the holder even when the delegate throws")
+		void clearsOnException() {
+			ContextAwareToolCallback callback = new ContextAwareToolCallback(mockDelegate);
+			when(mockDelegate.call(any(), any())).thenThrow(new RuntimeException("boom"));
+
+			org.assertj.core.api.Assertions.assertThatThrownBy(() -> callback.call("input", mockToolContext))
+				.isInstanceOf(RuntimeException.class)
+				.hasMessage("boom");
+			assertThat(ToolContextHolder.get()).isNull();
+		}
+
+		@Test
+		@DisplayName("replaces a pre-existing holder value during invocation")
+		void replacesExistingHolderValue() {
+			ToolContext outer = new ToolContext(Map.of("scope", "outer"));
+			ToolContextHolder.set(outer);
+
+			ContextAwareToolCallback callback = new ContextAwareToolCallback(mockDelegate);
+			when(mockDelegate.call(any(), any())).thenAnswer(invocation -> {
+				assertThat(ToolContextHolder.get()).isSameAs(mockToolContext);
+				return "ok";
+			});
+
+			callback.call("input", mockToolContext);
+
+			// after the call, the holder is cleared (not restored to outer)
+			assertThat(ToolContextHolder.get()).isNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Integration: @Tool method without ToolContext parameter")
+	class IntegrationTests {
+
+		@Test
+		@DisplayName("a tool method that does not declare ToolContext can read it from the holder")
+		void toolMethodReadsHolder() {
+			ToolContext expected = new ToolContext(Map.of("userId", "u-42"));
+			ToolContextHolder.set(expected);
+
+			ContextAwareToolCallback callback = new ContextAwareToolCallback(mockDelegate);
+			when(mockDelegate.call(any(), any())).thenAnswer(invocation -> {
+				// Simulating a @Tool method that does NOT declare a ToolContext parameter
+				// but reads it from the holder.
+				ToolContext ctx = ToolContextHolder.get();
+				assertThat(ctx).isSameAs(expected);
+				assertThat(ctx.getContext()).containsEntry("userId", "u-42");
+				return ctx.getContext().get("userId").toString();
+			});
+
+			String result = callback.call("input", expected);
+
+			assertThat(result).isEqualTo("u-42");
+			assertThat(ToolContextHolder.get()).isNull();
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Add `ContextAwareToolCallback` and `ToolContextHolder` so that `@Tool` methods whose signatures do **not** declare a `ToolContext` parameter can still access the `ToolContext` (e.g. user id, tenant id, trace id).

- `ToolContextHolder` — an `InheritableThreadLocal` holder for the `ToolContext` flowing through a tool call invocation.
- `ContextAwareToolCallback` — a `ToolCallback` decorator that publishes the `ToolContext` received in `call(String, ToolContext)` to the holder for the duration of the delegate invocation. The holder is cleared automatically in a `finally` block.

## Motivation

Today, if a `@Tool` method does not declare a `ToolContext` parameter, the framework has no way to surface the `ToolContext` to it. This is especially limiting for tools defined in third-party libraries whose method signatures cannot be modified — for example tools provided via MCP or by community projects like [spring-ai-agent-utils](https://github.com/spring-ai-community/spring-ai-agent-utils).

This change introduces a thread-local bridge: the decorator binds the `ToolContext` for the duration of the delegate call, and the tool method can read it via `ToolContextHolder.get()`. No changes to `MethodToolCallback` or the `ToolCallback` interface are required.

## Usage

```java
ToolCallback wrapped = new ContextAwareToolCallback(originalCallback);
```

```java
@Tool
String myTool(String input) {   // no ToolContext parameter needed
    ToolContext ctx = ToolContextHolder.get();
    String userId = ctx != null ? (String) ctx.getContext().get("userId") : null;
    return "hello " + userId;
}
```

## Testing

- 13 new unit tests covering: holder behaviour, constructor validation, single-arg and two-arg `call`, holder clearing on exception, and an integration scenario.
- `./mvnw -pl spring-ai-model process-sources` — 0 checkstyle violations.
- `./mvnw -pl spring-ai-model -Dtest=ContextAwareToolCallbackTest test` — all tests pass.