### PR TITLE
Prevent infinite tool-call loops with identical tool arguments

### DIFF
--- a/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
+++ b/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
@@ -121,7 +121,8 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 			String systemMessageSuffix, boolean referenceToolNameAccumulation, @Nullable Integer maxResults,
 			boolean conversationHistoryEnabled, String sessionIdKeyName, ToolIndexEvictionStrategy evictionStrategy) {
 
-		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled);
+		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled,
+				DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT);
 		this.toolIndex = toolIndex;
 		this.systemMessageSuffix = systemMessageSuffix;
 		this.referenceToolNameAccumulation = referenceToolNameAccumulation;

--- a/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
+++ b/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.advisor.AdvisorLoopGuard;
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
@@ -119,10 +120,11 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 	protected ToolSearchToolCallingAdvisor(ToolCallingManager toolCallingManager, int advisorOrder,
 			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, ToolIndex toolIndex,
 			String systemMessageSuffix, boolean referenceToolNameAccumulation, @Nullable Integer maxResults,
-			boolean conversationHistoryEnabled, String sessionIdKeyName, ToolIndexEvictionStrategy evictionStrategy) {
+			boolean conversationHistoryEnabled, String sessionIdKeyName, ToolIndexEvictionStrategy evictionStrategy,
+			AdvisorLoopGuard advisorLoopGuard) {
 
 		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled,
-				DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT);
+				advisorLoopGuard);
 		this.toolIndex = toolIndex;
 		this.systemMessageSuffix = systemMessageSuffix;
 		this.referenceToolNameAccumulation = referenceToolNameAccumulation;
