### PR TITLE
Fix tool-search reference extraction for parallel calls

### DIFF
--- a/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
+++ b/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
@@ -290,21 +290,30 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 
 	private List<String> extractToolNameReferences(List<Message> messages) {
 
-		List<ToolResponse> toolSearchToolResponses = messages.stream()
+		// Group toolSearchTool responses per tool-response message, i.e. per assistant
+		// turn. A single turn may contain several parallel toolSearchTool calls, all of
+		// which arrive within one ToolResponseMessage.
+		List<List<ToolResponse>> toolSearchResponsesPerTurn = messages.stream()
 			.filter(m -> m.getMessageType() == MessageType.TOOL)
-			.map(r -> ((ToolResponseMessage) r).getResponses())
-			.flatMap(List::stream)
-			.filter(r -> r.name().equalsIgnoreCase(this.toolSearchToolCallback.getToolDefinition().name()))
+			.map(m -> ((ToolResponseMessage) m).getResponses()
+				.stream()
+				.filter(r -> r.name().equalsIgnoreCase(this.toolSearchToolCallback.getToolDefinition().name()))
+				.toList())
+			.filter(responses -> !responses.isEmpty())
 			.toList();
 
-		if (CollectionUtils.isEmpty(toolSearchToolResponses)) {
+		if (toolSearchResponsesPerTurn.isEmpty()) {
 			return List.of();
 		}
 
-		toolSearchToolResponses = (this.referenceToolNameAccumulation) ? toolSearchToolResponses
-				: List.of(toolSearchToolResponses.get(toolSearchToolResponses.size() - 1));
+		// When accumulation is disabled only the most recent search turn is honored, but
+		// that turn may contain multiple parallel toolSearchTool calls that must all be
+		// kept.
+		List<List<ToolResponse>> selectedTurns = this.referenceToolNameAccumulation ? toolSearchResponsesPerTurn
+				: List.of(toolSearchResponsesPerTurn.get(toolSearchResponsesPerTurn.size() - 1));
 
-		return toolSearchToolResponses.stream()
+		return selectedTurns.stream()
+			.flatMap(List::stream)
 			.map(r -> jsonHelper.fromJson(r.responseData(), new ParameterizedTypeReference<List<String>>() {
 			}))
 			.flatMap(List::stream)

--- a/advisors/spring-ai-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisorCallTests.java
+++ b/advisors/spring-ai-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisorCallTests.java
@@ -667,7 +667,140 @@ public class ToolSearchToolCallingAdvisorCallTests {
 		verify(this.toolIndex, times(1)).clearIndex(anyString());
 	}
 
+	/**
+	 * Multiple parallel toolSearchTool calls are emitted in a single assistant turn and
+	 * arrive within one ToolResponseMessage. Even with accumulation disabled, the
+	 * references from all parallel calls in that last turn must be retained — not just
+	 * the last single response.
+	 */
+	@Test
+	void testNonAccumulation_keepsAllParallelToolSearchResponsesInSameTurn() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.referenceToolNameAccumulation(false)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		TestToolCallingChatOptions toolOptions = new TestToolCallingChatOptions();
+		toolOptions
+			.setToolCallbacks(List.of(mockCallback("currentTime"), mockCallback("weather"), mockCallback("clothing")));
+
+		// One turn with three parallel toolSearchTool calls -> one ToolResponseMessage
+		// holding three ToolResponse entries.
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(
+					new ToolResponseMessage.ToolResponse("id1", "toolSearchTool",
+							"[\"currentTime\",\"weather\",\"clothing\"]"),
+					new ToolResponseMessage.ToolResponse("id2", "toolSearchTool",
+							"[\"weather\",\"currentTime\",\"clothing\"]"),
+					new ToolResponseMessage.ToolResponse("id3", "toolSearchTool", "[\"clothing\"]")))
+			.build();
+
+		ToolCallingChatOptions captured = captureToolOptionsForPrompt(advisor,
+				List.of(new SystemMessage("System message"), new UserMessage("test"),
+						AssistantMessage.builder().content("searching").build(), toolResponseMessage),
+				toolOptions);
+
+		assertThat(captured.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder("toolSearchTool", "currentTime", "weather", "clothing");
+	}
+
+	/**
+	 * With accumulation disabled, only the most recent turn's tool search references are
+	 * honored — references discovered in an earlier turn are dropped.
+	 */
+	@Test
+	void testNonAccumulation_keepsOnlyLastTurnAcrossTurns() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.referenceToolNameAccumulation(false)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		TestToolCallingChatOptions toolOptions = new TestToolCallingChatOptions();
+		toolOptions.setToolCallbacks(List.of(mockCallback("weather"), mockCallback("clothing")));
+
+		ToolResponseMessage turn1 = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id1", "toolSearchTool", "[\"weather\"]")))
+			.build();
+		ToolResponseMessage turn2 = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id2", "toolSearchTool", "[\"clothing\"]")))
+			.build();
+
+		ToolCallingChatOptions captured = captureToolOptionsForPrompt(advisor,
+				List.of(new UserMessage("test"), turn1, AssistantMessage.builder().content("again").build(), turn2),
+				toolOptions);
+
+		assertThat(captured.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder("toolSearchTool", "clothing");
+	}
+
+	/**
+	 * With accumulation enabled, references from all turns are retained.
+	 */
+	@Test
+	void testAccumulation_keepsReferencesAcrossTurns() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.referenceToolNameAccumulation(true)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		TestToolCallingChatOptions toolOptions = new TestToolCallingChatOptions();
+		toolOptions.setToolCallbacks(List.of(mockCallback("weather"), mockCallback("clothing")));
+
+		ToolResponseMessage turn1 = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id1", "toolSearchTool", "[\"weather\"]")))
+			.build();
+		ToolResponseMessage turn2 = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id2", "toolSearchTool", "[\"clothing\"]")))
+			.build();
+
+		ToolCallingChatOptions captured = captureToolOptionsForPrompt(advisor,
+				List.of(new UserMessage("test"), turn1, AssistantMessage.builder().content("again").build(), turn2),
+				toolOptions);
+
+		assertThat(captured.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder("toolSearchTool", "weather", "clothing");
+	}
+
 	// Helper methods
