### PR TITLE
Add injected Bedrock API constructors

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
@@ -94,6 +94,7 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 	public AbstractBedrockApi(String modelId, String region) {
 		this(modelId, ProfileCredentialsProvider.builder().build(), region, JacksonUtils.getDefaultJsonMapper(), Duration.ofMinutes(5));
 	}
+
 	/**
 	 * Create a new AbstractBedrockApi instance using default credentials provider and object mapper.
 	 *
@@ -103,6 +104,34 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 	 */
 	public AbstractBedrockApi(String modelId, String region, Duration timeout) {
 		this(modelId, ProfileCredentialsProvider.builder().build(), region, JacksonUtils.getDefaultJsonMapper(), timeout);
+	}
+
+	/**
+	 * Create a new AbstractBedrockApi instance using the provided Bedrock runtime clients
+	 * and default object mapper.
+	 *
+	 * @param modelId The model id to use.
+	 * @param client The Bedrock runtime client to use for non-streaming invocations.
+	 * @param clientStreaming The Bedrock runtime async client to use for streaming invocations.
+	 * @param region The AWS region to use.
+	 */
+	public AbstractBedrockApi(String modelId, BedrockRuntimeClient client, BedrockRuntimeAsyncClient clientStreaming,
+			String region) {
+		this(modelId, client, clientStreaming, Region.of(region), JacksonUtils.getDefaultJsonMapper());
+	}
+
+	/**
+	 * Create a new AbstractBedrockApi instance using the provided Bedrock runtime clients.
+	 *
+	 * @param modelId The model id to use.
+	 * @param client The Bedrock runtime client to use for non-streaming invocations.
+	 * @param clientStreaming The Bedrock runtime async client to use for streaming invocations.
+	 * @param region The AWS region to use.
+	 * @param jsonMapper The JSON mapper to use for JSON serialization and deserialization.
+	 */
+	public AbstractBedrockApi(String modelId, BedrockRuntimeClient client, BedrockRuntimeAsyncClient clientStreaming,
+			String region, JsonMapper jsonMapper) {
+		this(modelId, client, clientStreaming, Region.of(region), jsonMapper);
 	}
 
 	/**
@@ -147,27 +176,31 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 	 */
 	public AbstractBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
 			JsonMapper jsonMapper, Duration timeout) {
+		this(modelId, createClient(credentialsProvider, region, timeout),
+				createAsyncClient(credentialsProvider, region, timeout), region, jsonMapper);
+	}
 
