### PR TITLE
Add ToolChoice support for Google GenAI chat model

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatProperties.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions.ToolChoice;
 import org.springframework.ai.google.genai.common.GoogleGenAiSafetySetting;
 import org.springframework.ai.google.genai.common.GoogleGenAiServiceTier;
 import org.springframework.ai.google.genai.common.GoogleGenAiThinkingLevel;
@@ -49,6 +50,8 @@ public class GoogleGenAiChatProperties {
 	private @Nullable Double topP;
 
 	private @Nullable Integer topK;
+
+	private @Nullable ToolChoice toolChoice;
 
 	private @Nullable Integer candidateCount;
 
@@ -116,6 +119,14 @@ public class GoogleGenAiChatProperties {
 
 	public @Nullable Integer getTopK() {
 		return this.topK;
+	}
+
+	public @Nullable ToolChoice getToolChoice() {
+		return this.toolChoice;
+	}
+
+	public void setToolChoice(@Nullable ToolChoice toolChoice) {
+		this.toolChoice = toolChoice;
 	}
 
 	public void setTopK(@Nullable Integer topK) {
@@ -295,6 +306,7 @@ public class GoogleGenAiChatProperties {
 			.temperature(this.temperature)
 			.topP(this.topP)
 			.topK(this.topK)
+			.toolChoice(this.toolChoice)
 			.candidateCount(this.candidateCount)
 			.maxOutputTokens(this.maxOutputTokens)
 			.responseMimeType(this.responseMimeType)

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiPropertiesTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.model.google.genai.autoconfigure.chat;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions.ToolChoice;
 import org.springframework.ai.model.google.genai.autoconfigure.embedding.GoogleGenAiEmbeddingConnectionProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -146,6 +147,39 @@ public class GoogleGenAiPropertiesTests {
 			GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
 			// Should be null when not set
 			assertThat(chatProperties.toOptions().getIncludeThoughts()).isNull();
+		});
+	}
+
+	@Test
+	void toolChoiceModeOnlyBinding() {
+		this.contextRunner.withPropertyValues("spring.ai.google.genai.chat.tool-choice.mode=ANY").run(context -> {
+			GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
+			ToolChoice toolChoice = chatProperties.toOptions().getToolChoice();
+			assertThat(toolChoice).isNotNull();
+			assertThat(toolChoice.mode()).isEqualTo(ToolChoice.Mode.ANY);
+			assertThat(toolChoice.allowedFunctionNames()).isNull();
+		});
+	}
+
+	@Test
+	void toolChoiceWithAllowedFunctionNamesBinding() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.google.genai.chat.tool-choice.mode=ANY",
+					"spring.ai.google.genai.chat.tool-choice.allowed-function-names=funcA,funcB")
+			.run(context -> {
+				GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
+				ToolChoice toolChoice = chatProperties.toOptions().getToolChoice();
+				assertThat(toolChoice).isNotNull();
+				assertThat(toolChoice.mode()).isEqualTo(ToolChoice.Mode.ANY);
+				assertThat(toolChoice.allowedFunctionNames()).containsExactly("funcA", "funcB");
+			});
+	}
+
+	@Test
+	void toolChoiceNotSetByDefault() {
+		this.contextRunner.run(context -> {
+			GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
+			assertThat(chatProperties.toOptions().getToolChoice()).isNull();
 		});
 	}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatPropertiesTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -122,6 +124,21 @@ public class OpenAiChatPropertiesTests {
 
 				assertThat(options.getPromptCacheKey()).isEqualTo("test-cache-key");
 			});
+	}
+
+	@Test
+	public void chatToolChoiceStringValuesTest() {
+
+		for (String toolChoice : List.of("none", "auto", "required")) {
+			this.contextRunner.withPropertyValues("spring.ai.openai.api-key=API_KEY",
+					"spring.ai.openai.base-url=http://TEST.BASE.URL", "spring.ai.openai.chat.tool-choice=" + toolChoice)
+				.withConfiguration(
+						AutoConfigurations.of(OpenAiChatAutoConfiguration.class, ToolCallingAutoConfiguration.class))
+				.run(context -> {
+					var chatProperties = context.getBean(OpenAiChatProperties.class);
+					assertThat(chatProperties.toOptions().getToolChoice()).isEqualTo(toolChoice);
+				});
+		}
 	}
 
 }

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -32,6 +32,8 @@ import com.google.genai.types.Candidate;
 import com.google.genai.types.Content;
 import com.google.genai.types.FinishReason;
 import com.google.genai.types.FunctionCall;
