### PR TITLE
Preserve Streamable HTTP endpoint query parameters

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpStreamableHttpClientConnectionResolver.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpStreamableHttpClientConnectionResolver.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import java.net.URI;
+import java.util.Objects;
+
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties.ConnectionParameters;
+
+/**
+ * Resolves configured Streamable HTTP client connection parameters into transport
+ * configuration values.
+ *
+ * @author Jewoo Shin
+ */
+public final class McpStreamableHttpClientConnectionResolver {
+
+	private static final String DEFAULT_ENDPOINT = "/mcp";
+
+	private McpStreamableHttpClientConnectionResolver() {
+	}
+
+	/**
+	 * Resolve the configured connection parameters into the base URL and endpoint values
+	 * consumed by Streamable HTTP transports.
+	 * @param connectionName the configured connection name
+	 * @param connectionParameters the configured connection parameters
+	 * @return resolved transport connection values
+	 */
+	public static ResolvedConnection resolve(String connectionName, ConnectionParameters connectionParameters) {
+		Objects.requireNonNull(connectionParameters, "Connection parameters must not be null");
+		String url = Objects.requireNonNull(connectionParameters.url(),
+				"Missing url for server named " + connectionName);
+		String endpoint = connectionParameters.endpoint();
+		if (endpoint != null) {
+			return new ResolvedConnection(url, endpoint);
+		}
+
+		URI uri = URI.create(url);
+		return new ResolvedConnection(baseUrl(uri, url), endpoint(uri));
+	}
+
+	private static String baseUrl(URI uri, String url) {
+		if (uri.getScheme() == null || uri.getRawAuthority() == null) {
+			return url;
+		}
+		return uri.getScheme() + "://" + uri.getRawAuthority();
+	}
+
+	private static String endpoint(URI uri) {
+		String path = uri.getRawPath();
+		if (path == null || path.isEmpty() || path.equals("/")) {
+			path = DEFAULT_ENDPOINT;
+		}
+		String query = uri.getRawQuery();
+		if (query == null) {
+			return path;
+		}
+		return path + "?" + query;
+	}
+
+	/**
+	 * Resolved base URL and endpoint for a Streamable HTTP client connection.
+	 *
+	 * @param baseUrl the base URL for the transport
+	 * @param endpoint the endpoint path and optional query string for the transport
+	 */
+	public record ResolvedConnection(String baseUrl, String endpoint) {
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpStreamableHttpClientConnectionResolverTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpStreamableHttpClientConnectionResolverTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties.ConnectionParameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link McpStreamableHttpClientConnectionResolver}.
+ *
+ * @author Jewoo Shin
+ */
+class McpStreamableHttpClientConnectionResolverTests {
+
+	@Test
+	void originOnlyUrlUsesDefaultEndpoint() {
+		var connection = McpStreamableHttpClientConnectionResolver.resolve("server",
+				new ConnectionParameters("https://mcp.example.com", null));
+
+		assertThat(connection.baseUrl()).isEqualTo("https://mcp.example.com");
+		assertThat(connection.endpoint()).isEqualTo("/mcp");
+	}
+
+	@Test
+	void fullUrlWithoutEndpointUsesPathAndQueryAsEndpoint() {
+		var connection = McpStreamableHttpClientConnectionResolver.resolve("server",
+				new ConnectionParameters("https://mcp.example.com/mcp?key=test", null));
+
+		assertThat(connection.baseUrl()).isEqualTo("https://mcp.example.com");
+		assertThat(connection.endpoint()).isEqualTo("/mcp?key=test");
+	}
+
+	@Test
+	void queryOnlyUrlUsesDefaultPathAndQueryAsEndpoint() {
+		var connection = McpStreamableHttpClientConnectionResolver.resolve("server",
+				new ConnectionParameters("https://mcp.example.com?key=test", null));
+
+		assertThat(connection.baseUrl()).isEqualTo("https://mcp.example.com");
+		assertThat(connection.endpoint()).isEqualTo("/mcp?key=test");
+	}
+
+	@Test
+	void explicitEndpointWins() {
+		var connection = McpStreamableHttpClientConnectionResolver.resolve("server",
+				new ConnectionParameters("https://mcp.example.com/base?ignored=true", "/mcp?key=test"));
+
+		assertThat(connection.baseUrl()).isEqualTo("https://mcp.example.com/base?ignored=true");
+		assertThat(connection.endpoint()).isEqualTo("/mcp?key=test");
+	}
+
+	@Test
+	void rawPathAndQueryArePreserved() {
+		var connection = McpStreamableHttpClientConnectionResolver.resolve("server",
+				new ConnectionParameters("https://mcp.example.com/mcp%20path?key=a%2Fb%20c#fragment", null));
+
+		assertThat(connection.baseUrl()).isEqualTo("https://mcp.example.com");
+		assertThat(connection.endpoint()).isEqualTo("/mcp%20path?key=a%2Fb%20c");
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
@@ -25,6 +25,8 @@ import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTranspor
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import tools.jackson.databind.json.JsonMapper;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpClientConnectionResolver;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpClientConnectionResolver.ResolvedConnection;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties;
@@ -100,13 +102,12 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 			.entrySet()) {
 
 			String name = serverParameters.getKey();
-			String baseUrl = serverParameters.getValue().url();
-			String streamableHttpEndpoint = serverParameters.getValue().endpoint() != null
-					? serverParameters.getValue().endpoint() : "/mcp";
+			ResolvedConnection connection = McpStreamableHttpClientConnectionResolver.resolve(name,
+					serverParameters.getValue());
 
 			HttpClientStreamableHttpTransport.Builder transportBuilder = HttpClientStreamableHttpTransport
-				.builder(baseUrl)
-				.endpoint(streamableHttpEndpoint)
+				.builder(connection.baseUrl())
+				.endpoint(connection.endpoint())
 				.clientBuilder(HttpClient.newBuilder())
 				.jsonMapper(new JacksonMcpJsonMapper(jsonMapper));
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.client.autoconfigure;
 
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.List;
 
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
@@ -109,6 +110,40 @@ public class StreamableHttpHttpClientTransportAutoConfigurationTests {
 	}
 
 	@Test
+	void fullUrlWithoutEndpointUsesPathAndQueryAsEndpoint() {
+		this.applicationContext
+			.withPropertyValues(
+					"spring.ai.mcp.client.streamable-http.connections.amap.url=https://mcp.amap.com/mcp?key=test")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpHttpClientTransports",
+						List.class);
+
+				assertThat(transports).hasSize(1);
+				HttpClientStreamableHttpTransport transport = (HttpClientStreamableHttpTransport) transports.get(0)
+					.transport();
+				assertThat(getBaseUri(transport)).isEqualTo(URI.create("https://mcp.amap.com"));
+				assertThat(getStreamableHttpEndpoint(transport)).isEqualTo("/mcp?key=test");
+			});
+	}
+
+	@Test
+	void explicitEndpointWithQueryIsRespected() {
+		this.applicationContext
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.amap.url=https://mcp.amap.com",
+					"spring.ai.mcp.client.streamable-http.connections.amap.endpoint=/mcp?key=test")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpHttpClientTransports",
+						List.class);
+
+				assertThat(transports).hasSize(1);
+				HttpClientStreamableHttpTransport transport = (HttpClientStreamableHttpTransport) transports.get(0)
+					.transport();
+				assertThat(getBaseUri(transport)).isEqualTo(URI.create("https://mcp.amap.com"));
+				assertThat(getStreamableHttpEndpoint(transport)).isEqualTo("/mcp?key=test");
+			});
+	}
+
+	@Test
 	void customJsonMapperIsUsed() {
 		this.applicationContext.withUserConfiguration(CustomJsonMapperConfiguration.class)
 			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:8080")
@@ -166,6 +201,12 @@ public class StreamableHttpHttpClientTransportAutoConfigurationTests {
 		Field privateField = ReflectionUtils.findField(HttpClientStreamableHttpTransport.class, "endpoint");
 		ReflectionUtils.makeAccessible(privateField);
 		return (String) ReflectionUtils.getField(privateField, transport);
+	}
+
+	private URI getBaseUri(HttpClientStreamableHttpTransport transport) {
+		Field privateField = ReflectionUtils.findField(HttpClientStreamableHttpTransport.class, "baseUri");
+		ReflectionUtils.makeAccessible(privateField);
+		return (URI) ReflectionUtils.getField(privateField, transport);
 	}
 
 	@Configuration

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfiguration.java
@@ -19,11 +19,12 @@ package org.springframework.ai.mcp.client.webflux.autoconfigure;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import tools.jackson.databind.json.JsonMapper;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpClientConnectionResolver;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpClientConnectionResolver.ResolvedConnection;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties;
@@ -102,13 +103,12 @@ public class StreamableHttpWebFluxTransportAutoConfiguration {
 		for (Map.Entry<String, ConnectionParameters> serverParameters : streamableProperties.getConnections()
 			.entrySet()) {
 			String connectionName = serverParameters.getKey();
-			String url = Objects.requireNonNull(serverParameters.getValue().url(),
-					"Missing url for server named " + connectionName);
-			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(url);
-			String streamableHttpEndpoint = Objects.requireNonNullElse(serverParameters.getValue().endpoint(), "/mcp");
+			ResolvedConnection connection = McpStreamableHttpClientConnectionResolver.resolve(connectionName,
+					serverParameters.getValue());
+			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(connection.baseUrl());
 
 			var transportBuilder = WebClientStreamableHttpTransport.builder(webClientBuilder)
-				.endpoint(streamableHttpEndpoint)
+				.endpoint(connection.endpoint())
 				.jsonMapper(new JacksonMcpJsonMapper(jsonMapper));
 
 			for (McpClientCustomizer<WebClientStreamableHttpTransport.Builder> customizer : transportCustomizers) {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfigurationTests.java
@@ -130,6 +130,36 @@ public class StreamableHttpWebFluxTransportAutoConfigurationTests {
 	}
 
 	@Test
+	void fullUrlWithoutEndpointUsesPathAndQueryAsEndpoint() {
+		this.applicationContext
+			.withPropertyValues(
+					"spring.ai.mcp.client.streamable-http.connections.amap.url=https://mcp.amap.com/mcp?key=test")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpWebFluxClientTransports",
+						List.class);
+
+				assertThat(transports).hasSize(1);
+				assertThat(getStreamableHttpEndpoint((WebClientStreamableHttpTransport) transports.get(0).transport()))
+					.isEqualTo("/mcp?key=test");
+			});
+	}
+
+	@Test
+	void explicitEndpointWithQueryIsRespected() {
+		this.applicationContext
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.amap.url=https://mcp.amap.com",
+					"spring.ai.mcp.client.streamable-http.connections.amap.endpoint=/mcp?key=test")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpWebFluxClientTransports",
+						List.class);
+
+				assertThat(transports).hasSize(1);
+				assertThat(getStreamableHttpEndpoint((WebClientStreamableHttpTransport) transports.get(0).transport()))
+					.isEqualTo("/mcp?key=test");
+			});
+	}
+
+	@Test
 	void customWebClientBuilderIsUsed() {
 		this.applicationContext.withUserConfiguration(CustomWebClientConfiguration.class)
 			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:8080")

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.webflux.transport;
+
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebClientStreamableHttpTransport}.
+ *
+ * @author Jewoo Shin
+ */
+class WebClientStreamableHttpTransportTests {
+
+	@Test
+	void endpointQueryIsPreservedForPostRequests() {
+		AtomicReference<URI> requestedUri = new AtomicReference<>();
+		WebClient.Builder builder = WebClient.builder().baseUrl("https://mcp.amap.com").exchangeFunction(request -> {
+			requestedUri.set(request.url());
+			return Mono.just(ClientResponse.create(HttpStatus.ACCEPTED).build());
+		});
+
+		var transport = WebClientStreamableHttpTransport.builder(builder).endpoint("/mcp?key=test").build();
+
+		StepVerifier.create(transport.connect(Function.identity())).verifyComplete();
+		StepVerifier.create(transport.sendMessage(createTestMessage())).verifyComplete();
+
+		assertThat(requestedUri.get()).isEqualTo(URI.create("https://mcp.amap.com/mcp?key=test"));
+	}
+
+	private McpSchema.JSONRPCRequest createTestMessage() {
+		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_03_26,
+				McpSchema.ClientCapabilities.builder().roots(true).build(),
+				new McpSchema.Implementation("Test Client", "1.0.0"));
+		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE, "test-id",
+				initializeRequest);
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -322,11 +322,11 @@ Properties for Streamable-HTTP transport are prefixed with `spring.ai.mcp.client
 |-
 
 |`connections.[name].url`
-|Base URL endpoint for Streamable-Http communication with the MCP server
+|Base URL for Streamable-HTTP communication with the MCP server. If `endpoint` is omitted, this may include the endpoint path and query parameters.
 |-
 
 |`connections.[name].endpoint`
-|the streamable-http endpoint (as url suffix) to use for the connection
+|Streamable-HTTP endpoint path and optional query parameters to use for the connection
 |`/mcp`
 |===
 
@@ -343,8 +343,15 @@ spring:
               url: http://localhost:8080
             server2:
               url: http://otherserver:8081
-              endpoint: /custom-sse
+              endpoint: /custom-mcp
+            server3:
+              url: https://mcp.example.com/mcp?key=abc123
+            server4:
+              url: https://mcp.example.com
+              endpoint: /mcp?key=abc123
 ----
+
+When `endpoint` is omitted, `url` may include the Streamable-HTTP endpoint path and query string. When `endpoint` is provided, put connection-specific path and query parameters on `endpoint`; the configured `endpoint` takes precedence.
 
 === SSE Transport Properties
 
@@ -435,11 +442,11 @@ Properties for Streamable Http transport are prefixed with `spring.ai.mcp.client
 |-
 
 |`connections.[name].url`