+	/**
+	 * Create a new AbstractBedrockApi instance using the provided Bedrock runtime clients.
+	 *
+	 * @param modelId The model id to use.
+	 * @param client The Bedrock runtime client to use for non-streaming invocations.
+	 * @param clientStreaming The Bedrock runtime async client to use for streaming invocations.
+	 * @param region The AWS region to use.
+	 * @param jsonMapper The JSON mapper to use for JSON serialization and deserialization.
+	 */
+	public AbstractBedrockApi(String modelId, BedrockRuntimeClient client, BedrockRuntimeAsyncClient clientStreaming,
+			Region region, JsonMapper jsonMapper) {
 		Assert.hasText(modelId, "Model id must not be empty");
-		Assert.notNull(credentialsProvider, "Credentials provider must not be null");
+		Assert.notNull(client, "Bedrock runtime client must not be null");
+		Assert.notNull(clientStreaming, "Bedrock runtime async client must not be null");
 		Assert.notNull(jsonMapper, "JSON mapper must not be null");
-		Assert.notNull(timeout, "Timeout must not be null");
 
 		this.modelId = modelId;
 		this.jsonMapper = jsonMapper;
 		this.region = getRegion(region);
-
-		this.client = BedrockRuntimeClient.builder()
-				.region(this.region)
-				.credentialsProvider(credentialsProvider)
-				.overrideConfiguration(c -> c.apiCallTimeout(timeout))
-				.build();
-
-		this.clientStreaming = BedrockRuntimeAsyncClient.builder()
-				.region(this.region)
-				.credentialsProvider(credentialsProvider)
-				.overrideConfiguration(c -> c.apiCallTimeout(timeout))
-				.build();
+		this.client = client;
+		this.clientStreaming = clientStreaming;
 	}
 
 	/**
@@ -338,6 +371,45 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 		else {
 			return region;
 		}
+	}
+
+	private static BedrockRuntimeClient createClient(AwsCredentialsProvider credentialsProvider, Region region,
+			Duration timeout) {
+		Assert.notNull(credentialsProvider, "Credentials provider must not be null");
+		Assert.notNull(timeout, "Timeout must not be null");
+
+		Region resolvedRegion = getRegionStatic(region);
+		return BedrockRuntimeClient.builder()
+			.region(resolvedRegion)
+			.credentialsProvider(credentialsProvider)
+			.overrideConfiguration(c -> c.apiCallTimeout(timeout))
+			.build();
+	}
+
+	private static BedrockRuntimeAsyncClient createAsyncClient(AwsCredentialsProvider credentialsProvider,
+			Region region, Duration timeout) {
+		Assert.notNull(credentialsProvider, "Credentials provider must not be null");
+		Assert.notNull(timeout, "Timeout must not be null");
+
+		Region resolvedRegion = getRegionStatic(region);
+		return BedrockRuntimeAsyncClient.builder()
+			.region(resolvedRegion)
+			.credentialsProvider(credentialsProvider)
+			.overrideConfiguration(c -> c.apiCallTimeout(timeout))
+			.build();
+	}
+
+	private static Region getRegionStatic(Region region) {
+		if (ObjectUtils.isEmpty(region)) {
+			try {
+				return DefaultAwsRegionProviderChain.builder().build().getRegion();
+			}
+			catch (SdkClientException e) {
+				throw new IllegalArgumentException(
+						"Region is empty and cannot be loaded from DefaultAwsRegionProviderChain: " + e.getMessage(), e);
+			}
+		}
+		return region;
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
@@ -25,11 +25,14 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.bedrock.api.AbstractBedrockApi;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingResponse;
+import org.springframework.ai.util.JacksonUtils;
 
 /**
  * Cohere Embedding API. <a href=
@@ -80,6 +83,58 @@ public class CohereEmbeddingBedrockApi
 	 */
 	public CohereEmbeddingBedrockApi(String modelId, String region, Duration timeout) {
 		super(modelId, region, timeout);
+	}
+
+	/**
+	 * Create a new CohereEmbeddingBedrockApi instance using the provided Bedrock runtime
+	 * clients and default object mapper.
+	 * @param modelId The model id to use. See the {@link CohereEmbeddingModel} for the
+	 * supported models.
+	 * @param bedrockRuntimeClient The Bedrock runtime client to use for non-streaming
+	 * invocations.
+	 * @param bedrockRuntimeAsyncClient The Bedrock runtime async client to use for
+	 * streaming invocations.
+	 * @param region The AWS region to use.
+	 */
+	public CohereEmbeddingBedrockApi(String modelId, BedrockRuntimeClient bedrockRuntimeClient,
+			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, String region) {
+		super(modelId, bedrockRuntimeClient, bedrockRuntimeAsyncClient, region, JacksonUtils.getDefaultJsonMapper());
+	}
+
+	/**
+	 * Create a new CohereEmbeddingBedrockApi instance using the provided Bedrock runtime
+	 * clients.
+	 * @param modelId The model id to use. See the {@link CohereEmbeddingModel} for the
+	 * supported models.
+	 * @param bedrockRuntimeClient The Bedrock runtime client to use for non-streaming
+	 * invocations.
+	 * @param bedrockRuntimeAsyncClient The Bedrock runtime async client to use for
+	 * streaming invocations.
+	 * @param region The AWS region to use.
+	 * @param jsonMapper The JSON mapper to use for JSON serialization and
+	 * deserialization.
+	 */
+	public CohereEmbeddingBedrockApi(String modelId, BedrockRuntimeClient bedrockRuntimeClient,
+			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, String region, JsonMapper jsonMapper) {
+		super(modelId, bedrockRuntimeClient, bedrockRuntimeAsyncClient, region, jsonMapper);
+	}
+
+	/**
+	 * Create a new CohereEmbeddingBedrockApi instance using the provided Bedrock runtime
+	 * clients.
+	 * @param modelId The model id to use. See the {@link CohereEmbeddingModel} for the
+	 * supported models.
+	 * @param bedrockRuntimeClient The Bedrock runtime client to use for non-streaming
+	 * invocations.
+	 * @param bedrockRuntimeAsyncClient The Bedrock runtime async client to use for
+	 * streaming invocations.
+	 * @param region The AWS region to use.
+	 * @param jsonMapper The JSON mapper to use for JSON serialization and
+	 * deserialization.
+	 */
+	public CohereEmbeddingBedrockApi(String modelId, BedrockRuntimeClient bedrockRuntimeClient,
+			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, Region region, JsonMapper jsonMapper) {
+		super(modelId, bedrockRuntimeClient, bedrockRuntimeAsyncClient, region, jsonMapper);
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
@@ -26,11 +26,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.bedrock.api.AbstractBedrockApi;
 import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingRequest;
 import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingResponse;
+import org.springframework.ai.util.JacksonUtils;
 import org.springframework.util.Assert;
 
 /**
@@ -54,6 +57,56 @@ public class TitanEmbeddingBedrockApi extends
 	 */
 	public TitanEmbeddingBedrockApi(String modelId, String region, Duration timeout) {
 		super(modelId, region, timeout);
+	}
+
+	/**
+	 * Create a new TitanEmbeddingBedrockApi instance using the provided Bedrock runtime
+	 * clients and default object mapper.
+	 * @param modelId The model id to use. See the {@link TitanEmbeddingModel} for the
+	 * supported models.
+	 * @param bedrockRuntimeClient The Bedrock runtime client to use for non-streaming
+	 * invocations.
+	 * @param bedrockRuntimeAsyncClient The Bedrock runtime async client to use for
+	 * streaming invocations.
+	 * @param region The AWS region to use.
+	 */
+	public TitanEmbeddingBedrockApi(String modelId, BedrockRuntimeClient bedrockRuntimeClient,
+			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, String region) {
+		super(modelId, bedrockRuntimeClient, bedrockRuntimeAsyncClient, region, JacksonUtils.getDefaultJsonMapper());
+	}
+
+	/**
+	 * Create a new TitanEmbeddingBedrockApi instance using the provided Bedrock runtime
+	 * clients.
+	 * @param modelId The model id to use. See the {@link TitanEmbeddingModel} for the
+	 * supported models.
+	 * @param bedrockRuntimeClient The Bedrock runtime client to use for non-streaming
+	 * invocations.
+	 * @param bedrockRuntimeAsyncClient The Bedrock runtime async client to use for
+	 * streaming invocations.
+	 * @param region The AWS region to use.
+	 * @param jsonMapper The JSON mapper to use for JSON serialization and deserialization.
+	 */
+	public TitanEmbeddingBedrockApi(String modelId, BedrockRuntimeClient bedrockRuntimeClient,
+			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, String region, JsonMapper jsonMapper) {
+		super(modelId, bedrockRuntimeClient, bedrockRuntimeAsyncClient, region, jsonMapper);
+	}
+
+	/**
+	 * Create a new TitanEmbeddingBedrockApi instance using the provided Bedrock runtime
+	 * clients.
+	 * @param modelId The model id to use. See the {@link TitanEmbeddingModel} for the
+	 * supported models.
+	 * @param bedrockRuntimeClient The Bedrock runtime client to use for non-streaming
+	 * invocations.
+	 * @param bedrockRuntimeAsyncClient The Bedrock runtime async client to use for
+	 * streaming invocations.
+	 * @param region The AWS region to use.
+	 * @param jsonMapper The JSON mapper to use for JSON serialization and deserialization.
+	 */
+	public TitanEmbeddingBedrockApi(String modelId, BedrockRuntimeClient bedrockRuntimeClient,
+			BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient, Region region, JsonMapper jsonMapper) {
+		super(modelId, bedrockRuntimeClient, bedrockRuntimeAsyncClient, region, jsonMapper);
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/api/AbstractBedrockApiTest.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/api/AbstractBedrockApiTest.java
@@ -25,15 +25,22 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 import tools.jackson.databind.json.JsonMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,6 +55,12 @@ class AbstractBedrockApiTest {
 	@Mock
 	private JsonMapper jsonMapper = mock(JsonMapper.class);
 
+	@Mock
+	private BedrockRuntimeClient bedrockRuntimeClient;
+
+	@Mock
+	private BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient;
+
 	@Test
 	void shouldLoadRegionFromAwsDefaults() {
 		try (MockedStatic<DefaultAwsRegionProviderChain> mocked = mockStatic(DefaultAwsRegionProviderChain.class)) {
@@ -57,6 +70,22 @@ class AbstractBedrockApiTest {
 					this.awsCredentialsProvider, null, this.jsonMapper, Duration.ofMinutes(5));
 			assertThat(testBedrockApi.getRegion()).isEqualTo(Region.AF_SOUTH_1);
 		}
+	}
+
+	@Test
+	void shouldUseInjectedRuntimeClientsForInvocations() throws Exception {
+		Object expected = new Object();
+		when(this.jsonMapper.writeValueAsString("request")).thenReturn("{\"request\":\"value\"}");
+		when(this.bedrockRuntimeClient.invokeModel(any(InvokeModelRequest.class))).thenReturn(
+				InvokeModelResponse.builder().body(SdkBytes.fromUtf8String("{\"response\":\"value\"}")).build());
+		when(this.jsonMapper.readValue("{\"response\":\"value\"}", Object.class)).thenReturn(expected);
+
+		TestBedrockApi testBedrockApi = new TestBedrockApi("modelId", this.bedrockRuntimeClient,
+				this.bedrockRuntimeAsyncClient, Region.US_EAST_1, this.jsonMapper);
+
+		assertThat(testBedrockApi.invoke("request")).isSameAs(expected);
+		assertThat(testBedrockApi.getRegion()).isEqualTo(Region.US_EAST_1);
+		verify(this.bedrockRuntimeClient).invokeModel(any(InvokeModelRequest.class));
 	}
 
 	@Test
@@ -79,6 +108,11 @@ class AbstractBedrockApiTest {
 			super(modelId, credentialsProvider, region, jsonMapper, timeout);
 		}
 
+		protected TestBedrockApi(String modelId, BedrockRuntimeClient client, BedrockRuntimeAsyncClient clientStreaming,
+				Region region, JsonMapper jsonMapper) {
+			super(modelId, client, clientStreaming, region, jsonMapper);
+		}
+
 		@Override
 		protected Object embedding(Object request) {
 			return null;
@@ -91,7 +125,11 @@ class AbstractBedrockApiTest {
 
 		@Override
 		protected Object internalInvocation(Object request, Class<Object> clazz) {
-			return null;
+			return super.internalInvocation(request, clazz);
+		}
+
+		Object invoke(Object request) {
+			return this.internalInvocation(request, Object.class);
 		}
 
 	}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApiTests.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApiTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.cohere.api;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
+
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest;
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest.InputType;
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest.Truncate;
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CohereEmbeddingBedrockApiTests {
+
+	@Test
+	void shouldUseInjectedRuntimeClients() {
+		BedrockRuntimeClient client = mock(BedrockRuntimeClient.class);
+		BedrockRuntimeAsyncClient asyncClient = mock(BedrockRuntimeAsyncClient.class);
+		when(client.invokeModel(any(InvokeModelRequest.class))).thenReturn(InvokeModelResponse.builder()
+			.body(SdkBytes.fromUtf8String(
+					"{\"id\":\"embed-1\",\"embeddings\":[[1.0,2.0]],\"texts\":[\"hello\"],\"response_type\":\"embeddings\"}"))
+			.build());
+
+		CohereEmbeddingBedrockApi api = new CohereEmbeddingBedrockApi("cohere.embed-english-v3", client, asyncClient,
+				"us-east-1");
+
+		CohereEmbeddingResponse response = api
+			.embedding(new CohereEmbeddingRequest(List.of("hello"), InputType.SEARCH_DOCUMENT, Truncate.END));
+
+		assertThat(response.id()).isEqualTo("embed-1");
+		assertThat(response.texts()).containsExactly("hello");
+		assertThat(response.embeddings()).hasSize(1);
+		verify(client).invokeModel(any(InvokeModelRequest.class));
+	}
+
+}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApiTests.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApiTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.titan.api;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
+
+import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingRequest;
+import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TitanEmbeddingBedrockApiTests {
+
+	@Test
+	void shouldUseInjectedRuntimeClients() {
+		BedrockRuntimeClient client = mock(BedrockRuntimeClient.class);
+		BedrockRuntimeAsyncClient asyncClient = mock(BedrockRuntimeAsyncClient.class);
+		when(client.invokeModel(any(InvokeModelRequest.class))).thenReturn(InvokeModelResponse.builder()
+			.body(SdkBytes.fromUtf8String(
+					"{\"embedding\":[1.0,2.0],\"inputTextTokenCount\":2,\"successCount\":1,\"failureCount\":0,\"embeddingsByType\":{}}"))
+			.build());
+
+		TitanEmbeddingBedrockApi api = new TitanEmbeddingBedrockApi("amazon.titan-embed-text-v2:0", client, asyncClient,
+				"us-east-1");
+
+		TitanEmbeddingResponse response = api.embedding(TitanEmbeddingRequest.builder().inputText("hello").build());
+
+		assertThat(response.inputTextTokenCount()).isEqualTo(2);
+		assertThat(response.successCount()).isEqualTo(1);
+		assertThat(response.failureCount()).isEqualTo(0);
+		assertThat(response.embeddingsByType()).isEqualTo(Map.of());
+		verify(client).invokeModel(any(InvokeModelRequest.class));
+	}
+
+}


### PR DESCRIPTION
Allow Bedrock API implementations to accept pre-built runtime
clients so callers do not need to subclass and duplicate
invocation logic for custom AWS client configuration.

Adds constructor overloads for injecting `BedrockRuntimeClient`
and `BedrockRuntimeAsyncClient` while keeping the existing
credentials-based constructors intact.

Also adds tests covering the injected-client path for
`AbstractBedrockApi`, `CohereEmbeddingBedrockApi`, and
`TitanEmbeddingBedrockApi`.

Fixes #6450