### PR TITLE
Fix shared mutable state in chat options builder `clone()`

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
@@ -212,7 +212,7 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		@Override
 		public B clone() {
 			B copy = super.clone();
-			copy.requestParameters = this.requestParameters;
+			copy.requestParameters = this.requestParameters == null ? null : new HashMap<>(this.requestParameters);
 			return copy;
 		}
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.bedrock.converse;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -103,6 +104,23 @@ class BedrockChatOptionsTests extends AbstractChatOptionsTests<BedrockChatOption
 
 		assertThat(merged.getRequestParameters()).containsEntry("base-key", "base-value");
 		assertThat(merged.getRequestParameters()).containsEntry("override-key", "override-value");
+	}
+
+	@Test
+	void cloneCreatesIndependentRequestParameters() {
+		Map<String, String> requestParameters = new HashMap<>();
+		requestParameters.put("key", "value");
+
+		Builder source = BedrockChatOptions.builder().requestParameters(requestParameters);
+		Builder clone = source.clone();
+		requestParameters.put("anotherKey", "anotherValue");
+
+		assertThat(clone.build().getRequestParameters()).containsOnlyKeys("key");
+	}
+
+	@Test
+	void cloneHandlesNullRequestParameters() {
+		assertThat(BedrockChatOptions.builder().clone().build().getRequestParameters()).isNull();
 	}
 
 }

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
@@ -289,7 +289,7 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 		@Override
 		public B clone() {
 			B copy = super.clone();
-			copy.tools = this.tools;
+			copy.tools = this.tools == null ? null : new ArrayList<>(this.tools);
 			return copy;
 		}
 

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatOptionsTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatOptionsTests.java
@@ -16,11 +16,16 @@
 
 package org.springframework.ai.deepseek;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.deepseek.DeepSeekChatOptions.Builder;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
 import org.springframework.ai.test.options.AbstractChatOptionsTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link DeepSeekChatOptions}.
@@ -52,6 +57,26 @@ class DeepSeekChatOptionsTests extends AbstractChatOptionsTests<DeepSeekChatOpti
 		DeepSeekChatOptions merged = base.mutate().combineWith(override.mutate()).build();
 
 		org.assertj.core.api.Assertions.assertThat(merged.getTools()).containsExactlyInAnyOrder(baseTool, overrideTool);
+	}
+
+	@Test
+	void cloneCreatesIndependentToolsList() {
+		DeepSeekApi.FunctionTool tool = new DeepSeekApi.FunctionTool(DeepSeekApi.FunctionTool.Type.FUNCTION,
+				new DeepSeekApi.FunctionTool.Function("function", "", "{}"));
+		List<DeepSeekApi.FunctionTool> tools = new ArrayList<>();
+		tools.add(tool);
+
+		Builder source = DeepSeekChatOptions.builder().tools(tools);
+		Builder clone = source.clone();
+		tools.add(new DeepSeekApi.FunctionTool(DeepSeekApi.FunctionTool.Type.FUNCTION,
+				new DeepSeekApi.FunctionTool.Function("other", "", "{}")));
+
+		assertThat(clone.build().getTools()).containsExactly(tool);
+	}
+
+	@Test
+	void cloneHandlesNullToolsList() {
+		assertThat(DeepSeekChatOptions.builder().clone().build().getTools()).isNull();
 	}
 
 }

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
@@ -454,8 +454,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		@Override
 		public B clone() {
 			B copy = super.clone();
-			copy.safetySettings = this.safetySettings;
-			copy.labels = this.labels;
+			copy.safetySettings = this.safetySettings == null ? null : new ArrayList<>(this.safetySettings);
+			copy.labels = this.labels == null ? null : new HashMap<>(this.labels);
 			return copy;
 		}
 

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.google.genai;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -268,6 +270,37 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 		assertThat(merged.getLabels()).containsEntry("base-key", "base-value");
 		assertThat(merged.getLabels()).containsEntry("override-key", "override-value");
 		assertThat(merged.getSafetySettings()).containsExactlyInAnyOrder(baseSafetySetting, overrideSafetySetting);
