### PR TITLE
Use model-independent assertions for tool-call token usage

### DIFF
--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelIT.java
@@ -319,7 +319,10 @@ class AnthropicChatModelIT {
 			response = this.chatModel.call(prompt);
 		}
 		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
-		assertThat(response.getMetadata().getUsage().getTotalTokens()).isGreaterThan(100);
+		Usage usage = response.getMetadata().getUsage();
+		assertThat(usage.getPromptTokens()).isPositive();
+		assertThat(usage.getCompletionTokens()).isPositive();
+		assertThat(usage.getTotalTokens()).isEqualTo(usage.getPromptTokens() + usage.getCompletionTokens());
 	}
 
 	@Test
@@ -380,8 +383,9 @@ class AnthropicChatModelIT {
 		assertThat(lastResponse).isNotNull();
 		Usage usage = lastResponse.getMetadata().getUsage();
 		assertThat(usage).isNotNull();
-		// Tool calling uses more tokens due to multi-turn conversation
-		assertThat(usage.getTotalTokens()).isGreaterThan(100);
+		assertThat(usage.getPromptTokens()).isPositive();
+		assertThat(usage.getCompletionTokens()).isPositive();
+		assertThat(usage.getTotalTokens()).isEqualTo(usage.getPromptTokens() + usage.getCompletionTokens());
 	}
 
 	@Test

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -455,9 +455,9 @@ public class OpenAiChatModelIT {
 		assertThat(usage).isNotNull();
 		assertThat(usage).isNotInstanceOf(EmptyUsage.class);
 		assertThat(usage).isInstanceOf(DefaultUsage.class);
-		assertThat(usage.getPromptTokens()).isGreaterThan(450).isLessThan(600);
-		assertThat(usage.getCompletionTokens()).isGreaterThan(420).isLessThan(800);
-		assertThat(usage.getTotalTokens()).isGreaterThan(900).isLessThan(1400);
+		assertThat(usage.getPromptTokens()).isPositive();
+		assertThat(usage.getCompletionTokens()).isPositive();
+		assertThat(usage.getTotalTokens()).isEqualTo(usage.getPromptTokens() + usage.getCompletionTokens());
 	}
 
 	@Test
@@ -484,9 +484,9 @@ public class OpenAiChatModelIT {
 		assertThat(usage).isNotNull();
 		assertThat(usage).isNotInstanceOf(EmptyUsage.class);
 		assertThat(usage).isInstanceOf(DefaultUsage.class);
-		assertThat(usage.getPromptTokens()).isGreaterThan(450).isLessThan(600);
-		assertThat(usage.getCompletionTokens()).isGreaterThan(100).isLessThan(500);
-		assertThat(usage.getTotalTokens()).isGreaterThan(550).isLessThan(1100);
+		assertThat(usage.getPromptTokens()).isPositive();
+		assertThat(usage.getCompletionTokens()).isPositive();
+		assertThat(usage.getTotalTokens()).isEqualTo(usage.getPromptTokens() + usage.getCompletionTokens());
 	}
 
 	@Test


### PR DESCRIPTION
Replace the hardcoded token-count ranges in the function-call usage tests with deterministic invariants: prompt and completion tokens are positive and the total equals their sum.
