### PR TITLE
Add streaming support for OpenAI audio transcription model

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.ai.model.openai.autoconfigure;
 import java.util.List;
 
 import com.openai.client.OpenAIClient;
+import com.openai.client.OpenAIClientAsync;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 
@@ -45,6 +46,7 @@ import org.springframework.context.annotation.Bean;
  * @author Issam El-atif
  * @author Ilayaperumal Gopinathan
  * @author Sebastien Deleuze
+ * @author guan xu
  */
 @AutoConfiguration
 @ConditionalOnProperty(name = SpringAIModelProperties.AUDIO_TRANSCRIPTION_MODEL, havingValue = SpringAIModels.OPENAI,
@@ -62,8 +64,11 @@ public class OpenAiAudioTranscriptionAutoConfiguration {
 				transcriptionProperties);
 		List<OpenAiHttpClientBuilderCustomizer> customizers = httpClientBuilderCustomizers.orderedStream().toList();
 		OpenAIClient client = openAiClient(resolvedProperties, observationRegistry, meterRegistry, customizers);
+		OpenAIClientAsync clientAsync = openAiClientAsync(resolvedProperties, observationRegistry, meterRegistry,
+				customizers);
 		return OpenAiAudioTranscriptionModel.builder()
 			.openAiClient(client)
+			.openAiClientAsync(clientAsync)
 			.options(transcriptionProperties.toOptions())
 			.build();
 	}