@@ -488,7 +490,8 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 			return new ToolSearchToolCallingAdvisor(getToolCallingManager(), getAdvisorOrder(),
 					getToolExecutionEligibilityChecker(), this.toolIndex,
 					Objects.requireNonNull(this.systemMessageSuffix), this.referenceToolNameAccumulation,
-					this.maxResults, this.isConversationHistoryEnabled(), this.sessionIdKeyName, this.evictionStrategy);
+					this.maxResults, this.isConversationHistoryEnabled(), this.sessionIdKeyName, this.evictionStrategy,
+					getAdvisorLoopGuard());
 		}
 
 		@Override

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/AdvisorLoopGuard.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/AdvisorLoopGuard.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.util.Assert;
+
+/**
+ * Strategy for detecting and breaking out of infinite loops in a recursive advisor —
+ * any advisor that repeatedly calls the model and inspects each round's response to
+ * decide whether to loop again (e.g. a tool-calling loop or a structured-output
+ * validation retry loop). The guard governs a single advisor execution (one non-streaming
+ * call or one stream subscription).
+ * <p>
+ * A fresh {@link LoopState} is created for every loop via {@link #begin()} so that any
+ * state an implementation accumulates (e.g. per-round counts) is isolated to a single
+ * conversation turn and is never shared across requests or subscriptions.
+ * <p>
+ * For each round, {@link LoopState#check(ChatResponse)} is invoked just before the
+ * recursive advisor acts on the round (e.g. before executing tool calls) and returns a
+ * {@link Decision} that tells the advisor whether to {@link Decision.Action#CONTINUE
+ * continue}, {@link Decision.Action#STOP stop gracefully} (returning the latest response
+ * to the caller without acting on the round), or {@link Decision.Action#ERROR abort with
+ * an error}. This lets budget-style guards (e.g. time or token budgets) terminate
+ * gracefully instead of failing the request.
+ * <p>
+ * A tool-call-oriented implementation is {@link MaxIdenticalToolCallLoopGuard}, which
+ * breaks the loop when the same tool is repeatedly invoked with identical arguments.
+ * Provide a custom implementation to plug in alternative loop-detection policies (e.g. a
+ * maximum total number of rounds, time-based budgets, etc.).
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ * @see MaxIdenticalToolCallLoopGuard
+ */
+@FunctionalInterface
+public interface AdvisorLoopGuard {
+
+	/**
+	 * Begins a new, isolated guard state for a single recursive advisor loop.
+	 * @return a stateful {@link LoopState} bound to one loop
+	 */
+	LoopState begin();
+
+	/**
+	 * Stateful, single-loop view of an {@link AdvisorLoopGuard}. Implementations inspect
+	 * each round's response and return a {@link Decision} that controls whether the loop
+	 * continues, stops gracefully or aborts with an error.
+	 */
+	@FunctionalInterface
+	interface LoopState {
+
+		/**
+		 * Inspects the given response for the current loop and decides how the loop
+		 * should proceed.
+		 * @param chatResponse the aggregated model response for the round about to be
+		 * acted upon
+		 * @return the {@link Decision} describing how the loop should proceed
+		 */
+		Decision check(ChatResponse chatResponse);
+
+	}
+
+	/**
+	 * The outcome of a {@link LoopState#check(ChatResponse)} invocation.
+	 */
+	final class Decision {
+
+		/**
+		 * The action the recursive advisor should take for the current round.
+		 */
+		public enum Action {
+
+			/**
+			 * Proceed to act on the current round (e.g. execute its tool calls).
+			 */
+			CONTINUE,
+
+			/**
+			 * Stop the loop gracefully without acting on the current round, returning the
+			 * latest response to the caller.
+			 */
+			STOP,
+
+			/**
+			 * Abort the loop by failing the request.
+			 */
+			ERROR
+
+		}
+
+		private static final Decision CONTINUE = new Decision(Action.CONTINUE, null);
+
+		private static final Decision STOP = new Decision(Action.STOP, null);
+
+		private final Action action;
+
+		@Nullable private final String message;
+
+		private Decision(Action action, @Nullable String message) {
+			this.action = action;
+			this.message = message;
+		}
+
+		/**
+		 * Returns a decision to continue acting on the current round.
+		 * @return a {@link Action#CONTINUE} decision
+		 */
+		public static Decision continueLoop() {
+			return CONTINUE;
+		}
+
+		/**
+		 * Returns a decision to stop the loop gracefully, returning the latest response
+		 * to the caller without acting on the current round.
+		 * @return a {@link Action#STOP} decision
+		 */
+		public static Decision stop() {
+			return STOP;
+		}
+
+		/**
+		 * Returns a decision to stop the loop gracefully with an explanatory message.
+		 * @param message the reason the loop is being stopped
+		 * @return a {@link Action#STOP} decision carrying the given message
+		 */
+		public static Decision stop(String message) {
+			Assert.hasText(message, "message must not be empty");
+			return new Decision(Action.STOP, message);
+		}
+
+		/**
+		 * Returns a decision to abort the loop by failing the request.
+		 * @param message the error message describing why the loop was aborted
+		 * @return an {@link Action#ERROR} decision carrying the given message
+		 */
+		public static Decision error(String message) {
+			Assert.hasText(message, "message must not be empty");
+			return new Decision(Action.ERROR, message);
+		}
+
+		/**
+		 * Returns the action the advisor should take.
+		 * @return the {@link Action}
+		 */
+		public Action action() {
+			return this.action;
+		}
+
+		/**
+		 * Returns the message associated with this decision, if any.
+		 * @return the message, or {@code null} for a plain {@link Action#CONTINUE} or
+		 * {@link Action#STOP} decision
+		 */
+		@Nullable public String message() {
+			return this.message;
+		}
+
+	}
+
+}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/AdvisorLoopGuard.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/AdvisorLoopGuard.java
@@ -22,28 +22,21 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.util.Assert;
 
 /**
- * Strategy for detecting and breaking out of infinite loops in a recursive advisor —
- * any advisor that repeatedly calls the model and inspects each round's response to
- * decide whether to loop again (e.g. a tool-calling loop or a structured-output
- * validation retry loop). The guard governs a single advisor execution (one non-streaming
- * call or one stream subscription).
+ * Strategy for detecting and breaking out of infinite loops in a recursive advisor, such
+ * as a tool-calling loop or a structured-output validation retry loop. A guard governs a
+ * single advisor execution: one non-streaming call or one stream subscription.
  * <p>
- * A fresh {@link LoopState} is created for every loop via {@link #begin()} so that any
- * state an implementation accumulates (e.g. per-round counts) is isolated to a single
- * conversation turn and is never shared across requests or subscriptions.
+ * {@link #begin()} creates a fresh {@link LoopState} for every loop, so any state an
+ * implementation accumulates (e.g. per-round counts) is isolated to a single conversation
+ * turn. Before acting on each round (e.g. before executing tool calls), the advisor calls
+ * {@link LoopState#check(ChatResponse)}, which returns a {@link Decision} to
+ * {@link Decision.Action#CONTINUE continue}, {@link Decision.Action#STOP stop gracefully}
+ * (returning the latest response without acting on the round), or
+ * {@link Decision.Action#ERROR abort with an error}.
  * <p>
- * For each round, {@link LoopState#check(ChatResponse)} is invoked just before the
- * recursive advisor acts on the round (e.g. before executing tool calls) and returns a
- * {@link Decision} that tells the advisor whether to {@link Decision.Action#CONTINUE
- * continue}, {@link Decision.Action#STOP stop gracefully} (returning the latest response
- * to the caller without acting on the round), or {@link Decision.Action#ERROR abort with
- * an error}. This lets budget-style guards (e.g. time or token budgets) terminate
- * gracefully instead of failing the request.
- * <p>
- * A tool-call-oriented implementation is {@link MaxIdenticalToolCallLoopGuard}, which
- * breaks the loop when the same tool is repeatedly invoked with identical arguments.
- * Provide a custom implementation to plug in alternative loop-detection policies (e.g. a
- * maximum total number of rounds, time-based budgets, etc.).
+ * {@link MaxIdenticalToolCallLoopGuard} is the default, tool-call-oriented
+ * implementation. Provide a custom implementation for other policies, e.g. a maximum
+ * round count or a time budget.
  *
  * @author Christian Tzolov
  * @since 2.0.0

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MaxIdenticalToolCallLoopGuard.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MaxIdenticalToolCallLoopGuard.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.util.Assert;
+
+/**
+ * {@link AdvisorLoopGuard} implementation that breaks a tool-calling loop when a tool is
+ * repeatedly invoked with identical arguments.
+ * <p>
+ * Within a single loop the guard tracks each distinct {@code (tool name, arguments)}
+ * combination and returns an {@link AdvisorLoopGuard.Decision.Action#ERROR error}
+ * decision once the same combination is seen more than
+ * {@link #getMaxIdenticalToolCallCount()} times. This prevents infinite loops where a
+ * model keeps calling the same tool with the same arguments after receiving an error or
+ * otherwise unhelpful response.
+ * <p>
+ * Because the count accumulates across the entire loop within a single conversation turn,
+ * a model that legitimately re-invokes an idempotent tool with identical arguments (e.g.
+ * polling a {@code get_status} or {@code list_files} tool) more than
+ * {@link #getMaxIdenticalToolCallCount()} times could trip the guard. Such tools can be
+ * exempted from the check via {@link Builder#excludedToolNames(java.util.Collection)};
+ * alternatively, increase the limit via {@link Builder#maxIdenticalToolCallCount(int)}.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public class MaxIdenticalToolCallLoopGuard implements AdvisorLoopGuard {
+
+	/**
+	 * Default maximum number of times a tool may be called with identical arguments
+	 * within a single advisor loop. A value of 15 is tolerant of legitimate repeats (e.g.
+	 * a model polling an idempotent tool or retrying after transient errors) while still
+	 * breaking infinite loops where the model never changes the tool arguments. Since the
+	 * guard keys on the tool name <em>and</em> identical arguments, seeing the same call
+	 * 15 times is already a strong infinite-loop signal; the limit mainly governs how
+	 * many identical retries are tolerated before aborting.
+	 */
+	public static final int DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT = 15;
+
+	private final int maxIdenticalToolCallCount;
+
+	private final Set<String> excludedToolNames;
+
+	/**
+	 * Creates a guard with the given limit and excluded tool names.
+	 * @param maxIdenticalToolCallCount the maximum number of identical tool calls allowed
+	 * within a single loop (must be positive)
+	 * @param excludedToolNames the names of tools that are exempt from the identical
+	 * tool-call check (must not be null)
+	 */
+	protected MaxIdenticalToolCallLoopGuard(int maxIdenticalToolCallCount, Collection<String> excludedToolNames) {
+		Assert.isTrue(maxIdenticalToolCallCount > 0, "maxIdenticalToolCallCount must be positive");
+		Assert.notNull(excludedToolNames, "excludedToolNames must not be null");
+		this.maxIdenticalToolCallCount = maxIdenticalToolCallCount;
+		this.excludedToolNames = new HashSet<>(excludedToolNames);
+	}
+
+	/**
+	 * Returns the configured maximum number of identical tool calls allowed within a
+	 * single loop.
+	 * @return the maximum identical tool call count
+	 */
+	public int getMaxIdenticalToolCallCount() {
+		return this.maxIdenticalToolCallCount;
+	}
+
+	/**
+	 * Returns an unmodifiable view of the tool names that are exempt from the identical
+	 * tool-call check.
+	 * @return the excluded tool names
+	 */
+	public Set<String> getExcludedToolNames() {
+		return Set.copyOf(this.excludedToolNames);
+	}
+
+	@Override
+	public LoopState begin() {
+		// Loop-local tracker so identical-call detection is isolated to a single loop and
+		// never shared across requests or subscriptions.
+		Map<String, Integer> seenToolCalls = new HashMap<>();
+		return chatResponse -> checkForRepeatedToolCalls(chatResponse, seenToolCalls);
+	}
+
+	/**
+	 * Inspects the tool calls in the given response, updating the per-loop invocation
+	 * counts and returning an {@link Decision.Action#ERROR error} decision once any
+	 * {@code (tool name, arguments)} combination exceeds
+	 * {@link #getMaxIdenticalToolCallCount()}. Otherwise returns a
+	 * {@link Decision.Action#CONTINUE continue} decision.
+	 * <p>
+	 * Subclasses may override this method to customize how repeated tool calls are keyed,
+	 * counted or reported.
+	 * @param chatResponse the aggregated model response containing the tool calls about
+	 * to be executed in this round
+	 * @param seenToolCalls the loop-local map tracking how many times each
+	 * {@code (tool name, arguments)} combination has been seen
+	 * @return the {@link Decision} describing how the loop should proceed
+	 */
+	protected Decision checkForRepeatedToolCalls(ChatResponse chatResponse, Map<String, Integer> seenToolCalls) {
+		return chatResponse.getResults()
+			.stream()
+			.filter(g -> g.getOutput().getToolCalls() != null && !g.getOutput().getToolCalls().isEmpty())
+			.flatMap(g -> g.getOutput().getToolCalls().stream())
+			.filter(toolCall -> !this.excludedToolNames.contains(toolCall.name()))
+			.map(toolCall -> {
+				String args = toolCall.arguments() != null ? toolCall.arguments() : "";
+				String key = toolCall.name() + "::" + args;
+				int count = seenToolCalls.merge(key, 1, Integer::sum);
+				if (count > this.maxIdenticalToolCallCount) {
+					return Decision.error("Identical tool call detected: tool '" + toolCall.name() + "' was called "
+							+ count
+							+ " time(s) with identical arguments. This may indicate an infinite tool-call loop. "
+							+ "Adjust the tool response to guide the model, or increase maxIdenticalToolCallCount.");
+				}
+				return Decision.continueLoop();
+			})
+			.filter(decision -> decision.action() == Decision.Action.ERROR)
+			.findFirst()
+			.orElseGet(Decision::continueLoop);
+	}
+
+	/**
+	 * Creates a new Builder instance for constructing a
+	 * {@link MaxIdenticalToolCallLoopGuard}.
+	 * @return a new Builder instance
+	 */
+	public static Builder<?> builder() {
+		return new Builder<>();
+	}
+
+	/**
+	 * Builder for creating instances of {@link MaxIdenticalToolCallLoopGuard}.
+	 * <p>
+	 * This builder uses the self-referential generic pattern to support extensibility, so
+	 * that subclasses can add their own configuration while preserving fluent method
+	 * chaining.
+	 *
+	 * @param <T> the builder type, used for self-referential generics to support method
+	 * chaining in subclasses
+	 */
+	public static class Builder<T extends Builder<T>> {
+
+		private int maxIdenticalToolCallCount = DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT;
+
+		private final Set<String> excludedToolNames = new HashSet<>();
+
+		protected Builder() {
+		}
+
+		/**
+		 * Returns this builder cast to the appropriate type for method chaining.
+		 * Subclasses should override this method to return the correct type.
+		 * @return this builder instance
+		 */
+		@SuppressWarnings("unchecked")
+		protected T self() {
+			return (T) this;
+		}
+
+		/**
+		 * Sets the maximum number of times a tool may be called with identical arguments
+		 * within a single loop. Defaults to
+		 * {@link #DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT}.
+		 * @param maxIdenticalToolCallCount the maximum count (must be positive)
+		 * @return this Builder instance for method chaining
+		 */
+		public T maxIdenticalToolCallCount(int maxIdenticalToolCallCount) {
+			this.maxIdenticalToolCallCount = maxIdenticalToolCallCount;
+			return self();
+		}
+
+		/**
+		 * Sets the names of tools that are exempt from the identical tool-call check.
+		 * Replaces any previously configured names. Useful for idempotent tools that a
+		 * model may legitimately poll several times with identical arguments within a
+		 * single turn (e.g. {@code get_status}, {@code list_files}). Empty by default.
+		 * @param excludedToolNames the tool names to exclude (must not be null)
+		 * @return this Builder instance for method chaining
+		 */
+		public T excludedToolNames(Collection<String> excludedToolNames) {
+			Assert.notNull(excludedToolNames, "excludedToolNames must not be null");
+			this.excludedToolNames.clear();
+			this.excludedToolNames.addAll(excludedToolNames);
+			return self();
+		}
+
+		/**
+		 * Adds the given tool names to the set exempt from the identical tool-call check.
+		 * @param toolNames the tool names to exclude (must not be null)
+		 * @return this Builder instance for method chaining
+		 */
+		public T excludeToolNames(String... toolNames) {
+			Assert.notNull(toolNames, "toolNames must not be null");
+			this.excludedToolNames.addAll(Set.of(toolNames));
+			return self();
+		}
+
+		/**
+		 * Returns the configured maximum identical tool call count.
+		 * @return the maximum identical tool call count
+		 */
+		protected int getMaxIdenticalToolCallCount() {
+			return this.maxIdenticalToolCallCount;
+		}
+
+		/**
+		 * Returns the configured excluded tool names.
+		 * @return the excluded tool names
+		 */
+		protected Set<String> getExcludedToolNames() {
+			return this.excludedToolNames;
+		}
+
+		/**
+		 * Builds and returns a new {@link MaxIdenticalToolCallLoopGuard} instance with
+		 * the configured properties.
+		 * @return a new {@link MaxIdenticalToolCallLoopGuard} instance
+		 * @throws IllegalArgumentException if {@code maxIdenticalToolCallCount} is not
+		 * positive
+		 */
+		public MaxIdenticalToolCallLoopGuard build() {
+			return new MaxIdenticalToolCallLoopGuard(this.maxIdenticalToolCallCount, this.excludedToolNames);
+		}
+
+	}
+
+}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MaxIdenticalToolCallLoopGuard.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MaxIdenticalToolCallLoopGuard.java
@@ -36,12 +36,11 @@ import org.springframework.util.Assert;
  * model keeps calling the same tool with the same arguments after receiving an error or
  * otherwise unhelpful response.
  * <p>
