### PR TITLE
Fix Milvus filters with custom metadata field

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverter.java
@@ -30,8 +30,20 @@ import org.springframework.util.Assert;
  *
  * @author Christian Tzolov
  * @author Soby Chacko
+ * @author Taewoong Kim
  */
 public class MilvusFilterExpressionConverter extends AbstractFilterExpressionConverter {
+
+	private final String metadataFieldName;
+
+	public MilvusFilterExpressionConverter() {
+		this(MilvusVectorStore.METADATA_FIELD_NAME);
+	}
+
+	public MilvusFilterExpressionConverter(String metadataFieldName) {
+		Assert.hasText(metadataFieldName, "Metadata field name must not be empty");
+		this.metadataFieldName = metadataFieldName;
+	}
 
 	@Override
 	protected void doExpression(Expression exp, StringBuilder context) {
@@ -65,7 +77,7 @@ public class MilvusFilterExpressionConverter extends AbstractFilterExpressionCon
 	@Override
 	protected void doKey(Key key, StringBuilder context) {
 		var identifier = key.key();
-		context.append("metadata[");
+		context.append(this.metadataFieldName).append("[");
 		emitJsonValue(identifier, context);
 		context.append("]");
 	}

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
@@ -143,6 +143,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  * @author chabinhwang
+ * @author Taewoong Kim
  * @see org.springframework.ai.vectorstore.VectorStore
  * @see io.milvus.client.MilvusServiceClient
  */
@@ -173,7 +174,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 			MetricType.COSINE, VectorStoreSimilarityMetric.COSINE, MetricType.L2, VectorStoreSimilarityMetric.EUCLIDEAN,
 			MetricType.IP, VectorStoreSimilarityMetric.DOT);
 
-	public final FilterExpressionConverter filterExpressionConverter = new MilvusFilterExpressionConverter();
+	public final FilterExpressionConverter filterExpressionConverter;
 
 	private final MilvusServiceClient milvusClient;
 
@@ -222,6 +223,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		this.contentFieldName = builder.contentFieldName;
 		this.metadataFieldName = builder.metadataFieldName;
 		this.embeddingFieldName = builder.embeddingFieldName;
+		this.filterExpressionConverter = new MilvusFilterExpressionConverter(this.metadataFieldName);
 	}
 
 	/**

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverterTests.java
@@ -54,6 +54,15 @@ public class MilvusFilterExpressionConverterTests {
 	}
 
 	@Test
+	public void testEQWithCustomMetadataFieldName() {
+		FilterExpressionConverter customConverter = new MilvusFilterExpressionConverter("meta");
+
+		String vectorExpr = customConverter.convertExpression(new Expression(EQ, new Key("country"), new Value("BG")));
+
+		assertThat(vectorExpr).isEqualTo("meta[\"country\"] == \"BG\"");
+	}
+
+	@Test
 	public void tesEqAndGte() {
 		// genre == "drama" AND year >= 2020
 		String vectorExpr = this.converter

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreCustomMetadataFieldFilterIT.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreCustomMetadataFieldFilterIT.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.milvus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.param.ConnectParam;
+import io.milvus.param.IndexType;
+import io.milvus.param.MetricType;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.milvus.MilvusContainer;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.embedding.TokenCountBatchingStrategy;
+import org.springframework.ai.vectorstore.SearchRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Taewoong Kim
+ */
+@Testcontainers
+class MilvusVectorStoreCustomMetadataFieldFilterIT {
+
+	@Container
+	private static final MilvusContainer milvusContainer = new MilvusContainer(MilvusImage.DEFAULT_IMAGE);
+
+	@Test
+	void shouldFilterWithCustomMetadataFieldName() throws Exception {
+		MilvusServiceClient milvusClient = new MilvusServiceClient(ConnectParam.newBuilder()
+			.withAuthorization("minioadmin", "minioadmin")
+			.withUri(milvusContainer.getEndpoint())
+			.build());
+
+		String collectionName = "test_custom_metadata_filter_" + UUID.randomUUID().toString().replace("-", "");
+		MilvusVectorStore vectorStore = MilvusVectorStore.builder(milvusClient, new TestEmbeddingModel())
+			.collectionName(collectionName)
+			.databaseName(MilvusVectorStore.DEFAULT_DATABASE_NAME)
+			.indexType(IndexType.IVF_FLAT)
+			.metricType(MetricType.COSINE)
+			.embeddingDimension(3)
+			.metadataFieldName("meta")
+			.batchingStrategy(new TokenCountBatchingStrategy())
+			.initializeSchema(true)
+			.build();
+
+		boolean collectionCreated = false;
+		try {
+			vectorStore.afterPropertiesSet();
+			collectionCreated = true;
+
+			Document matchingDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+					Map.of("age", 35, "country", "NL"));
+			Document filteredDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+					Map.of("age", 20, "country", "BG"));
+			vectorStore.add(List.of(matchingDocument, filteredDocument));
+
+			List<Document> results = vectorStore.similaritySearch(SearchRequest.builder()
+				.query("The World")
+				.topK(5)
+				.similarityThresholdAll()
+				.filterExpression("age > 30")
+				.build());
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getId()).isEqualTo(matchingDocument.getId());
+		}
+		finally {
+			if (collectionCreated) {
+				vectorStore.dropCollection();
+			}
+			milvusClient.close(1);
+		}
+	}
+
+	private static final class TestEmbeddingModel implements EmbeddingModel {
+
+		@Override
+		public float[] embed(Document document) {
+			return embed(document.getText());
+		}
+
+		@Override
+		public float[] embed(String text) {
+			return new float[] { 0.1f, 0.2f, 0.3f };
+		}
+
+		@Override
+		public EmbeddingResponse call(EmbeddingRequest request) {
+			List<Embedding> embeddings = new ArrayList<>();
+			for (int i = 0; i < request.getInstructions().size(); i++) {
+				embeddings.add(new Embedding(new float[] { 0.1f, 0.2f, 0.3f }, i));
+			}
+			return new EmbeddingResponse(embeddings);
+		}
+
+		@Override
+		public int dimensions() {
+			return 3;
+		}
+
+	}
+
+}

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreTest.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreTest.java
@@ -119,6 +119,31 @@ class MilvusVectorStoreTest {
 	}
 
 	@Test
