### PR TITLE
Add model capabilities SPI

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/CompositeModelCapabilitiesProvider.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/CompositeModelCapabilitiesProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.util.Assert;
+
+/**
+ * Composite {@link ModelCapabilitiesProvider} that queries providers in order and returns
+ * the first matching capabilities.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.1
+ */
+public final class CompositeModelCapabilitiesProvider implements ModelCapabilitiesProvider {
+
+	private final List<ModelCapabilitiesProvider> providers;
+
+	/**
+	 * Create a composite provider that queries the given providers in iteration order.
+	 * @param providers the providers to query
+	 */
+	public CompositeModelCapabilitiesProvider(List<ModelCapabilitiesProvider> providers) {
+		Assert.notNull(providers, "providers cannot be null");
+		Assert.noNullElements(providers, "providers cannot contain null elements");
+		this.providers = List.copyOf(providers);
+	}
+
+	@Override
+	public Optional<ModelCapabilities> getCapabilities(ModelCapabilitiesRequest request) {
+		Assert.notNull(request, "request cannot be null");
+		return this.providers.stream()
+			.map(provider -> provider.getCapabilities(request))
+			.filter(Optional::isPresent)
+			.map(Optional::get)
+			.findFirst();
+	}
+
+	/**
+	 * Return the providers queried by this composite.
+	 * @return the providers in query order
+	 */
+	public List<ModelCapabilitiesProvider> getProviders() {
+		return this.providers;
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelCapabilities.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelCapabilities.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * Runtime metadata describing known capabilities and limits for a model.
+ * <p>
+ * Nullable values are unknown and should not be interpreted as unsupported.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.1
+ */
+public final class ModelCapabilities {
+
+	private final @Nullable Integer contextWindowTokens;
+
+	private final @Nullable Integer maxOutputTokens;
+
+	private final Set<ModelFeature> supportedFeatures;
+
+	private final Map<String, Object> metadata;
+
+	private ModelCapabilities(Builder builder) {
+		this.contextWindowTokens = builder.contextWindowTokens;
+		this.maxOutputTokens = builder.maxOutputTokens;
+		this.supportedFeatures = builder.supportedFeatures.isEmpty() ? Set.of() : Set.copyOf(builder.supportedFeatures);
+		this.metadata = Map.copyOf(builder.metadata);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Return the model context window size in tokens, or {@code null} when unknown.
+	 * @return the context window size in tokens
+	 */
+	public @Nullable Integer getContextWindowTokens() {
+		return this.contextWindowTokens;
+	}
+
+	/**
+	 * Return the maximum output size in tokens, or {@code null} when unknown.
+	 * @return the maximum output size in tokens
+	 */
+	public @Nullable Integer getMaxOutputTokens() {
+		return this.maxOutputTokens;
+	}
+
+	/**
+	 * Return the features known to be supported by the model. A missing feature means
+	 * that support is not advertised by this metadata.
+	 * @return the supported features
+	 */
+	public Set<ModelFeature> getSupportedFeatures() {
+		return this.supportedFeatures;
+	}
+
+	/**
+	 * Return whether this metadata advertises support for the given feature.
+	 * @param feature the feature to check
+	 * @return {@code true} when the feature is known to be supported
+	 */
+	public boolean supports(ModelFeature feature) {
+		Assert.notNull(feature, "feature cannot be null");
+		return this.supportedFeatures.contains(feature);
+	}
+
+	/**
+	 * Return provider-specific metadata associated with these capabilities.
+	 * @return the provider-specific metadata
+	 */
+	public Map<String, Object> getMetadata() {
+		return this.metadata;
+	}
+
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof ModelCapabilities that)) {
+			return false;
+		}
+		return Objects.equals(this.contextWindowTokens, that.contextWindowTokens)
+				&& Objects.equals(this.maxOutputTokens, that.maxOutputTokens)
+				&& this.supportedFeatures.equals(that.supportedFeatures) && this.metadata.equals(that.metadata);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.contextWindowTokens, this.maxOutputTokens, this.supportedFeatures, this.metadata);
+	}
+
+	@Override
+	public String toString() {
+		return "ModelCapabilities{" + "contextWindowTokens=" + this.contextWindowTokens + ", maxOutputTokens="
+				+ this.maxOutputTokens + ", supportedFeatures=" + this.supportedFeatures + ", metadata=" + this.metadata
+				+ '}';
+	}
+
+	public static final class Builder {
+
+		private @Nullable Integer contextWindowTokens;
+
+		private @Nullable Integer maxOutputTokens;
+
+		private Set<ModelFeature> supportedFeatures = EnumSet.noneOf(ModelFeature.class);
+
+		private Map<String, Object> metadata = Map.of();
+
+		private Builder() {
+		}
+
+		/**
+		 * Set the model context window size in tokens.
+		 * @param contextWindowTokens the context window size in tokens, or {@code null}
+		 * when unknown
+		 * @return this builder
+		 */
+		public Builder contextWindowTokens(@Nullable Integer contextWindowTokens) {
+			assertPositive(contextWindowTokens, "contextWindowTokens");
+			this.contextWindowTokens = contextWindowTokens;
+			return this;
+		}
+
+		/**
+		 * Set the maximum output size in tokens.
+		 * @param maxOutputTokens the maximum output size in tokens, or {@code null} when
+		 * unknown
+		 * @return this builder
+		 */
+		public Builder maxOutputTokens(@Nullable Integer maxOutputTokens) {
+			assertPositive(maxOutputTokens, "maxOutputTokens");
+			this.maxOutputTokens = maxOutputTokens;
+			return this;
+		}
+
+		/**
+		 * Set the features known to be supported by the model.
+		 * @param supportedFeatures the supported features
+		 * @return this builder
+		 */
+		public Builder supportedFeatures(Set<ModelFeature> supportedFeatures) {
+			Assert.notNull(supportedFeatures, "supportedFeatures cannot be null");
+			this.supportedFeatures = supportedFeatures.isEmpty() ? EnumSet.noneOf(ModelFeature.class)
+					: EnumSet.copyOf(supportedFeatures);
+			return this;
+		}
+
+		/**
+		 * Set provider-specific metadata associated with these capabilities.
+		 * @param metadata the provider-specific metadata
+		 * @return this builder
+		 */
+		public Builder metadata(Map<String, Object> metadata) {
+			Assert.notNull(metadata, "metadata cannot be null");
+			this.metadata = Map.copyOf(metadata);
+			return this;
+		}
+
+		/**
+		 * Build the immutable capabilities instance.
+		 * @return a new {@link ModelCapabilities}
+		 */
+		public ModelCapabilities build() {
+			return new ModelCapabilities(this);
+		}
+
+		private static void assertPositive(@Nullable Integer value, String name) {
+			Assert.isTrue(value == null || value > 0, name + " must be greater than zero");
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelCapabilitiesProvider.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelCapabilitiesProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model;
+
+import java.util.Optional;
+
+/**
+ * Strategy interface for looking up known runtime capabilities of a model.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.1
+ */
+@FunctionalInterface
+public interface ModelCapabilitiesProvider {
+
+	/**
+	 * Return known capabilities for the requested model, or {@link Optional#empty()} when
+	 * this provider has no metadata for it.
+	 * @param request the lookup request
+	 * @return optional capabilities for the requested model
+	 */
+	Optional<ModelCapabilities> getCapabilities(ModelCapabilitiesRequest request);
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelCapabilitiesRequest.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelCapabilitiesRequest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * Request object used to look up model capabilities.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.1
+ */
+public final class ModelCapabilitiesRequest {
+
+	private final String provider;
+
+	private final String model;
+
+	private final Map<String, Object> metadata;
+
+	/**
+	 * Create a request for the given provider and model.
+	 * @param provider the provider identifier
+	 * @param model the model identifier
+	 */
+	public ModelCapabilitiesRequest(String provider, String model) {
+		this(provider, model, Map.of());
+	}
+
+	/**
+	 * Create a request for the given provider, model, and lookup metadata.
+	 * @param provider the provider identifier
+	 * @param model the model identifier
+	 * @param metadata additional provider-specific lookup metadata
+	 */
+	public ModelCapabilitiesRequest(String provider, String model, Map<String, Object> metadata) {
+		Assert.hasText(provider, "provider cannot be empty");
+		Assert.hasText(model, "model cannot be empty");
+		Assert.notNull(metadata, "metadata cannot be null");
+		this.provider = provider;
+		this.model = model;
+		this.metadata = Map.copyOf(metadata);
+	}
+
+	/**
+	 * Return the provider identifier.
+	 * @return the provider identifier
+	 */
+	public String getProvider() {
+		return this.provider;
+	}
+
+	/**
+	 * Return the model identifier.
+	 * @return the model identifier
+	 */
+	public String getModel() {
+		return this.model;
+	}
+
+	/**
+	 * Return provider-specific lookup metadata.
+	 * @return provider-specific lookup metadata
+	 */
+	public Map<String, Object> getMetadata() {
+		return this.metadata;
+	}
+
+	/**
+	 * Return a provider-specific lookup metadata value.
+	 * @param key the metadata key
+	 * @return the metadata value, or {@code null} when not present
+	 */
+	public @Nullable Object getMetadata(String key) {
+		Assert.notNull(key, "key cannot be null");
+		return this.metadata.get(key);
+	}
+
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof ModelCapabilitiesRequest that)) {
+			return false;
+		}
+		return this.provider.equals(that.provider) && this.model.equals(that.model)
+				&& this.metadata.equals(that.metadata);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.provider, this.model, this.metadata);
+	}
+
+	@Override
+	public String toString() {
+		return "ModelCapabilitiesRequest{" + "provider='" + this.provider + '\'' + ", model='" + this.model + '\''
+				+ ", metadata=" + this.metadata + '}';
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelFeature.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelFeature.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model;
+
+/**
+ * Portable model features that applications can use for runtime capability checks.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.1
+ */
+public enum ModelFeature {
+
+	/**
+	 * Tool or function calling support.
+	 */
+	TOOL_CALLING,
+
+	/**
+	 * Streaming response support.
+	 */
+	STREAMING,
+
+	/**
+	 * Multimodal input support.
+	 */
+	MULTIMODAL_INPUT,
+
+	/**
+	 * Reasoning capability support.
+	 */
+	REASONING
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/CompositeModelCapabilitiesProviderTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/CompositeModelCapabilitiesProviderTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class CompositeModelCapabilitiesProviderTests {
+
+	@Test
+	void returnsFirstMatchingCapabilities() {
+		ModelCapabilities first = ModelCapabilities.builder()
+			.contextWindowTokens(128000)
+			.supportedFeatures(Set.of(ModelFeature.STREAMING))
+			.build();
+		ModelCapabilities second = ModelCapabilities.builder().contextWindowTokens(256000).build();
+		CompositeModelCapabilitiesProvider provider = new CompositeModelCapabilitiesProvider(
+				List.of(request -> Optional.empty(), request -> Optional.of(first), request -> Optional.of(second)));
+
+		Optional<ModelCapabilities> capabilities = provider
+			.getCapabilities(new ModelCapabilitiesRequest("openai", "gpt-4.1"));
+
+		assertThat(capabilities).containsSame(first);
+	}
+
+	@Test
+	void returnsEmptyWhenNoProviderMatches() {
+		CompositeModelCapabilitiesProvider provider = new CompositeModelCapabilitiesProvider(
+				List.of(request -> Optional.empty()));
+
+		Optional<ModelCapabilities> capabilities = provider
+			.getCapabilities(new ModelCapabilitiesRequest("openai", "unknown"));
+
+		assertThat(capabilities).isEmpty();
+	}
+
+	@Test
+	void exposesImmutableProviderList() {
+		CompositeModelCapabilitiesProvider provider = new CompositeModelCapabilitiesProvider(
+				List.of(request -> Optional.empty()));
+
+		assertThat(provider.getProviders()).isUnmodifiable();
+	}
+
+	@Test
+	void rejectsNullProviderElements() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> new CompositeModelCapabilitiesProvider(Collections.singletonList(null)))
+			.withMessageContaining("providers");
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/ModelCapabilitiesRequestTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/ModelCapabilitiesRequestTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class ModelCapabilitiesRequestTests {
+
+	@Test
+	void exposesProviderModelAndMetadata() {
+		ModelCapabilitiesRequest request = new ModelCapabilitiesRequest("openai", "gpt-4.1",
+				Map.of("deployment", "production"));
+
+		assertThat(request.getProvider()).isEqualTo("openai");
+		assertThat(request.getModel()).isEqualTo("gpt-4.1");
+		assertThat(request.getMetadata()).containsEntry("deployment", "production");
+		assertThat(request.getMetadata("deployment")).isEqualTo("production");
+	}
+
+	@Test
+	void exposesImmutableMetadata() {
+		ModelCapabilitiesRequest request = new ModelCapabilitiesRequest("openai", "gpt-4.1",
+				Map.of("deployment", "production"));
+
+		assertThat(request.getMetadata()).isUnmodifiable();
+	}
+
+	@Test
+	void requiresProviderAndModel() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new ModelCapabilitiesRequest("", "gpt-4.1"))
+			.withMessageContaining("provider");
+		assertThatIllegalArgumentException().isThrownBy(() -> new ModelCapabilitiesRequest("openai", ""))
+			.withMessageContaining("model");
+	}
+
+	@Test
+	void requiresMetadataKey() {
+		ModelCapabilitiesRequest request = new ModelCapabilitiesRequest("openai", "gpt-4.1");
+
+		assertThatIllegalArgumentException().isThrownBy(() -> request.getMetadata(null)).withMessageContaining("key");
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/ModelCapabilitiesTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/ModelCapabilitiesTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class ModelCapabilitiesTests {
+
+	@Test
+	void unknownValuesRemainNull() {
+		ModelCapabilities capabilities = ModelCapabilities.builder().build();
+
+		assertThat(capabilities.getContextWindowTokens()).isNull();
+		assertThat(capabilities.getMaxOutputTokens()).isNull();
+		assertThat(capabilities.getSupportedFeatures()).isEmpty();
+		assertThat(capabilities.getMetadata()).isEmpty();
+	}
+
+	@Test
+	void exposesKnownLimitsFeaturesAndMetadata() {
+		ModelCapabilities capabilities = ModelCapabilities.builder()
+			.contextWindowTokens(128000)
+			.maxOutputTokens(16000)
+			.supportedFeatures(Set.of(ModelFeature.TOOL_CALLING, ModelFeature.STREAMING))
+			.metadata(Map.of("providerModelId", "gpt-4.1"))
+			.build();
+
+		assertThat(capabilities.getContextWindowTokens()).isEqualTo(128000);
+		assertThat(capabilities.getMaxOutputTokens()).isEqualTo(16000);
+		assertThat(capabilities.supports(ModelFeature.TOOL_CALLING)).isTrue();
+		assertThat(capabilities.supports(ModelFeature.REASONING)).isFalse();
+		assertThat(capabilities.getMetadata()).containsEntry("providerModelId", "gpt-4.1");
+	}
+
+	@Test
+	void exposesImmutableCollections() {
+		ModelCapabilities capabilities = ModelCapabilities.builder()
+			.supportedFeatures(Set.of(ModelFeature.STREAMING))
+			.metadata(Map.of("providerModelId", "gpt-4.1"))
+			.build();
+
+		assertThat(capabilities.getSupportedFeatures()).isUnmodifiable();
+		assertThat(capabilities.getMetadata()).isUnmodifiable();
+	}
+
+	@Test
+	void rejectsNonPositiveLimits() {
+		assertThatIllegalArgumentException().isThrownBy(() -> ModelCapabilities.builder().contextWindowTokens(0))
+			.withMessageContaining("contextWindowTokens");
+		assertThatIllegalArgumentException().isThrownBy(() -> ModelCapabilities.builder().maxOutputTokens(-1))
+			.withMessageContaining("maxOutputTokens");
+	}
+
+	@Test
+	void supportsRequiresFeature() {
+		ModelCapabilities capabilities = ModelCapabilities.builder().build();
+
+		assertThatIllegalArgumentException().isThrownBy(() -> capabilities.supports(null))
+			.withMessageContaining("feature");
+	}
+
+}


### PR DESCRIPTION
This PR sketches a small provider-neutral model capabilities SPI in `spring-ai-model`.

The goal is to let provider modules or applications expose known runtime model metadata, such as context window size, maximum output tokens, and portable feature support, without making Spring AI a central catalog of all provider/model facts.

## Design notes

This is intentionally not a framework-maintained model catalog.

Model capability data can change frequently and can depend on the provider route or deployment context. For that reason, this PR keeps unknown values unknown:

- nullable numeric limits mean unknown, not unsupported
- `supportedFeatures` contains features known to be supported by the returned metadata
- missing features should not be interpreted as an authoritative unsupported signal
- provider-specific details can be carried in the metadata map without expanding the core API for every provider feature

`CompositeModelCapabilitiesProvider` uses a first-match strategy intentionally. This keeps each returned `ModelCapabilities` instance coherent and avoids defining premature merge rules for limits, supported features, and provider-specific metadata. It also leaves room for application-provided capability providers to override provider defaults by ordering.

## Testing

```bash
./mvnw -pl spring-ai-model package
```

See #6486.