### PR TITLE
Fix shared mutable state in `AnthropicChatOptions.Builder.clone()`

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -562,15 +562,9 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 		@Override
 		public B clone() {
 			AbstractBuilder<B> copy = super.clone();
-			if (this.customHeaders != null && !this.customHeaders.isEmpty()) {
-				copy.customHeaders = this.customHeaders;
-			}
-			if (this.citationDocuments != null && !this.citationDocuments.isEmpty()) {
-				copy.citationDocuments = this.citationDocuments;
-			}
-			if (this.httpHeaders != null && !this.httpHeaders.isEmpty()) {
-				copy.httpHeaders = this.httpHeaders;
-			}
+			copy.customHeaders = this.customHeaders == null ? null : new HashMap<>(this.customHeaders);
+			copy.citationDocuments = this.citationDocuments == null ? null : new ArrayList<>(this.citationDocuments);
+			copy.httpHeaders = this.httpHeaders == null ? null : new HashMap<>(this.httpHeaders);
 			return (B) copy;
 		}
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -709,4 +709,48 @@ class AnthropicChatOptionsTests extends AbstractChatOptionsTests<AnthropicChatOp
 		assertThat(adaptive.display().get()).isEqualTo(ThinkingConfigAdaptive.Display.OMITTED);
 	}
 
+	@Test
+	void cloneDoesNotShareCitationDocuments() {
+		AnthropicCitationDocument docA = AnthropicCitationDocument.builder().plainText("doc-a").build();
+		AnthropicCitationDocument docB = AnthropicCitationDocument.builder().plainText("doc-b").build();
+
+		Builder builder = AnthropicChatOptions.builder().addCitationDocument(docA);
+		Builder clone = builder.clone();
+		clone.addCitationDocument(docB);
+
+		assertThat(builder.build().getCitationDocuments()).containsExactly(docA);
+		assertThat(clone.build().getCitationDocuments()).containsExactly(docA, docB);
+	}
+
+	@Test
+	void cloneCopiesCollectionFields() {
+		AnthropicCitationDocument doc = AnthropicCitationDocument.builder().plainText("doc").build();
+		Map<String, String> customHeaders = new HashMap<>();
+		customHeaders.put("X-Custom", "value");
+		Map<String, String> httpHeaders = new HashMap<>();
+		httpHeaders.put("anthropic-beta", "beta-feature");
+
+		Builder builder = AnthropicChatOptions.builder()
+			.customHeaders(customHeaders)
+			.httpHeaders(httpHeaders)
+			.addCitationDocument(doc);
+
+		AnthropicChatOptions cloned = builder.clone().build();
+
+		assertThat(cloned.getCustomHeaders()).containsEntry("X-Custom", "value");
+		assertThat(cloned.getHttpHeaders()).containsEntry("anthropic-beta", "beta-feature");
+		assertThat(cloned.getCitationDocuments()).containsExactly(doc);
+	}
+
+	@Test
+	void cloneHandlesNullCollections() {
+		Builder builder = AnthropicChatOptions.builder();
+
+		AnthropicChatOptions cloned = builder.clone().build();
+
+		assertThat(cloned.getCustomHeaders()).isNull();
+		assertThat(cloned.getCitationDocuments()).isNull();
+		assertThat(cloned.getHttpHeaders()).isNull();
+	}
+
 }


### PR DESCRIPTION
`AnthropicChatOptions.Builder.clone()` assigned the source builder's `customHeaders`, `citationDocuments`, and `httpHeaders` references to the clone instead of copying them. As a result, a cloned builder shared these mutable collections with the source, so mutating one — for example via `addCitationDocument(...)` after `clone()` — also affected the other. This violates the expectation that a clone is independent, and is inconsistent with the superclass `clone()`, which defensively copies its own mutable collections.

This change creates an independent copy of each of the three collections, matching the pattern already used by `DefaultChatOptionsBuilder` and `DefaultToolCallingChatOptions.Builder`.

## Testing

Added 3 unit tests:

- A cloned builder's citation documents are independent from the source builder.
- All three collection fields (`customHeaders`, `citationDocuments`, `httpHeaders`) are copied into the clone.
- Null collections are handled without error.

`./mvnw -pl models/spring-ai-anthropic clean package` passes, including tests, Checkstyle, and formatting.