+	void shouldPerformSimilaritySearchWithFilterExpressionUsingCustomMetadataFieldName() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+			.metadataFieldName("meta")
+			.build();
+
+		try (MockedStatic<EmbeddingUtils> mockedEmbeddingUtils = mockStatic(EmbeddingUtils.class);
+				MockedConstruction<SearchResultsWrapper> mockedSearchResultsWrapper = mockConstruction(
+						SearchResultsWrapper.class,
+						(mock, context) -> when(mock.getRowRecords(0)).thenReturn(List.of()))) {
+
+			String query = "sample query";
+			SearchRequest request = SearchRequest.builder()
+				.query(query)
+				.topK(5)
+				.similarityThreshold(0.7)
+				.filterExpression("age > 30")
+				.build();
+
+			SearchParam capturedParam = performSimilaritySearch(mockedEmbeddingUtils, request);
+
+			assertThat(capturedParam.getExpr()).isEqualTo("meta[\"age\"] > 30");
+		}
+	}
+
+	@Test
 	void shouldPerformSimilaritySearchWithOriginalSearchRequest() {
 		try (MockedStatic<EmbeddingUtils> mockedEmbeddingUtils = mockStatic(EmbeddingUtils.class);
 				MockedConstruction<SearchResultsWrapper> mockedSearchResultsWrapper = mockConstruction(


### PR DESCRIPTION
Use the configured metadata field name when converting Spring AI filter expressions for Milvus.

Previously, a store configured with `metadataFieldName("meta")` still generated filters against the default `metadata` field. For example, a filter expression such as `age > 30` was converted to:

```text
metadata["age"] > 30
```

instead of:

```text
meta["age"] > 30
```

This updates `MilvusFilterExpressionConverter` to use the metadata field name configured by `MilvusVectorStore`, while preserving the default `metadata` behavior.

Added unit coverage and a Milvus Testcontainers integration test for filtered search with a custom metadata field name. Tested locally.

Fixes #6469
