### PR TITLE
Add WebP support for Google GenAI and Vertex AI

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/MimeTypeDetector.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/MimeTypeDetector.java
@@ -35,6 +35,7 @@ import org.springframework.util.MimeTypeUtils;
  * <li>image/gif
  * <li>image/png
  * <li>image/jpeg
+ * <li>image/webp
  * <li>video/mov
  * <li>video/mpeg
  * <li>video/mp4
@@ -109,6 +110,7 @@ public abstract class MimeTypeDetector {
 		GEMINI_MIME_TYPES.put("jpeg", MimeTypeUtils.IMAGE_JPEG);
 		GEMINI_MIME_TYPES.put("jpg", MimeTypeUtils.IMAGE_JPEG);
 		GEMINI_MIME_TYPES.put("gif", MimeTypeUtils.IMAGE_GIF);
+		GEMINI_MIME_TYPES.put("webp", MimeTypeUtils.parseMimeType("image/webp"));
 		GEMINI_MIME_TYPES.put("mov", new MimeType("video", "mov"));
 		GEMINI_MIME_TYPES.put("mp4", new MimeType("video", "mp4"));
 		GEMINI_MIME_TYPES.put("mpg", new MimeType("video", "mpg"));

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/MimeTypeDetectorTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/MimeTypeDetectorTests.java
@@ -101,7 +101,7 @@ class MimeTypeDetectorTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "JPG", "PNG", "GIF" })
+	@ValueSource(strings = { "JPG", "PNG", "GIF", "WEBP" })
 	void getMimeTypeByStringWithUppercaseExtensionsShouldWork(String uppercaseExt) {
 		String upperFileName = "test." + uppercaseExt;
 		String lowerFileName = "test." + uppercaseExt.toLowerCase();
@@ -118,7 +118,7 @@ class MimeTypeDetectorTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "test.jpg", "test.png", "test.gif" })
+	@ValueSource(strings = { "test.jpg", "test.png", "test.gif", "test.webp" })
 	void getMimeTypeSupportedFileAcrossDifferentMethodsShouldBeConsistent(String fileName) {
 		MimeType stringResult = MimeTypeDetector.getMimeType(fileName);
 		MimeType fileResult = MimeTypeDetector.getMimeType(new File(fileName));

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
@@ -78,7 +78,8 @@ public class VertexAiMultimodalEmbeddingModel implements DocumentEmbeddingModel 
 	private static final MimeType VIDEO_MIME_TYPE = MimeTypeUtils.parseMimeType("video/*");
 
 	private static final List<MimeType> SUPPORTED_IMAGE_MIME_SUB_TYPES = List.of(MimeTypeUtils.IMAGE_JPEG,
-			MimeTypeUtils.IMAGE_GIF, MimeTypeUtils.IMAGE_PNG, MimeTypeUtils.parseMimeType("image/bmp"));
+			MimeTypeUtils.IMAGE_GIF, MimeTypeUtils.IMAGE_PNG, MimeTypeUtils.parseMimeType("image/bmp"),
+			MimeTypeUtils.parseMimeType("image/webp"));
 
 	private static final Map<String, Integer> KNOWN_EMBEDDING_DIMENSIONS = Stream
 		.of(VertexAiMultimodalEmbeddingModelName.values())


### PR DESCRIPTION
Gemini chat models and Vertex AI Multimodal Embedding both accept `image/webp` inputs, but Spring AI rejected those payloads before they could reach the provider.

### Problem

* `MimeTypeDetector` (`spring-ai-google-genai`) registered only `png`, `jpeg`, `jpg` and `gif`, so any `.webp` `URL`/`URI`/`File`/`Path`/`Resource`/`String` passed to a Gemini chat client raised `Unable to detect the MIME type`. Its class javadoc also listed only `image/gif`, `image/png` and `image/jpeg` as supported, which contradicts the upstream Gemini model reference, which has accepted `image/webp` since 1.5.
* `VertexAiMultimodalEmbeddingModel` allowed `image/jpeg`, `image/gif`, `image/png` and `image/bmp`, and rejected `image/webp` at `SUPPORTED_IMAGE_MIME_SUB_TYPES`, throwing `Unsupported image mime type` even though the Vertex multimodal embedding API supports WebP.

The use case in the linked issue - pre-processing media into WebP and then sending it to a multimodal model through Spring AI - therefore fails on the Spring AI side, not at the provider.

### Changes

* `MimeTypeDetector`: register `webp` ? `image/webp` and add `image/webp` to the supported-types list in the class javadoc.
* `MimeTypeDetectorTests`: include `WEBP` in the uppercase-extension parameter set and `test.webp` in the cross-method consistency parameter set. The existing parameterized tests sourced from `GEMINI_MIME_TYPES` (URL, URI, `File`, `Path`, `Resource`, `String`) automatically cover the new mapping.
* `VertexAiMultimodalEmbeddingModel`: add `image/webp` to `SUPPORTED_IMAGE_MIME_SUB_TYPES`.

No public API was added or changed; existing supported MIME types still behave exactly as before.

### Testing

`./mvnw -pl models/spring-ai-google-genai -am test` - parameterized `MimeTypeDetectorTests` exercise URL/URI/File/Path/Resource/String detection for the new `webp` mapping. Integration tests against live Gemini/Vertex were not run.

Fixes #6474