### PR TITLE
Fix null parent for tool call observations in blocking mode

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -213,8 +213,12 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 				returnDirect = returnDirect && toolCallback.getToolMetadata().returnDirect();
 			}
 
+			// In streaming/reactive mode the parent observation is propagated through the
+			// Reactor context captured in ToolCallReactiveContextHolder. In blocking mode
+			// that holder is never populated, so fall back to the observation currently
+			// in scope on the calling thread to keep the observation hierarchy intact.
 			Observation parent = ToolCallReactiveContextHolder.getContext()
-				.getOrDefault(ObservationThreadLocalAccessor.KEY, null);
+				.getOrDefault(ObservationThreadLocalAccessor.KEY, this.observationRegistry.getCurrentObservation());
 
 			ToolCallingObservationContext observationContext = ToolCallingObservationContext.builder()
 				.toolDefinition(toolCallback.getToolDefinition())

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTests.java
@@ -17,10 +17,14 @@
 package org.springframework.ai.model.tool;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.ObservationView;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -38,6 +42,7 @@ import org.springframework.ai.tool.execution.ToolExecutionException;
 import org.springframework.ai.tool.execution.ToolExecutionExceptionProcessor;
 import org.springframework.ai.tool.metadata.ToolMetadata;
 import org.springframework.ai.tool.method.MethodToolCallback;
+import org.springframework.ai.tool.observation.ToolCallingObservationContext;
 import org.springframework.ai.tool.resolution.StaticToolCallbackResolver;
 import org.springframework.ai.tool.resolution.ToolCallbackResolver;
 
@@ -329,6 +334,53 @@ class DefaultToolCallingManagerTests {
 		ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, chatResponse);
 
 		assertThat(toolExecutionResult.conversationHistory()).contains(expectedToolResponse);
+	}
+
+	@Test
+	void whenBlockingExecutionThenToolCallObservationHasCurrentObservationAsParent() {
+		ToolCallback toolCallback = new TestToolCallback("toolA");
+		ToolCallbackResolver toolCallbackResolver = new StaticToolCallbackResolver(List.of(toolCallback));
+
+		ObservationRegistry observationRegistry = ObservationRegistry.create();
+		List<ObservationView> capturedParents = new ArrayList<>();
+		observationRegistry.observationConfig()
+			.observationHandler(new ObservationHandler<ToolCallingObservationContext>() {
+				@Override
+				public void onStart(ToolCallingObservationContext context) {
+					capturedParents.add(context.getParentObservation());
+				}
+
+				@Override
+				public boolean supportsContext(Observation.Context context) {
+					return context instanceof ToolCallingObservationContext;
+				}
+			});
+
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder()
+			.observationRegistry(observationRegistry)
+			.toolCallbackResolver(toolCallbackResolver)
+			.build();
+
+		Prompt prompt = new Prompt(new UserMessage("Hello"), ToolCallingChatOptions.builder().build());
+		ChatResponse chatResponse = ChatResponse.builder()
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.content("")
+				.properties(Map.of())
+				.toolCalls(List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}")))
+				.build())))
+			.build();
+
+		// Simulate the blocking ChatClient flow where an outer observation holds an open
+		// scope on the calling thread (ToolCallReactiveContextHolder is never populated).
+		Observation parentObservation = Observation.start("parent", observationRegistry);
+		try (Observation.Scope ignored = parentObservation.openScope()) {
+			toolCallingManager.executeToolCalls(prompt, chatResponse);
+		}
+		finally {
+			parentObservation.stop();
+		}
+
+		assertThat(capturedParents).containsExactly(parentObservation);
 	}
 
 	@Test


### PR DESCRIPTION
DefaultToolCallingManager read the tool call observation parent only from ToolCallReactiveContextHolder, which is populated solely in the streaming/reactive path. In blocking mode the holder is empty, so the explicit parentObservation(null) overwrote the parent that Micrometer had already auto-resolved from the current observation at creation time, leaving tool call observations without a parent and breaking the observability hierarchy.

Fall back to the observation currently in scope on the calling thread when the reactive context holder has no parent. This restores the pre-2.0.0 behavior for the blocking path while preserving the reactor-context parent required for the streaming hierarchy.

Fixes #6457