### PR TITLE
Validate `TokenTextSplitter` builder arguments

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
@@ -121,6 +121,10 @@ public class TokenTextSplitter extends TextSplitter {
 	private TokenTextSplitter(EncodingType encodingType, int chunkSize, int minChunkSizeChars,
 			int minChunkLengthToEmbed, int maxNumChunks, boolean keepSeparator, List<Character> punctuationMarks) {
 		Assert.notNull(encodingType, "encodingType must not be null");
+		Assert.isTrue(chunkSize > 0, "chunkSize must be greater than zero");
+		Assert.isTrue(maxNumChunks > 0, "maxNumChunks must be greater than zero");
+		Assert.isTrue(minChunkSizeChars >= 0, "minChunkSizeChars must not be negative");
+		Assert.isTrue(minChunkLengthToEmbed >= 0, "minChunkLengthToEmbed must not be negative");
 		this.encoding = this.registry.getEncoding(encodingType);
 		this.chunkSize = chunkSize;
 		this.minChunkSizeChars = minChunkSizeChars;

--- a/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/TokenTextSplitterTest.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/TokenTextSplitterTest.java
@@ -216,6 +216,51 @@ public class TokenTextSplitterTest {
 	}
 
 	@Test
+	public void testTokenTextSplitterWithZeroChunkSizeThrows() {
+		// A chunkSize of 0 previously caused doSplit to loop forever; it must now fail
+		// fast.
+		assertThatIllegalArgumentException().isThrownBy(() -> TokenTextSplitter.builder().withChunkSize(0).build())
+			.withMessage("chunkSize must be greater than zero");
+	}
+
+	@Test
+	public void testTokenTextSplitterWithNegativeChunkSizeThrows() {
+		assertThatIllegalArgumentException().isThrownBy(() -> TokenTextSplitter.builder().withChunkSize(-1).build())
+			.withMessage("chunkSize must be greater than zero");
+	}
+
+	@Test
+	public void testTokenTextSplitterWithNonPositiveMaxNumChunksThrows() {
+		assertThatIllegalArgumentException().isThrownBy(() -> TokenTextSplitter.builder().withMaxNumChunks(0).build())
+			.withMessage("maxNumChunks must be greater than zero");
+	}
+
+	@Test
+	public void testTokenTextSplitterWithNegativeMinChunkSizeCharsThrows() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> TokenTextSplitter.builder().withMinChunkSizeChars(-1).build())
+			.withMessage("minChunkSizeChars must not be negative");
+	}
+
+	@Test
+	public void testTokenTextSplitterWithNegativeMinChunkLengthToEmbedThrows() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> TokenTextSplitter.builder().withMinChunkLengthToEmbed(-1).build())
+			.withMessage("minChunkLengthToEmbed must not be negative");
+	}
+
+	@Test
+	public void testTokenTextSplitterWithChunkSizeOneTerminates() {
+		// chunkSize == 1 is the smallest valid value: it must terminate and produce
+		// chunks.
+		var splitter = TokenTextSplitter.builder().withChunkSize(1).withMinChunkLengthToEmbed(0).build();
+
+		var chunks = splitter.apply(List.of(new Document("Hello world from Spring AI")));
+
+		assertThat(chunks).isNotEmpty();
+	}
+
+	@Test
 	public void testTokenTextSplitterWithDifferentEncodingTypes() {
 		var contentFormatter1 = DefaultContentFormatter.defaultConfig();
 		var contentFormatter2 = DefaultContentFormatter.defaultConfig();


### PR DESCRIPTION
Fixes an infinite loop in `TokenTextSplitter` and adds fail-fast validation for the builder's numeric arguments.

### Why

`TokenTextSplitter.Builder` doesn't validate `chunkSize`. With `chunkSize == 0`, `doSplit(...)` loops forever: the chunk sublist is empty, so the remaining tokens never shrink and `num_chunks` is never incremented. A negative `chunkSize` fails later with a confusing `IllegalArgumentException: fromIndex(0) > toIndex(-1)` from `List.subList`.

```java
// hangs forever
TokenTextSplitter.builder().withChunkSize(0).build()
    .apply(List.of(new Document("any non-empty text")));
```

### What changed

- Validate the numeric builder arguments in the constructor, next to the existing `encodingType` check:
  - `chunkSize` must be greater than zero
  - `maxNumChunks` must be greater than zero
  - `minChunkSizeChars` must not be negative
  - `minChunkLengthToEmbed` must not be negative
- Misconfiguration now fails fast at build time with a clear message instead of hanging or throwing an internal error.
- The checks run once at construction, so the hot splitting path (`doSplit`) is unchanged — no runtime/throughput impact.

### Tests

Added regression tests for each rejected argument (matching the existing `testTokenTextSplitterWithNullEncodingTypeThrows` style) plus a `chunkSize == 1` boundary test proving the smallest valid value terminates and produces chunks. Existing tests are unchanged.

```
./mvnw -pl spring-ai-commons clean test -Dtest=TokenTextSplitterTest \
  io.spring.javaformat:spring-javaformat-maven-plugin:validate
[INFO] You have 0 Checkstyle violations.
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

Closes #6447