+	}
+
+	@Test
+	public void cloneCreatesIndependentCollections() {
+		GoogleGenAiSafetySetting safetySetting = new GoogleGenAiSafetySetting.Builder()
+			.withCategory(GoogleGenAiSafetySetting.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT)
+			.withThreshold(GoogleGenAiSafetySetting.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE)
+			.build();
+		List<GoogleGenAiSafetySetting> safetySettings = new ArrayList<>();
+		safetySettings.add(safetySetting);
+		Map<String, String> labels = new HashMap<>();
+		labels.put("key", "value");
+
+		Builder source = GoogleGenAiChatOptions.builder().safetySettings(safetySettings).labels(labels);
+		Builder clone = source.clone();
+		safetySettings.add(new GoogleGenAiSafetySetting.Builder()
+			.withCategory(GoogleGenAiSafetySetting.HarmCategory.HARM_CATEGORY_HARASSMENT)
+			.withThreshold(GoogleGenAiSafetySetting.HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE)
+			.build());
+		labels.put("anotherKey", "anotherValue");
+
+		GoogleGenAiChatOptions cloned = clone.build();
+		assertThat(cloned.getSafetySettings()).containsExactly(safetySetting);
+		assertThat(cloned.getLabels()).containsOnlyKeys("key");
+	}
+
+	@Test
+	public void cloneHandlesNullCollections() {
+		GoogleGenAiChatOptions cloned = GoogleGenAiChatOptions.builder().clone().build();
+		assertThat(cloned.getSafetySettings()).isNull();
+		assertThat(cloned.getLabels()).isNull();
 	}
 
 }

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
@@ -349,7 +349,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions, StructuredO
 		@Override
 		public B clone() {
 			AbstractBuilder<B> copy = super.clone();
-			copy.tools = this.tools;
+			copy.tools = this.tools == null ? null : new ArrayList<>(this.tools);
 			return (B) copy;
 		}
 

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatOptionsTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatOptionsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.mistralai;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -545,6 +546,26 @@ class MistralAiChatOptionsTests extends AbstractChatOptionsTests<MistralAiChatOp
 		MistralAiChatOptions merged = base.mutate().combineWith(override.mutate()).build();
 
 		assertThat(merged.getTools()).containsExactlyInAnyOrder(baseTool, overrideTool);
+	}
+
+	@Test
+	void cloneCreatesIndependentToolsList() {
+		MistralAiApi.FunctionTool tool = new MistralAiApi.FunctionTool(MistralAiApi.FunctionTool.Type.FUNCTION,
+				new MistralAiApi.FunctionTool.Function("function", "", "{}"));
+		List<MistralAiApi.FunctionTool> tools = new ArrayList<>();
+		tools.add(tool);
+
+		Builder source = MistralAiChatOptions.builder().tools(tools);
+		Builder clone = source.clone();
+		tools.add(new MistralAiApi.FunctionTool(MistralAiApi.FunctionTool.Type.FUNCTION,
+				new MistralAiApi.FunctionTool.Function("other", "", "{}")));
+
+		assertThat(clone.build().getTools()).containsExactly(tool);
+	}
+
+	@Test
+	void cloneHandlesNullToolsList() {
+		assertThat(MistralAiChatOptions.builder().clone().build().getTools()).isNull();
 	}
 
 	// Test record for schema generation tests

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -727,12 +727,11 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 		@Override
 		public B clone() {
 			B copy = super.clone();
-			if (this.customHeaders != null && !this.customHeaders.isEmpty()) {
-				copy.customHeaders = this.customHeaders;
-			}
-			copy.logitBias = this.logitBias;
-			copy.outputModalities = this.outputModalities;
-			copy.metadata = this.metadata;
+			copy.customHeaders = this.customHeaders == null ? null : new HashMap<>(this.customHeaders);
+			copy.logitBias = this.logitBias == null ? null : new HashMap<>(this.logitBias);
+			copy.outputModalities = this.outputModalities == null ? null : new ArrayList<>(this.outputModalities);
+			copy.metadata = this.metadata == null ? null : new HashMap<>(this.metadata);
+			copy.extraBody = this.extraBody == null ? null : new HashMap<>(this.extraBody);
 			return copy;
 		}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.openai.chat;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -608,6 +609,50 @@ public class OpenAiChatOptionsTests extends AbstractChatOptionsTests<OpenAiChatO
 		assertThat(options.getResponseFormat().getType()).isEqualTo(ResponseFormat.Type.JSON_SCHEMA);
 		assertThat(options.getResponseFormat().getJsonSchema()).isEqualTo(schema);
 		assertThat(options.getOutputSchema()).isEqualTo(schema);