+import com.google.genai.types.FunctionCallingConfig;
+import com.google.genai.types.FunctionCallingConfigMode;
 import com.google.genai.types.FunctionDeclaration;
 import com.google.genai.types.FunctionResponse;
 import com.google.genai.types.GenerateContentConfig;
@@ -44,6 +46,7 @@ import com.google.genai.types.Schema;
 import com.google.genai.types.ThinkingConfig;
 import com.google.genai.types.ThinkingLevel;
 import com.google.genai.types.Tool;
+import com.google.genai.types.ToolConfig;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -751,10 +754,29 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			configBuilder.tools(tools);
 		}
 
-		// Build ToolConfig if includeServerSideToolInvocations is enabled
-		if (Boolean.TRUE.equals(requestOptions.getIncludeServerSideToolInvocations())) {
-			configBuilder
-				.toolConfig(com.google.genai.types.ToolConfig.builder().includeServerSideToolInvocations(true));
+		if (requestOptions.getToolChoice() != null
+				|| Boolean.TRUE.equals(requestOptions.getIncludeServerSideToolInvocations())) {
+
+			ToolConfig.Builder toolConfigBuilder = ToolConfig.builder();
+
+			// Build ToolConfig if includeServerSideToolInvocations is enabled
+			if (Boolean.TRUE.equals(requestOptions.getIncludeServerSideToolInvocations())) {
+				toolConfigBuilder.includeServerSideToolInvocations(true);
+			}
+
+			if (requestOptions.getToolChoice() != null) {
+				var fccBuilder = FunctionCallingConfig.builder()
+					.mode(mapToFunctionCallingConfigMode(requestOptions.getToolChoice().mode()));
+
+				if (requestOptions.getToolChoice().mode() == GoogleGenAiChatOptions.ToolChoice.Mode.ANY
+						&& !CollectionUtils.isEmpty(requestOptions.getToolChoice().allowedFunctionNames())) {
+					fccBuilder.allowedFunctionNames(requestOptions.getToolChoice().allowedFunctionNames());
+				}
+
+				toolConfigBuilder.functionCallingConfig(fccBuilder.build());
+			}
+
+			configBuilder.toolConfig(toolConfigBuilder.build());
 		}
 
 		// Handle cached content
@@ -828,6 +850,16 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			case LOW -> new ThinkingLevel(ThinkingLevel.Known.LOW);
 			case MEDIUM -> new ThinkingLevel(ThinkingLevel.Known.MEDIUM);
 			case HIGH -> new ThinkingLevel(ThinkingLevel.Known.HIGH);
+		};
+	}
+
+	private static FunctionCallingConfigMode mapToFunctionCallingConfigMode(
+			GoogleGenAiChatOptions.ToolChoice.Mode mode) {
+		return switch (mode) {
+			case AUTO -> new FunctionCallingConfigMode(FunctionCallingConfigMode.Known.AUTO);
+			case ANY -> new FunctionCallingConfigMode(FunctionCallingConfigMode.Known.ANY);
+			case VALIDATED -> new FunctionCallingConfigMode(FunctionCallingConfigMode.Known.VALIDATED);
+			case NONE -> new FunctionCallingConfigMode(FunctionCallingConfigMode.Known.NONE);
 		};
 	}
 

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
@@ -34,6 +34,7 @@ import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
 import org.springframework.ai.model.tool.StructuredOutputChatOptions;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.util.Assert;
 
 /**
  * Options for the Google GenAI Chat API.
@@ -72,6 +73,11 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	 * Optional. If specified, top k sampling will be used.
 	 */
 	private final @Nullable Integer topK;
