### PR TITLE
Preserve delta additional properties during streaming chunk conversion

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1128,6 +1128,7 @@ public final class OpenAiChatModel implements ChatModel {
 				ChatCompletionMessage.Builder msgBuilder = ChatCompletionMessage.builder()
 					.content(cccc.delta().content())
 					.refusal(cccc.delta().refusal());
+				cccc.delta()._additionalProperties().forEach(msgBuilder::putAdditionalProperty);
 				cccc.delta().toolCalls().ifPresent(ccctcs -> {
 					msgBuilder.toolCalls(ccctcs.stream().map(tc -> {
 						ChatCompletionMessageFunctionToolCall.Builder toolCallBuilder = ChatCompletionMessageFunctionToolCall


### PR DESCRIPTION
Fixes:

During streaming aggregation, delta additionalProperties were not copied into ChatCompletionMessage.

This causes reasoning_content from OpenAI-compatible providers (such as DashScope Qwen) to be lost before getReasoningContent(...) is executed.

This change preserves delta additional properties when converting ChatCompletionChunk into ChatCompletion.