### PR TITLE
Fix OpenAI streaming tool call chunk merging

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1034,7 +1034,8 @@ public final class OpenAiChatModel implements ChatModel {
 	private static final class ChunkMerger {
 
 		static boolean hasToolCall(ChatCompletionChunk chunk) {
-			return !chunk.choices().isEmpty() && chunk.choices().get(0).delta().toolCalls().isPresent();
+			return !chunk.choices().isEmpty()
+					&& chunk.choices().get(0).delta().toolCalls().filter(toolCalls -> !toolCalls.isEmpty()).isPresent();
 		}
 
 		static boolean toolCallsDone(ChatCompletionChunk chunk) {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1069,38 +1069,57 @@ public final class OpenAiChatModel implements ChatModel {
 		}
 
 		private static Delta mergeDeltas(Delta left, Delta right) {
-			var tcs = Stream.of(left.toolCalls(), right.toolCalls()).flatMap(Optional::stream).reduce((tcs1, tcs2) -> {
-				if (tcs2.isEmpty()) {
-					return tcs1;
-				}
-				Assert.isTrue(tcs2.size() == 1, "no more than one tool call per message currently supported");
-				ToolCall toolCall = tcs2.get(0);
-				if (toolCall.id().isPresent()) {
-					List<ToolCall> result = new ArrayList<>(tcs1);
-					result.add(toolCall);
-					return result;
-				}
-				else {
-					ToolCall lastFromTc1 = tcs1.get(tcs1.size() - 1);
-					Function lastFromTc1F = lastFromTc1.function().get();
-
-					var concatenatedArgs = Stream
-						.of(lastFromTc1F.arguments(), toolCall.function().flatMap(Function::arguments))
-						.flatMap(Optional::stream)
-						.reduce((args1, args2) -> args1 + args2)
-						.orElse("");
-
-					List<ToolCall> result = new ArrayList<>(tcs1);
-					result.set(tcs1.size() - 1,
-							lastFromTc1.toBuilder()
-								.putAllAdditionalProperties(toolCall._additionalProperties())
-								.function(lastFromTc1F.toBuilder().arguments(concatenatedArgs).build())
-								.build());
-					return result;
-				}
-			}).orElse(List.of());
+			List<ToolCall> tcs = new ArrayList<>(left.toolCalls().orElse(List.of()));
+			right.toolCalls().ifPresent(toolCalls -> toolCalls.forEach(toolCall -> mergeToolCall(tcs, toolCall)));
 
 			return left.toBuilder().toolCalls(tcs).build();
+		}
+
+		private static void mergeToolCall(List<ToolCall> existingToolCalls, ToolCall toolCall) {
+			Optional<Integer> existingIndex = findExistingToolCallIndex(existingToolCalls, toolCall);
+			if (existingIndex.isEmpty()) {
+				existingToolCalls.add(toolCall);
+				return;
+			}
+
+			ToolCall existingToolCall = existingToolCalls.get(existingIndex.get());
+			ToolCall.Builder builder = existingToolCall.toBuilder()
+				.putAllAdditionalProperties(toolCall._additionalProperties())
+				.function(mergeToolCallFunctions(existingToolCall.function(), toolCall.function()));
+			if (existingToolCall.id().isEmpty()) {
+				toolCall.id().ifPresent(builder::id);
+			}
+			existingToolCalls.set(existingIndex.get(), builder.build());
+		}
+
+		private static Optional<Integer> findExistingToolCallIndex(List<ToolCall> existingToolCalls,
+				ToolCall toolCall) {
+			for (int i = existingToolCalls.size() - 1; i >= 0; i--) {
+				ToolCall existingToolCall = existingToolCalls.get(i);
+				if (existingToolCall.index() == toolCall.index() || existingToolCall.id()
+					.filter(id -> toolCall.id().filter(id::equals).isPresent())
+					.isPresent()) {
+					return Optional.of(i);
+				}
+			}
+			return Optional.empty();
+		}
+
+		private static Function mergeToolCallFunctions(Optional<Function> left, Optional<Function> right) {
+			Function.Builder builder = left.map(Function::toBuilder).orElseGet(Function::builder);
+
+			Stream.of(left.flatMap(Function::name), right.flatMap(Function::name))
+				.flatMap(Optional::stream)
+				.findFirst()
+				.ifPresent(builder::name);
+
+			var concatenatedArgs = Stream.of(left.flatMap(Function::arguments), right.flatMap(Function::arguments))
+				.flatMap(Optional::stream)
+				.reduce((args1, args2) -> args1 + args2)
+				.orElse("");
+			builder.arguments(concatenatedArgs);
+
+			return builder.build();
 		}
 
 		/**
@@ -1136,11 +1155,16 @@ public final class OpenAiChatModel implements ChatModel {
 					msgBuilder.toolCalls(ccctcs.stream().map(tc -> {
 						ChatCompletionMessageFunctionToolCall.Builder toolCallBuilder = ChatCompletionMessageFunctionToolCall
 							.builder();
+						Function function = tc.function()
+							.orElseThrow(() -> new IllegalStateException("Tool call function is missing"));
 						toolCallBuilder.putAllAdditionalProperties(tc._additionalProperties());
-						toolCallBuilder.id(tc.id().get());
+						toolCallBuilder
+							.id(tc.id().orElseThrow(() -> new IllegalStateException("Tool call id is missing")));
 						toolCallBuilder.function(ChatCompletionMessageFunctionToolCall.Function.builder()
-							.name(tc.function().get().name().get())
-							.arguments(tc.function().get().arguments().get())
+							.name(function.name()
+								.filter(StringUtils::hasText)
+								.orElseThrow(() -> new IllegalStateException("Tool call function name is missing")))
+							.arguments(function.arguments().orElse(""))
 							.build());
 						return ChatCompletionMessageToolCall.ofFunction(toolCallBuilder.build());
 					}).toList());

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -264,6 +264,172 @@ class OpenAiChatModelTests {
 	}
 
 	@Test
+	void mergeStreamToolCallWhenIdNameAndArgumentsArriveInSeparateChunks() {
+		ChatServiceAsync chatServiceAsync = mock(ChatServiceAsync.class);
+		ChatCompletionServiceAsync chatCompletionServiceAsync = mock(ChatCompletionServiceAsync.class);
+		when(this.openAiClientAsync.chat()).thenReturn(chatServiceAsync);
+		when(chatServiceAsync.completions()).thenReturn(chatCompletionServiceAsync);
+		when(chatCompletionServiceAsync.createStreaming(any(ChatCompletionCreateParams.class)))
+			.thenReturn(asyncStreamResponse(ChatCompletionChunk.builder()
+				.id("chatcmpl-stream-test")
+				.created(1777799928)
+				.model("vllm-openai-compatible")
+				.addChoice(ChatCompletionChunk.Choice.builder()
+					.index(0)
+					.finishReason(Optional.empty())
+					.delta(ChatCompletionChunk.Choice.Delta.builder()
+						.addToolCall(ChatCompletionChunk.Choice.Delta.ToolCall.builder().index(0).id("call_1").build())
+						.build())
+					.build())
+				.build(),
+					ChatCompletionChunk.builder()
+						.id("chatcmpl-stream-test")
+						.created(1777799928)
+						.model("vllm-openai-compatible")
+						.addChoice(ChatCompletionChunk.Choice.builder()
+							.index(0)
+							.finishReason(Optional.empty())
+							.delta(ChatCompletionChunk.Choice.Delta.builder()
+								.addToolCall(ChatCompletionChunk.Choice.Delta.ToolCall.builder()
+									.index(0)
+									.function(ChatCompletionChunk.Choice.Delta.ToolCall.Function.builder()
+										.name("get_current_weather")
+										.build())
+									.build())
+								.build())
+							.build())
+						.build(),
+					ChatCompletionChunk.builder()
+						.id("chatcmpl-stream-test")
+						.created(1777799928)
+						.model("vllm-openai-compatible")
+						.addChoice(ChatCompletionChunk.Choice.builder()
+							.index(0)
+							.finishReason(Optional.empty())
+							.delta(ChatCompletionChunk.Choice.Delta.builder()
+								.addToolCall(ChatCompletionChunk.Choice.Delta.ToolCall.builder()
+									.index(0)
+									.function(ChatCompletionChunk.Choice.Delta.ToolCall.Function.builder()
+										.arguments("{\"location\":\"Seoul\"}")
+										.build())
+									.build())
+								.build())
+							.build())
+						.build(),
+					ChatCompletionChunk.builder()
+						.id("chatcmpl-stream-test")
+						.created(1777799928)
+						.model("vllm-openai-compatible")
+						.addChoice(ChatCompletionChunk.Choice.builder()
+							.index(0)
+							.finishReason(ChatCompletionChunk.Choice.FinishReason.TOOL_CALLS)
+							.delta(ChatCompletionChunk.Choice.Delta.builder().build())
+							.build())
+						.build()));
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("vllm-openai-compatible").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.stream(new Prompt("hi", options)).blockLast();
+
+		assertThat(response).isNotNull();
+		AssistantMessage assistantMessage = response.getResult().getOutput();
+		assertThat(assistantMessage.getToolCalls()).singleElement().satisfies(toolCall -> {
+			assertThat(toolCall.id()).isEqualTo("call_1");
+			assertThat(toolCall.name()).isEqualTo("get_current_weather");
+			assertThat(toolCall.arguments()).isEqualTo("{\"location\":\"Seoul\"}");
+		});
+	}
+
+	@Test
+	void mergeStreamToolCallWhenProviderRepeatsIdAcrossChunks() {
+		ChatServiceAsync chatServiceAsync = mock(ChatServiceAsync.class);
+		ChatCompletionServiceAsync chatCompletionServiceAsync = mock(ChatCompletionServiceAsync.class);
+		when(this.openAiClientAsync.chat()).thenReturn(chatServiceAsync);
+		when(chatServiceAsync.completions()).thenReturn(chatCompletionServiceAsync);
+		when(chatCompletionServiceAsync.createStreaming(any(ChatCompletionCreateParams.class)))
+			.thenReturn(asyncStreamResponse(ChatCompletionChunk.builder()
+				.id("chatcmpl-stream-test")
+				.created(1777799928)
+				.model("vllm-openai-compatible")
+				.addChoice(ChatCompletionChunk.Choice.builder()
+					.index(0)
+					.finishReason(Optional.empty())
+					.delta(ChatCompletionChunk.Choice.Delta.builder()
+						.addToolCall(ChatCompletionChunk.Choice.Delta.ToolCall.builder().index(0).id("call_1").build())
+						.build())
+					.build())
+				.build(),
+					ChatCompletionChunk.builder()
+						.id("chatcmpl-stream-test")
+						.created(1777799928)
+						.model("vllm-openai-compatible")
+						.addChoice(ChatCompletionChunk.Choice.builder()
+							.index(0)
+							.finishReason(Optional.empty())
+							.delta(ChatCompletionChunk.Choice.Delta.builder()
+								.addToolCall(ChatCompletionChunk.Choice.Delta.ToolCall.builder()
+									.index(0)
+									.id("call_1")
+									.function(ChatCompletionChunk.Choice.Delta.ToolCall.Function.builder()
+										.name("get_current_weather")
+										.build())
+									.build())
+								.build())
+							.build())
+						.build(),
+					ChatCompletionChunk.builder()
+						.id("chatcmpl-stream-test")
+						.created(1777799928)
+						.model("vllm-openai-compatible")
+						.addChoice(ChatCompletionChunk.Choice.builder()
+							.index(0)
+							.finishReason(Optional.empty())
+							.delta(ChatCompletionChunk.Choice.Delta.builder()
+								.addToolCall(ChatCompletionChunk.Choice.Delta.ToolCall.builder()
+									.index(0)
+									.id("call_1")
+									.function(ChatCompletionChunk.Choice.Delta.ToolCall.Function.builder()
+										.arguments("{\"location\":\"Seoul\"}")
+										.build())
+									.build())
+								.build())
+							.build())
+						.build(),
+					ChatCompletionChunk.builder()
+						.id("chatcmpl-stream-test")
+						.created(1777799928)
+						.model("vllm-openai-compatible")
+						.addChoice(ChatCompletionChunk.Choice.builder()
+							.index(0)
+							.finishReason(ChatCompletionChunk.Choice.FinishReason.TOOL_CALLS)
+							.delta(ChatCompletionChunk.Choice.Delta.builder().build())
+							.build())
+						.build()));
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("vllm-openai-compatible").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.stream(new Prompt("hi", options)).blockLast();
+
+		assertThat(response).isNotNull();
+		AssistantMessage assistantMessage = response.getResult().getOutput();
+		assertThat(assistantMessage.getToolCalls()).singleElement().satisfies(toolCall -> {
+			assertThat(toolCall.id()).isEqualTo("call_1");
+			assertThat(toolCall.name()).isEqualTo("get_current_weather");
+			assertThat(toolCall.arguments()).isEqualTo("{\"location\":\"Seoul\"}");
+		});
+	}
+
+	@Test
 	void restoreUnmappedToolCallAdditionalProperties() {
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gemini-3.5-flash").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()


### PR DESCRIPTION
## Summary

Fix OpenAI streaming tool call chunk merging for OpenAI-compatible providers.

Some OpenAI-compatible servers, observed with vLLM-backed endpoints, stream one logical tool call across multiple chunks. The tool call id, function name, and function arguments can arrive in separate chunks, and some providers repeat the same tool call id on later chunks.

The previous `ChunkMerger` appended every chunk that contained a tool call id as a new tool call. That could split one logical tool call into multiple incomplete tool calls. In practice this caused stream aggregation or downstream tool execution failures, including errors like:

- `NoSuchElementException` / aggregation errors while converting merged chunks
- `toolName cannot be null or empty` when an incomplete merged tool call reached tool execution
- `No ToolCallback found` when the logical function metadata was split incorrectly across chunks

## Changes

- Merge streaming tool call chunks by tool call `index` or repeated `id` instead of appending every id-bearing chunk.
- Preserve the first available function name.
- Concatenate streamed function argument fragments.
- Keep conversion strict so a final merged tool call must still contain id/function/name.
- Add regression tests for:
  - `id`, `function.name`, and `function.arguments` arriving in separate chunks
  - providers repeating the same tool call id across chunks

## Verification

Ran:

```bash
mvn -pl models/spring-ai-openai -Dtest=OpenAiChatModelTests test
```

Result: `Tests run: 24, Failures: 0, Errors: 0, Skipped: 0`.
