### PR TITLE
Apply validation constraints to tool parameters

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -19,6 +19,7 @@ package org.springframework.ai.util.json.schema;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -35,6 +36,7 @@ import com.github.victools.jsonschema.generator.SchemaVersion;
 import com.github.victools.jsonschema.module.jackson.JacksonOption;
 import com.github.victools.jsonschema.module.jackson.JacksonSchemaModule;
 import com.github.victools.jsonschema.module.swagger2.Swagger2Module;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
@@ -69,6 +71,12 @@ import org.springframework.util.StringUtils;
  * <p>
  * If none of these annotations are present, the default behavior is to consider the
  * property as required and not to include a description.
+ * <p>
+ * Validation constraints declared via {@code @Schema} (e.g. {@code minLength},
+ * {@code maxLength}, {@code pattern}, {@code minimum}, {@code maximum},
+ * {@code multipleOf}) and {@code @ArraySchema} (e.g. {@code minItems}, {@code maxItems},
+ * {@code uniqueItems}) are also reflected in the generated schema, for both type fields
+ * and method parameters.
  * <p>
  *
  * @author Thomas Vitale
@@ -174,6 +182,7 @@ public final class JsonSchemaGenerator {
 			if (StringUtils.hasText(parameterDescription)) {
 				parameterNode.put("description", parameterDescription);
 			}
+			applyParameterConstraints(parameterNode, method.getParameters()[i]);
 			properties.set(parameterName, parameterNode);
 		}
 
