### PR TITLE
Fix Milvus metadata integer values deserialized as Long instead of Double

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
@@ -25,7 +25,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import com.google.gson.ToNumberPolicy;
 import com.google.gson.reflect.TypeToken;
 import io.milvus.client.MilvusServiceClient;
 import io.milvus.common.clientenum.ConsistencyLevelEnum;
@@ -403,7 +405,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 					// skip the ParamException if metadata doesn't exist for the custom
 					// collection
 				}
-				Gson gson = new Gson();
+				Gson gson = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
 				Type type = new TypeToken<Map<String, Object>>() {
 				}.getType();
 				return Document.builder()

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreTest.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreTest.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.vectorstore.milvus;
 
 import java.util.List;
+import java.util.Map;
 
+import com.google.gson.JsonObject;
 import io.milvus.client.MilvusServiceClient;
 import io.milvus.grpc.MutationResult;
 import io.milvus.grpc.SearchResultData;
@@ -25,6 +27,7 @@ import io.milvus.grpc.SearchResults;
 import io.milvus.param.R;
 import io.milvus.param.dml.DeleteParam;
 import io.milvus.param.dml.SearchParam;
+import io.milvus.response.QueryResultsWrapper.RowRecord;
 import io.milvus.response.SearchResultsWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +39,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.model.EmbeddingUtils;
 import org.springframework.ai.vectorstore.SearchRequest;
@@ -163,6 +167,44 @@ class MilvusVectorStoreTest {
 			assertThat(capturedParam.getTopK()).isEqualTo(request.getTopK());
 			assertThat(capturedParam.getExpr()).isEqualTo("metadata[\"age\"] > 30"); // filter
 			assertThat(capturedParam.getParams()).isEqualTo("{}");
+		}
+	}
+
+	@Test
+	void shouldPreserveMetadataIntegerNumberTypesInSearchResults() {
+		long externalId = 10_000_000_000_000_001L;
+		JsonObject metadata = new JsonObject();
+		metadata.addProperty("external_id", externalId);
+		metadata.addProperty("priority", 7);
+		metadata.addProperty("weight", 1.5);
+
+		RowRecord rowRecord = new RowRecord();
+		rowRecord.put(MilvusVectorStore.DOC_ID_FIELD_NAME, "doc-1");
+		rowRecord.put(MilvusVectorStore.CONTENT_FIELD_NAME, "content");
+		rowRecord.put(MilvusVectorStore.METADATA_FIELD_NAME, metadata);
+		rowRecord.put(MilvusVectorStore.SIMILARITY_FIELD_NAME, 0.75f);
+
+		try (MockedStatic<EmbeddingUtils> mockedEmbeddingUtils = mockStatic(EmbeddingUtils.class);
+				MockedConstruction<SearchResultsWrapper> mockedSearchResultsWrapper = mockConstruction(
+						SearchResultsWrapper.class,
+						(mock, context) -> when(mock.getRowRecords(0)).thenReturn(List.of(rowRecord)))) {
+
+			List<Float> mockVector = List.of(1.0f, 2.0f, 3.0f);
+			mockedEmbeddingUtils.when(() -> EmbeddingUtils.toList(any())).thenReturn(mockVector);
+
+			SearchResults mockResults = mock(SearchResults.class);
+			when(mockResults.getResults()).thenReturn(SearchResultData.getDefaultInstance());
+			when(this.milvusClient.search(any(SearchParam.class))).thenReturn(R.success(mockResults));
+
+			List<Document> results = this.vectorStore
+				.doSimilaritySearch(SearchRequest.builder().query("sample query").build());
+
+			assertThat(results).hasSize(1);
+			Map<String, Object> resultMetadata = results.get(0).getMetadata();
+			assertThat(resultMetadata.get("external_id")).isInstanceOf(Long.class).isEqualTo(externalId);
+			assertThat(resultMetadata.get("priority")).isInstanceOf(Long.class).isEqualTo(7L);
+			assertThat(resultMetadata.get("weight")).isInstanceOf(Double.class).isEqualTo(1.5);
+			assertThat(resultMetadata.get(DocumentMetadata.DISTANCE.value())).isEqualTo(0.25);
 		}
 	}
 


### PR DESCRIPTION
Milvus search result metadata is read back into `Map<String, Object>` with Gson.
With a plain `new Gson()` instance, Gson uses the `DOUBLE` strategy for numbers deserialized as `Object`, 
so integer metadata values are returned as `Double`.

That can break exact follow-up lookups when metadata contains large numeric identifiers. 
For example, Milvus can return raw metadata like:

```text
{"external_id":10000000000000001,"priority":7,"weight":1.5}
```

With the current parsing, the large identifier is returned as:

```text
external_id -> Double 1.0E16
```

Converting that value back to `long` produces a different identifier:

```text
10000000000000000
```

This change uses Gson's `LONG_OR_DOUBLE` strategy when deserializing Milvus search result metadata.
With this strategy, integer metadata values that fit in `Long` are returned as `Long`, 
while decimal metadata values continue to be returned as `Double`.

Also checked locally against a live `milvusdb/milvus:v2.5.4` container:

```text
raw Milvus metadata: {"priority":7,"weight":1.5,"external_id":10000000000000001}
default Gson external_id: java.lang.Double 1.0E16 -> long 10000000000000000
fixed Gson external_id: java.lang.Long 10000000000000001
Spring AI external_id: java.lang.Long 10000000000000001
```
