### PR TITLE
Fix OpenAI stream handling for empty tool_calls

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1034,7 +1034,8 @@ public final class OpenAiChatModel implements ChatModel {
 	private static final class ChunkMerger {
 
 		static boolean hasToolCall(ChatCompletionChunk chunk) {
-			return !chunk.choices().isEmpty() && chunk.choices().get(0).delta().toolCalls().isPresent();
+			return !chunk.choices().isEmpty()
+					&& chunk.choices().get(0).delta().toolCalls().filter(toolCalls -> !toolCalls.isEmpty()).isPresent();
 		}
 
 		static boolean toolCallsDone(ChatCompletionChunk chunk) {


### PR DESCRIPTION
This fixes streaming for OpenAI-compatible endpoints that emit an empty `tool_calls` array on normal text delta chunks.

Previously, `ChunkMerger.hasToolCall` treated the presence of the optional `tool_calls` field as an active tool call, even when the list was empty. Some vLLM/OpenAI-compatible endpoints include `tool_calls: []` while streaming regular text. That caused Spring AI to enter the tool-call aggregation path and buffer normal text chunks, which could collapse the streamed response to only the first text fragment.

The fix only treats a chunk as containing tool calls when the `tool_calls` list is present and non-empty.

Validation:
- `./mvnw.cmd -pl models/spring-ai-openai -am -DskipTests -DskipITs -Dspring-javaformat.skip=true -Dcheckstyle.skip=true install`