- * Because the count accumulates across the entire loop within a single conversation turn,
- * a model that legitimately re-invokes an idempotent tool with identical arguments (e.g.
- * polling a {@code get_status} or {@code list_files} tool) more than
- * {@link #getMaxIdenticalToolCallCount()} times could trip the guard. Such tools can be
- * exempted from the check via {@link Builder#excludedToolNames(java.util.Collection)};
- * alternatively, increase the limit via {@link Builder#maxIdenticalToolCallCount(int)}.
+ * Because the count accumulates across the entire loop, a model that legitimately polls
+ * an idempotent tool (e.g. {@code get_status} or {@code list_files}) with identical
+ * arguments more than {@link #getMaxIdenticalToolCallCount()} times could trip the guard.
+ * Exempt such tools via {@link Builder#excludedToolNames(java.util.Collection)}, or raise
+ * the limit via {@link Builder#maxIdenticalToolCallCount(int)}.
  *
  * @author Christian Tzolov
  * @since 2.0.0
@@ -50,12 +49,9 @@ public class MaxIdenticalToolCallLoopGuard implements AdvisorLoopGuard {
 
 	/**
 	 * Default maximum number of times a tool may be called with identical arguments
-	 * within a single advisor loop. A value of 15 is tolerant of legitimate repeats (e.g.
-	 * a model polling an idempotent tool or retrying after transient errors) while still
-	 * breaking infinite loops where the model never changes the tool arguments. Since the
-	 * guard keys on the tool name <em>and</em> identical arguments, seeing the same call
-	 * 15 times is already a strong infinite-loop signal; the limit mainly governs how
-	 * many identical retries are tolerated before aborting.
+	 * within a single advisor loop. A value of 15 tolerates legitimate repeats (e.g. a
+	 * model polling an idempotent tool) while still breaking infinite loops where the
+	 * model never changes the tool arguments.
 	 */
 	public static final int DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT = 15;
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -30,7 +30,8 @@ public class ToolCallAdvisor extends ToolCallingAdvisor {
 	protected ToolCallAdvisor(ToolCallingManager toolCallingManager,
 			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, int advisorOrder,
 			boolean conversationHistoryEnabled) {
-		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled);
+		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled,
+				DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT);
 	}
 
 	/**

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -29,9 +29,9 @@ public class ToolCallAdvisor extends ToolCallingAdvisor {
 
 	protected ToolCallAdvisor(ToolCallingManager toolCallingManager,
 			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, int advisorOrder,
-			boolean conversationHistoryEnabled) {
+			boolean conversationHistoryEnabled, AdvisorLoopGuard advisorLoopGuard) {
 		super(toolCallingManager, toolExecutionEligibilityChecker, advisorOrder, conversationHistoryEnabled,
-				DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT);
+				advisorLoopGuard);
 	}
 
 	/**
@@ -56,7 +56,7 @@ public class ToolCallAdvisor extends ToolCallingAdvisor {
 		@Override
 		public ToolCallAdvisor build() {
 			return new ToolCallAdvisor(getToolCallingManager(), getToolExecutionEligibilityChecker(), getAdvisorOrder(),
-					isConversationHistoryEnabled());
+					isConversationHistoryEnabled(), getAdvisorLoopGuard());
 		}
 
 	}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -16,7 +16,9 @@
 
 package org.springframework.ai.chat.client.advisor;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import reactor.core.publisher.Flux;
@@ -73,6 +75,15 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 	 */
 	public static final int DEFAULT_ORDER = Ordered.HIGHEST_PRECEDENCE + 300;
 
+	/**
+	 * Default maximum number of times a tool may be called with identical arguments
+	 * within a single advisor loop. Exceeding this limit throws an
+	 * {@link IllegalStateException} to prevent infinite loops. A value of 3 allows for
+	 * limited retries while still breaking pathological loops where the model never
+	 * changes the tool arguments.
+	 */
+	public static final int DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT = 3;
+
 	protected static final ToolExecutionEligibilityChecker DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER = chatResponse -> chatResponse != null
 			&& chatResponse.hasToolCalls();
 
@@ -91,18 +102,22 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 	private final boolean conversationHistoryEnabled;
 
+	private final int maxIdenticalToolCallCount;
+
 	protected ToolCallingAdvisor(ToolCallingManager toolCallingManager,
 			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, int advisorOrder,
-			boolean conversationHistoryEnabled) {
+			boolean conversationHistoryEnabled, int maxIdenticalToolCallCount) {
 		Assert.notNull(toolCallingManager, "toolCallingManager must not be null");
 		Assert.notNull(toolExecutionEligibilityChecker, "toolExecutionEligibilityChecker must not be null");
 		Assert.isTrue(advisorOrder > BaseAdvisor.HIGHEST_PRECEDENCE && advisorOrder < BaseAdvisor.LOWEST_PRECEDENCE,
 				"advisorOrder must be between HIGHEST_PRECEDENCE and LOWEST_PRECEDENCE");
+		Assert.isTrue(maxIdenticalToolCallCount > 0, "maxIdenticalToolCallCount must be positive");
 
 		this.toolCallingManager = toolCallingManager;
 		this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
 		this.advisorOrder = advisorOrder;
 		this.conversationHistoryEnabled = conversationHistoryEnabled;
+		this.maxIdenticalToolCallCount = maxIdenticalToolCallCount;
 	}
 
 	@Override
@@ -135,6 +150,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 		ChatClientResponse chatClientResponse = null;
 		UsageAccumulator usageAccumulator = new UsageAccumulator();
+		Map<String, Integer> seenToolCalls = new HashMap<>();
 
 		boolean isToolCall = false;
 
@@ -160,6 +176,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 			if (isToolCall) {
 				Assert.notNull(chatResponse, "redundant check that should never fail, but here to help NullAway");
+				this.checkForRepeatedToolCalls(chatResponse, seenToolCalls);
 				ToolExecutionResult toolExecutionResult = this.toolCallingManager
 					.executeToolCalls(processedChatClientRequest.prompt(), chatResponse);
 
@@ -241,14 +258,17 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			ChatClientRequest initializedRequest = this.doInitializeLoopStream(chatClientRequest, streamAdvisorChain);
 			// Subscription-local accumulator so usage is not shared across subscriptions.
 			UsageAccumulator usageAccumulator = new UsageAccumulator();
+			// Subscription-local tracker so identical-call detection is not shared across
+			// subscriptions.
+			Map<String, Integer> seenToolCalls = new HashMap<>();
 			return this.internalStream(streamAdvisorChain, initializedRequest, toolCallingChatOptions,
-					initializedRequest.prompt().getInstructions(), usageAccumulator);
+					initializedRequest.prompt().getInstructions(), usageAccumulator, seenToolCalls);
 		});
 	}
 
 	private Flux<ChatClientResponse> internalStream(StreamAdvisorChain streamAdvisorChain,
 			ChatClientRequest originalRequest, ToolCallingChatOptions toolCallingChatOptions,
-			List<Message> instructions, UsageAccumulator usageAccumulator) {
+			List<Message> instructions, UsageAccumulator usageAccumulator, Map<String, Integer> seenToolCalls) {
 
 		return Flux.deferContextual(contextView -> {
 			// Build request with current instructions
@@ -267,13 +287,13 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
 
 			return streamWithToolCallResponses(responseFlux, finalRequest, streamAdvisorChain, originalRequest,
-					toolCallingChatOptions, usageAccumulator);
+					toolCallingChatOptions, usageAccumulator, seenToolCalls);
 		});
 	}
 
 	private Flux<ChatClientResponse> streamWithToolCallResponses(Flux<ChatClientResponse> responseFlux,
 			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator) {
+			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator, Map<String, Integer> seenToolCalls) {
 
 		AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
 		// Snapshot of the usage accumulated from previous rounds (before this round).
@@ -283,7 +303,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			.map(chatClientResponse -> UsageAccumulator.applyPreviousAccumulatedUsageToChunk(chatClientResponse,
 					previousAccumulatedResponse))
 			.concatWith(Flux.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest,
-					streamAdvisorChain, originalRequest, optionsCopy, usageAccumulator)))
+					streamAdvisorChain, originalRequest, optionsCopy, usageAccumulator, seenToolCalls)))
 			.filter(ccr -> !this.toolExecutionEligibilityChecker.isToolCallResponse(ccr.chatResponse()));
 	}
 