@@ -285,6 +294,73 @@ public final class JsonSchemaGenerator {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Applies the JSON Schema validation keywords declared via {@link Schema} and
+	 * {@link ArraySchema} on a method parameter to its generated schema node.
+	 *
+	 * <p>
+	 * Such constraints are honored by the underlying generator when the annotations are
+	 * placed on a type's fields, but a method parameter's annotations are invisible to
+	 * it. They are therefore applied here so that tool method parameters behave
+	 * consistently with type fields. The supported keywords mirror those produced for
+	 * fields:
+	 * <ul>
+	 * <li>{@code minLength}, {@code maxLength}, {@code pattern} for strings;</li>
+	 * <li>{@code minimum}, {@code maximum}, {@code exclusiveMinimum},
+	 * {@code exclusiveMaximum}, {@code multipleOf} for numbers;</li>
+	 * <li>{@code minItems}, {@code maxItems}, {@code uniqueItems} for arrays.</li>
+	 * </ul>
+	 */
+	private static void applyParameterConstraints(ObjectNode parameterNode, Parameter parameter) {
+		JsonNode typeNode = parameterNode.get("type");
+		String type = (typeNode != null && typeNode.isString()) ? typeNode.asString() : null;
+
+		if ("array".equals(type)) {
+			ArraySchema arraySchema = parameter.getAnnotation(ArraySchema.class);
+			if (arraySchema != null) {
+				if (arraySchema.minItems() != Integer.MAX_VALUE) {
+					parameterNode.put("minItems", arraySchema.minItems());
+				}
+				if (arraySchema.maxItems() != Integer.MIN_VALUE) {
+					parameterNode.put("maxItems", arraySchema.maxItems());
+				}
+				if (arraySchema.uniqueItems()) {
+					parameterNode.put("uniqueItems", true);
+				}
+			}
+			return;
+		}
+
+		Schema schema = parameter.getAnnotation(Schema.class);
+		if (schema == null) {
+			return;
+		}
+		if ("string".equals(type)) {
+			if (schema.minLength() > 0) {
+				parameterNode.put("minLength", schema.minLength());
+			}
+			if (schema.maxLength() < Integer.MAX_VALUE) {
+				parameterNode.put("maxLength", schema.maxLength());
+			}
+			if (StringUtils.hasText(schema.pattern())) {
+				parameterNode.put("pattern", schema.pattern());
+			}
+		}
+		else if ("integer".equals(type) || "number".equals(type)) {
+			if (StringUtils.hasText(schema.minimum())) {
+				parameterNode.put(schema.exclusiveMinimum() ? "exclusiveMinimum" : "minimum",
+						new BigDecimal(schema.minimum()));
+			}
+			if (StringUtils.hasText(schema.maximum())) {
+				parameterNode.put(schema.exclusiveMaximum() ? "exclusiveMaximum" : "maximum",
+						new BigDecimal(schema.maximum()));
+			}
+			if (schema.multipleOf() != 0) {
+				parameterNode.put("multipleOf", BigDecimal.valueOf(schema.multipleOf()));
+			}
+		}
 	}
 
 	/**

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -260,6 +261,65 @@ class JsonSchemaGeneratorTests {
 
 		JsonNode jsonNode = JacksonUtils.getDefaultJsonMapper().readTree(schema);
 		assertThat(jsonNode.has("additionalProperties")).isFalse();
+	}
+
+	@Test
+	void generateSchemaForMethodWithArraySchemaConstraints() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("arraySchemaConstraintsMethod", List.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+
+		JsonNode tags = JacksonUtils.getDefaultJsonMapper().readTree(schema).path("properties").path("tags");
+		assertThat(tags.path("type").asString()).isEqualTo("array");
+		assertThat(tags.path("items").path("type").asString()).isEqualTo("string");
+		assertThat(tags.path("minItems").asInt()).isEqualTo(1);
+		assertThat(tags.path("maxItems").asInt()).isEqualTo(50);
+		assertThat(tags.path("uniqueItems").asBoolean()).isTrue();
+	}
+
+	@Test
+	void generateSchemaForMethodWithStringSchemaConstraints() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("stringSchemaConstraintsMethod", String.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+
+		JsonNode code = JacksonUtils.getDefaultJsonMapper().readTree(schema).path("properties").path("code");
+		assertThat(code.path("type").asString()).isEqualTo("string");
+		assertThat(code.path("minLength").asInt()).isEqualTo(3);
+		assertThat(code.path("maxLength").asInt()).isEqualTo(20);
+		assertThat(code.path("pattern").asString()).isEqualTo("[a-z]+");
+	}
+
+	@Test
+	void generateSchemaForMethodWithNumberSchemaConstraints() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("numberSchemaConstraintsMethod", int.class, double.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+
+		JsonNode root = JacksonUtils.getDefaultJsonMapper().readTree(schema);
+		JsonNode score = root.path("properties").path("score");
+		assertThat(score.path("minimum").asInt()).isEqualTo(0);
+		assertThat(score.path("maximum").asInt()).isEqualTo(100);
+		assertThat(score.path("multipleOf").asInt()).isEqualTo(5);
+
+		JsonNode ratio = root.path("properties").path("ratio");
+		assertThat(ratio.path("minimum").asInt()).isEqualTo(0);
+		assertThat(ratio.has("maximum")).isFalse();
+		assertThat(ratio.path("exclusiveMaximum").asInt()).isEqualTo(1);
+	}
+
+	@Test
+	void methodParameterConstraintsMatchFieldConstraints() throws Exception {
+		String fieldSchema = JsonSchemaGenerator.generateForType(ConstrainedTags.class);
+		Method method = TestMethods.class.getDeclaredMethod("arraySchemaConstraintsMethod", List.class);
+		String parameterSchema = JsonSchemaGenerator.generateForMethodInput(method);
+
+		JsonNode fieldTags = JacksonUtils.getDefaultJsonMapper().readTree(fieldSchema).path("properties").path("tags");
+		JsonNode parameterTags = JacksonUtils.getDefaultJsonMapper()
+			.readTree(parameterSchema)
+			.path("properties")
+			.path("tags");
+		assertThat(parameterTags).isEqualTo(fieldTags);
 	}
 
 	@Test
@@ -993,6 +1053,18 @@ class JsonSchemaGeneratorTests {
 		public void peerReferenceMethod(PeerA.SearchRequest a, PeerB.SearchRequest b) {
 		}
 
+		public void arraySchemaConstraintsMethod(
+				@ArraySchema(minItems = 1, maxItems = 50, uniqueItems = true) List<String> tags) {
+		}
+
+		public void stringSchemaConstraintsMethod(
+				@Schema(minLength = 3, maxLength = 20, pattern = "[a-z]+") String code) {
+		}
+
+		public void numberSchemaConstraintsMethod(@Schema(minimum = "0", maximum = "100", multipleOf = 5) int score,
+				@Schema(minimum = "0", maximum = "1", exclusiveMaximum = true) double ratio) {
+		}
+
 	}
 
 	record RecursiveFilter(String field, String operator, List<RecursiveFilter> filters) {
@@ -1045,6 +1117,10 @@ class JsonSchemaGeneratorTests {
 	}
 
 	record TestData(int id, @ToolParam(description = "The special name") String name) {
+
+	}
+
+	record ConstrainedTags(@ArraySchema(minItems = 1, maxItems = 50, uniqueItems = true) List<String> tags) {
 
 	}
 


### PR DESCRIPTION
## What's broken

JSON Schema validation keywords declared with `@Schema` / `@ArraySchema` on a tool **method parameter** are silently dropped from the generated schema. For example:

```java
void search(@ArraySchema(minItems = 1, maxItems = 50) List<String> tags) { ... }
```

generates `{"type":"array","items":{"type":"string"}}` — the `minItems` / `maxItems` keywords are missing. The same annotations declared on a **type's field** are honored, so the two code paths are inconsistent.

## Root cause

`generateForMethodInput` builds each parameter's schema from the parameter's bare `Type` via victools. The victools modules only inspect annotations attached to a field/getter; a method parameter's annotations are never seen. Until now only `description` and `required` were re-derived manually from the `Parameter`, so every validation constraint was lost.

## Fix

Post-process each parameter node (mirroring the existing manual overlay for `description` / `required`) by reading `@Schema` / `@ArraySchema` directly off the `Parameter`, gated by the node's JSON Schema `type`:

- **strings** — `minLength`, `maxLength`, `pattern`
- **numbers** — `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
- **arrays** — `minItems`, `maxItems`, `uniqueItems`

The keywords use the same sentinel/default checks the Swagger module already applies on fields, so a constraint declared on a method parameter now yields the exact same sub-schema as the equivalent field. A new test asserts this parameter-path == field-path equality, alongside per-category tests for strings, numbers and arrays. The full `spring-ai-model` test suite (820 tests) passes.

An earlier attempt, #5639, was withdrawn by its author before any review; this change addresses the issue more completely by covering the string and numeric constraints in addition to the array ones.

Fixes #5633