+
+	/**
+	 * Optional. The tool choice for the model to use for tool calling.
+	 */
+	private final @Nullable ToolChoice toolChoice;
 
 	/**
 	 * Optional. The maximum number of tokens to generate.
@@ -203,12 +209,12 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	protected GoogleGenAiChatOptions(@Nullable String model, @Nullable Double frequencyPenalty,
 			@Nullable Integer maxOutputTokens, @Nullable Double presencePenalty, @Nullable List<String> stopSequences,
 			@Nullable Double temperature, @Nullable Integer topK, @Nullable Double topP,
-			@Nullable List<ToolCallback> toolCallbacks, @Nullable Map<String, Object> toolContext,
-			@Nullable Integer candidateCount, @Nullable String responseMimeType, @Nullable String responseSchema,
-			@Nullable Integer thinkingBudget, @Nullable Boolean includeThoughts,
-			@Nullable GoogleGenAiThinkingLevel thinkingLevel, @Nullable Boolean includeExtendedUsageMetadata,
-			@Nullable String cachedContentName, @Nullable Boolean useCachedContent,
-			@Nullable Integer autoCacheThreshold, @Nullable Duration autoCacheTtl,
+			@Nullable ToolChoice toolChoice, @Nullable List<ToolCallback> toolCallbacks,
+			@Nullable Map<String, Object> toolContext, @Nullable Integer candidateCount,
+			@Nullable String responseMimeType, @Nullable String responseSchema, @Nullable Integer thinkingBudget,
+			@Nullable Boolean includeThoughts, @Nullable GoogleGenAiThinkingLevel thinkingLevel,
+			@Nullable Boolean includeExtendedUsageMetadata, @Nullable String cachedContentName,
+			@Nullable Boolean useCachedContent, @Nullable Integer autoCacheThreshold, @Nullable Duration autoCacheTtl,
 			@Nullable Boolean googleSearchRetrieval, @Nullable Boolean includeServerSideToolInvocations,
 			@Nullable List<GoogleGenAiSafetySetting> safetySettings, @Nullable Map<String, String> labels,
 			@Nullable GoogleGenAiServiceTier serviceTier) {
@@ -220,6 +226,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		this.temperature = temperature != null ? temperature : 0.7;
 		this.topK = topK;
 		this.topP = topP != null ? topP : 1.0;
+		this.toolChoice = toolChoice;
 		this.toolCallbacks = (toolCallbacks != null ? List.copyOf(toolCallbacks) : null);
 		this.toolContext = (toolContext != null ? Map.copyOf(toolContext) : null);
 		this.candidateCount = candidateCount;
@@ -262,6 +269,15 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	@Override
 	public @Nullable Integer getTopK() {
 		return this.topK;
+	}
+
+	/**
+	 * Returns the tool choice configuration.
+	 * @return the tool choice, or {@code null} if not set
+	 * @since 2.0.1
+	 */
+	public @Nullable ToolChoice getToolChoice() {
+		return this.toolChoice;
 	}
 
 	public @Nullable Integer getCandidateCount() {
@@ -382,7 +398,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 				&& Objects.equals(this.includeServerSideToolInvocations, that.includeServerSideToolInvocations)
 				&& Objects.equals(this.stopSequences, that.stopSequences)
 				&& Objects.equals(this.temperature, that.temperature) && Objects.equals(this.topP, that.topP)
-				&& Objects.equals(this.topK, that.topK) && Objects.equals(this.candidateCount, that.candidateCount)
+				&& Objects.equals(this.toolChoice, that.toolChoice) && Objects.equals(this.topK, that.topK)
+				&& Objects.equals(this.candidateCount, that.candidateCount)
 				&& Objects.equals(this.frequencyPenalty, that.frequencyPenalty)
 				&& Objects.equals(this.presencePenalty, that.presencePenalty)
 				&& Objects.equals(this.thinkingBudget, that.thinkingBudget)
@@ -399,11 +416,12 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.stopSequences, this.temperature, this.topP, this.topK, this.candidateCount,
-				this.frequencyPenalty, this.presencePenalty, this.thinkingBudget, this.includeThoughts,
-				this.thinkingLevel, this.maxOutputTokens, this.model, this.responseMimeType, this.responseSchema,
-				this.toolCallbacks, this.googleSearchRetrieval, this.includeServerSideToolInvocations,
-				this.safetySettings, this.toolContext, this.labels, this.serviceTier);
+		return Objects.hash(this.stopSequences, this.temperature, this.topP, this.topK, this.toolChoice,
+				this.candidateCount, this.frequencyPenalty, this.presencePenalty, this.thinkingBudget,
+				this.includeThoughts, this.thinkingLevel, this.maxOutputTokens, this.model, this.responseMimeType,
+				this.responseSchema, this.toolCallbacks, this.googleSearchRetrieval,
+				this.includeServerSideToolInvocations, this.safetySettings, this.toolContext, this.labels,
+				this.serviceTier);
 	}
 
 	@Override