@@ -293,7 +313,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 	 */
 	private Flux<ChatClientResponse> handleToolCallRecursion(ChatClientResponse aggregatedResponse,
 			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator) {
+			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator, Map<String, Integer> seenToolCalls) {
 
 		if (aggregatedResponse == null) {
 			return Flux.empty();
@@ -317,6 +337,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		}
 
 		Assert.notNull(chatResponse, "redundant check that should never fail, but here to help NullAway");
+		this.checkForRepeatedToolCalls(chatResponse, seenToolCalls);
 		final ChatClientResponse finalAggregatedResponse = aggregatedResponse;
 
 		// Execute tool calls on bounded elastic scheduler (tool execution is blocking)
@@ -345,10 +366,28 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 				List<Message> nextInstructions = this.doGetNextInstructionsForToolCallStream(finalRequest,
 						finalAggregatedResponse, toolExecutionResult);
 				return this.internalStream(streamAdvisorChain, originalRequest, optionsCopy, nextInstructions,
-						usageAccumulator);
+						usageAccumulator, seenToolCalls);
 			}
 		});
 		return toolCallFlux.subscribeOn(Schedulers.boundedElastic());
+	}
+
+	private void checkForRepeatedToolCalls(ChatResponse chatResponse, Map<String, Integer> seenToolCalls) {
+		chatResponse.getResults()
+			.stream()
+			.filter(g -> g.getOutput().getToolCalls() != null && !g.getOutput().getToolCalls().isEmpty())
+			.flatMap(g -> g.getOutput().getToolCalls().stream())
+			.forEach(toolCall -> {
+				String args = toolCall.arguments() != null ? toolCall.arguments() : "";
+				String key = toolCall.name() + "::" + args;
+				int count = seenToolCalls.merge(key, 1, Integer::sum);
+				if (count > this.maxIdenticalToolCallCount) {
+					throw new IllegalStateException("Identical tool call detected: tool '" + toolCall.name()
+							+ "' was called " + count
+							+ " time(s) with identical arguments. This may indicate an infinite tool-call loop. "
+							+ "Adjust the tool response to guide the model, or increase maxIdenticalToolCallCount.");
+				}
+			});
 	}
 
 	/**
@@ -447,6 +486,8 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 		private boolean conversationHistoryEnabled = true;
 
+		private int maxIdenticalToolCallCount = DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT;
+
 		protected Builder() {
 		}
 
@@ -516,6 +557,20 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		}
 
 		/**
+		 * Sets the maximum number of times a specific tool may be called with identical
+		 * arguments within a single advisor loop. When the count is exceeded, an
+		 * {@link IllegalStateException} is thrown to break potential infinite loops.
+		 * Defaults to {@link #DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT}.
+		 * @param maxIdenticalToolCallCount the maximum count (must be positive)
+		 * @return this Builder instance for method chaining
+		 * @since 2.0.0
+		 */
+		public T maxIdenticalToolCallCount(int maxIdenticalToolCallCount) {
+			this.maxIdenticalToolCallCount = maxIdenticalToolCallCount;
+			return self();
+		}
+
+		/**
 		 * Returns the configured ToolCallingManager.
 		 * @return the ToolCallingManager instance
 		 */
@@ -554,6 +609,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			copy.toolExecutionEligibilityChecker = this.toolExecutionEligibilityChecker;
 			copy.advisorOrder = this.advisorOrder;
 			copy.conversationHistoryEnabled = this.conversationHistoryEnabled;
+			copy.maxIdenticalToolCallCount = this.maxIdenticalToolCallCount;
 			return copy;
 		}
 
@@ -585,7 +641,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		 */
 		public ToolCallingAdvisor build() {
 			return new ToolCallingAdvisor(this.toolCallingManager, this.toolExecutionEligibilityChecker,
-					this.advisorOrder, this.conversationHistoryEnabled);
+					this.advisorOrder, this.conversationHistoryEnabled, this.maxIdenticalToolCallCount);
 		}
 
 	}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -16,9 +16,7 @@
 
 package org.springframework.ai.chat.client.advisor;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import reactor.core.publisher.Flux;
@@ -75,15 +73,6 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 	 */
 	public static final int DEFAULT_ORDER = Ordered.HIGHEST_PRECEDENCE + 300;
 
-	/**
-	 * Default maximum number of times a tool may be called with identical arguments
-	 * within a single advisor loop. Exceeding this limit throws an
-	 * {@link IllegalStateException} to prevent infinite loops. A value of 3 allows for
-	 * limited retries while still breaking pathological loops where the model never
-	 * changes the tool arguments.
-	 */
-	public static final int DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT = 3;
-
 	protected static final ToolExecutionEligibilityChecker DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER = chatResponse -> chatResponse != null
 			&& chatResponse.hasToolCalls();
 
@@ -102,22 +91,22 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 	private final boolean conversationHistoryEnabled;
 
-	private final int maxIdenticalToolCallCount;
+	private final AdvisorLoopGuard advisorLoopGuard;
 
 	protected ToolCallingAdvisor(ToolCallingManager toolCallingManager,
 			ToolExecutionEligibilityChecker toolExecutionEligibilityChecker, int advisorOrder,
-			boolean conversationHistoryEnabled, int maxIdenticalToolCallCount) {
+			boolean conversationHistoryEnabled, AdvisorLoopGuard advisorLoopGuard) {
 		Assert.notNull(toolCallingManager, "toolCallingManager must not be null");
 		Assert.notNull(toolExecutionEligibilityChecker, "toolExecutionEligibilityChecker must not be null");
 		Assert.isTrue(advisorOrder > BaseAdvisor.HIGHEST_PRECEDENCE && advisorOrder < BaseAdvisor.LOWEST_PRECEDENCE,
 				"advisorOrder must be between HIGHEST_PRECEDENCE and LOWEST_PRECEDENCE");
-		Assert.isTrue(maxIdenticalToolCallCount > 0, "maxIdenticalToolCallCount must be positive");
+		Assert.notNull(advisorLoopGuard, "advisorLoopGuard must not be null");
 
 		this.toolCallingManager = toolCallingManager;
 		this.toolExecutionEligibilityChecker = toolExecutionEligibilityChecker;
 		this.advisorOrder = advisorOrder;
 		this.conversationHistoryEnabled = conversationHistoryEnabled;
-		this.maxIdenticalToolCallCount = maxIdenticalToolCallCount;
+		this.advisorLoopGuard = advisorLoopGuard;
 	}
 
 	@Override
