### PR TITLE
Fix incorrect assertions in `CouchbaseSearchVectorStore.Builder`

### DIFF
--- a/vector-stores/spring-ai-couchbase-store/src/main/java/org/springframework/ai/vectorstore/couchbase/CouchbaseSearchVectorStore.java
+++ b/vector-stores/spring-ai-couchbase-store/src/main/java/org/springframework/ai/vectorstore/couchbase/CouchbaseSearchVectorStore.java
@@ -79,7 +79,7 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 
 	private final String vectorIndexName;
 
-	private final Integer dimensions;
+	private final int dimensions;
 
 	private final CouchbaseSimilarityFunction similarityFunction;
 
@@ -371,7 +371,7 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 
 		private String vectorIndexName = DEFAULT_INDEX_NAME;
 
-		private Integer dimensions = 1536;
+		private int dimensions = 1536;
 
 		private CouchbaseSimilarityFunction similarityFunction = CouchbaseSimilarityFunction.dot_product;
 
@@ -409,8 +409,7 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 		 * @return this builder
 		 */
 		public CouchbaseSearchVectorStore.Builder collectionName(String collectionName) {
-			Assert.notNull(collectionName, "Collection Name must not be null");
-			Assert.notNull(collectionName, "Collection Name must not be empty");
+			Assert.hasText(collectionName, "Collection Name must not be empty");
 			this.collectionName = collectionName;
 			return this;
 		}
@@ -422,8 +421,7 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 		 * @return this builder
 		 */
 		public CouchbaseSearchVectorStore.Builder scopeName(String scopeName) {
-			Assert.notNull(scopeName, "Scope Name must not be null");
-			Assert.notNull(scopeName, "Scope Name must not be empty");
+			Assert.hasText(scopeName, "Scope Name must not be empty");
 			this.scopeName = scopeName;
 			return this;
 		}
@@ -434,8 +432,7 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 		 * @return this builder
 		 */
 		public CouchbaseSearchVectorStore.Builder bucketName(String bucketName) {
-			Assert.notNull(bucketName, "Bucket Name must not be null");
-			Assert.notNull(bucketName, "Bucket Name must not be empty");
+			Assert.hasText(bucketName, "Bucket Name must not be empty");
 			this.bucketName = bucketName;
 			return this;
 		}
@@ -447,8 +444,7 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 		 * @return this builder
 		 */
 		public CouchbaseSearchVectorStore.Builder vectorIndexName(String vectorIndexName) {
-			Assert.notNull(vectorIndexName, "Vector Index Name must not be null");
-			Assert.notNull(vectorIndexName, "Vector Index Name must not be empty");
+			Assert.hasText(vectorIndexName, "Vector Index Name must not be empty");
 			this.vectorIndexName = vectorIndexName;
 			return this;
 		}
@@ -458,9 +454,8 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 		 * @param dimensions
 		 * @return this builder
 		 */
-		public CouchbaseSearchVectorStore.Builder dimensions(Integer dimensions) {
-			Assert.notNull(dimensions, "Dimensions must not be null");
-			Assert.notNull(dimensions, "Dimensions must not be empty");
+		public CouchbaseSearchVectorStore.Builder dimensions(int dimensions) {
+			Assert.isTrue(dimensions > 0, "Dimensions must be greater than 0");
 			this.dimensions = dimensions;
 			return this;
 		}
@@ -473,7 +468,6 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 		 */
 		public CouchbaseSearchVectorStore.Builder similarityFunction(CouchbaseSimilarityFunction similarityFunction) {
 			Assert.notNull(similarityFunction, "Couchbase Similarity Function must not be null");
-			Assert.notNull(similarityFunction, "Couchbase Similarity Function must not be empty");
 			this.similarityFunction = similarityFunction;
 			return this;
 		}
@@ -485,7 +479,6 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 		 */
 		public CouchbaseSearchVectorStore.Builder indexOptimization(CouchbaseIndexOptimization indexOptimization) {
 			Assert.notNull(indexOptimization, "Index Optimization must not be null");
-			Assert.notNull(indexOptimization, "Index Optimization must not be empty");
 			this.indexOptimization = indexOptimization;
 			return this;
 		}


### PR DESCRIPTION
`CouchbaseSearchVectorStore.Builder` contains several validation inconsistencies compared to other vector stores.

* String fields (`collectionName`, `scopeName`, `bucketName`, `vectorIndexName`) used `Assert.notNull` twice with different messages. Since `Assert.notNull` does not reject empty or blank strings, replaced the duplicate checks with a single `Assert.hasText`, matching the validation used in `GemFireVectorStore` and `PineconeVectorStore`.

* `dimensions` used two `Assert.notNull` checks, including one with the message `"must not be empty"`, which is not meaningful for an integer and still allows non-positive values. Replaced these with `Assert.isTrue(dimensions > 0, ...)` and changed the type from `Integer` to primitive `int`, matching `OpenSearchVectorStore` and `OracleVectorStore`.

* Enum fields (`similarityFunction`, `indexOptimization`) also contained duplicate `Assert.notNull` checks with the misleading message `"must not be empty"`. Removed the redundant assertions.
