### PR TITLE
Remove fastjson2 dependency from `spring-ai-azure-store`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,6 @@
 		<commonmark.version>0.22.0</commonmark.version>
 		<couchbase.version>3.9.1</couchbase.version>
 		<djl.version>0.36.0</djl.version>
-		<fastjson2.version>2.0.46</fastjson2.version>
 		<gemfire.testcontainers.version>2.3.3</gemfire.testcontainers.version>
 		<grpc-netty-shaded.version>1.82.1</grpc-netty-shaded.version>
 		<jsonschema.version>5.0.0</jsonschema.version>

--- a/vector-stores/spring-ai-azure-store/pom.xml
+++ b/vector-stores/spring-ai-azure-store/pom.xml
@@ -66,12 +66,6 @@
 			<artifactId>azure-json</artifactId>
 			<version>${azure-json.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>com.alibaba.fastjson2</groupId>
-			<artifactId>fastjson2</artifactId>
-			<version>${fastjson2.version}</version>
-		</dependency>
-
 		<!-- TESTING -->
 		<dependency>
 			<groupId>org.springframework.ai</groupId>

--- a/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
-import com.alibaba.fastjson2.JSONObject;
-import com.alibaba.fastjson2.TypeReference;
 import com.azure.core.util.Context;
 import com.azure.search.documents.SearchClient;
 import com.azure.search.documents.SearchDocument;
@@ -54,6 +52,7 @@ import org.springframework.ai.embedding.EmbeddingOptions;
 import org.springframework.ai.model.EmbeddingUtils;
 import org.springframework.ai.observation.conventions.VectorStoreProvider;
 import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetric;
+import org.springframework.ai.util.JsonHelper;
 import org.springframework.ai.vectorstore.AbstractVectorStoreBuilder;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.filter.FilterExpressionConverter;
@@ -85,6 +84,8 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 	public static final String DEFAULT_INDEX_NAME = "spring_ai_azure_vector_store";
 
 	private static final Log logger = LogFactory.getLog(AzureVectorStore.class);
+
+	private static final JsonHelper jsonHelper = new JsonHelper();
 
 	private static final String SPRING_AI_VECTOR_CONFIG = "spring-ai-vector-config";
 
@@ -180,7 +181,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 			searchDocument.put(ID_FIELD_NAME, document.getId());
 			searchDocument.put(this.embeddingFieldName, embeddings.get(i));
 			searchDocument.put(this.contentFieldName, document.getText());
-			searchDocument.put(this.metadataFieldName, new JSONObject(document.getMetadata()).toJSONString());
+			searchDocument.put(this.metadataFieldName, jsonHelper.toJson(document.getMetadata()));
 
 			// Add the filterable metadata fields as top level fields, allowing filler
 			// expressions on them.
@@ -344,11 +345,9 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 			return new HashMap<>();
 		}
 		try {
-			Map<String, Object> parsed = JSONObject.parseObject(metadataJson, new TypeReference<Map<String, Object>>() {
-			});
-			return (parsed == null) ? new HashMap<>() : new HashMap<>(parsed);
+			return new HashMap<>(jsonHelper.fromJsonToMap(metadataJson));
 		}
-		catch (Exception ex) {
+		catch (IllegalStateException ex) {
 			if (logger.isWarnEnabled()) {
 				logger.warn("Failed to parse metadata JSON. Using empty metadata. json=" + metadataJson, ex);
 			}

--- a/vector-stores/spring-ai-azure-store/src/test/java/org/springframework/ai/vectorstore/azure/AzureVectorStoreMetadataTests.java
+++ b/vector-stores/spring-ai-azure-store/src/test/java/org/springframework/ai/vectorstore/azure/AzureVectorStoreMetadataTests.java
@@ -20,12 +20,17 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.util.JacksonUtils;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for {@link AzureVectorStore#parseMetadataToMutable(String)}.
+ * Unit tests for {@link AzureVectorStore} metadata serialization and deserialization,
+ * covering both {@link AzureVectorStore#parseMetadataToMutable(String)} and the Jackson
+ * serialization used in {@code doAdd}.
  *
  * @author Jinwoo Lee
+ * @author Ilayaperumal Gopinathan
  */
 class AzureVectorStoreMetadataTests {
 
@@ -50,6 +55,27 @@ class AzureVectorStoreMetadataTests {
 		assertThat(map).containsEntry("k", "v");
 		map.put("distance", 0.4);
 		assertThat(map).containsEntry("distance", 0.4);
+	}
+
+	@Test
+	void returnsEmptyMutableMapForInvalidJson() {
+		Map<String, Object> map = AzureVectorStore.parseMetadataToMutable("not-valid-json");
+		assertThat(map).isEmpty();
+		map.put("distance", 0.5);
+		assertThat(map).containsEntry("distance", 0.5);
+	}
+
+	@Test
+	void roundTripPreservesMultipleValueTypes() throws Exception {
+		Map<String, Object> original = Map.of("name", "test", "version", 3, "enabled", Boolean.FALSE, "score", 0.7);
+		String json = JacksonUtils.getDefaultJsonMapper().writeValueAsString(original);
+		Map<String, Object> restored = AzureVectorStore.parseMetadataToMutable(json);
+		assertThat(restored).containsEntry("name", "test")
+			.containsEntry("version", 3)
+			.containsEntry("enabled", Boolean.FALSE)
+			.containsEntry("score", 0.7);
+		restored.put("distance", 0.1);
+		assertThat(restored).containsEntry("distance", 0.1);
 	}
 
 }


### PR DESCRIPTION
  - Replace the `fastjson2` dependency in `AzureVectorStore` with the Jackson 3.x `JsonMapper` to make it consistent across the usages.
  - Add tests