@@ -150,7 +139,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 		ChatClientResponse chatClientResponse = null;
 		UsageAccumulator usageAccumulator = new UsageAccumulator();
-		Map<String, Integer> seenToolCalls = new HashMap<>();
+		AdvisorLoopGuard.LoopState loopState = this.advisorLoopGuard.begin();
 
 		boolean isToolCall = false;
 
@@ -176,7 +165,15 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 			if (isToolCall) {
 				Assert.notNull(chatResponse, "redundant check that should never fail, but here to help NullAway");
-				this.checkForRepeatedToolCalls(chatResponse, seenToolCalls);
+				AdvisorLoopGuard.Decision decision = loopState.check(chatResponse);
+				if (decision.action() == AdvisorLoopGuard.Decision.Action.ERROR) {
+					throw new IllegalStateException(decision.message());
+				}
+				if (decision.action() == AdvisorLoopGuard.Decision.Action.STOP) {
+					// Stop the loop gracefully: skip this round's tool execution and
+					// return the latest response to the caller.
+					break;
+				}
 				ToolExecutionResult toolExecutionResult = this.toolCallingManager
 					.executeToolCalls(processedChatClientRequest.prompt(), chatResponse);
 
@@ -258,17 +255,17 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			ChatClientRequest initializedRequest = this.doInitializeLoopStream(chatClientRequest, streamAdvisorChain);
 			// Subscription-local accumulator so usage is not shared across subscriptions.
 			UsageAccumulator usageAccumulator = new UsageAccumulator();
-			// Subscription-local tracker so identical-call detection is not shared across
+			// Subscription-local guard scope so loop detection is not shared across
 			// subscriptions.
-			Map<String, Integer> seenToolCalls = new HashMap<>();
+			AdvisorLoopGuard.LoopState loopState = this.advisorLoopGuard.begin();
 			return this.internalStream(streamAdvisorChain, initializedRequest, toolCallingChatOptions,
-					initializedRequest.prompt().getInstructions(), usageAccumulator, seenToolCalls);
+					initializedRequest.prompt().getInstructions(), usageAccumulator, loopState);
 		});
 	}
 
 	private Flux<ChatClientResponse> internalStream(StreamAdvisorChain streamAdvisorChain,
 			ChatClientRequest originalRequest, ToolCallingChatOptions toolCallingChatOptions,
-			List<Message> instructions, UsageAccumulator usageAccumulator, Map<String, Integer> seenToolCalls) {
+			List<Message> instructions, UsageAccumulator usageAccumulator, AdvisorLoopGuard.LoopState loopState) {
 
 		return Flux.deferContextual(contextView -> {
 			// Build request with current instructions
@@ -287,13 +284,14 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
 
 			return streamWithToolCallResponses(responseFlux, finalRequest, streamAdvisorChain, originalRequest,
-					toolCallingChatOptions, usageAccumulator, seenToolCalls);
+					toolCallingChatOptions, usageAccumulator, loopState);
 		});
 	}
 
 	private Flux<ChatClientResponse> streamWithToolCallResponses(Flux<ChatClientResponse> responseFlux,
 			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator, Map<String, Integer> seenToolCalls) {
+			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator,
+			AdvisorLoopGuard.LoopState loopState) {
 
 		AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
 		// Snapshot of the usage accumulated from previous rounds (before this round).
@@ -303,7 +301,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			.map(chatClientResponse -> UsageAccumulator.applyPreviousAccumulatedUsageToChunk(chatClientResponse,
 					previousAccumulatedResponse))
 			.concatWith(Flux.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest,
-					streamAdvisorChain, originalRequest, optionsCopy, usageAccumulator, seenToolCalls)))
+					streamAdvisorChain, originalRequest, optionsCopy, usageAccumulator, loopState)))
 			.filter(ccr -> !this.toolExecutionEligibilityChecker.isToolCallResponse(ccr.chatResponse()));
 	}
 
@@ -313,7 +311,8 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 	 */
 	private Flux<ChatClientResponse> handleToolCallRecursion(ChatClientResponse aggregatedResponse,
 			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator, Map<String, Integer> seenToolCalls) {
+			ToolCallingChatOptions optionsCopy, UsageAccumulator usageAccumulator,
+			AdvisorLoopGuard.LoopState loopState) {
 
 		if (aggregatedResponse == null) {
 			return Flux.empty();
@@ -337,7 +336,18 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		}
 
 		Assert.notNull(chatResponse, "redundant check that should never fail, but here to help NullAway");
-		this.checkForRepeatedToolCalls(chatResponse, seenToolCalls);
+		AdvisorLoopGuard.Decision decision = loopState.check(chatResponse);
+		if (decision.action() == AdvisorLoopGuard.Decision.Action.ERROR) {
+			return Flux.error(new IllegalStateException(decision.message()));
+		}
+		if (decision.action() == AdvisorLoopGuard.Decision.Action.STOP) {
+			// Stop the loop gracefully: skip this round's tool execution and finalize.
+			// The round's chunks have already been streamed; emit a trailing usage-only
+			// response if needed to keep the aggregated stream usage correct.
+			Flux<ChatClientResponse> finalEmissions = UsageAccumulator
+				.emitFinalUsageCorrectionIfNecessary(aggregatedResponse, chatResponse, accumulatedChatResponse);
+			return this.doFinalizeLoopStream(finalEmissions, streamAdvisorChain);
+		}
 		final ChatClientResponse finalAggregatedResponse = aggregatedResponse;
 
 		// Execute tool calls on bounded elastic scheduler (tool execution is blocking)
@@ -366,28 +376,10 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 				List<Message> nextInstructions = this.doGetNextInstructionsForToolCallStream(finalRequest,
 						finalAggregatedResponse, toolExecutionResult);
 				return this.internalStream(streamAdvisorChain, originalRequest, optionsCopy, nextInstructions,
-						usageAccumulator, seenToolCalls);
+						usageAccumulator, loopState);
 			}
 		});
 		return toolCallFlux.subscribeOn(Schedulers.boundedElastic());
-	}
-
-	private void checkForRepeatedToolCalls(ChatResponse chatResponse, Map<String, Integer> seenToolCalls) {
-		chatResponse.getResults()
-			.stream()
-			.filter(g -> g.getOutput().getToolCalls() != null && !g.getOutput().getToolCalls().isEmpty())
-			.flatMap(g -> g.getOutput().getToolCalls().stream())
-			.forEach(toolCall -> {
-				String args = toolCall.arguments() != null ? toolCall.arguments() : "";
-				String key = toolCall.name() + "::" + args;
-				int count = seenToolCalls.merge(key, 1, Integer::sum);
-				if (count > this.maxIdenticalToolCallCount) {
-					throw new IllegalStateException("Identical tool call detected: tool '" + toolCall.name()
-							+ "' was called " + count
-							+ " time(s) with identical arguments. This may indicate an infinite tool-call loop. "
-							+ "Adjust the tool response to guide the model, or increase maxIdenticalToolCallCount.");
-				}
-			});
 	}
 
 	/**
@@ -486,7 +478,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 		private boolean conversationHistoryEnabled = true;
 
-		private int maxIdenticalToolCallCount = DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT;
+		private AdvisorLoopGuard advisorLoopGuard = MaxIdenticalToolCallLoopGuard.builder().build();
 
 		protected Builder() {
 		}
@@ -557,16 +549,16 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		}
 
 		/**
-		 * Sets the maximum number of times a specific tool may be called with identical
-		 * arguments within a single advisor loop. When the count is exceeded, an
-		 * {@link IllegalStateException} is thrown to break potential infinite loops.
-		 * Defaults to {@link #DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT}.
-		 * @param maxIdenticalToolCallCount the maximum count (must be positive)
+		 * Sets the strategy used to detect and break out of infinite tool-calling loops.
+		 * Defaults to a {@link MaxIdenticalToolCallLoopGuard} with its default
+		 * configuration, which breaks the loop when the same tool is repeatedly called
+		 * with identical arguments.
+		 * @param advisorLoopGuard the loop guard strategy (must not be null)
 		 * @return this Builder instance for method chaining
 		 * @since 2.0.0
 		 */