@@ -418,6 +436,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 			.temperature(this.temperature)
 			.topK(this.topK)
 			.topP(this.topP)
+			.toolChoice(this.toolChoice)
 			// ToolCallingChatOptions
 			.toolCallbacks(this.getToolCallbacks())
 			.toolContext(this.getToolContext())
@@ -459,6 +478,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 			return copy;
 		}
 
+		protected @Nullable ToolChoice toolChoice;
+
 		protected @Nullable Integer candidateCount;
 
 		protected @Nullable String responseMimeType;
@@ -490,6 +511,14 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		protected @Nullable Map<String, String> labels;
 
 		protected @Nullable GoogleGenAiServiceTier serviceTier;
+
+		/**
+		 * @since 2.0.1
+		 */
+		public B toolChoice(@Nullable ToolChoice toolChoice) {
+			this.toolChoice = toolChoice;
+			return self();
+		}
 
 		public B candidateCount(@Nullable Integer candidateCount) {
 			this.candidateCount = candidateCount;
@@ -663,6 +692,9 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 				if (that.serviceTier != null) {
 					this.serviceTier = that.serviceTier;
 				}
+				if (that.toolChoice != null) {
+					this.toolChoice = that.toolChoice;
+				}
 			}
 			return self();
 		}
@@ -670,13 +702,85 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		@Override
 		public GoogleGenAiChatOptions build() {
 			return new GoogleGenAiChatOptions(this.model, this.frequencyPenalty, this.maxTokens, this.presencePenalty,
-					this.stopSequences, this.temperature, this.topK, this.topP, this.toolCallbacks, this.toolContext,
-					this.candidateCount, this.responseMimeType, this.responseSchema, this.thinkingBudget,
-					this.includeThoughts, this.thinkingLevel, this.includeExtendedUsageMetadata, this.cachedContentName,
-					this.useCachedContent, this.autoCacheThreshold, this.autoCacheTtl, this.googleSearchRetrieval,
-					this.includeServerSideToolInvocations, this.safetySettings, this.labels, this.serviceTier);
+					this.stopSequences, this.temperature, this.topK, this.topP, this.toolChoice, this.toolCallbacks,
+					this.toolContext, this.candidateCount, this.responseMimeType, this.responseSchema,
+					this.thinkingBudget, this.includeThoughts, this.thinkingLevel, this.includeExtendedUsageMetadata,
+					this.cachedContentName, this.useCachedContent, this.autoCacheThreshold, this.autoCacheTtl,
+					this.googleSearchRetrieval, this.includeServerSideToolInvocations, this.safetySettings, this.labels,
+					this.serviceTier);
 		}
 
+	}
+
+	/**
+	 * Configures function calling behavior when tools are provided.
+	 *
+	 * @since 2.0.1
+	 */
+	public static record ToolChoice(Mode mode, @Nullable List<String> allowedFunctionNames) {
+
+		public ToolChoice {
+			Assert.notNull(mode, "mode must not be null");
+		}
+
+		/**
+		 * Controls how the model selects functions to call.
+		 *
+		 * @since 2.0.1
+		 */
+		public enum Mode {
+
+			/**
+			 * Model decides whether to call a function or return a natural language
+			 * response.
+			 */
+			AUTO,
+
+			/**
+			 * Model is constrained to always predict a function call. If
+			 * {@code allowedFunctionNames} is set, the call is limited to those
+			 * functions.
+			 */
+			ANY,
+
+			/**
+			 * Model predicts either a function call or a natural language response. If
+			 * {@code allowedFunctionNames} is set, the call is limited to those
+			 * functions.
+			 */
+			VALIDATED,
+
+			/** Model will not call any functions. */
+			NONE
+
+		}
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		public static class Builder {
+
+			private Mode mode = Mode.AUTO;
+
+			private @Nullable List<String> allowedFunctionNames;
+
+			public Builder mode(Mode mode) {
+				Assert.notNull(mode, "Mode must not be null");
+				this.mode = mode;
+				return this;
+			}
+
+			public Builder allowedFunctionNames(List<String> allowedFunctionNames) {
+				this.allowedFunctionNames = allowedFunctionNames;
+				return this;
+			}
+
+			public ToolChoice build() {
+				return new ToolChoice(this.mode, this.allowedFunctionNames);
+			}
+
+		}
 	}
 
 }

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.google.genai.Client;
 import com.google.genai.types.Content;
