### PR TITLE
Use Locale.ROOT for Pinecone filter operators

### DIFF
--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/converter/PineconeFilterExpressionConverter.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/converter/PineconeFilterExpressionConverter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.vectorstore.filter.converter;
 
+import java.util.Locale;
+
 import org.springframework.ai.vectorstore.filter.Filter.Expression;
 import org.springframework.ai.vectorstore.filter.Filter.ExpressionType;
 import org.springframework.ai.vectorstore.filter.Filter.Key;
@@ -53,7 +55,7 @@ public class PineconeFilterExpressionConverter extends AbstractFilterExpressionC
 	}
 
 	private String getOperationSymbol(Expression exp) {
-		return "\"$" + exp.type().toString().toLowerCase() + "\": ";
+		return "\"$" + exp.type().toString().toLowerCase(Locale.ROOT) + "\": ";
 	}
 
 	@Override

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/converter/PineconeFilterExpressionConverterTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/converter/PineconeFilterExpressionConverterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.vectorstore.filter.converter;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -295,6 +296,28 @@ public class PineconeFilterExpressionConverterTests {
 		});
 		assertThat(map).hasSize(1);
 		assertThat(map).containsKey("x\" : { \"$or\": [ {} ] }, \"y");
+	}
+
+	@Test
+	void operatorSymbolsAreSerializedLocaleIndependently() {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			// Under the Turkish locale, "IN".toLowerCase() yields "ın" (dotless 'ı'),
+			// which is not a valid Pinecone operator. Operator symbols must be converted
+			// with a fixed locale so they stay "$in" / "$nin".
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+			String in = this.converter
+				.convertExpression(new Expression(IN, new Key("genre"), new Value(List.of("comedy", "drama"))));
+			assertThat(in).isEqualTo("{\"genre\": {\"$in\": [\"comedy\",\"drama\"]}}");
+
+			String nin = this.converter
+				.convertExpression(new Expression(NIN, new Key("city"), new Value(List.of("Sofia", "Plovdiv"))));
+			assertThat(nin).isEqualTo("{\"city\": {\"$nin\": [\"Sofia\",\"Plovdiv\"]}}");
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 }


### PR DESCRIPTION
## What
Use `Locale.ROOT` when `PineconeFilterExpressionConverter` lowercases the `ExpressionType` enum name into a Pinecone operator symbol.

## Why
`toLowerCase()` without a `Locale` uses the default locale. On Turkish (`tr_TR`), `"IN".toLowerCase()` is `"ın"` and `"NIN".toLowerCase()` is `"nın"`, so the converter emits `"$ın"` / `"$nın"` — not valid Pinecone operators — and any metadata filter using `IN` / `NIN` fails. The enum name is always uppercase, so the failure is deterministic on `tr_TR`.

Same bug class as #5340 (Gemini) and #6477 (OpenAI); this is a different, unreported path in `spring-ai-vector-store`.

## How
- `exp.type().toString().toLowerCase()` → `...toLowerCase(Locale.ROOT)`.
- Add `operatorSymbolsAreSerializedLocaleIndependently` asserting `IN`/`NIN` convert to `$in`/`$nin` under the Turkish locale.

## Test plan
- [x] New test fails before the fix (`$ın`) and passes after (`$in`).
- [x] `./mvnw -pl spring-ai-vector-store -am test -Dtest=PineconeFilterExpressionConverterTests` — 24 tests, 0 failures.
- [x] `spring-javaformat` check passes.

Closes #6478
See #5340