### PR TITLE
Use Locale.ROOT for OpenAI protocol values

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechOptions.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai;
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -155,7 +156,7 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 
 	@Override
 	public @Nullable String getFormat() {
-		return this.responseFormat.toLowerCase();
+		return this.responseFormat.toLowerCase(Locale.ROOT);
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -21,6 +21,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -385,7 +386,8 @@ public final class OpenAiChatModel implements ChatModel {
 		if (message.audio().isPresent() && StringUtils.hasText(message.audio().get().data())
 				&& request.audio().isPresent()) {
 			var audioOutput = message.audio().get();
-			String mimeType = String.format("audio/%s", request.audio().get().format().value().name().toLowerCase());
+			String mimeType = String.format("audio/%s",
+					request.audio().get().format().value().name().toLowerCase(Locale.ROOT));
 			byte[] audioData = Base64.getDecoder().decode(audioOutput.data());
 			Resource resource = new ByteArrayResource(audioData);
 			Media.builder().mimeType(MimeTypeUtils.parseMimeType(mimeType)).data(resource).id(audioOutput.id()).build();
@@ -729,7 +731,7 @@ public final class OpenAiChatModel implements ChatModel {
 		if (requestOptions.getOutputModalities() != null) {
 			builder.modalities(requestOptions.getOutputModalities()
 				.stream()
-				.map(modality -> ChatCompletionCreateParams.Modality.of(modality.toLowerCase()))
+				.map(modality -> ChatCompletionCreateParams.Modality.of(modality.toLowerCase(Locale.ROOT)))
 				.toList());
 		}
 		if (requestOptions.getOutputAudio() != null) {
@@ -795,7 +797,7 @@ public final class OpenAiChatModel implements ChatModel {
 			builder.parallelToolCalls(requestOptions.getParallelToolCalls());
 		}
 		if (requestOptions.getReasoningEffort() != null) {
-			builder.reasoningEffort(ReasoningEffort.of(requestOptions.getReasoningEffort().toLowerCase()));
+			builder.reasoningEffort(ReasoningEffort.of(requestOptions.getReasoningEffort().toLowerCase(Locale.ROOT)));
 		}
 		if (requestOptions.getVerbosity() != null) {
 			builder.verbosity(ChatCompletionCreateParams.Verbosity.of(requestOptions.getVerbosity()));
@@ -1110,8 +1112,8 @@ public final class OpenAiChatModel implements ChatModel {
 
 				choiceBuilder.finishReason(ChatCompletion.Choice.FinishReason.of(""));
 				cccc.finishReason()
-					.ifPresent(finishReason -> choiceBuilder.finishReason(
-							ChatCompletion.Choice.FinishReason.of(finishReason.value().name().toLowerCase())));
+					.ifPresent(finishReason -> choiceBuilder.finishReason(ChatCompletion.Choice.FinishReason
+						.of(finishReason.value().name().toLowerCase(Locale.ROOT))));
 
 				if (cccc.logprobs().isPresent()) {
 					var logprobs = cccc.logprobs().get();

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -650,10 +651,10 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 		public ChatCompletionAudioParam toChatCompletionAudioParam() {
 			ChatCompletionAudioParam.Builder builder = ChatCompletionAudioParam.builder();
 			if (this.voice() != null) {
-				builder.voice(voice().name().toLowerCase());
+				builder.voice(voice().name().toLowerCase(Locale.ROOT));
 			}
 			if (this.format() != null) {
-				builder.format(ChatCompletionAudioParam.Format.of(this.format().name().toLowerCase()));
+				builder.format(ChatCompletionAudioParam.Format.of(this.format().name().toLowerCase(Locale.ROOT)));
 			}
 			return builder.build();
 		}

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
@@ -20,6 +20,7 @@ import java.net.Proxy;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import com.openai.azure.AzureOpenAIServiceVersion;
@@ -233,7 +234,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 			}
 			if (openAiCreateParams.encodingFormat().isPresent()) {
 				this.encodingFormat = EncodingFormat
-					.valueOf(openAiCreateParams.encodingFormat().get().asString().toUpperCase());
+					.valueOf(openAiCreateParams.encodingFormat().get().asString().toUpperCase(Locale.ROOT));
 			}
 			if (openAiCreateParams.dimensions().isPresent()) {
 				this.dimensions = Math.toIntExact(openAiCreateParams.dimensions().get());

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai;
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -195,16 +196,17 @@ public class OpenAiImageOptions extends AbstractOpenAiOptions implements ImageOp
 			builder.n(this.getN().longValue());
 		}
 		if (this.getQuality() != null) {
-			builder.quality(ImageGenerateParams.Quality.of(this.getQuality().toLowerCase()));
+			builder.quality(ImageGenerateParams.Quality.of(this.getQuality().toLowerCase(Locale.ROOT)));
 		}
 		if (this.getResponseFormat() != null) {
-			builder.responseFormat(ImageGenerateParams.ResponseFormat.of(this.getResponseFormat().toLowerCase()));
+			builder.responseFormat(
+					ImageGenerateParams.ResponseFormat.of(this.getResponseFormat().toLowerCase(Locale.ROOT)));
 		}
 		if (this.getSize() != null) {
 			builder.size(ImageGenerateParams.Size.of(this.getSize()));
 		}
 		if (this.getStyle() != null) {
-			builder.style(ImageGenerateParams.Style.of(this.getStyle().toLowerCase()));
+			builder.style(ImageGenerateParams.Style.of(this.getStyle().toLowerCase(Locale.ROOT)));
 		}
 		if (this.getUser() != null) {
 			builder.user(this.getUser());

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
@@ -18,8 +18,10 @@ package org.springframework.ai.openai.chat;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
+import com.openai.models.chat.completions.ChatCompletionAudioParam;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.prompt.ChatOptions;
@@ -608,6 +610,29 @@ public class OpenAiChatOptionsTests extends AbstractChatOptionsTests<OpenAiChatO
 		assertThat(options.getResponseFormat().getType()).isEqualTo(ResponseFormat.Type.JSON_SCHEMA);
 		assertThat(options.getResponseFormat().getJsonSchema()).isEqualTo(schema);
 		assertThat(options.getOutputSchema()).isEqualTo(schema);
+	}
+
+	@Test
+	void audioParametersAreSerializedLocaleIndependently() {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			// Under the Turkish locale, "SHIMMER".toLowerCase() yields "shımmer" (dotless
+			// 'ı'), which is not a valid OpenAI audio voice. Protocol enum values must be
+			// converted using a fixed locale so the wire value stays "shimmer".
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+			OpenAiChatOptions.AudioParameters audioParameters = new OpenAiChatOptions.AudioParameters(
+					OpenAiChatOptions.AudioParameters.Voice.SHIMMER,
+					OpenAiChatOptions.AudioParameters.AudioResponseFormat.MP3);
+
+			ChatCompletionAudioParam audioParam = audioParameters.toChatCompletionAudioParam();
+
+			assertThat(audioParam.voice().asString()).isEqualTo("shimmer");
+			assertThat(audioParam.format().asString()).isEqualTo("mp3");
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 }


### PR DESCRIPTION
## What
Use `Locale.ROOT` for the case conversions in `spring-ai-openai` that produce OpenAI API protocol values, so they no longer depend on the default JVM locale.

## Why
`String#toLowerCase()/toUpperCase()` without a `Locale` use the default locale. On Turkish (`tr_TR`), `"SHIMMER".toLowerCase()` is `"shımmer"` (dotless ı), which is not a valid OpenAI voice, so audio chat requests with the `SHIMMER` voice fail with a 400. `voice().name()` is always the uppercase enum constant, so the failure is deterministic. The same pattern affected reasoning effort, output modalities, finish-reason normalization, the audio mime type, image quality/style/response format, the speech response format and the embedding encoding format.

Same bug class as #5340 (which fixes `JsonSchemaGenerator` for Gemini); this PR covers the OpenAI module instances #5340 does not touch.

## How
- Replace every locale-sensitive `toLowerCase()/toUpperCase()` on a protocol value in `spring-ai-openai` with the `Locale.ROOT` overload.
- Add `OpenAiChatOptionsTests#audioParametersAreSerializedLocaleIndependently`, which serializes the `SHIMMER` voice under the Turkish locale and asserts the wire value is `shimmer`.

## Test plan
- [x] New test fails before the fix (`shımmer`) and passes after (`shimmer`).
- [x] `./mvnw -pl models/spring-ai-openai -am test` for the touched classes — 61 tests, 0 failures.
- [x] `spring-javaformat` check passes.

Closes #6476
See #5340