+import com.google.genai.types.FunctionCallingConfigMode;
 import com.google.genai.types.Part;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -582,6 +583,116 @@ public class CreateGeminiRequestTests {
 
 		// Default is false, so no ToolConfig should be set
 		assertThat(request.config().toolConfig()).isNotPresent();
+	}
+
+	@Test
+	public void createRequestWithToolChoiceAuto() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.toolChoice(GoogleGenAiChatOptions.ToolChoice.builder()
+						.mode(GoogleGenAiChatOptions.ToolChoice.Mode.AUTO)
+						.build())
+					.build()));
+
+		assertThat(request.config().toolConfig()).isPresent();
+		assertThat(request.config().toolConfig().get().functionCallingConfig()).isPresent();
+		var fcc = request.config().toolConfig().get().functionCallingConfig().get();
+		assertThat(fcc.mode()).isPresent();
+		assertThat(fcc.mode().get().knownEnum()).isEqualTo(FunctionCallingConfigMode.Known.AUTO);
+		assertThat(fcc.allowedFunctionNames()).isNotPresent();
+	}
+
+	@Test
+	public void createRequestWithToolChoiceNone() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.toolChoice(GoogleGenAiChatOptions.ToolChoice.builder()
+						.mode(GoogleGenAiChatOptions.ToolChoice.Mode.NONE)
+						.build())
+					.build()));
+
+		assertThat(request.config().toolConfig()).isPresent();
+		assertThat(request.config().toolConfig().get().functionCallingConfig()).isPresent();
+		var fcc = request.config().toolConfig().get().functionCallingConfig().get();
+		assertThat(fcc.mode()).isPresent();
+		assertThat(fcc.mode().get().knownEnum()).isEqualTo(FunctionCallingConfigMode.Known.NONE);
+		assertThat(fcc.allowedFunctionNames()).isNotPresent();
+	}
+
+	@Test
+	public void createRequestWithToolChoiceAnyAndAllowedFunctionNames() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.toolChoice(GoogleGenAiChatOptions.ToolChoice.builder()
+						.mode(GoogleGenAiChatOptions.ToolChoice.Mode.ANY)
+						.allowedFunctionNames(List.of("funcA", "funcB"))
+						.build())
+					.build()));
+
+		assertThat(request.config().toolConfig()).isPresent();
+		var fcc = request.config().toolConfig().get().functionCallingConfig().get();
+		assertThat(fcc.mode().get().knownEnum()).isEqualTo(FunctionCallingConfigMode.Known.ANY);
+		assertThat(fcc.allowedFunctionNames()).isPresent();
+		assertThat(fcc.allowedFunctionNames().get()).containsExactly("funcA", "funcB");
+	}
+
+	@Test
+	public void createRequestWithToolChoiceAnyIgnoresAllowedFunctionNamesForNonAnyMode() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.toolChoice(GoogleGenAiChatOptions.ToolChoice.builder()
+						.mode(GoogleGenAiChatOptions.ToolChoice.Mode.AUTO)
+						.allowedFunctionNames(List.of("funcA"))
+						.build())
+					.build()));
+
+		var fcc = request.config().toolConfig().get().functionCallingConfig().get();
+		assertThat(fcc.mode().get().knownEnum()).isEqualTo(FunctionCallingConfigMode.Known.AUTO);
+		assertThat(fcc.allowedFunctionNames()).isNotPresent();
+	}
+
+	@Test
+	public void createRequestWithToolChoiceCombinedWithServerSideToolInvocations() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.options(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.includeServerSideToolInvocations(true)
+					.toolChoice(GoogleGenAiChatOptions.ToolChoice.builder()
+						.mode(GoogleGenAiChatOptions.ToolChoice.Mode.ANY)
+						.build())
+					.build()));
+
+		assertThat(request.config().toolConfig()).isPresent();
+		var toolConfig = request.config().toolConfig().get();
+		assertThat(toolConfig.includeServerSideToolInvocations()).isPresent();
+		assertThat(toolConfig.includeServerSideToolInvocations().get()).isTrue();
+		assertThat(toolConfig.functionCallingConfig()).isPresent();
+		assertThat(toolConfig.functionCallingConfig().get().mode().get().knownEnum())
+			.isEqualTo(FunctionCallingConfigMode.Known.ANY);
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
@@ -127,6 +127,8 @@ The prefix `spring.ai.google.genai.chat` is the property prefix that lets you co
 | spring.ai.google.genai.chat.auto-cache-ttl | Time-to-live (Duration) for auto-cached content in ISO-8601 format (e.g., `PT1H` for 1 hour). Used when auto-caching is enabled. | PT1H
 | spring.ai.google.genai.chat.enable-cached-content | Enable the `GoogleGenAiCachedContentService` bean for managing cached content. | true
 | spring.ai.google.genai.chat.service-tier | The service tier to use for the request. Valid values: `STANDARD`, `PRIORITY`, `FLEX`. | -