@@ -76,6 +81,22 @@ public class OpenAiAudioTranscriptionAutoConfiguration {
 				? meterRegistry.getIfAvailable() : null;
 
 		return OpenAiSetup.setupSyncClient(commonProperties.getBaseUrl(), commonProperties.getApiKey(),
+				commonProperties.getCredential(), commonProperties.getMicrosoftDeploymentName(),
+				commonProperties.getMicrosoftFoundryServiceVersion(), commonProperties.getOrganizationId(),
+				commonProperties.isMicrosoftFoundry(), commonProperties.isGitHubModels(), commonProperties.getModel(),
+				commonProperties.getTimeout(), commonProperties.getMaxRetries(), commonProperties.getProxy(),
+				commonProperties.getCustomHeaders(), observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
+				meterRegistryToUse, httpClientCustomizers);
+	}
+
+	private OpenAIClientAsync openAiClientAsync(OpenAiCommonProperties commonProperties,
+			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
+			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
+
+		MeterRegistry meterRegistryToUse = commonProperties.isConnectionPoolMetricsEnabled()
+				? meterRegistry.getIfAvailable() : null;
+
+		return OpenAiSetup.setupAsyncClient(commonProperties.getBaseUrl(), commonProperties.getApiKey(),
 				commonProperties.getCredential(), commonProperties.getMicrosoftDeploymentName(),
 				commonProperties.getMicrosoftFoundryServiceVersion(), commonProperties.getOrganizationId(),
 				commonProperties.isMicrosoftFoundry(), commonProperties.isGitHubModels(), commonProperties.getModel(),

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -151,23 +151,21 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 			logger.trace("OpenAiAudioTranscriptionModel stream with model: " + mergedOptions.getModel());
 		}
 
-		Flux<TranscriptionStreamEvent> chunk = Flux.create(sink -> {
-			this.openAiClientAsync.audio()
-				.transcriptions()
-				.createStreaming(params)
-				.subscribe(sink::next)
-				.onCompleteFuture()
-				.whenComplete((unused, throwable) -> {
-					if (throwable != null) {
-						sink.error(throwable);
-					}
-					else {
-						sink.complete();
-					}
-				});
-		});
+		Flux<TranscriptionStreamEvent> chunks = Flux.create(sink -> this.openAiClientAsync.audio()
+			.transcriptions()
+			.createStreaming(params)
+			.subscribe(sink::next)
+			.onCompleteFuture()
+			.whenComplete((unused, throwable) -> {
+				if (throwable != null) {
+					sink.error(throwable);
+				}
+				else {
+					sink.complete();
+				}
+			}));
 
-		return chunk.map(event -> {
+		return chunks.map(event -> {
 			String text = extractStreamEventText(event);
 			AudioTranscription transcript = new AudioTranscription(text);
 			return new AudioTranscriptionResponse(transcript, new AudioTranscriptionResponseMetadata());

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -24,13 +24,17 @@ import java.util.List;
 import java.util.Objects;
 
 import com.openai.client.OpenAIClient;
+import com.openai.client.OpenAIClientAsync;
 import com.openai.core.MultipartField;
+import com.openai.core.http.AsyncStreamResponse;
 import com.openai.models.audio.transcriptions.TranscriptionCreateParams;
 import com.openai.models.audio.transcriptions.TranscriptionCreateResponse;
+import com.openai.models.audio.transcriptions.TranscriptionStreamEvent;
 import io.micrometer.observation.ObservationRegistry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Flux;
 
 import org.springframework.ai.audio.transcription.AudioTranscription;
 import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
@@ -52,12 +56,15 @@ import org.springframework.util.Assert;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  * @author Sebastien Deleuze
+ * @author guan xu
  */
 public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 
 	private static final Log logger = LogFactory.getLog(OpenAiAudioTranscriptionModel.class);
 
 	private final OpenAIClient openAiClient;
+
+	private final OpenAIClientAsync openAiClientAsync;
 
 	private final OpenAiAudioTranscriptionOptions options;
 
@@ -87,6 +94,14 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
 						this.options.getCustomHeaders(), ObservationRegistry.NOOP, null,
 						builder.httpClientCustomizers));
+		this.openAiClientAsync = Objects.requireNonNullElseGet(builder.openAiClientAsync,
+				() -> OpenAiSetup.setupAsyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
+						this.options.getCredential(), this.options.getMicrosoftDeploymentName(),
+						this.options.getMicrosoftFoundryServiceVersion(), this.options.getOrganizationId(),
+						this.options.isMicrosoftFoundry(), this.options.isGitHubModels(), this.options.getModel(),
+						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
+						this.options.getCustomHeaders(), ObservationRegistry.NOOP, null,
+						builder.httpClientCustomizers));
 	}
 
 	/**
@@ -99,33 +114,65 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 
 	@Override
 	public AudioTranscriptionResponse call(AudioTranscriptionPrompt transcriptionPrompt) {
-		OpenAiAudioTranscriptionOptions options = this.options;
-		if (transcriptionPrompt.getOptions() != null) {
-			if (transcriptionPrompt.getOptions() instanceof OpenAiAudioTranscriptionOptions runtimeOptions) {
-				options = merge(runtimeOptions, options);
-			}
-			else {
-				throw new IllegalArgumentException("Prompt options are not of type OpenAiAudioTranscriptionOptions: "
-						+ transcriptionPrompt.getOptions().getClass().getSimpleName());
-			}
-		}
+		// Merge request options with default options
+		OpenAiAudioTranscriptionOptions mergedOptions = OpenAiAudioTranscriptionOptions.builder()
+			.from(this.options)
+			.merge(transcriptionPrompt.getOptions())
+			.build();
 
 		Resource audioResource = transcriptionPrompt.getInstructions();
 		byte[] audioBytes = toBytes(audioResource);
-		String filename = audioResource.getFilename();
-		if (filename == null) {
-			filename = "audio";
-		}
+		String filename = getFilename(audioResource);
 
-		TranscriptionCreateParams params = buildParams(options, audioBytes, filename);
+		TranscriptionCreateParams params = buildParams(mergedOptions, audioBytes, filename);
 		if (logger.isTraceEnabled()) {
-			logger.trace("OpenAiAudioTranscriptionModel call with model: " + options.getModel());
+			logger.trace("OpenAiAudioTranscriptionModel call with model: " + mergedOptions.getModel());
 		}
 
 		TranscriptionCreateResponse response = this.openAiClient.audio().transcriptions().create(params);
 		String text = extractText(response);
 		AudioTranscription transcript = new AudioTranscription(text);
 		return new AudioTranscriptionResponse(transcript, new AudioTranscriptionResponseMetadata());
+	}
+
+	@Override
+	public Flux<AudioTranscriptionResponse> stream(AudioTranscriptionPrompt transcriptionPrompt) {
+		// Merge request options with default options
+		OpenAiAudioTranscriptionOptions mergedOptions = OpenAiAudioTranscriptionOptions.builder()
+			.from(this.options)
+			.merge(transcriptionPrompt.getOptions())
+			.build();
+
+		Resource audioResource = transcriptionPrompt.getInstructions();
+		byte[] audioBytes = toBytes(audioResource);
+		String filename = getFilename(audioResource);
+
+		TranscriptionCreateParams params = buildParams(mergedOptions, audioBytes, filename);
+		if (logger.isTraceEnabled()) {
+			logger.trace("OpenAiAudioTranscriptionModel stream with model: " + mergedOptions.getModel());
+		}
+
+		Flux<TranscriptionStreamEvent> chunk = Flux.create(sink -> {
+			AsyncStreamResponse<TranscriptionStreamEvent> response = this.openAiClientAsync.audio()
+				.transcriptions()
+				.createStreaming(params);
+			response.subscribe(sink::next);
+			sink.onDispose(response::close);
+			response.onCompleteFuture().whenComplete((unused, throwable) -> {
+				if (throwable != null) {
+					sink.error(throwable);
+				}
+				else {
+					sink.complete();
+				}
+			});
+		});
+
+		return chunk.map(event -> {
+			String text = extractStreamEventText(event);
+			AudioTranscription transcript = new AudioTranscription(text);
+			return new AudioTranscriptionResponse(transcript, new AudioTranscriptionResponseMetadata());
+		});
 	}
 
 	private TranscriptionCreateParams buildParams(OpenAiAudioTranscriptionOptions options, byte[] audioBytes,
@@ -175,6 +222,16 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 		return "";
 	}
 
+	private static String extractStreamEventText(TranscriptionStreamEvent event) {
+		if (event.isTranscriptTextDelta()) {
+			return event.asTranscriptTextDelta().delta();
+		}
+		if (event.isTranscriptTextSegment()) {
+			return event.asTranscriptTextSegment().text();
+		}
+		return "";
+	}
+
 	private static byte[] toBytes(Resource resource) {
 		Assert.notNull(resource, "Resource must not be null");
 		try {
@@ -185,9 +242,12 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 		}
 	}
 
-	private static OpenAiAudioTranscriptionOptions merge(OpenAiAudioTranscriptionOptions source,
-			OpenAiAudioTranscriptionOptions target) {
-		return OpenAiAudioTranscriptionOptions.builder().from(target).merge(source).build();
+	private static String getFilename(Resource audioResource) {
+		String filename = audioResource.getFilename();
+		if (filename == null) {
+			filename = "audio";
+		}
+		return filename;
 	}
 
 	/**
@@ -196,6 +256,8 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 	public static final class Builder {
 
 		private @Nullable OpenAIClient openAiClient;
+
+		private @Nullable OpenAIClientAsync openAiClientAsync;
 
 		private @Nullable OpenAiAudioTranscriptionOptions options;
 
@@ -206,6 +268,7 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 
 		private Builder(OpenAiAudioTranscriptionModel model) {
 			this.openAiClient = model.openAiClient;
+			this.openAiClientAsync = model.openAiClientAsync;
 			this.options = model.options;
 		}
 
@@ -216,6 +279,16 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 		 */
 		public Builder openAiClient(OpenAIClient openAiClient) {
 			this.openAiClient = openAiClient;
+			return this;
+		}
+
+		/**
+		 * Sets the OpenAI client async.
+		 * @param openAiClientAsync the OpenAI client async
+		 * @return this builder
+		 */
+		public Builder openAiClientAsync(OpenAIClientAsync openAiClientAsync) {
+			this.openAiClientAsync = openAiClientAsync;
 			return this;
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.MultipartField;
-import com.openai.core.http.AsyncStreamResponse;
 import com.openai.models.audio.transcriptions.TranscriptionCreateParams;
 import com.openai.models.audio.transcriptions.TranscriptionCreateResponse;
 import com.openai.models.audio.transcriptions.TranscriptionStreamEvent;
@@ -153,19 +152,19 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 		}
 
 		Flux<TranscriptionStreamEvent> chunk = Flux.create(sink -> {
-			AsyncStreamResponse<TranscriptionStreamEvent> response = this.openAiClientAsync.audio()
+			this.openAiClientAsync.audio()
 				.transcriptions()
-				.createStreaming(params);
-			response.subscribe(sink::next);
-			sink.onDispose(response::close);
-			response.onCompleteFuture().whenComplete((unused, throwable) -> {
-				if (throwable != null) {
-					sink.error(throwable);
-				}
-				else {
-					sink.complete();
-				}
-			});
+				.createStreaming(params)
+				.subscribe(sink::next)
+				.onCompleteFuture()
+				.whenComplete((unused, throwable) -> {
+					if (throwable != null) {
+						sink.error(throwable);
+					}
+					else {
+						sink.complete();
+					}
+				});
 		});
 
 		return chunk.map(event -> {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelIT.java
@@ -130,10 +130,10 @@ public class OpenAiAudioTranscriptionModelIT {
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
 		Flux<AudioTranscriptionResponse> flux = this.transcriptionModel.stream(prompt);
 
-		List<AudioTranscriptionResponse> responses = flux.collectList().block();
+		List<AudioTranscriptionResponse> chunks = flux.collectList().block();
 
-		assertThat(responses).isNotEmpty();
-		String text = responses.stream()
+		assertThat(chunks).isNotNull();
+		String text = chunks.stream()
 			.map(AudioTranscriptionResponse::getResult)
 			.filter(Objects::nonNull)
 			.map(AudioTranscription::getOutput)
@@ -142,28 +142,28 @@ public class OpenAiAudioTranscriptionModelIT {
 	}
 
 	@Test
-	void streamWithResourceTest() {
-		Flux<String> flux = this.transcriptionModel.stream(new ClassPathResource("/speech.flac"));
+	void streamTranscribeWithResourceTest() {
+		Flux<String> flux = this.transcriptionModel.streamTranscribe(new ClassPathResource("/speech.flac"));
 
 		List<String> chunks = flux.collectList().block();
 
-		assertThat(chunks).isNotEmpty();
+		assertThat(chunks).isNotNull();
 		String text = String.join("", chunks);
 		assertThat(text).isNotBlank();
 	}
 
 	@Test
-	void streamWithResourceAndOptionsTest() {
+	void streamTranscribeWithResourceAndOptionsTest() {
 		OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
 			.language("en")
 			.temperature(0f)
 			.build();
 
-		Flux<String> flux = this.transcriptionModel.stream(new ClassPathResource("/speech.flac"), options);
+		Flux<String> flux = this.transcriptionModel.streamTranscribe(new ClassPathResource("/speech.flac"), options);
 
 		List<String> chunks = flux.collectList().block();
 
-		assertThat(chunks).isNotEmpty();
+		assertThat(chunks).isNotNull();
 		String text = String.join("", chunks);
 		assertThat(text).isNotBlank();
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelIT.java
@@ -16,10 +16,16 @@
 
 package org.springframework.ai.openai.transcription;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import com.openai.models.audio.AudioResponseFormat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import reactor.core.publisher.Flux;
 
+import org.springframework.ai.audio.transcription.AudioTranscription;
 import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
 import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
@@ -38,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author guan xu
  */
 @SpringBootTest(classes = OpenAiTestConfiguration.class)
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
@@ -116,6 +123,49 @@ public class OpenAiAudioTranscriptionModelIT {
 
 		assertThat(response.getResults()).hasSize(1);
 		assertThat(response.getResult().getOutput()).isNotBlank();
+	}
+
+	@Test
+	void streamTest() {
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
+		Flux<AudioTranscriptionResponse> flux = this.transcriptionModel.stream(prompt);
+
+		List<AudioTranscriptionResponse> responses = flux.collectList().block();
+
+		assertThat(responses).isNotEmpty();
+		String text = responses.stream()
+			.map(AudioTranscriptionResponse::getResult)
+			.filter(Objects::nonNull)
+			.map(AudioTranscription::getOutput)
+			.collect(Collectors.joining());
+		assertThat(text).isNotBlank();
+	}
+
+	@Test
+	void streamWithResourceTest() {
+		Flux<String> flux = this.transcriptionModel.stream(new ClassPathResource("/speech.flac"));
+
+		List<String> chunks = flux.collectList().block();
+
+		assertThat(chunks).isNotEmpty();
+		String text = String.join("", chunks);
+		assertThat(text).isNotBlank();
+	}
+
+	@Test
+	void streamWithResourceAndOptionsTest() {
+		OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
+			.language("en")
+			.temperature(0f)
+			.build();
+
+		Flux<String> flux = this.transcriptionModel.stream(new ClassPathResource("/speech.flac"), options);
+
+		List<String> chunks = flux.collectList().block();
+
+		assertThat(chunks).isNotEmpty();
+		String text = String.join("", chunks);
+		assertThat(text).isNotBlank();
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
@@ -16,10 +16,21 @@
 
 package org.springframework.ai.openai.transcription;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 import com.openai.client.OpenAIClient;
+import com.openai.client.OpenAIClientAsync;
+import com.openai.core.http.AsyncStreamResponse;
 import com.openai.models.audio.AudioResponseFormat;
 import com.openai.models.audio.transcriptions.Transcription;
 import com.openai.models.audio.transcriptions.TranscriptionCreateResponse;
+import com.openai.models.audio.transcriptions.TranscriptionStreamEvent;
+import com.openai.models.audio.transcriptions.TranscriptionTextDeltaEvent;
+import com.openai.services.async.AudioServiceAsync;
+import com.openai.services.async.audio.TranscriptionServiceAsync;
 import com.openai.services.blocking.AudioService;
 import com.openai.services.blocking.audio.TranscriptionService;
 import org.junit.jupiter.api.Test;
@@ -44,6 +55,7 @@ import static org.mockito.Mockito.when;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  * @author Sebastien Deleuze
+ * @author guan xu
  */
 class OpenAiAudioTranscriptionModelTests {
 
@@ -57,6 +69,16 @@ class OpenAiAudioTranscriptionModelTests {
 		return client;
 	}
 
+	private OpenAIClientAsync createMockAsyncClient(AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse) {
+		OpenAIClientAsync clientAsync = mock(OpenAIClientAsync.class);
+		AudioServiceAsync audioServiceAsync = mock(AudioServiceAsync.class);
+		TranscriptionServiceAsync transcriptionServiceAsync = mock(TranscriptionServiceAsync.class);
+		when(clientAsync.audio()).thenReturn(audioServiceAsync);
+		when(audioServiceAsync.transcriptions()).thenReturn(transcriptionServiceAsync);
+		when(transcriptionServiceAsync.createStreaming(any())).thenReturn(mockAsyncResponse);
+		return clientAsync;
+	}
+
 	@Test
 	void callReturnsTranscriptionText() {
 		TranscriptionCreateResponse mockResponse = TranscriptionCreateResponse
@@ -64,7 +86,10 @@ class OpenAiAudioTranscriptionModelTests {
 
 		OpenAIClient client = createMockClient(mockResponse);
 
-		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder().openAiClient(client).build();
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(client)
+			.openAiClientAsync(mock(OpenAIClientAsync.class))
+			.build();
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
 		AudioTranscriptionResponse response = model.call(prompt);
 
@@ -78,7 +103,10 @@ class OpenAiAudioTranscriptionModelTests {
 
 		OpenAIClient client = createMockClient(mockResponse);
 
-		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder().openAiClient(client).build();
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(client)
+			.openAiClientAsync(mock(OpenAIClientAsync.class))
+			.build();
 
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
 		AudioTranscriptionResponse response = model.call(prompt);
@@ -99,7 +127,10 @@ class OpenAiAudioTranscriptionModelTests {
 			.responseFormat(AudioResponseFormat.JSON)
 			.build();
 
-		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder().openAiClient(client).build();
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(client)
+			.openAiClientAsync(mock(OpenAIClientAsync.class))
+			.build();
 
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"), options);
 		AudioTranscriptionResponse response = model.call(prompt);
@@ -114,7 +145,10 @@ class OpenAiAudioTranscriptionModelTests {
 
 		OpenAIClient client = createMockClient(mockResponse);
 
-		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder().openAiClient(client).build();
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(client)
+			.openAiClientAsync(mock(OpenAIClientAsync.class))
+			.build();
 		String text = model.transcribe(new ClassPathResource("/speech.flac"));
 
 		assertThat(text).isEqualTo("Simple output");
@@ -133,6 +167,7 @@ class OpenAiAudioTranscriptionModelTests {
 			.build();
 		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
 			.openAiClient(client)
+			.openAiClientAsync(mock(OpenAIClientAsync.class))
 			.options(options)
 			.build();
 		String text = model.transcribe(new ClassPathResource("/speech.flac"), options);
@@ -242,6 +277,7 @@ class OpenAiAudioTranscriptionModelTests {
 
 		OpenAiAudioTranscriptionModel originalModel = OpenAiAudioTranscriptionModel.builder()
 			.openAiClient(client)
+			.openAiClientAsync(mock(OpenAIClientAsync.class))
 			.options(options)
 			.build();
 
@@ -268,6 +304,7 @@ class OpenAiAudioTranscriptionModelTests {
 
 		OpenAiAudioTranscriptionModel originalModel = OpenAiAudioTranscriptionModel.builder()
 			.openAiClient(client)
+			.openAiClientAsync(mock(OpenAIClientAsync.class))
 			.options(originalOptions)
 			.build();
 
@@ -281,6 +318,66 @@ class OpenAiAudioTranscriptionModelTests {
 
 		assertThat(mutatedModel.getOptions().getLanguage()).isEqualTo("de");
 		assertThat(mutatedModel.getOptions().getTemperature()).isEqualTo(0.5f);
+	}
+
+	@Test
+	void streamReturnsTranscriptionTextChunks() {
+		AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse = asyncStreamResponse(
+				TranscriptionStreamEvent
+					.ofTranscriptTextDelta(TranscriptionTextDeltaEvent.builder().delta("Hello, ").build()),
+				TranscriptionStreamEvent.ofTranscriptTextDelta(
+						TranscriptionTextDeltaEvent.builder().delta("streamed transcription result").build()));
+
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(mock(OpenAIClient.class))
+			.openAiClientAsync(createMockAsyncClient(mockAsyncResponse))
+			.build();
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
+
+		List<String> chunks = model.stream(prompt)
+			.map(response -> response.getResult().getOutput())
+			.collectList()
+			.block();
+		assertThat(chunks).isNotNull();
+		String text = String.join("", chunks);
+		assertThat(text).isEqualTo("Hello, streamed transcription result");
+	}
+
+	private <T> AsyncStreamResponse<T> asyncStreamResponse(T... chunks) {
+		return new AsyncStreamResponse<>() {
+			private final CompletableFuture<Void> completion = new CompletableFuture<>();
+
+			@Override
+			public AsyncStreamResponse<T> subscribe(AsyncStreamResponse.Handler<? super T> handler) {
+				try {
+					for (T chunk : chunks) {
+						handler.onNext(chunk);
+					}
+					handler.onComplete(Optional.empty());
+					this.completion.complete(null);
+				}
+				catch (Throwable throwable) {
+					handler.onComplete(Optional.of(throwable));
+					this.completion.completeExceptionally(throwable);
+				}
+				return this;
+			}
+
+			@Override
+			public AsyncStreamResponse<T> subscribe(AsyncStreamResponse.Handler<? super T> handler, Executor executor) {
+				executor.execute(() -> subscribe(handler));
+				return this;
+			}
+
+			@Override
+			public CompletableFuture<Void> onCompleteFuture() {
+				return this.completion;
+			}
+
+			@Override
+			public void close() {
+			}
+		};
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
@@ -59,26 +59,6 @@ import static org.mockito.Mockito.when;
  */
 class OpenAiAudioTranscriptionModelTests {
 
-	private OpenAIClient createMockClient(TranscriptionCreateResponse mockResponse) {
-		OpenAIClient client = mock(OpenAIClient.class);
-		AudioService audioService = mock(AudioService.class);
-		TranscriptionService transcriptionService = mock(TranscriptionService.class);
-		when(client.audio()).thenReturn(audioService);
-		when(audioService.transcriptions()).thenReturn(transcriptionService);
-		when(transcriptionService.create(any())).thenReturn(mockResponse);
-		return client;
-	}
-
-	private OpenAIClientAsync createMockAsyncClient(AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse) {
-		OpenAIClientAsync clientAsync = mock(OpenAIClientAsync.class);
-		AudioServiceAsync audioServiceAsync = mock(AudioServiceAsync.class);
-		TranscriptionServiceAsync transcriptionServiceAsync = mock(TranscriptionServiceAsync.class);
-		when(clientAsync.audio()).thenReturn(audioServiceAsync);
-		when(audioServiceAsync.transcriptions()).thenReturn(transcriptionServiceAsync);
-		when(transcriptionServiceAsync.createStreaming(any())).thenReturn(mockAsyncResponse);
-		return clientAsync;
-	}
-
 	@Test
 	void callReturnsTranscriptionText() {
 		TranscriptionCreateResponse mockResponse = TranscriptionCreateResponse
@@ -97,7 +77,7 @@ class OpenAiAudioTranscriptionModelTests {
 	}
 
 	@Test
-	void callWithOptions() {
+	void callWithPrompt() {
 		TranscriptionCreateResponse mockResponse = TranscriptionCreateResponse
 			.ofTranscription(Transcription.builder().text("Hello, this is a test transcription.").build());
 
@@ -328,19 +308,118 @@ class OpenAiAudioTranscriptionModelTests {
 				TranscriptionStreamEvent.ofTranscriptTextDelta(
 						TranscriptionTextDeltaEvent.builder().delta("streamed transcription result").build()));
 
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
+
 		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
 			.openAiClient(mock(OpenAIClient.class))
 			.openAiClientAsync(createMockAsyncClient(mockAsyncResponse))
 			.build();
-		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
 
 		List<String> chunks = model.stream(prompt)
 			.map(response -> response.getResult().getOutput())
 			.collectList()
 			.block();
+
 		assertThat(chunks).isNotNull();
 		String text = String.join("", chunks);
 		assertThat(text).isEqualTo("Hello, streamed transcription result");
+	}
+
+	@Test
+	void streamWithPromptOptions() {
+		AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse = asyncStreamResponse(
+				TranscriptionStreamEvent
+					.ofTranscriptTextDelta(TranscriptionTextDeltaEvent.builder().delta("Hello, ").build()),
+				TranscriptionStreamEvent.ofTranscriptTextDelta(
+						TranscriptionTextDeltaEvent.builder().delta("streamed transcription result").build()));
+
+		OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
+			.temperature(0.5f)
+			.responseFormat(AudioResponseFormat.JSON)
+			.build();
+
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"), options);
+
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(mock(OpenAIClient.class))
+			.openAiClientAsync(createMockAsyncClient(mockAsyncResponse))
+			.build();
+
+		List<String> chunks = model.stream(prompt)
+			.map(response -> response.getResult().getOutput())
+			.collectList()
+			.block();
+
+		assertThat(chunks).isNotNull();
+		String text = String.join("", chunks);
+		assertThat(text).isEqualTo("Hello, streamed transcription result");
+	}
+
+	@Test
+	void streamTranscribeWithResource() {
+		AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse = asyncStreamResponse(
+				TranscriptionStreamEvent
+					.ofTranscriptTextDelta(TranscriptionTextDeltaEvent.builder().delta("Hello, ").build()),
+				TranscriptionStreamEvent.ofTranscriptTextDelta(
+						TranscriptionTextDeltaEvent.builder().delta("streamed transcription result").build()));
+
+		OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
+			.temperature(0.5f)
+			.responseFormat(AudioResponseFormat.JSON)
+			.build();
+
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(mock(OpenAIClient.class))
+			.openAiClientAsync(createMockAsyncClient(mockAsyncResponse))
+			.build();
+
+		List<String> chunks = model.streamTranscribe(new ClassPathResource("/speech.flac"), options)
+			.collectList()
+			.block();
+
+		assertThat(chunks).isNotNull();
+		String text = String.join("", chunks);
+		assertThat(text).isEqualTo("Hello, streamed transcription result");
+	}
+
+	@Test
+	void streamTranscribeWithResourceAndOptions() {
+		AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse = asyncStreamResponse(
+				TranscriptionStreamEvent
+					.ofTranscriptTextDelta(TranscriptionTextDeltaEvent.builder().delta("Hello, ").build()),
+				TranscriptionStreamEvent.ofTranscriptTextDelta(
+						TranscriptionTextDeltaEvent.builder().delta("streamed transcription result").build()));
+
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(mock(OpenAIClient.class))
+			.openAiClientAsync(createMockAsyncClient(mockAsyncResponse))
+			.build();
+
+		List<String> chunks = model.streamTranscribe(new ClassPathResource("/speech.flac")).collectList().block();
+
+		assertThat(chunks).isNotNull();
+		String text = String.join("", chunks);
+		assertThat(text).isEqualTo("Hello, streamed transcription result");
+	}
+
+	private OpenAIClient createMockClient(TranscriptionCreateResponse mockResponse) {
+		OpenAIClient client = mock(OpenAIClient.class);
+		AudioService audioService = mock(AudioService.class);
+		TranscriptionService transcriptionService = mock(TranscriptionService.class);
+		when(client.audio()).thenReturn(audioService);
+		when(audioService.transcriptions()).thenReturn(transcriptionService);
+		when(transcriptionService.create(any())).thenReturn(mockResponse);
+		return client;
+	}
+
+	private OpenAIClientAsync createMockAsyncClient(AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse) {
+		OpenAIClientAsync clientAsync = mock(OpenAIClientAsync.class);
+		AudioServiceAsync audioServiceAsync = mock(AudioServiceAsync.class);
+		TranscriptionServiceAsync transcriptionServiceAsync = mock(TranscriptionServiceAsync.class);
+		when(clientAsync.audio()).thenReturn(audioServiceAsync);
+		when(audioServiceAsync.transcriptions()).thenReturn(transcriptionServiceAsync);
+		when(transcriptionServiceAsync.createStreaming(any())).thenReturn(mockAsyncResponse);
+		return clientAsync;
 	}
 
 	private <T> AsyncStreamResponse<T> asyncStreamResponse(T... chunks) {

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -122,6 +122,46 @@ new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider, Exception.class
 new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
 ----
 
+=== TranscriptionModel Now Extends StreamingTranscriptionModel
+
+`TranscriptionModel` now extends `StreamingTranscriptionModel`, making streaming transcription a first-class capability of every transcription model.
+
+==== Impact
+
+Custom implementations of `TranscriptionModel` that do not already provide a `stream(AudioTranscriptionPrompt)` method will fail to compile.
+
+==== Migration
+
+Implement the `stream(AudioTranscriptionPrompt)` method from `StreamingTranscriptionModel`.
+If streaming is not applicable to your use case, return `Flux.error(new UnsupportedOperationException(...))` or wrap the synchronous result in a single-element `Flux`:
+
+[source,java]
+----
+// Before — TranscriptionModel only required call()
+public class CustomTranscriptionModel implements TranscriptionModel {
+
+    @Override
+    public AudioTranscriptionResponse call(AudioTranscriptionPrompt prompt) {
+        // ...
+    }
+}
+
+// After — stream() is also required
+public class CustomTranscriptionModel implements TranscriptionModel {
+
+    @Override
+    public AudioTranscriptionResponse call(AudioTranscriptionPrompt prompt) {
+        // ...
+    }
+
+    @Override
+    public Flux<AudioTranscriptionResponse> stream(AudioTranscriptionPrompt prompt) {
+        // Return the call result as a single-element Flux, or throw if unsupported
+        return Flux.just(call(prompt));
+    }
+}
+----
+
 [[upgrading-to-2-0-0]]
 == Upgrading to 2.0.0
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -126,27 +126,19 @@ new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
 
 `TranscriptionModel` now extends `StreamingTranscriptionModel`, making streaming transcription a first-class capability of every transcription model.
 
+`StreamingTranscriptionModel` provides a default `stream(AudioTranscriptionPrompt)` implementation that returns `Flux.error(new UnsupportedOperationException(...))`, so existing custom implementations of `TranscriptionModel` continue to compile without changes.
+
 ==== Impact
 
-Custom implementations of `TranscriptionModel` that do not already provide a `stream(AudioTranscriptionPrompt)` method will fail to compile.
+Calling `stream()` on a custom implementation that does not override it will return a `Flux` that emits an `UnsupportedOperationException`.
 
 ==== Migration
 
-Implement the `stream(AudioTranscriptionPrompt)` method from `StreamingTranscriptionModel`.
-If streaming is not applicable to your use case, return `Flux.error(new UnsupportedOperationException(...))` or wrap the synchronous result in a single-element `Flux`:
+If your custom `TranscriptionModel` needs to support streaming transcription, override the `stream(AudioTranscriptionPrompt)` method.
+You can provide a native streaming implementation, or wrap the synchronous `call()` result in a single-element `Flux`:
 
 [source,java]
 ----
-// Before — TranscriptionModel only required call()
-public class CustomTranscriptionModel implements TranscriptionModel {
-
-    @Override
-    public AudioTranscriptionResponse call(AudioTranscriptionPrompt prompt) {
-        // ...
-    }
-}
-
-// After — stream() is also required
 public class CustomTranscriptionModel implements TranscriptionModel {
 
     @Override
@@ -156,11 +148,13 @@ public class CustomTranscriptionModel implements TranscriptionModel {
 
     @Override
     public Flux<AudioTranscriptionResponse> stream(AudioTranscriptionPrompt prompt) {
-        // Return the call result as a single-element Flux, or throw if unsupported
+        // Wrap the synchronous call result as a single-element Flux
         return Flux.just(call(prompt));
     }
 }
 ----
+
+If streaming is not needed, no action is required — the default implementation is inherited automatically.
 
 [[upgrading-to-2-0-0]]
 == Upgrading to 2.0.0

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/StreamingTranscriptionModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/StreamingTranscriptionModel.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.audio.transcription;
+
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.model.StreamingModel;
+import org.springframework.core.io.Resource;
+
+/**
+ * Interface for the streaming transcription model. This extends {@link StreamingModel} to
+ * provide a streaming API for speech-to-text transcription, where audio input is
+ * converted to text output incrementally.
+ *
+ * @author guan xu
+ * @since 2.0.1
+ */
+@FunctionalInterface
+public interface StreamingTranscriptionModel
+		extends StreamingModel<AudioTranscriptionPrompt, AudioTranscriptionResponse> {
+
+	/**
+	 * Streams a transcription request to the model, returning the transcription results
+	 * incrementally as they become available.
+	 * @param transcriptionPrompt the transcription prompt containing the audio input and
+	 * options
+	 * @return a {@link Flux} of {@link AudioTranscriptionResponse} chunks representing
+	 * incremental transcription results
+	 */
+	Flux<AudioTranscriptionResponse> stream(AudioTranscriptionPrompt transcriptionPrompt);
+
+	/**
+	 * A convenience method for streaming the transcription of an audio resource.
+	 * @param resource the audio resource to transcribe
+	 * @return a {@link Flux} of transcribed text segments
+	 */
+	default Flux<String> stream(Resource resource) {
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource);
+		return stream(prompt).map(response -> (response.getResult() == null || response.getResult().getOutput() == null)
+				? "" : response.getResult().getOutput());
+	}
+
+	/**
+	 * A convenience method for streaming the transcription of an audio resource with the
+	 * given options.
+	 * @param resource the audio resource to transcribe
+	 * @param options the transcription options
+	 * @return a {@link Flux} of transcribed text segments
+	 */
+	default Flux<String> stream(Resource resource, @Nullable AudioTranscriptionOptions options) {
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource, options);
+		return stream(prompt).map(response -> (response.getResult() == null || response.getResult().getOutput() == null)
+				? "" : response.getResult().getOutput());
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/StreamingTranscriptionModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/StreamingTranscriptionModel.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.audio.transcription;
 
+import java.util.Optional;
+
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 
@@ -30,7 +32,6 @@ import org.springframework.core.io.Resource;
  * @author guan xu
  * @since 2.0.1
  */
-@FunctionalInterface
 public interface StreamingTranscriptionModel
 		extends StreamingModel<AudioTranscriptionPrompt, AudioTranscriptionResponse> {
 
@@ -42,17 +43,17 @@ public interface StreamingTranscriptionModel
 	 * @return a {@link Flux} of {@link AudioTranscriptionResponse} chunks representing
 	 * incremental transcription results
 	 */
-	Flux<AudioTranscriptionResponse> stream(AudioTranscriptionPrompt transcriptionPrompt);
+	default Flux<AudioTranscriptionResponse> stream(AudioTranscriptionPrompt transcriptionPrompt) {
+		return Flux.error(new UnsupportedOperationException("Streaming transcription is not supported"));
+	}
 
 	/**
 	 * A convenience method for streaming the transcription of an audio resource.
 	 * @param resource the audio resource to transcribe
 	 * @return a {@link Flux} of transcribed text segments
 	 */
-	default Flux<String> stream(Resource resource) {
-		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource);
-		return stream(prompt).map(response -> (response.getResult() == null || response.getResult().getOutput() == null)
-				? "" : response.getResult().getOutput());
+	default Flux<String> streamTranscribe(Resource resource) {
+		return this.streamTranscribe(resource, null);
 	}
 
 	/**
@@ -62,10 +63,10 @@ public interface StreamingTranscriptionModel
 	 * @param options the transcription options
 	 * @return a {@link Flux} of transcribed text segments
 	 */
-	default Flux<String> stream(Resource resource, @Nullable AudioTranscriptionOptions options) {
+	default Flux<String> streamTranscribe(Resource resource, @Nullable AudioTranscriptionOptions options) {
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource, options);
-		return stream(prompt).map(response -> (response.getResult() == null || response.getResult().getOutput() == null)
-				? "" : response.getResult().getOutput());
+		return stream(prompt)
+			.map(response -> Optional.ofNullable(response.getResult()).map(AudioTranscription::getOutput).orElse(""));
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/TranscriptionModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/TranscriptionModel.java
@@ -26,9 +26,11 @@ import org.springframework.core.io.Resource;
  * known as Speech-to-Text.
  *
  * @author Mudabir Hussain
+ * @author guan xu
  * @since 1.0.0
  */
-public interface TranscriptionModel extends Model<AudioTranscriptionPrompt, AudioTranscriptionResponse> {
+public interface TranscriptionModel
+		extends Model<AudioTranscriptionPrompt, AudioTranscriptionResponse>, StreamingTranscriptionModel {
 
 	/**
 	 * Transcribes the audio from the given prompt.


### PR DESCRIPTION
# Summary
Introduce `StreamingTranscriptionModel` interface and implement streaming audio transcription in `OpenAiAudioTranscriptionModel` using the async OpenAI client

# Changes
 - Add `StreamingTranscriptionModel` interface with stream methods
 - Implement stream method in `OpenAiAudioTranscriptionModel` via `OpenAIClientAsync`
 - Register `OpenAIClientAsync` in `OpenAiAudioTranscriptionAutoConfiguration`
 - Add unit and integration tests for streaming transcription