### PR TITLE
Fix MCP stdio connections without args

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpStdioClientProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpStdioClientProperties.java
@@ -89,7 +89,7 @@ public class McpStdioClientProperties {
 			return mcpServerJsonConfig.entrySet().stream().collect(Collectors.toMap(kv -> kv.getKey(), kv -> {
 				Parameters parameters = kv.getValue();
 				return ServerParameters.builder(parameters.command())
-					.args(parameters.args())
+					.args(parameters.argsOrEmpty())
 					.env(parameters.env())
 					.build();
 			}));
@@ -130,7 +130,11 @@ public class McpStdioClientProperties {
 			@JsonProperty("env") @Nullable Map<String, String> env) {
 
 		public ServerParameters toServerParameters() {
-			return ServerParameters.builder(this.command()).args(this.args()).env(this.env()).build();
+			return ServerParameters.builder(this.command()).args(this.argsOrEmpty()).env(this.env()).build();
+		}
+
+		private List<String> argsOrEmpty() {
+			return this.args() != null ? this.args() : Collections.emptyList();
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpStdioClientPropertiesTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpStdioClientPropertiesTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure.properties;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link McpStdioClientProperties}.
+ */
+class McpStdioClientPropertiesTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(TestConfiguration.class);
+
+	@Test
+	void stdioConnectionWithoutArgsUsesNoArguments() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.client.stdio.connections.server1.command=echo")
+			.run(context -> {
+				McpStdioClientProperties properties = context.getBean(McpStdioClientProperties.class);
+
+				assertThatCode(properties::toServerParameters).doesNotThrowAnyException();
+				assertThat(properties.toServerParameters()).containsKey("server1");
+			});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableConfigurationProperties(McpStdioClientProperties.class)
+	static class TestConfiguration {
+
+	}
+
+}


### PR DESCRIPTION
Closes gh-6532.

When an MCP stdio connection is configured with only a command, Spring Boot binds the missing `args` property as `null`. The conversion to MCP `ServerParameters` then passes that `null` into `ServerParameters.Builder.args(...)`, which rejects it with `IllegalArgumentException: The args can not be null`.

This treats omitted args the same as an empty argument list when building stdio server parameters, while preserving explicitly configured args.

Verification:

- `JAVA_HOME=/Users/hutiefang/Library/Java/JavaVirtualMachines/ms-21.0.10/Contents/Home ./mvnw -pl auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common -Dtest=McpStdioClientPropertiesTests test`
- `JAVA_HOME=/Users/hutiefang/Library/Java/JavaVirtualMachines/ms-21.0.10/Contents/Home ./mvnw -pl auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common -Dmaven.build.cache.enabled=false test`