+| spring.ai.google.genai.chat.tool-choice.mode | Controls how the model selects functions when tools are provided. Valid values: `AUTO` (model decides), `ANY` (always calls a function), `VALIDATED` (function call or natural language), `NONE` (no function calls). See <<tool-choice>>. | -
+| spring.ai.google.genai.chat.tool-choice.allowed-function-names | Comma-separated list of function names the model may call. Only applied when `tool-choice.mode=ANY`; ignored for other modes. | -
 
 |====
 
@@ -161,6 +163,77 @@ TIP: In addition to the model specific `GoogleGenAiChatOptions` you can use a po
 For most applications, use `ChatClient` with the auto-registered `ToolCallingAdvisor` — see xref:api/tools.adoc[Tool Calling]. For low-level control where you drive the loop yourself, see xref:api/tools/chatmodel-tool-calling.adoc[ChatModel Tool Calling].
 
 See xref:#server-side-tool-invocations[Server-Side Tool Invocations] below for Google's built-in tools (Search, Maps, URL Context) and how to combine them with client-side function calling.
+
+=== Tool Choice [[tool-choice]]
+
+`GoogleGenAiChatOptions.ToolChoice` configures how the model selects functions when tools are provided.
+It maps to Google GenAI's https://ai.google.dev/api/generate-content#v1beta.FunctionCallingConfig[FunctionCallingConfig].
+
+[cols="1,3", stripes=even]
+|====
+| Mode | Behavior
+
+| `AUTO` | The model decides whether to call a function or return a natural language response (default behavior).
+| `ANY` | The model always predicts a function call.
+When `allowedFunctionNames` is set, calls are limited to those functions.
+| `VALIDATED` | The model may call a function or return a natural language response.
+When `allowedFunctionNames` is set, calls are limited to those functions.
+| `NONE` | The model does not call any functions and returns a natural language response.
+|====
+
+NOTE: `allowedFunctionNames` is only applied when mode is `ANY` and is silently ignored for all other modes.
+
+==== Programmatic Configuration
+
+[source,java]
+----
+ChatResponse response = chatModel.call(
+    new Prompt(
+        "What is the weather in Paris?",
+        GoogleGenAiChatOptions.builder()
+            .toolChoice(new GoogleGenAiChatOptions.ToolChoice(
+                GoogleGenAiChatOptions.ToolChoice.Mode.ANY,
+                List.of("get_weather")))
+            .build()
+    ));
+----
+
+To apply a mode without restricting to specific functions:
+
+[source,java]
+----
+GoogleGenAiChatOptions.builder()
+    .toolChoice(new GoogleGenAiChatOptions.ToolChoice(
+        GoogleGenAiChatOptions.ToolChoice.Mode.NONE, null))
+    .build();
+----
+
+==== Property-Based Configuration
+
+[source,application.properties]
+----
+# Force the model to always call a function
+spring.ai.google.genai.chat.tool-choice.mode=ANY
+
+# Optionally restrict to specific functions (only applies when mode=ANY)
+spring.ai.google.genai.chat.tool-choice.allowed-function-names=get_weather,get_forecast
+----
+
+Or in YAML:
+
+[source,yaml]
+----
+spring:
+  ai:
+    google:
+      genai:
+        chat:
+          tool-choice:
+            mode: ANY
+            allowed-function-names:
+              - get_weather
+              - get_forecast
+----
 
 == Server-Side Tool Invocations [[server-side-tool-invocations]]
 


### PR DESCRIPTION
- Add GoogleGenAiChatOptions.ToolChoice with Mode enum (AUTO, ANY, VALIDATED, NONE) to control function calling behavior.
- Wire it through GoogleGenAiChatProperties for property-based configuration and map it to the SDK's FunctionCallingConfig in GoogleGenAiChatModel.
- Restrict allowedFunctionNames forwarding to ANY mode only.
- Add tests and update the Google GenAI reference documentation.

Fixes #6523
