### PR TITLE
GH-6499: Fix ThinkingTagCleaner builder ignoring withoutDefaultPatterns()

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/converter/ThinkingTagCleaner.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/converter/ThinkingTagCleaner.java
@@ -129,18 +129,18 @@ public class ThinkingTagCleaner implements ResponseTextCleaner {
 
 		private final List<Pattern> patterns = new ArrayList<>(DEFAULT_PATTERNS);
 
-		private boolean useDefaultPatterns = true;
-
 		private Builder() {
 		}
 
 		/**
-		 * Disable default patterns. Only custom patterns added via
-		 * {@link #addPattern(String)} or {@link #addPattern(Pattern)} will be used.
+		 * Disable the default patterns so that only custom patterns added via
+		 * {@link #addPattern(String)} or {@link #addPattern(Pattern)} are used.
+		 * <p>At least one custom pattern must be added afterwards, since a cleaner
+		 * cannot be built without any patterns.
 		 * @return this builder
 		 */
 		public Builder withoutDefaultPatterns() {
-			this.useDefaultPatterns = false;
+			this.patterns.clear();
 			return this;
 		}
 
@@ -151,10 +151,6 @@ public class ThinkingTagCleaner implements ResponseTextCleaner {
 		 */
 		public Builder addPattern(String patternString) {
 			Assert.hasText(patternString, "patternString cannot be empty");
-			if (!this.useDefaultPatterns) {
-				this.patterns.clear();
-				this.useDefaultPatterns = true; // Reset flag after first custom pattern
-			}
 			this.patterns.add(Pattern.compile(patternString, Pattern.CASE_INSENSITIVE));
 			return this;
 		}
@@ -166,10 +162,6 @@ public class ThinkingTagCleaner implements ResponseTextCleaner {
 		 */
 		public Builder addPattern(Pattern pattern) {
 			Assert.notNull(pattern, "pattern cannot be null");
-			if (!this.useDefaultPatterns) {
-				this.patterns.clear();
-				this.useDefaultPatterns = true; // Reset flag after first custom pattern
-			}
 			this.patterns.add(pattern);
 			return this;
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/converter/ThinkingTagCleanerTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/converter/ThinkingTagCleanerTest.java
@@ -149,4 +149,28 @@ class ThinkingTagCleanerTest {
 			.hasMessageContaining("patternStrings cannot be empty");
 	}
 
+	@Test
+	void shouldApplyOnlyCustomPatternsWhenDefaultsDisabled() {
+		var cleaner = ThinkingTagCleaner.builder()
+			.withoutDefaultPatterns()
+			.addPattern("(?s)<a>.*?</a>\\s*")
+			.addPattern("(?s)<b>.*?</b>\\s*")
+			.build();
+
+		String input = "<thinking>kept</thinking><a>first</a><b>second</b>Content";
+		String result = cleaner.clean(input);
+		// Default <thinking> patterns are disabled; both custom patterns are applied.
+		assertThat(result).isEqualTo("<thinking>kept</thinking>Content");
+	}
+
+	@Test
+	void shouldThrowWhenBuildingWithoutDefaultPatternsAndNoCustomPattern() {
+		// withoutDefaultPatterns() must actually clear the defaults, so building with no
+		// custom pattern added yields no patterns at all rather than silently retaining
+		// the defaults.
+		assertThatThrownBy(() -> ThinkingTagCleaner.builder().withoutDefaultPatterns().build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("patterns cannot be empty");
+	}
+
 }


### PR DESCRIPTION
`ThinkingTagCleaner.Builder` clears the default patterns lazily — only inside
`addPattern(...)`, and only the first time it runs after
`withoutDefaultPatterns()` was called. Consequently `withoutDefaultPatterns()`
has no effect unless a custom pattern is added afterwards:
`ThinkingTagCleaner.builder().withoutDefaultPatterns().build()` silently keeps
all default patterns, contradicting the method's documented contract
("Disable default patterns").

This clears the default patterns immediately in `withoutDefaultPatterns()` and
removes the now-redundant `useDefaultPatterns` flag and the lazy-clear logic in
both `addPattern(...)` overloads. Building with no patterns now fails fast with
the constructor's existing `patterns cannot be empty` assertion.

Existing builder behavior is unchanged:
- `withoutDefaultPatterns().addPattern(x)...` → only custom patterns are applied
- `addPattern(x)` (without `withoutDefaultPatterns()`) → defaults + custom

Regression tests are added for the disabled-defaults and no-pattern cases.

Closes gh-6499