+	}
+
+	@Test
+	void cloneCreatesIndependentCollections() {
+		Map<String, String> customHeaders = new HashMap<>();
+		customHeaders.put("key", "value");
+		Map<String, Integer> logitBias = new HashMap<>();
+		logitBias.put("key", 1);
+		List<String> outputModalities = new ArrayList<>();
+		outputModalities.add("text");
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("key", "value");
+		Map<String, Object> extraBody = new HashMap<>();
+		extraBody.put("key", "value");
+
+		Builder source = OpenAiChatOptions.builder()
+			.customHeaders(customHeaders)
+			.logitBias(logitBias)
+			.outputModalities(outputModalities)
+			.metadata(metadata)
+			.extraBody(extraBody);
+		Builder clone = source.clone();
+		customHeaders.put("anotherKey", "anotherValue");
+		logitBias.put("anotherKey", 2);
+		outputModalities.add("audio");
+		metadata.put("anotherKey", "anotherValue");
+		extraBody.put("anotherKey", "anotherValue");
+
+		OpenAiChatOptions cloned = clone.build();
+		assertThat(cloned.getCustomHeaders()).containsOnlyKeys("key");
+		assertThat(cloned.getLogitBias()).containsOnlyKeys("key");
+		assertThat(cloned.getOutputModalities()).containsExactly("text");
+		assertThat(cloned.getMetadata()).containsOnlyKeys("key");
+		assertThat(cloned.getExtraBody()).containsOnlyKeys("key");
+	}
+
+	@Test
+	void cloneHandlesNullCollections() {
+		OpenAiChatOptions cloned = OpenAiChatOptions.builder().clone().build();
+		assertThat(cloned.getCustomHeaders()).isNull();
+		assertThat(cloned.getLogitBias()).isNull();
+		assertThat(cloned.getOutputModalities()).isNull();
+		assertThat(cloned.getMetadata()).isNull();
+		assertThat(cloned.getExtraBody()).isNull();
 	}
 
 }


### PR DESCRIPTION
The builder `clone()` methods in several `ChatOptions` implementations copied mutable collection fields by reference instead of creating independent copies. A builder obtained via `clone()` therefore shared those collections with its source, so mutating one affected the other.

This mirrors the fix applied to `AnthropicChatOptions` in #6487 and aligns each `clone()` with the defensive copying these builders already perform in `combineWith()`, and that the base `ChatOptions` builder (`stopSequences`) and the tool-calling builder (`toolCallbacks`, `toolContext`) already perform in their own `clone()`.

Affected builders:

- `BedrockChatOptions` — `requestParameters`
- `DeepSeekChatOptions` — `tools`
- `GoogleGenAiChatOptions` — `safetySettings`, `labels`
- `MistralAiChatOptions` — `tools`
- `OpenAiChatOptions` — `customHeaders`, `logitBias`, `outputModalities`, `metadata`, and the previously uncopied `extraBody`

Testing:

Added regression tests for each builder that explicitly fail on the previous aliasing behavior.

Added null-safety tests for each modified clone() method.

Note: I am happy to split this into per-module PRs if you would prefer separate reviews.

See #6487