### PR TITLE
Propagate MCP errors from annotated tools

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -18,6 +18,7 @@ package org.springframework.ai.mcp.annotation.method.tool;
 
 import java.lang.reflect.Method;
 
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.reactivestreams.Publisher;
@@ -66,21 +67,18 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 
 			// Check if the Mono contains CallToolResult
 			if (ReactiveUtils.isReactiveReturnTypeOfCallToolResult(this.toolMethod)) {
-				return (Mono<CallToolResult>) monoResult;
+				return ((Mono<CallToolResult>) monoResult).onErrorResume(this::propagateMcpError);
 			}
 
 			// Handle Mono<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return monoResult
-					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()));
+					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
+					.onErrorResume(this::propagateMcpError);
 			}
 
 			// Handle other Mono types - map the emitted value to CallToolResult
-			return monoResult.map(this::mapValueToCallToolResult)
-				.onErrorResume(e -> Mono.just(CallToolResult.builder()
-					.isError(true)
-					.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
-					.build()));
+			return monoResult.map(this::mapValueToCallToolResult).onErrorResume(this::mapReactiveError);
 		}
 
 		// Handle Flux by taking the first element
@@ -89,22 +87,18 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 
 			// Check if the Flux contains CallToolResult
 			if (ReactiveUtils.isReactiveReturnTypeOfCallToolResult(this.toolMethod)) {
-				return ((Flux<CallToolResult>) fluxResult).next();
+				return ((Flux<CallToolResult>) fluxResult).next().onErrorResume(this::propagateMcpError);
 			}
 
 			// Handle Mono<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return fluxResult
-					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()));
+					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
+					.onErrorResume(this::propagateMcpError);
 			}
 
 			// Handle other Flux types by taking the first element and mapping
-			return fluxResult.next()
-				.map(this::mapValueToCallToolResult)
-				.onErrorResume(e -> Mono.just(CallToolResult.builder()
-					.isError(true)
-					.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
-					.build()));
+			return fluxResult.next().map(this::mapValueToCallToolResult).onErrorResume(this::mapReactiveError);
 		}
 
 		// Handle other Publisher types
@@ -114,21 +108,18 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 
 			// Check if the Publisher contains CallToolResult
 			if (ReactiveUtils.isReactiveReturnTypeOfCallToolResult(this.toolMethod)) {
-				return (Mono<CallToolResult>) monoFromPublisher;
+				return ((Mono<CallToolResult>) monoFromPublisher).onErrorResume(this::propagateMcpError);
 			}
 
 			// Handle Mono<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return monoFromPublisher
-					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()));
+					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
+					.onErrorResume(this::propagateMcpError);
 			}
 
 			// Handle other Publisher types by mapping the emitted value
-			return monoFromPublisher.map(this::mapValueToCallToolResult)
-				.onErrorResume(e -> Mono.just(CallToolResult.builder()
-					.isError(true)
-					.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
-					.build()));
+			return monoFromPublisher.map(this::mapValueToCallToolResult).onErrorResume(this::mapReactiveError);
 		}
 
 		// This should not happen in async context, but handle as fallback