-|Base URL endpoint for Streamable-Http communication with the MCP server
+|Base URL for Streamable-HTTP communication with the MCP server. If `endpoint` is omitted, this may include the endpoint path and query parameters.
 |-
 
 |`connections.[name].endpoint`
-|the streamable-http endpoint (as url suffix) to use for the connection
+|Streamable-HTTP endpoint path and optional query parameters to use for the connection
 |`/mcp`
 |===
 
@@ -456,8 +463,15 @@ spring:
               url: http://localhost:8080
             server2:
               url: http://otherserver:8081
-              endpoint: /custom-sse
+              endpoint: /custom-mcp
+            server3:
+              url: https://mcp.example.com/mcp?key=abc123
+            server4:
+              url: https://mcp.example.com
+              endpoint: /mcp?key=abc123
 ----
+
+When `endpoint` is omitted, `url` may include the Streamable-HTTP endpoint path and query string. When `endpoint` is provided, put connection-specific path and query parameters on `endpoint`; the configured `endpoint` takes precedence.
 
 == Features
 


### PR DESCRIPTION
Streamable HTTP MCP client configuration could lose query parameters when a full endpoint URL was supplied through `url` without an explicit `endpoint`.

This normalizes Streamable HTTP client configuration into a base URL plus endpoint path/query before constructing the WebFlux and HttpClient transports. Explicit `endpoint` values remain authoritative, so `endpoint=/mcp?key=...` continues to work without merging query parameters from `url`.

The regression tests cover the shared resolver, both WebFlux and HttpClient auto-configuration paths, and the WebFlux request URI built from an endpoint containing query parameters.

Closes #6505.