### PR TITLE
Fix S3 vector filter deletion

### DIFF
--- a/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/S3VectorStore.java
+++ b/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/S3VectorStore.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.vectorstore.s3;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,9 @@ import java.util.Optional;
 import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.services.s3vectors.S3VectorsClient;
 import software.amazon.awssdk.services.s3vectors.model.DeleteVectorsRequest;
+import software.amazon.awssdk.services.s3vectors.model.ListOutputVector;
+import software.amazon.awssdk.services.s3vectors.model.ListVectorsRequest;
+import software.amazon.awssdk.services.s3vectors.model.ListVectorsResponse;
 import software.amazon.awssdk.services.s3vectors.model.PutInputVector;
 import software.amazon.awssdk.services.s3vectors.model.PutVectorsRequest;
 import software.amazon.awssdk.services.s3vectors.model.QueryOutputVector;
@@ -44,11 +48,17 @@ import org.springframework.ai.vectorstore.observation.AbstractObservationVectorS
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Matej Nedic
+ * @author Jewoo Shin
  */
 public class S3VectorStore extends AbstractObservationVectorStore implements InitializingBean {
+
+	private static final int LIST_VECTORS_MAX_RESULTS = 500;
+
+	private static final int DELETE_VECTORS_MAX_KEYS = 500;
 
 	private final S3VectorsClient s3VectorsClient;
 
@@ -57,6 +67,8 @@ public class S3VectorStore extends AbstractObservationVectorStore implements Ini
 	private final String indexName;
 
 	private final S3VectorFilterExpressionConverter filterExpressionConverter;
+
+	private final S3VectorStoreFilterExpressionEvaluator filterExpressionEvaluator;
 
 	/**
 	 * Creates a new S3VectorStore instance with the specified builder settings.
@@ -73,6 +85,7 @@ public class S3VectorStore extends AbstractObservationVectorStore implements Ini
 		this.s3VectorsClient = builder.s3VectorsClient;
 		this.indexName = builder.indexName;
 		this.filterExpressionConverter = builder.filterExpressionConverter;
+		this.filterExpressionEvaluator = new S3VectorStoreFilterExpressionEvaluator();
 		this.vectorBucketName = builder.vectorBucketName;
 	}
 
@@ -100,35 +113,38 @@ public class S3VectorStore extends AbstractObservationVectorStore implements Ini
 
 	@Override
 	public void doDelete(List<String> idList) {
-		this.s3VectorsClient.deleteVectors(DeleteVectorsRequest.builder()
-			.keys(idList)
-			.indexName(this.indexName)
-			.vectorBucketName(this.vectorBucketName)
-			.build());
+		deleteVectors(idList);
 	}
 
 	@Override
 	public void doDelete(Filter.Expression filterExpression) {
-		Assert.notNull(filterExpression, "Filter expression mus not be null");
+		Assert.notNull(filterExpression, "Filter expression must not be null");
 
-		software.amazon.awssdk.core.document.Document filterDoc = this.filterExpressionConverter
-			.convertExpression(filterExpression);
-		QueryVectorsRequest request = QueryVectorsRequest.builder()
-			.filter(filterDoc)
-			.vectorBucketName(this.vectorBucketName)
-			.indexName(this.indexName)
-			.build();
-		List<String> keys = this.s3VectorsClient.queryVectors(request)
-			.vectors()
-			.stream()
-			.map(QueryOutputVector::key)
-			.toList();
+		String nextToken = null;
+		List<String> keys = new ArrayList<>();
+		do {
+			ListVectorsRequest.Builder requestBuilder = ListVectorsRequest.builder()
+				.vectorBucketName(this.vectorBucketName)
+				.indexName(this.indexName)
+				.maxResults(LIST_VECTORS_MAX_RESULTS)
+				.returnMetadata(true)
+				.returnData(false);
 
-		this.s3VectorsClient.deleteVectors(DeleteVectorsRequest.builder()
-			.vectorBucketName(this.vectorBucketName)
-			.keys(keys)
-			.indexName(this.indexName)
-			.build());
+			if (StringUtils.hasText(nextToken)) {
+				requestBuilder.nextToken(nextToken);
+			}
+
+			ListVectorsResponse response = this.s3VectorsClient.listVectors(requestBuilder.build());
+			for (ListOutputVector vector : response.vectors()) {
+				if (matchesFilter(vector, filterExpression)) {
+					keys.add(vector.key());
+				}
+			}
+			nextToken = response.nextToken();
+		}
+		while (StringUtils.hasText(nextToken));
+
+		deleteVectors(keys);
 	}
 
 	@Override
@@ -166,6 +182,28 @@ public class S3VectorStore extends AbstractObservationVectorStore implements Ini
 			metadata.put("SPRING_AI_S3_DISTANCE", vector.distance());
 		}
 		return Document.builder().metadata(metadata).text(vector.key()).build();
+	}
+
+	private boolean matchesFilter(ListOutputVector vector, Filter.Expression filterExpression) {
+		software.amazon.awssdk.core.document.Document metadataDocument = vector.metadata();
+		Map<String, Object> metadata = (metadataDocument != null) ? DocumentUtils.fromDocument(metadataDocument) : null;
+		return this.filterExpressionEvaluator.evaluate(filterExpression,
+				(metadata != null) ? metadata : Collections.emptyMap());
+	}
+
+	private void deleteVectors(List<String> keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		if (keys.isEmpty()) {
+			return;
+		}
+		for (int i = 0; i < keys.size(); i += DELETE_VECTORS_MAX_KEYS) {
+			List<String> batch = keys.subList(i, Math.min(i + DELETE_VECTORS_MAX_KEYS, keys.size()));
+			this.s3VectorsClient.deleteVectors(DeleteVectorsRequest.builder()
+				.keys(batch)
+				.indexName(this.indexName)
+				.vectorBucketName(this.vectorBucketName)
+				.build());
+		}
 	}
 
 	private static software.amazon.awssdk.core.document.Document constructMetadata(

--- a/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/S3VectorStoreFilterExpressionEvaluator.java
+++ b/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/S3VectorStoreFilterExpressionEvaluator.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.s3;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.vectorstore.filter.Filter;
+
+/**
+ * Package-private helper used by {@link S3VectorStore} to evaluate a
+ * {@link Filter.Expression} against metadata returned by the S3 Vectors ListVectors API.
+ *
+ * @author Jewoo Shin
+ */
+final class S3VectorStoreFilterExpressionEvaluator {
+
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+		.withZone(ZoneOffset.UTC);
+
+	boolean evaluate(Filter.Expression expression, Map<String, Object> metadata) {
+		return evaluateExpression(expression, metadata);
+	}
+
+	private boolean evaluateOperand(Filter.Operand operand, Map<String, Object> metadata) {
+		if (operand instanceof Filter.Group group) {
+			return evaluateOperand(group.content(), metadata);
+		}
+		if (operand instanceof Filter.Expression expression) {
+			return evaluateExpression(expression, metadata);
+		}
+		throw new IllegalArgumentException("Unsupported operand type: " + operand.getClass().getName());
+	}
+
+	private boolean evaluateExpression(Filter.Expression expression, Map<String, Object> metadata) {
+		return switch (expression.type()) {
+			case AND -> evaluateOperand(left(expression), metadata) && evaluateOperand(right(expression), metadata);
+			case OR -> evaluateOperand(left(expression), metadata) || evaluateOperand(right(expression), metadata);
+			case NOT -> !evaluateOperand(left(expression), metadata);
+			case EQ -> compare(metadataValue(left(expression), metadata), filterValue(right(expression))) == 0;
+			case NE -> compare(metadataValue(left(expression), metadata), filterValue(right(expression))) != 0;
+			case GT -> compare(metadataValue(left(expression), metadata), filterValue(right(expression))) > 0;
+			case GTE -> compare(metadataValue(left(expression), metadata), filterValue(right(expression))) >= 0;
+			case LT -> compare(metadataValue(left(expression), metadata), filterValue(right(expression))) < 0;
+			case LTE -> compare(metadataValue(left(expression), metadata), filterValue(right(expression))) <= 0;
+			case IN -> {
+				Object metaVal = metadataValue(left(expression), metadata);
+				List<?> list = asList(filterValue(right(expression)), expression);
+				yield list.stream().anyMatch(item -> compare(metaVal, item) == 0);
+			}
+			case NIN -> {
+				Object metaVal = metadataValue(left(expression), metadata);
+				List<?> list = asList(filterValue(right(expression)), expression);
+				yield list.stream().noneMatch(item -> compare(metaVal, item) == 0);
+			}
+			case ISNULL -> metadataValue(left(expression), metadata) == null;
+			case ISNOTNULL -> metadataValue(left(expression), metadata) != null;
+		};
+	}
+
+	private Filter.Operand left(Filter.Expression expression) {
+		Filter.Operand left = expression.left();
+		if (left == null) {
+			throw new IllegalArgumentException(
+					"Expression of type %s requires a left operand".formatted(expression.type()));
+		}
+		return left;
+	}
+
+	private Filter.Operand right(Filter.Expression expression) {
+		Filter.Operand right = expression.right();
+		if (right == null) {
+			throw new IllegalArgumentException(
+					"Expression of type %s requires a right operand".formatted(expression.type()));
+		}
+		return right;
+	}
+
+	private @Nullable Object metadataValue(Filter.Operand operand, Map<String, Object> metadata) {
+		if (operand instanceof Filter.Key key) {
+			String k = key.key();
+			if (k.length() >= 2
+					&& ((k.startsWith("\"") && k.endsWith("\"")) || (k.startsWith("'") && k.endsWith("'")))) {
+				k = k.substring(1, k.length() - 1);
+			}
+			return metadata.get(k);
+		}
+		throw new IllegalArgumentException("Expected a Key operand but got: " + operand.getClass().getName());
+	}
+
+	private Object filterValue(Filter.Operand operand) {
+		if (operand instanceof Filter.Value filterValue) {
+			Object value = filterValue.value();
+			return (value instanceof Date date) ? DATE_FORMATTER.format(date.toInstant()) : value;
+		}
+		throw new IllegalArgumentException("Expected a Value operand but got: " + operand.getClass().getName());
+	}
+
+	@SuppressWarnings("unchecked")
+	private int compare(@Nullable Object metaVal, @Nullable Object filterVal) {
+		if (metaVal == null && filterVal == null) {
+			return 0;
+		}
+		if (metaVal == null) {
+			return -1;
+		}
+		if (filterVal == null) {
+			return 1;
+		}
+		if (metaVal instanceof Number n1 && filterVal instanceof Number n2) {
+			return Double.compare(n1.doubleValue(), n2.doubleValue());
+		}
+		if (Objects.equals(metaVal, filterVal)) {
+			return 0;
+		}
+		if (metaVal instanceof Comparable comparable && filterVal instanceof Comparable) {
+			try {
+				return comparable.compareTo(filterVal);
+			}
+			catch (ClassCastException ex) {
+				throw new IllegalArgumentException("Cannot compare values of incompatible types %s and %s"
+					.formatted(metaVal.getClass().getName(), filterVal.getClass().getName()), ex);
+			}
+		}
+		throw new IllegalArgumentException("Cannot compare values of types %s and %s"
+			.formatted(metaVal.getClass().getName(), filterVal.getClass().getName()));
+	}
+
+	private List<?> asList(Object value, Filter.Expression expression) {
+		if (value instanceof List<?> list) {
+			return list;
+		}
+		throw new IllegalArgumentException(
+				"Expected a List value for %s expression but got: %s".formatted(expression.type(), value));
+	}
+
+}

--- a/vector-stores/spring-ai-s3-vector-store/src/test/java/S3VectorStoreTests.java
+++ b/vector-stores/spring-ai-s3-vector-store/src/test/java/S3VectorStoreTests.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.document.Document;
+import software.amazon.awssdk.services.s3vectors.S3VectorsClient;
+import software.amazon.awssdk.services.s3vectors.model.DeleteVectorsRequest;
+import software.amazon.awssdk.services.s3vectors.model.ListOutputVector;
+import software.amazon.awssdk.services.s3vectors.model.ListVectorsRequest;
+import software.amazon.awssdk.services.s3vectors.model.ListVectorsResponse;
+import software.amazon.awssdk.services.s3vectors.model.QueryVectorsRequest;
+
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+import org.springframework.ai.vectorstore.s3.DocumentUtils;
+import org.springframework.ai.vectorstore.s3.S3VectorStore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Jewoo Shin
+ */
+class S3VectorStoreTests {
+
+	@Test
+	void filterDeleteListsVectorsWithMetadataAndDeletesMatchingKeys() {
+		S3VectorsClient s3VectorsClient = mock(S3VectorsClient.class);
+		when(s3VectorsClient.listVectors(any(ListVectorsRequest.class))).thenReturn(ListVectorsResponse.builder()
+			.vectors(vector("chunk-1", Map.of("fileId", "file-1", "page", 1)),
+					vector("chunk-2", Map.of("fileId", "file-2", "page", 1)),
+					vector("chunk-3", Map.of("fileId", "file-1", "page", 2)))
+			.build());
+
+		S3VectorStore vectorStore = vectorStore(s3VectorsClient);
+
+		vectorStore.delete(new FilterExpressionBuilder().eq("fileId", "file-1").build());
+
+		ArgumentCaptor<ListVectorsRequest> listRequestCaptor = ArgumentCaptor.forClass(ListVectorsRequest.class);
+		verify(s3VectorsClient).listVectors(listRequestCaptor.capture());
+		assertThat(listRequestCaptor.getValue().vectorBucketName()).isEqualTo("test-vector-bucket");
+		assertThat(listRequestCaptor.getValue().indexName()).isEqualTo("test-index");
+		assertThat(listRequestCaptor.getValue().returnMetadata()).isTrue();
+		assertThat(listRequestCaptor.getValue().returnData()).isFalse();
+		assertThat(listRequestCaptor.getValue().maxResults()).isEqualTo(500);
+
+		ArgumentCaptor<DeleteVectorsRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteVectorsRequest.class);
+		verify(s3VectorsClient).deleteVectors(deleteRequestCaptor.capture());
+		assertThat(deleteRequestCaptor.getValue().keys()).containsExactly("chunk-1", "chunk-3");
+		assertThat(deleteRequestCaptor.getValue().vectorBucketName()).isEqualTo("test-vector-bucket");
+		assertThat(deleteRequestCaptor.getValue().indexName()).isEqualTo("test-index");
+
+		verify(s3VectorsClient, never()).queryVectors(any(QueryVectorsRequest.class));
+	}
+
+	@Test
+	void filterDeleteEvaluatesCompoundFilterExpressions() {
+		S3VectorsClient s3VectorsClient = mock(S3VectorsClient.class);
+		when(s3VectorsClient.listVectors(any(ListVectorsRequest.class))).thenReturn(ListVectorsResponse.builder()
+			.vectors(vector("chunk-1", Map.of("fileId", "file-1", "page", 1)),
+					vector("chunk-2", Map.of("fileId", "file-1", "page", 2)),
+					vector("chunk-3", Map.of("fileId", "file-2", "page", 3)))
+			.build());
+		FilterExpressionBuilder builder = new FilterExpressionBuilder();
+
+		S3VectorStore vectorStore = vectorStore(s3VectorsClient);
+
+		vectorStore.delete(builder.and(builder.eq("fileId", "file-1"), builder.gte("page", 2)).build());
+
+		ArgumentCaptor<DeleteVectorsRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteVectorsRequest.class);
+		verify(s3VectorsClient).deleteVectors(deleteRequestCaptor.capture());
+		assertThat(deleteRequestCaptor.getValue().keys()).containsExactly("chunk-2");
+	}
+
+	@Test
+	void filterDeleteScansAllListVectorsPages() {
+		S3VectorsClient s3VectorsClient = mock(S3VectorsClient.class);
+		when(s3VectorsClient.listVectors(any(ListVectorsRequest.class))).thenReturn(
+				ListVectorsResponse.builder()
+					.vectors(vector("chunk-1", Map.of("fileId", "file-1")))
+					.nextToken("next-page")
+					.build(),
+				ListVectorsResponse.builder().vectors(vector("chunk-2", Map.of("fileId", "file-1"))).build());
+
+		S3VectorStore vectorStore = vectorStore(s3VectorsClient);
+
+		vectorStore.delete(new FilterExpressionBuilder().eq("fileId", "file-1").build());
+
+		ArgumentCaptor<ListVectorsRequest> listRequestCaptor = ArgumentCaptor.forClass(ListVectorsRequest.class);
+		verify(s3VectorsClient, times(2)).listVectors(listRequestCaptor.capture());
+		assertThat(listRequestCaptor.getAllValues()).extracting(ListVectorsRequest::nextToken)
+			.containsExactly(null, "next-page");
+
+		ArgumentCaptor<DeleteVectorsRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteVectorsRequest.class);
+		verify(s3VectorsClient).deleteVectors(deleteRequestCaptor.capture());
+		assertThat(deleteRequestCaptor.getValue().keys()).containsExactly("chunk-1", "chunk-2");
+	}
+
+	@Test
+	void filterDeleteSplitsDeleteRequestsIntoBatches() {
+		S3VectorsClient s3VectorsClient = mock(S3VectorsClient.class);
+		List<ListOutputVector> vectors = IntStream.rangeClosed(1, 501)
+			.mapToObj(index -> vector("chunk-" + index, Map.of("fileId", "file-1")))
+			.toList();
+		when(s3VectorsClient.listVectors(any(ListVectorsRequest.class)))
+			.thenReturn(ListVectorsResponse.builder().vectors(vectors).build());
+
+		S3VectorStore vectorStore = vectorStore(s3VectorsClient);
+
+		vectorStore.delete(new FilterExpressionBuilder().eq("fileId", "file-1").build());
+
+		ArgumentCaptor<DeleteVectorsRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteVectorsRequest.class);
+		verify(s3VectorsClient, times(2)).deleteVectors(deleteRequestCaptor.capture());
+		assertThat(deleteRequestCaptor.getAllValues().get(0).keys()).hasSize(500);
+		assertThat(deleteRequestCaptor.getAllValues().get(1).keys()).containsExactly("chunk-501");
+	}
+
+	@Test
+	void filterDeleteSkipsDeleteWhenNoVectorsMatch() {
+		S3VectorsClient s3VectorsClient = mock(S3VectorsClient.class);
+		when(s3VectorsClient.listVectors(any(ListVectorsRequest.class)))
+			.thenReturn(ListVectorsResponse.builder().vectors(vector("chunk-1", Map.of("fileId", "file-2"))).build());
+
+		S3VectorStore vectorStore = vectorStore(s3VectorsClient);
+
+		vectorStore.delete(new FilterExpressionBuilder().eq("fileId", "file-1").build());
+
+		verify(s3VectorsClient, never()).deleteVectors(any(DeleteVectorsRequest.class));
+		verify(s3VectorsClient, never()).queryVectors(any(QueryVectorsRequest.class));
+	}
+
+	private static S3VectorStore vectorStore(S3VectorsClient s3VectorsClient) {
+		return new S3VectorStore.Builder(s3VectorsClient, mock(EmbeddingModel.class))
+			.vectorBucketName("test-vector-bucket")
+			.indexName("test-index")
+			.build();
+	}
+
+	private static ListOutputVector vector(String key, Map<String, Object> metadata) {
+		return ListOutputVector.builder().key(key).metadata(metadata(metadata)).build();
+	}
+
+	private static Document metadata(Map<String, Object> metadata) {
+		Map<String, Document> values = new LinkedHashMap<>(metadata.size());
+		metadata.forEach((key, value) -> values.put(key, DocumentUtils.toDocument(value)));
+		return Document.fromMap(values);
+	}
+
+}


### PR DESCRIPTION
This updates `S3VectorStore.delete(Filter.Expression)` so filter-based deletion no longer uses `QueryVectors` as a filter-only key lookup.

The delete path now lists vectors with metadata, evaluates the Spring AI filter expression locally, and deletes matching vector keys in `DeleteVectors` batches. This avoids the invalid `QueryVectorsRequest` reported in the issue and preserves the expected semantics of deleting all vectors that match the filter rather than only a `topK` subset.

The change also adds unit coverage for metadata listing, compound filter evaluation, pagination, delete batching, empty matches, and ensuring `QueryVectors` is not used for filter deletion.

Closes #6422