@@ -144,6 +135,25 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 	 */
 	protected CallToolResult mapValueToCallToolResult(Object value) {
 		return convertValueToCallToolResult(value);
+	}
+
+	private Mono<CallToolResult> mapReactiveError(Throwable e) {
+		McpError mcpError = findMcpError(e);
+		if (mcpError != null) {
+			return Mono.error(mcpError);
+		}
+		return Mono.just(CallToolResult.builder()
+			.isError(true)
+			.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
+			.build());
+	}
+
+	private <V> Mono<V> propagateMcpError(Throwable e) {
+		McpError mcpError = findMcpError(e);
+		if (mcpError != null) {
+			return Mono.error(mcpError);
+		}
+		return Mono.error(e);
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -19,11 +19,15 @@ package org.springframework.ai.mcp.annotation.method.tool;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.jspecify.annotations.Nullable;
@@ -213,6 +217,22 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 	 * @return true if the parameter type is an exchange or context type, false otherwise
 	 */
 	protected abstract boolean isExchangeOrContextType(Class<?> paramType);
+
+	/**
+	 * Walks the cause chain to find an {@link McpError}, returning the first match. If
+	 * none is found, returns {@code null}. Used to detect whether a thrown/caught
+	 * exception should propagate as a JSON-RPC error rather than be converted to a
+	 * {@link CallToolResult}.
+	 */
+	protected static McpError findMcpError(Throwable throwable) {
+		Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+		for (Throwable t = throwable; t != null && visited.add(t); t = t.getCause()) {
+			if (t instanceof McpError mcpError) {
+				return mcpError;
+			}
+		}
+		return null;
+	}
 
 	protected Throwable findCauseUsingPlainJava(Throwable throwable) {
 		Objects.requireNonNull(throwable);

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallback.java
@@ -21,6 +21,7 @@ import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import reactor.core.publisher.Mono;
@@ -94,7 +95,11 @@ public final class AsyncMcpToolMethodCallback
 
 			}
 			catch (Exception e) {
-				if (this.toolCallExceptionClass.isInstance(e)) {
+				McpError mcpError = findMcpError(e);
+				if (mcpError != null) {
+					throw mcpError;
+				}
+				else if (this.toolCallExceptionClass.isInstance(e)) {
 					return this.createAsyncErrorResult(e);
 				}
 				return Mono.error(e);

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallback.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp.annotation.method.tool;
 import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import reactor.core.publisher.Mono;
@@ -91,7 +92,11 @@ public final class AsyncStatelessMcpToolMethodCallback
 
 			}
 			catch (Exception e) {
-				if (this.toolCallExceptionClass.isInstance(e)) {
+				McpError mcpError = findMcpError(e);
+				if (mcpError != null) {
+					throw mcpError;
+				}
+				else if (this.toolCallExceptionClass.isInstance(e)) {
 					return this.createAsyncErrorResult(e);
 				}
 				return Mono.error(e);

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallback.java
@@ -20,6 +20,7 @@ import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 
@@ -90,7 +91,11 @@ public final class SyncMcpToolMethodCallback
 			return this.processResult(result);
 		}
 		catch (Exception e) {
-			if (this.toolCallExceptionClass.isInstance(e)) {
+			McpError mcpError = findMcpError(e);
+			if (mcpError != null) {
+				throw mcpError;
+			}
+			else if (this.toolCallExceptionClass.isInstance(e)) {
 				return this.createSyncErrorResult(e);
 			}
 			throw e;

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncStatelessMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncStatelessMcpToolMethodCallback.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp.annotation.method.tool;
 import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 
@@ -81,7 +82,11 @@ public final class SyncStatelessMcpToolMethodCallback
 			return this.processResult(result);
 		}
 		catch (Exception e) {
-			if (this.toolCallExceptionClass.isInstance(e)) {
+			McpError mcpError = findMcpError(e);
+			if (mcpError != null) {
+				throw mcpError;
+			}
+			else if (this.toolCallExceptionClass.isInstance(e)) {
 				return this.createSyncErrorResult(e);
 			}
 			throw e;

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/McpToolMethodCallbackMcpErrorHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/McpToolMethodCallbackMcpErrorHandlingTests.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.method.tool;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse.JSONRPCError;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.ai.mcp.annotation.McpTool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies that {@link McpError} thrown by {@code @McpTool} methods propagates correctly
+ * instead of being converted to an error {@link CallToolResult}.
+ *
+ * <p>
+ * Covers all four concrete callback variants (sync/async stateful/stateless), the
+ * wrapped-cause scenario where {@code callMethod()} wraps the original exception, and
+ * reactive errors emitted after an async method returns.
+ *
+ * @author Dongliang Xie
+ */
+public class McpToolMethodCallbackMcpErrorHandlingTests {
+
+	private static final McpError TEST_ERROR = new McpError(new JSONRPCError(-32000, "protocol-error", null));
+
+	/**
+	 * Provider with a tool method that throws {@link McpError} directly.
+	 */
+	private static class McpErrorToolProvider {
+
+		@McpTool(description = "throws McpError")
+		public String throwMcpError(String input) {
+			throw TEST_ERROR;
+		}
+
+		@McpTool(description = "throws ordinary exception")
+		public String throwOrdinaryException(String input) {
+			throw new IllegalArgumentException("ordinary-error");
+		}
+
+		@McpTool(description = "returns Mono error with McpError")
+		public Mono<String> monoMcpError(String input) {
+			return Mono.error(TEST_ERROR);
+		}
+
+		@McpTool(description = "returns Flux error with McpError")
+		public Flux<String> fluxMcpError(String input) {
+			return Flux.error(TEST_ERROR);
+		}
+
+		@McpTool(description = "returns Publisher error with McpError")
+		public Publisher<String> publisherMcpError(String input) {
+			return Mono.error(TEST_ERROR);
+		}
+
+		@McpTool(description = "returns Mono error with wrapped McpError")
+		public Mono<CallToolResult> monoWrappedMcpError(String input) {
+			return Mono.error(new IllegalStateException("wrapped-error", TEST_ERROR));
+		}
+
+		@McpTool(description = "returns Flux error with wrapped McpError")
+		public Flux<CallToolResult> fluxWrappedMcpError(String input) {
+			return Flux.error(new IllegalStateException("wrapped-error", TEST_ERROR));
+		}
+
+		@McpTool(description = "returns Mono<Void> error with wrapped McpError")
+		public Mono<Void> monoVoidWrappedMcpError(String input) {
+			return Mono.error(new IllegalStateException("wrapped-error", TEST_ERROR));
+		}
+
+		@McpTool(description = "returns Mono error with ordinary exception")
+		public Mono<String> monoOrdinaryException(String input) {
+			return Mono.error(new IllegalArgumentException("ordinary-reactive-error"));
+		}
+
+	}
+
+	// ---- Sync Stateful ----
+
+	@Nested
+	class SyncStatefulMcpErrorTests {
+
+		@Test
+		void mcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("throwMcpError", String.class);
+			SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(McpError.class);
+		}
+
+		@Test
+		void ordinaryExceptionShouldBecomeCallToolResult() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("throwOrdinaryException", String.class);
+			SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			CallToolResult result = callback.apply(exchange, request);
+
+			assertThat(result.isError()).isTrue();
+			assertThat(result.content()).hasSize(1);
+			assertThat(((TextContent) result.content().get(0)).text()).contains("ordinary-error");
+		}
+
+	}
+
+	// ---- Sync Stateless ----
+
+	@Nested
+	class SyncStatelessMcpErrorTests {
+
+		@Test
+		void mcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("throwMcpError", String.class);
+			SyncStatelessMcpToolMethodCallback callback = new SyncStatelessMcpToolMethodCallback(ReturnMode.TEXT,
+					method, provider);
+
+			McpTransportContext context = mock(McpTransportContext.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			assertThatThrownBy(() -> callback.apply(context, request)).isInstanceOf(McpError.class);
+		}
+
+		@Test
+		void ordinaryExceptionShouldBecomeCallToolResult() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("throwOrdinaryException", String.class);
+			SyncStatelessMcpToolMethodCallback callback = new SyncStatelessMcpToolMethodCallback(ReturnMode.TEXT,
+					method, provider);
+
+			McpTransportContext context = mock(McpTransportContext.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			CallToolResult result = callback.apply(context, request);
+
+			assertThat(result.isError()).isTrue();
+			assertThat(((TextContent) result.content().get(0)).text()).contains("ordinary-error");
+		}
+
+	}
+
+	// ---- Async Stateful ----
+
+	@Nested
+	class AsyncStatefulMcpErrorTests {
+
+		@Test
+		void mcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("throwMcpError", String.class);
+			AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(exchange, request)).expectError(McpError.class).verify();
+		}
+
+		@Test
+		void ordinaryExceptionShouldBecomeCallToolResult() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("throwOrdinaryException", String.class);
+			AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(exchange, request)).assertNext(result -> {
+				assertThat(result.isError()).isTrue();
+				assertThat(((TextContent) result.content().get(0)).text()).contains("ordinary-error");
+			}).verifyComplete();
+		}
+
+		@Test
+		void reactiveMonoMcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("monoMcpError", String.class);
+			AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(exchange, request))
+				.expectErrorSatisfies(throwable -> assertThat(throwable).isSameAs(TEST_ERROR))
+				.verify();
+		}
+
+		@Test
+		void reactiveFluxMcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("fluxMcpError", String.class);
+			AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(exchange, request))
+				.expectErrorSatisfies(throwable -> assertThat(throwable).isSameAs(TEST_ERROR))
+				.verify();
+		}
+
+		@Test
+		void reactivePublisherMcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("publisherMcpError", String.class);
+			AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(exchange, request))
+				.expectErrorSatisfies(throwable -> assertThat(throwable).isSameAs(TEST_ERROR))
+				.verify();
+		}
+
+		@Test
+		void reactiveWrappedMcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("monoWrappedMcpError", String.class);
+			AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(exchange, request))
+				.expectErrorSatisfies(throwable -> assertThat(throwable).isSameAs(TEST_ERROR))
+				.verify();
+		}
+
+		@Test
+		void reactiveFluxWrappedMcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("fluxWrappedMcpError", String.class);
+			AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(exchange, request))
+				.expectErrorSatisfies(throwable -> assertThat(throwable).isSameAs(TEST_ERROR))
+				.verify();
+		}
+
+		@Test
+		void reactiveVoidWrappedMcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("monoVoidWrappedMcpError", String.class);
+			AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.VOID, method, provider);
+
+			McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(exchange, request))
+				.expectErrorSatisfies(throwable -> assertThat(throwable).isSameAs(TEST_ERROR))
+				.verify();
+		}
+
+		@Test
+		void reactiveOrdinaryExceptionShouldBecomeCallToolResult() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("monoOrdinaryException", String.class);
+			AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+			McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(exchange, request)).assertNext(result -> {
+				assertThat(result.isError()).isTrue();
+				assertThat(((TextContent) result.content().get(0)).text()).contains("ordinary-reactive-error");
+			}).verifyComplete();
+		}
+
+	}
+
+	// ---- Async Stateless ----
+
+	@Nested
+	class AsyncStatelessMcpErrorTests {
+
+		@Test
+		void mcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("throwMcpError", String.class);
+			AsyncStatelessMcpToolMethodCallback callback = new AsyncStatelessMcpToolMethodCallback(ReturnMode.TEXT,
+					method, provider);
+
+			McpTransportContext context = mock(McpTransportContext.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(context, request)).expectError(McpError.class).verify();
+		}
+
+		@Test
+		void ordinaryExceptionShouldBecomeCallToolResult() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("throwOrdinaryException", String.class);
+			AsyncStatelessMcpToolMethodCallback callback = new AsyncStatelessMcpToolMethodCallback(ReturnMode.TEXT,
+					method, provider);
+
+			McpTransportContext context = mock(McpTransportContext.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(context, request)).assertNext(result -> {
+				assertThat(result.isError()).isTrue();
+				assertThat(((TextContent) result.content().get(0)).text()).contains("ordinary-error");
+			}).verifyComplete();
+		}
+
+		@Test
+		void reactiveMonoMcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("monoMcpError", String.class);
+			AsyncStatelessMcpToolMethodCallback callback = new AsyncStatelessMcpToolMethodCallback(ReturnMode.TEXT,
+					method, provider);
+
+			McpTransportContext context = mock(McpTransportContext.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(context, request))
+				.expectErrorSatisfies(throwable -> assertThat(throwable).isSameAs(TEST_ERROR))
+				.verify();
+		}
+
+		@Test
+		void reactiveFluxMcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("fluxMcpError", String.class);
+			AsyncStatelessMcpToolMethodCallback callback = new AsyncStatelessMcpToolMethodCallback(ReturnMode.TEXT,
+					method, provider);
+
+			McpTransportContext context = mock(McpTransportContext.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(context, request))
+				.expectErrorSatisfies(throwable -> assertThat(throwable).isSameAs(TEST_ERROR))
+				.verify();
+		}
+
+		@Test
+		void reactiveWrappedMcpErrorShouldPropagate() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("monoWrappedMcpError", String.class);
+			AsyncStatelessMcpToolMethodCallback callback = new AsyncStatelessMcpToolMethodCallback(ReturnMode.TEXT,
+					method, provider);
+
+			McpTransportContext context = mock(McpTransportContext.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(context, request))
+				.expectErrorSatisfies(throwable -> assertThat(throwable).isSameAs(TEST_ERROR))
+				.verify();
+		}
+
+		@Test
+		void reactiveOrdinaryExceptionShouldBecomeCallToolResult() throws Exception {
+			McpErrorToolProvider provider = new McpErrorToolProvider();
+			Method method = McpErrorToolProvider.class.getMethod("monoOrdinaryException", String.class);
+			AsyncStatelessMcpToolMethodCallback callback = new AsyncStatelessMcpToolMethodCallback(ReturnMode.TEXT,
+					method, provider);
+
+			McpTransportContext context = mock(McpTransportContext.class);
+			CallToolRequest request = new CallToolRequest("tool", Map.of("input", "test"));
+
+			StepVerifier.create(callback.apply(context, request)).assertNext(result -> {
+				assertThat(result.isError()).isTrue();
+				assertThat(((TextContent) result.content().get(0)).text()).contains("ordinary-reactive-error");
+			}).verifyComplete();
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Problem
`@McpTool` methods that throw `McpError` can have their JSON-RPC error
converted to a `CallToolResult`, which breaks MCP protocol error flows such
as URL elicitation. The low-level MCP API already propagates these errors
correctly; the annotation-based callback path should do the same.

## Fix
Detect `McpError` in the exception cause chain and propagate it instead of
mapping it to an error `CallToolResult`.

This covers:
- sync and async annotated tool callbacks
- stateful and stateless callback variants
- wrapped `McpError` causes
- reactive async failures emitted by `Mono`, `Flux`, and generic `Publisher`

Ordinary exceptions still become error `CallToolResult` values as before.

## Tests
Added MCP error propagation and ordinary-exception regression coverage for:
- sync/async stateful/stateless callbacks
- wrapped `McpError` causes
- reactive `Mono`, `Flux`, and `Publisher` error paths
- reactive `CallToolResult` and `Void` return paths

Local verification:

```shell
./mvnw -pl mcp/mcp-annotations -Dmaven.build.cache.enabled=false test
```

Result: 1378 tests run, 0 failures, 0 errors, 2 skipped.

Fixes #6456