-		public T maxIdenticalToolCallCount(int maxIdenticalToolCallCount) {
-			this.maxIdenticalToolCallCount = maxIdenticalToolCallCount;
+		public T advisorLoopGuard(AdvisorLoopGuard advisorLoopGuard) {
+			this.advisorLoopGuard = advisorLoopGuard;
 			return self();
 		}
 
@@ -609,7 +601,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			copy.toolExecutionEligibilityChecker = this.toolExecutionEligibilityChecker;
 			copy.advisorOrder = this.advisorOrder;
 			copy.conversationHistoryEnabled = this.conversationHistoryEnabled;
-			copy.maxIdenticalToolCallCount = this.maxIdenticalToolCallCount;
+			copy.advisorLoopGuard = this.advisorLoopGuard;
 			return copy;
 		}
 
@@ -633,6 +625,14 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		}
 
 		/**
+		 * Returns the configured tool-call loop guard.
+		 * @return the {@link AdvisorLoopGuard} instance
+		 */
+		protected AdvisorLoopGuard getAdvisorLoopGuard() {
+			return this.advisorLoopGuard;
+		}
+
+		/**
 		 * Builds and returns a new ToolCallingAdvisor instance with the configured
 		 * properties.
 		 * @return a new ToolCallingAdvisor instance
@@ -641,7 +641,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		 */
 		public ToolCallingAdvisor build() {
 			return new ToolCallingAdvisor(this.toolCallingManager, this.toolExecutionEligibilityChecker,
-					this.advisorOrder, this.conversationHistoryEnabled, this.maxIdenticalToolCallCount);
+					this.advisorOrder, this.conversationHistoryEnabled, this.advisorLoopGuard);
 		}
 
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MaxIdenticalToolCallLoopGuardTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MaxIdenticalToolCallLoopGuardTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link MaxIdenticalToolCallLoopGuard}.
+ *
+ * @author Christian Tzolov
+ */
+class MaxIdenticalToolCallLoopGuardTests {
+
+	@Test
+	void builderDefaultsToDefaultLimit() {
+		MaxIdenticalToolCallLoopGuard guard = MaxIdenticalToolCallLoopGuard.builder().build();
+		assertThat(guard.getMaxIdenticalToolCallCount())
+			.isEqualTo(MaxIdenticalToolCallLoopGuard.DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT);
+	}
+
+	@Test
+	void builderHonorsConfiguredLimit() {
+		MaxIdenticalToolCallLoopGuard guard = MaxIdenticalToolCallLoopGuard.builder()
+			.maxIdenticalToolCallCount(5)
+			.build();
+		assertThat(guard.getMaxIdenticalToolCallCount()).isEqualTo(5);
+	}
+
+	@Test
+	void builderRejectsNonPositiveLimit() {
+		assertThatThrownBy(() -> MaxIdenticalToolCallLoopGuard.builder().maxIdenticalToolCallCount(0).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("maxIdenticalToolCallCount must be positive");
+	}
+
+	@Test
+	void returnsErrorDecisionAfterLimitExceeded() {
+		MaxIdenticalToolCallLoopGuard guard = MaxIdenticalToolCallLoopGuard.builder()
+			.maxIdenticalToolCallCount(2)
+			.build();
+		AdvisorLoopGuard.LoopState scope = guard.begin();
+		ChatResponse response = responseWithToolCall("testTool", "{}");
+
+		// First two identical calls continue, the third exceeds the limit.
+		assertThat(scope.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+		assertThat(scope.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+		AdvisorLoopGuard.Decision decision = scope.check(response);
+		assertThat(decision.action()).isEqualTo(AdvisorLoopGuard.Decision.Action.ERROR);
+		assertThat(decision.message()).contains("Identical tool call detected").contains("testTool");
+	}
+
+	@Test
+	void differentArgumentsAreTrackedSeparately() {
+		MaxIdenticalToolCallLoopGuard guard = MaxIdenticalToolCallLoopGuard.builder()
+			.maxIdenticalToolCallCount(1)
+			.build();
+		AdvisorLoopGuard.LoopState scope = guard.begin();
+
+		assertThat(scope.check(responseWithToolCall("testTool", "{}")).action())
+			.isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+		// Different arguments -> different key, should continue.
+		assertThat(scope.check(responseWithToolCall("testTool", "{\"a\":1}")).action())
+			.isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+	}
+
+	@Test
+	void scopesAreIndependent() {
+		MaxIdenticalToolCallLoopGuard guard = MaxIdenticalToolCallLoopGuard.builder()
+			.maxIdenticalToolCallCount(1)
+			.build();
+		ChatResponse response = responseWithToolCall("testTool", "{}");
+
+		AdvisorLoopGuard.LoopState first = guard.begin();
+		assertThat(first.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+
+		// A fresh scope starts counting from zero.
+		AdvisorLoopGuard.LoopState second = guard.begin();
+		assertThat(second.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+	}
+
+	@Test
+	void nullArgumentsAreHandled() {
+		MaxIdenticalToolCallLoopGuard guard = MaxIdenticalToolCallLoopGuard.builder()
+			.maxIdenticalToolCallCount(1)
+			.build();
+		AdvisorLoopGuard.LoopState scope = guard.begin();
+		ChatResponse response = responseWithToolCall("testTool", null);
+
+		assertThat(scope.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+		assertThat(scope.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.ERROR);
+	}
+
+	@Test
+	void excludedToolNamesAreEmptyByDefault() {
+		assertThat(MaxIdenticalToolCallLoopGuard.builder().build().getExcludedToolNames()).isEmpty();
+	}
+
+	@Test
+	void excludedToolsAreNotGuarded() {
+		MaxIdenticalToolCallLoopGuard guard = MaxIdenticalToolCallLoopGuard.builder()
+			.maxIdenticalToolCallCount(1)
+			.excludedToolNames(List.of("get_status"))
+			.build();
+		AdvisorLoopGuard.LoopState scope = guard.begin();
+		ChatResponse response = responseWithToolCall("get_status", "{}");
+
+		assertThat(guard.getExcludedToolNames()).containsExactly("get_status");
+		// Excluded tool can be called any number of times with identical arguments.
+		assertThat(scope.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+		assertThat(scope.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+		assertThat(scope.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+	}
+
+	@Test
+	void nonExcludedToolsAreStillGuardedWhenExclusionsConfigured() {
+		MaxIdenticalToolCallLoopGuard guard = MaxIdenticalToolCallLoopGuard.builder()
+			.maxIdenticalToolCallCount(1)
+			.excludedToolNames(List.of("get_status"))
+			.build();
+		AdvisorLoopGuard.LoopState scope = guard.begin();
+		ChatResponse response = responseWithToolCall("testTool", "{}");
+
+		assertThat(scope.check(response).action()).isEqualTo(AdvisorLoopGuard.Decision.Action.CONTINUE);
+		AdvisorLoopGuard.Decision decision = scope.check(response);
+		assertThat(decision.action()).isEqualTo(AdvisorLoopGuard.Decision.Action.ERROR);
+		assertThat(decision.message()).contains("testTool");
+	}
+
+	@Test
+	void excludeToolNamesVarargsAccumulate() {
+		MaxIdenticalToolCallLoopGuard guard = MaxIdenticalToolCallLoopGuard.builder()
+			.excludeToolNames("a")
+			.excludeToolNames("b", "c")
+			.build();
+		assertThat(guard.getExcludedToolNames()).containsExactlyInAnyOrder("a", "b", "c");
+	}
+
+	@Test
+	void nullExcludedToolNamesAreRejected() {
+		assertThatThrownBy(() -> new MaxIdenticalToolCallLoopGuard(1, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("excludedToolNames must not be null");
+	}
+
+	private static ChatResponse responseWithToolCall(String toolName, String arguments) {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("tool-call-1", "function", toolName,
+				arguments);
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("response")
+			.toolCalls(List.of(toolCall))
+			.build();
+		return ChatResponse.builder().generations(List.of(new Generation(assistantMessage))).build();
+	}
+
+}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -1082,8 +1082,11 @@ public class ToolCallingAdvisorTests {
 
 	@Test
 	void identicalToolCallInCallPathThrowsByDefault() {
-		// Default maxIdenticalToolCallCount = 3; a 4th identical call must throw.
-		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+		// maxIdenticalToolCallCount = 3; a 4th identical call must throw.
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.advisorLoopGuard(MaxIdenticalToolCallLoopGuard.builder().maxIdenticalToolCallCount(3).build())
+			.build();
 
 		ChatClientRequest request = createMockRequest();
 		// Always return a tool-call response with identical args to simulate an infinite
@@ -1120,7 +1123,7 @@ public class ToolCallingAdvisorTests {
 		int[] callCount = { 0 };
 		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
 			.toolCallingManager(this.toolCallingManager)
-			.maxIdenticalToolCallCount(1)
+			.advisorLoopGuard(MaxIdenticalToolCallLoopGuard.builder().maxIdenticalToolCallCount(1).build())
 			.build();
 
 		ChatClientRequest request = createMockRequest();
@@ -1191,8 +1194,11 @@ public class ToolCallingAdvisorTests {
 
 	@Test
 	void identicalToolCallInStreamPathThrows() {
-		// Default maxIdenticalToolCallCount = 3; a 4th identical call must throw.
-		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+		// maxIdenticalToolCallCount = 3; a 4th identical call must throw.
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.advisorLoopGuard(MaxIdenticalToolCallLoopGuard.builder().maxIdenticalToolCallCount(3).build())
+			.build();
 
 		ChatClientRequest request = createMockRequest();
 		ChatClientResponse responseWithToolCall = createMockResponse(true);
@@ -1220,6 +1226,135 @@ public class ToolCallingAdvisorTests {
 
 		// 3 executions pass (count 1-3 ≤ default 3), the 4th is blocked before execution
 		verify(this.toolCallingManager, times(3)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void customAdvisorLoopGuardTakesPrecedenceOverMaxIdenticalToolCallCount() {
+		// A custom guard that aborts the loop after the very first tool-call round,
+		// regardless of arguments. It must take precedence over
+		// maxIdenticalToolCallCount.
+		AdvisorLoopGuard customGuard = () -> new AdvisorLoopGuard.LoopState() {
+			private int rounds = 0;
+
+			@Override
+			public AdvisorLoopGuard.Decision check(ChatResponse chatResponse) {
+				return ++this.rounds > 1 ? AdvisorLoopGuard.Decision.error("custom guard tripped")
+						: AdvisorLoopGuard.Decision.continueLoop();
+			}
+		};
+
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.advisorLoopGuard(MaxIdenticalToolCallLoopGuard.builder().maxIdenticalToolCallCount(100).build())
+			.advisorLoopGuard(customGuard)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> responseWithToolCall);
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		assertThatThrownBy(() -> advisor.adviseCall(request, realChain)).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("custom guard tripped");
+
+		// First round passes the guard and executes; the second round is blocked.
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void stopDecisionEndsCallLoopGracefullyWithoutExecutingRound() {
+		// A guard that stops gracefully on the 2nd round: the 1st round executes, the
+		// 2nd round returns the latest response to the caller without executing tools.
+		AdvisorLoopGuard stopGuard = () -> new AdvisorLoopGuard.LoopState() {
+			private int rounds = 0;
+
+			@Override
+			public AdvisorLoopGuard.Decision check(ChatResponse chatResponse) {
+				return ++this.rounds > 1 ? AdvisorLoopGuard.Decision.stop("budget exhausted")
+						: AdvisorLoopGuard.Decision.continueLoop();
+			}
+		};
+
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.advisorLoopGuard(stopGuard)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> responseWithToolCall);
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		ChatClientResponse result = advisor.adviseCall(request, realChain);
+
+		// The loop stops gracefully and returns the latest (tool-call) response.
+		assertThat(result).isEqualTo(responseWithToolCall);
+		// Only the first round executed tools; the second round was stopped before
+		// execution.
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void stopDecisionEndsStreamLoopGracefullyWithoutExecutingRound() {
+		AdvisorLoopGuard stopGuard = () -> new AdvisorLoopGuard.LoopState() {
+			private int rounds = 0;
+
+			@Override
+			public AdvisorLoopGuard.Decision check(ChatResponse chatResponse) {
+				return ++this.rounds > 1 ? AdvisorLoopGuard.Decision.stop() : AdvisorLoopGuard.Decision.continueLoop();
+			}
+		};
+
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.advisorLoopGuard(stopGuard)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor(
+				(req, chain) -> Flux.just(responseWithToolCall));
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
+
+		// The stream completes gracefully (no error). Only the first round executed
+		// tools; the second round was stopped before execution.
+		assertThat(results).isNotNull();
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
 	}
 
 	// Helper methods
@@ -1424,7 +1559,7 @@ public class ToolCallingAdvisorTests {
 
 		TestableToolCallingAdvisor(ToolCallingManager toolCallingManager, int advisorOrder, int[] hookCallCounts) {
 			super(toolCallingManager, DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER, advisorOrder, true,
-					DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT);
+					MaxIdenticalToolCallLoopGuard.builder().build());
 			this.hookCallCounts = hookCallCounts;
 		}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -1076,6 +1076,152 @@ public class ToolCallingAdvisorTests {
 		assertThat(advisor.getOrder()).isEqualTo(customOrder);
 	}
 
+	// -------------------------------------------------------------------------
+	// Repeated tool call guard tests
+	// -------------------------------------------------------------------------
+
+	@Test
+	void identicalToolCallInCallPathThrowsByDefault() {
+		// Default maxIdenticalToolCallCount = 3; a 4th identical call must throw.
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		// Always return a tool-call response with identical args to simulate an infinite
+		// loop
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			callCount[0]++;
+			return responseWithToolCall;
+		});
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		assertThatThrownBy(() -> advisor.adviseCall(request, realChain)).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("Identical tool call detected")
+			.hasMessageContaining("testTool");
+
+		// 3 executions pass (count 1-3 ≤ default 3), the 4th is blocked before execution
+		verify(this.toolCallingManager, times(3)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void maxIdenticalToolCallCountIsConfigurable() {
+		int[] callCount = { 0 };
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.maxIdenticalToolCallCount(1)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+		ChatClientResponse finalResponse = createMockResponse(false);
+
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] <= 1 ? responseWithToolCall : finalResponse;
+		});
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		ChatClientResponse result = advisor.adviseCall(request, realChain);
+
+		assertThat(result).isEqualTo(finalResponse);
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void differentToolCallArgumentsAreNotDetectedAsRepeated() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+
+		// First call uses args "{}", second call uses different args
+		ChatClientResponse firstResponse = createResponseWithToolCall("testTool", "{}");
+		ChatClientResponse secondResponse = createResponseWithToolCall("testTool", "{\"param\":\"different\"}");
+		ChatClientResponse finalResponse = createMockResponse(false);
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			callCount[0]++;
+			if (callCount[0] == 1) {
+				return firstResponse;
+			}
+			if (callCount[0] == 2) {
+				return secondResponse;
+			}
+			return finalResponse;
+		});
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		ChatClientResponse result = advisor.adviseCall(request, realChain);
+
+		assertThat(result).isEqualTo(finalResponse);
+		verify(this.toolCallingManager, times(2)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
+	void identicalToolCallInStreamPathThrows() {
+		// Default maxIdenticalToolCallCount = 3; a 4th identical call must throw.
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			return Flux.just(responseWithToolCall);
+		});
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<org.springframework.ai.chat.client.advisor.api.Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		assertThatThrownBy(() -> advisor.adviseStream(request, realChain).collectList().block())
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("Identical tool call detected");
+
+		// 3 executions pass (count 1-3 ≤ default 3), the 4th is blocked before execution
+		verify(this.toolCallingManager, times(3)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
 	// Helper methods
 
 	private ChatClientRequest createMockRequestWithSystemMessage() {
@@ -1118,6 +1264,19 @@ public class ToolCallingAdvisorTests {
 		});
 
 		return mockRequest;
+	}
+
+	private ChatClientResponse createResponseWithToolCall(String toolName, String arguments) {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("tool-call-1", "function", toolName,
+				arguments);
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("response")
+			.toolCalls(List.of(toolCall))
+			.build();
+		ChatResponse chatResponse = ChatResponse.builder()
+			.generations(List.of(new Generation(assistantMessage)))
+			.build();
+		return ChatClientResponse.builder().chatResponse(chatResponse).build();
 	}
 
 	private ChatClientResponse createResponse(boolean hasToolCalls, Usage usage) {
@@ -1264,7 +1423,8 @@ public class ToolCallingAdvisorTests {
 		private final int[] hookCallCounts;
 
 		TestableToolCallingAdvisor(ToolCallingManager toolCallingManager, int advisorOrder, int[] hookCallCounts) {
-			super(toolCallingManager, DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER, advisorOrder, true);
+			super(toolCallingManager, DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER, advisorOrder, true,
+					DEFAULT_MAX_IDENTICAL_TOOL_CALL_COUNT);
 			this.hookCallCounts = hookCallCounts;
 		}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -35,6 +35,7 @@ Spring AI ships two built-in recursive advisors that demonstrate this pattern.
 Highlights:
 
 * Loops through the advisor chain until the `ToolExecutionEligibilityChecker` reports no more tool calls.
+* Guards against infinite loops via a pluggable `AdvisorLoopGuard`, checked before each round's tool calls execute — by default `MaxIdenticalToolCallLoopGuard`, which aborts once a tool is called with identical arguments too many times. See xref:api/tools/tool-calling-advisor.adoc#loop-guard[Breaking Infinite Tool-Call Loops].
 * Uses `callAdvisorChain.copy(this)` to create a sub-chain for recursive calls — other advisors can observe and intercept every iteration.
 * Supports return-direct: when a tool's result has `returnDirect = true`, the advisor breaks the loop and returns the tool result to the caller without sending it back to the LLM.
 * Implements the `ToolAdvisor` marker interface, which `DefaultChatClient` uses to enforce the single-tool-advisor invariant — custom subclasses register transparently as replacements.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -235,6 +235,8 @@ image::tools/spring-ai-tool-calling-advisor-flow.png[Tool Calling Advisor Flow, 
 
 Both blocking (`.call()`) and streaming (`.stream()`) modes are fully supported.
 
+Before each iteration's tool calls are executed, a pluggable `AdvisorLoopGuard` checks for infinite-loop conditions (e.g. the same tool repeatedly called with identical arguments) and can abort the request or stop the loop gracefully. See xref:api/tools/tool-calling-advisor.adoc#loop-guard[Breaking Infinite Tool-Call Loops].
+
 `ToolCallingAdvisor` is a **recursive advisor** — it re-enters the downstream advisor chain on each iteration of the loop. The same mechanism drives structured-output validation retries and any other looped advisor pattern. See xref:api/advisors-recursive.adoc[Recursive Advisors] for the underlying pattern.
 
 `DefaultChatClient` enforces that **exactly one `ToolAdvisor` is present** in the chain. Attempting to register a second one fails with an explicit error.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools/tool-calling-advisor.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools/tool-calling-advisor.adoc
@@ -57,6 +57,10 @@ NOTE: Most applications don't construct `ToolCallingAdvisor` directly — `Defau
 | `disableInternalConversationHistory()`
 | Shortcut for `conversationHistoryEnabled(false)`.
 | —
+
+| `advisorLoopGuard(AdvisorLoopGuard)`
+| Strategy that detects and breaks out of infinite tool-calling loops. See xref:#loop-guard[Breaking Infinite Tool-Call Loops].
+| `MaxIdenticalToolCallLoopGuard` with default settings
 |====
 
 [[checker]]
@@ -115,6 +119,53 @@ var chatClient = ChatClient.builder(chatModel)
 ----
 
 TIP: With the auto-registered `ToolCallingAdvisor`, `DefaultChatClient` detects any `MemoryAdvisor` placed inside the loop and disables internal history automatically — you don't need to call `disableInternalConversationHistory()` yourself. The manual call is only needed when constructing `ToolCallingAdvisor` directly. See xref:api/tools.adoc#inside-the-loop[Memory: Inside the Loop].
+
+[[loop-guard]]
+== Breaking Infinite Tool-Call Loops
+
+A model can get stuck calling the same tool with the same arguments over and over, for example after receiving an error it doesn't know how to act on. `ToolCallingAdvisor` guards against this with a pluggable `AdvisorLoopGuard`, checked before each round's tool calls are executed.
+
+[[default-loop-guard]]
+=== Default Guard: `MaxIdenticalToolCallLoopGuard`
+
+By default, `ToolCallingAdvisor` uses `MaxIdenticalToolCallLoopGuard`, which tracks each distinct `(tool name, arguments)` combination seen within the current loop. Once a combination is seen more than `maxIdenticalToolCallCount` times (default `15`), the guard aborts the request with an `IllegalStateException`.
+
+Tune or exempt tools on the advisor builder:
+
+[source,java]
+----
+var toolCallingAdvisor = ToolCallingAdvisor.builder()
+    .advisorLoopGuard(MaxIdenticalToolCallLoopGuard.builder()
+        .maxIdenticalToolCallCount(5)
+        .excludeToolNames("get_status", "list_files")  // idempotent tools a model may legitimately poll
+        .build())
+    .build();
+----
+
+`excludeToolNames(String...)` (or `excludedToolNames(Collection<String>)` to replace the whole set) exempts tools that a model may legitimately call repeatedly with identical arguments, such as a polling `get_status` tool.
+
+[[custom-loop-guard]]
+=== Custom Guards
+
+`AdvisorLoopGuard` is a functional interface. `begin()` returns a fresh, loop-local `LoopState` for each request or stream subscription, whose `check(ChatResponse)` is called with the aggregated response for the round about to be acted upon. It returns a `Decision`:
+
+* `Decision.continueLoop()` — proceed to execute the round's tool calls.
+* `Decision.stop()` / `Decision.stop(message)` — stop gracefully and return the latest response to the caller without executing the round's tool calls.
+* `Decision.error(message)` — abort the request by throwing an `IllegalStateException` with the given message.
+
+[source,java]
+----
+AdvisorLoopGuard maxRoundsGuard = () -> {
+    AtomicInteger rounds = new AtomicInteger();
+    return chatResponse -> rounds.incrementAndGet() > 20
+            ? AdvisorLoopGuard.Decision.error("Exceeded 20 tool-call rounds")
+            : AdvisorLoopGuard.Decision.continueLoop();
+};
+
+var toolCallingAdvisor = ToolCallingAdvisor.builder()
+    .advisorLoopGuard(maxRoundsGuard)
+    .build();
+----
 
 [[hooks]]
 == Hook Methods
@@ -400,6 +451,7 @@ With auto-registration off, tools passed via `.tools(...)` are sent to the model
 == See Also
 
 * xref:api/tools.adoc#the-tool-calling-loop[Tool Calling: The Tool Calling Loop] — conceptual overview
+* xref:#loop-guard[Breaking Infinite Tool-Call Loops] — `AdvisorLoopGuard` and `MaxIdenticalToolCallLoopGuard`
 * xref:api/tools.adoc#memory-and-the-tool-loop[Tool Calling: Memory and the Tool Loop] — inside/outside ordering
 * xref:api/tools.adoc#extending-the-loop[Tool Calling: Extending the Loop] — auto-configuration extension point for custom subclasses
 * xref:api/tools/tool-search-tool.adoc[Tool Search Tool] — `ToolSearchToolCallingAdvisor`, a concrete subclass implementing progressive tool disclosure

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -122,6 +122,23 @@ new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider, Exception.class
 new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
 ----
 
+==== New: Infinite Tool-Call Loop Protection (`AdvisorLoopGuard`)
+
+`ToolCallingAdvisor` now guards against infinite tool-calling loops. By default it uses `MaxIdenticalToolCallLoopGuard`, which aborts the request with an `IllegalStateException` once the same tool is called with identical arguments more than 15 times within a single loop. This did not exist in 1.x, where a model stuck in such a loop would keep calling the model and the tool indefinitely.
+
+If your application legitimately calls a tool with identical arguments many times in a row (e.g. polling a `get_status` tool), exclude it from the check or raise the limit on the advisor builder:
+
+[source,java]
+----
+ToolCallingAdvisor advisor = ToolCallingAdvisor.builder()
+    .advisorLoopGuard(MaxIdenticalToolCallLoopGuard.builder()
+        .excludeToolNames("get_status")
+        .build())
+    .build();
+----
+
+See xref:api/tools/tool-calling-advisor.adoc#loop-guard[Breaking Infinite Tool-Call Loops] for the full configuration options and how to plug in a custom `AdvisorLoopGuard`.
+
 [[upgrading-to-2-0-0]]
 == Upgrading to 2.0.0
 


### PR DESCRIPTION
## Summary

- `ToolCallingAdvisor` now tracks identical tool calls (same tool name + same arguments) per conversation turn and throws `IllegalStateException` when the count exceeds `maxIdenticalToolCallCount` (configurable via builder; default: 3), breaking infinite retry loops.
- Per maintainer feedback, null/empty tool argument handling changes in `DefaultToolCallingManager` and MCP tool callbacks were removed from this PR and can be proposed separately if needed.

Fixes #5754

## Test plan

- [x] `ToolCallingAdvisorTests`: 4 tests covering repeated-call detection in both call and stream paths, configurable limit, and different-argument exemption
