### PR TITLE
Fix tool-search advisor auto-config ordering

### DIFF
--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/pom.xml
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/pom.xml
@@ -46,6 +46,16 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Optional compile-time dependency so @AutoConfiguration can reference
+		     ToolCallingAutoConfiguration.class for ordering (afterName equivalent).
+		     Marked optional to avoid leaking onto consumers' classpaths. -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- Optional: VectorStore support for VectorToolIndex auto-configuration -->
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
@@ -75,14 +85,6 @@
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
-			<version>${project.parent.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<!-- Provides ToolCallingAutoConfiguration to verify auto-configuration ordering -->
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/pom.xml
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/pom.xml
@@ -79,6 +79,14 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Provides ToolCallingAutoConfiguration to verify auto-configuration ordering -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-core</artifactId>

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
@@ -23,8 +23,10 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.client.advisor.toolsearch.ToolSearchToolCallingAdvisor;
+import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.tool.toolsearch.ToolIndex;
 import org.springframework.ai.tool.toolsearch.eviction.CompositeEvictionStrategy;
 import org.springframework.ai.tool.toolsearch.eviction.LruEvictionStrategy;
@@ -70,12 +72,24 @@ import org.springframework.util.StringUtils;
  * <li>{@code tool-index-type=vector} — embedding-based semantic search; requires a
  * {@link VectorStore} bean and {@code spring-ai-vector-store} on the classpath.</li>
  * </ul>
+ * <p>
+ * The auto-configuration ordering is significant:
+ * <ul>
+ * <li>{@code after = ToolCallingAutoConfiguration.class} — the builder bean is guarded by
+ * {@code @ConditionalOnBean(ToolCallingManager.class)}, so this configuration must
+ * process after {@link ToolCallingAutoConfiguration} has contributed the
+ * {@link ToolCallingManager}; otherwise the condition fails and the advisor is never
+ * registered.</li>
+ * <li>{@code before = ChatClientAutoConfiguration.class} — the
+ * {@link ToolCallingAdvisor.Builder} subtype registered here must exist before
+ * {@link ChatClientAutoConfiguration} evaluates its own {@code @ConditionalOnMissingBean}
+ * builder, so the default builder is skipped in favor of this one.</li>
+ * </ul>
  *
  * @author Christian Tzolov
  * @since 2.0.0
  */
-@AutoConfiguration(afterName = "org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration",
-		beforeName = "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration")
+@AutoConfiguration(after = ToolCallingAutoConfiguration.class, before = ChatClientAutoConfiguration.class)
 @ConditionalOnClass(ToolSearchToolCallingAdvisor.class)
 @EnableConfigurationProperties(ToolSearchAdvisorProperties.class)
 @ConditionalOnProperty(prefix = ToolSearchAdvisorProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
@@ -74,7 +74,8 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @since 2.0.0
  */
-@AutoConfiguration(beforeName = "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration")
+@AutoConfiguration(afterName = "org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration",
+		beforeName = "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration")
 @ConditionalOnClass(ToolSearchToolCallingAdvisor.class)
 @EnableConfigurationProperties(ToolSearchAdvisorProperties.class)
 @ConditionalOnProperty(prefix = ToolSearchAdvisorProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfigurationTests.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfigurationTests.java
@@ -21,8 +21,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.client.advisor.toolsearch.ToolSearchToolCallingAdvisor;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.tool.toolsearch.ToolIndex;
 import org.springframework.ai.tool.toolsearch.eviction.CompositeEvictionStrategy;
 import org.springframework.ai.tool.toolsearch.eviction.LruEvictionStrategy;
@@ -241,6 +244,56 @@ class ToolSearchAdvisorAutoConfigurationTests {
 				var builder = context.getBean(ToolCallingAdvisor.Builder.class);
 				assertThat(ReflectionTestUtils.getField(builder, "evictionStrategy"))
 					.isInstanceOf(CompositeEvictionStrategy.class);
+			});
+	}
+
+	// --- Auto-configuration ordering ---
+
+	/**
+	 * Regression test for the auto-configuration ordering: the
+	 * {@code toolCallingAdvisorBuilder} bean is guarded by
+	 * {@code @ConditionalOnBean(ToolCallingManager.class)}, and
+	 * {@link ToolCallingManager} is contributed by {@link ToolCallingAutoConfiguration}.
+	 * Unless this configuration is ordered after {@link ToolCallingAutoConfiguration},
+	 * its condition is evaluated before the manager exists, the tool-search builder backs
+	 * off, and {@link ChatClientAutoConfiguration} contributes the default
+	 * {@link ToolCallingAdvisor.Builder} instead.
+	 * <p>
+	 * All three auto-configurations are loaded together so the {@code @AutoConfiguration}
+	 * before/after metadata actually drives the evaluation order (a single auto-config
+	 * cannot exercise ordering). The runner does not pre-register a
+	 * {@link ToolCallingManager}, so the bean must come from
+	 * {@link ToolCallingAutoConfiguration} exactly as it does at runtime.
+	 */
+	@Test
+	void toolSearchBuilderReplacesDefaultWhenAllAutoConfigurationsAreLoaded() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ToolSearchAdvisorAutoConfiguration.class,
+					ToolCallingAutoConfiguration.class, ChatClientAutoConfiguration.class))
+			.withBean(ChatModel.class, () -> mock(ChatModel.class))
+			.withPropertyValues("spring.ai.chat.client.tool-search-advisor.enabled=true")
+			.run(context -> {
+				assertThat(context).hasSingleBean(ToolCallingAdvisor.Builder.class);
+				assertThat(context.getBean(ToolCallingAdvisor.Builder.class))
+					.isInstanceOf(ToolSearchToolCallingAdvisor.Builder.class);
+			});
+	}
+
+	/**
+	 * When the tool-search advisor is not enabled, the same three-way wiring must fall
+	 * back to the default {@link ChatClientAutoConfiguration} builder (and never the
+	 * tool-search subtype).
+	 */
+	@Test
+	void defaultBuilderIsUsedWhenToolSearchAdvisorDisabled() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ToolSearchAdvisorAutoConfiguration.class,
+					ToolCallingAutoConfiguration.class, ChatClientAutoConfiguration.class))
+			.withBean(ChatModel.class, () -> mock(ChatModel.class))
+			.run(context -> {
+				assertThat(context).hasSingleBean(ToolCallingAdvisor.Builder.class);
+				assertThat(context.getBean(ToolCallingAdvisor.Builder.class))
+					.isNotInstanceOf(ToolSearchToolCallingAdvisor.Builder.class);
 			});
 	}
 


### PR DESCRIPTION
Order ToolSearchAdvisorAutoConfiguration after ToolCallingAutoConfiguration so ToolCallingManager exists when its @ConditionalOnBean is evaluated. 
Without it, the tool-search builder backs off and ChatClientAutoConfiguration contributes the default ToolCallingAdvisor.Builder instead.

Add regression tests loading all three auto-configurations together.