+
+	private ToolCallback mockCallback(String name) {
+		ToolCallback callback = mock(ToolCallback.class);
+		when(callback.getToolDefinition()).thenReturn(
+				DefaultToolDefinition.builder().name(name).description(name + " desc").inputSchema("{}").build());
+		return callback;
+	}
+
+	private ToolCallingChatOptions captureToolOptionsForPrompt(ToolSearchToolCallingAdvisor advisor,
+			List<Message> instructions, ToolCallingChatOptions toolOptions) {
+		Prompt prompt = new Prompt(instructions, toolOptions);
+		Map<String, Object> context = new ConcurrentHashMap<>();
+		context.put(ChatMemory.CONVERSATION_ID, "test-session-id");
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.build()
+			.mutate()
+			.context(context)
+			.build();
+
+		ChatClientRequest[] captured = new ChatClientRequest[1];
+		CallAdvisorChain chain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> {
+				captured[0] = req;
+				return createMockResponse(false);
+			})))
+			.build();
+		advisor.adviseCall(request, chain);
+		return (ToolCallingChatOptions) captured[0].prompt().getOptions();
+	}
 
 	private ToolCallingChatOptions captureToolOptions(ToolSearchToolCallingAdvisor advisor) {
 		ChatClientRequest[] captured = new ChatClientRequest[1];

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools/tool-search-tool.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools/tool-search-tool.adoc
@@ -241,7 +241,7 @@ The default index when no explicit `tool-index-type` is configured.
 | Built-in template (see `DEFAULT_SYSTEM_PROMPT_SUFFIX.md`)
 
 | `referenceToolNameAccumulation(boolean)`
-| When `true`, tool names discovered across all prior `toolSearchTool` calls in a single turn are accumulated and injected. When `false`, only the most recent search result is used.
+| When `true`, tool names discovered across all prior `toolSearchTool` calls are accumulated and injected. When `false`, only the results from the most recent turn are used (including all parallel `toolSearchTool` calls within that turn).
 | `true`
 
 | `sessionIdKeyName(String)`
@@ -417,7 +417,7 @@ A custom `ToolIndex` bean declared by the application always takes precedence â€
 | `null`
 
 | `spring.ai.chat.client.tool-search-advisor.reference-tool-name-accumulation`
-| Accumulate tool names discovered across all search calls in a single turn.
+| When `true`, accumulate tool names across all search turns; when `false`, keep only the most recent turn (all parallel calls within it included).
 | `true`
 
 | `spring.ai.chat.client.tool-search-advisor.session-id-key-name`


### PR DESCRIPTION
When referenceToolNameAccumulation is false, retain references from all parallel toolSearchTool calls in the most recent turn instead of only the last single response.
Group responses per ToolResponseMessage (turn) and add regression tests.
