### PR TITLE
Fix grammatical errors in reference documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors.adoc
@@ -32,7 +32,7 @@ String response = this.chatClient.prompt()
 	.content();
 ----
 
-It is recommend to register the advisors at build time using builder's `defaultAdvisors()` method.
+It is recommended to register the advisors at build time using builder's `defaultAdvisors()` method.
 
 Advisors also participate in the Observability stack, so you can view metrics and traces related to their execution.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatmodel.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatmodel.adoc
@@ -151,7 +151,7 @@ This approach enables developers to easily work with different AI models and adj
 
 When using `ChatModel.call() / ChatModel/stream()`, the passed prompt needs to contain a full set of options that will completely take precedence over options set in the model (or use `null` options in the `Prompt` to use the model's defaults).
 
-The xref:api/chatclient.adoc[ChatClient] abstraction allows for an incremental approach where users can provide a "delta" customizer that
+The xref:api/chatclient.adoc[ChatClient] abstraction allows for an incremental approach where users can provide a "delta" customizer that overrides the default options on a per-request basis.
 
 Following flow diagram illustrates how Spring AI handles the configuration and execution of Chat Models:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/concepts.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/concepts.adoc
@@ -6,7 +6,7 @@ This section describes core concepts that Spring AI uses. We recommend reading i
 == Models
 
 AI models are algorithms designed to process and generate information, often mimicking human cognitive functions.
-By learning patterns and insights from large datasets, these models can make predictions, text, images, or other outputs, enhancing various applications across industries.
+By learning patterns and insights from large datasets, these models can make predictions, generate text and images, or other outputs, enhancing various applications across industries.
 
 There are many different types of AI models, each suited for a specific use case.
 While ChatGPT and its generative AI capabilities have captivated users through text input and output, many models and companies offer diverse inputs and outputs.


### PR DESCRIPTION
Fix three grammatical errors found in the reference documentation.

- `advisors.adoc`: Fix 'is recommend to' → 'is recommended to'
- - `concepts.adoc`: Fix incomplete verb 'make predictions, text, images' → 'make predictions, generate text and images'
- - `chatmodel.adoc`: Complete truncated sentence about ChatClient delta customizer (L154 was cut off mid-sentence)