### PR TITLE
Align @McpTool exception handling with @Tool contract

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp;
 import java.util.Map;
 
 import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -124,17 +125,22 @@ public class AsyncMcpToolCallback implements ToolCallback {
 		try {
 			var mcpMeta = toolContext != null ? this.toolContextToMcpMetaConverter.convert(toolContext) : null;
 
-			var request = CallToolRequest.builder()
-				// Use the original tool name, not the prefixed one from getToolDefinition
-				.name(this.tool.name())
-				.arguments(arguments)
-				.meta(mcpMeta)
-				.build();
+			// Use the original tool name, not the prefixed one from getToolDefinition
+			var request = CallToolRequest.builder(this.tool.name()).arguments(arguments).meta(mcpMeta).build();
 
-			response = this.mcpClient.callTool(request).onErrorMap(exception -> {
-				logger.error("Exception while tool calling: ", exception);
-				return new ToolExecutionException(this.getToolDefinition(), exception);
+			// Only map non-McpError exceptions to ToolExecutionException. McpError is a
+			// protocol-level signal (e.g. URL elicitation) that must propagate as a hard
+			// failure rather than being conveyed to the model as an error result.
+			response = this.mcpClient.callTool(request).onErrorMap(e -> !(e instanceof McpError), e -> {
+				logger.error("Exception while tool calling: ", e);
+				return new ToolExecutionException(this.getToolDefinition(), e);
 			}).contextWrite(ctx -> ctx.putAll(ToolCallReactiveContextHolder.getContext())).block();
+		}
+		catch (McpError ex) {
+			logger.error("Protocol error while calling tool: ", ex);
+			// Since the tool calling manager only handles ToolExecutionException, this
+			// bubbles up and fails the model interaction.
+			throw ex;
 		}
 		catch (Exception ex) {
 			logger.error("Exception while tool calling: ", ex);

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp;
 import java.util.Map;
 
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -125,16 +126,21 @@ public class SyncMcpToolCallback implements ToolCallback {
 		try {
 			var mcpMeta = toolContext != null ? this.toolContextToMcpMetaConverter.convert(toolContext) : null;
 
-			var request = CallToolRequest.builder()
-				// Use the original tool name, not the prefixed one from getToolDefinition
-				.name(this.tool.name())
-				.arguments(arguments)
-				.meta(mcpMeta)
-				.build();
+			// Use the original tool name, not the prefixed one from getToolDefinition
+			var request = CallToolRequest.builder(this.tool.name()).arguments(arguments).meta(mcpMeta).build();
 
 			// Note that we use the original tool name here, not the adapted one from
 			// getToolDefinition
 			response = this.mcpClient.callTool(request);
+		}
+		catch (McpError ex) {
+			// A protocol-level error indicates the tool invocation itself failed and
+			// must not be conveyed to the model. Rethrow it as a hard failure, mirroring
+			// how @Tool treats checked exceptions and Errors. Since the tool calling
+			// manager only handles ToolExecutionException, this bubbles up and fails the
+			// model interaction.
+			logger.error("Protocol error while calling tool: ", ex);
+			throw ex;
 		}
 		catch (Exception ex) {
 			logger.error("Exception while tool calling: ", ex);

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp;
 import java.util.Map;
 
 import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.Implementation;
 import org.junit.jupiter.api.Test;
@@ -79,6 +80,23 @@ class AsyncMcpToolCallbackTest {
 		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isInstanceOf(ToolExecutionException.class)
 			.rootCause()
 			.hasMessage("Testing tool error");
+	}
+
+	@Test
+	void callShouldPropagateMcpErrorAsHardFailure() {
+		when(this.tool.name()).thenReturn("testTool");
+		McpError mcpError = McpError.builder(-32603).message("Protocol failure").build();
+		when(this.mcpClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(Mono.error(mcpError));
+
+		var callback = AsyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName(this.tool.name())
+			.build();
+
+		// A protocol-level McpError must bubble up as-is rather than being wrapped in a
+		// ToolExecutionException and conveyed to the model.
+		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isSameAs(mcpError);
 	}
 
 	@Test

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -180,6 +181,25 @@ class SyncMcpToolCallbackTests {
 		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isInstanceOf(ToolExecutionException.class)
 			.rootCause()
 			.hasMessage("Testing tool error");
+	}
+
+	@Test
+	void callShouldPropagateMcpErrorAsHardFailure() {
+		when(this.tool.name()).thenReturn("testTool");
+		var clientInfo = Implementation.builder("testClient", "1.0.0").title("server1").build();
+		McpError mcpError = McpError.builder(-32603).message("Protocol failure").build();
+		when(this.mcpClient.callTool(any(CallToolRequest.class))).thenThrow(mcpError);
+
+		SyncMcpToolCallback callback = SyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName(McpToolUtils.prefixedToolName(clientInfo.name(), clientInfo.title(), this.tool.name()))
+			.toolContextToMcpMetaConverter(ToolContextToMcpMetaConverter.defaultConverter())
+			.build();
+
+		// A protocol-level McpError must bubble up as-is rather than being wrapped in a
+		// ToolExecutionException and conveyed to the model.
+		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isSameAs(mcpError);
 	}
 
 	@Test

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -85,13 +85,14 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 
 			// Check if the Mono contains CallToolResult
 			if (ReactiveUtils.isReactiveReturnTypeOfCallToolResult(this.toolMethod)) {
-				return (Mono<CallToolResult>) monoResult;
+				return ((Mono<CallToolResult>) monoResult).onErrorResume(this::toErrorResultOrPropagate);
 			}
 
 			// Handle Mono<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return monoResult
-					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()));
+					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
+					.onErrorResume(this::toErrorResultOrPropagate);
 			}
 
 			// Handle other Mono types - map the emitted value to CallToolResult
@@ -104,13 +105,14 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 
 			// Check if the Flux contains CallToolResult
 			if (ReactiveUtils.isReactiveReturnTypeOfCallToolResult(this.toolMethod)) {
-				return ((Flux<CallToolResult>) fluxResult).next();
+				return ((Flux<CallToolResult>) fluxResult).next().onErrorResume(this::toErrorResultOrPropagate);
 			}
 
 			// Handle Mono<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return fluxResult
-					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()));
+					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
+					.onErrorResume(this::toErrorResultOrPropagate);
 			}
 
 			// Handle other Flux types by taking the first element and mapping
@@ -124,13 +126,14 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 
 			// Check if the Publisher contains CallToolResult
 			if (ReactiveUtils.isReactiveReturnTypeOfCallToolResult(this.toolMethod)) {
-				return (Mono<CallToolResult>) monoFromPublisher;
+				return ((Mono<CallToolResult>) monoFromPublisher).onErrorResume(this::toErrorResultOrPropagate);
 			}
 
 			// Handle Mono<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return monoFromPublisher
-					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()));
+					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
+					.onErrorResume(this::toErrorResultOrPropagate);
 			}
 
 			// Handle other Publisher types by mapping the emitted value

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.mcp.annotation.method.tool;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.UndeclaredThrowableException;
 
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.reactivestreams.Publisher;
@@ -45,8 +47,25 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 
 	private static final JsonHelper jsonHelper = new JsonHelper();
 
-	protected final Class<? extends Throwable> toolCallExceptionClass;
+	/**
+	 * @deprecated no longer consulted. Exception handling now follows the {@code @Tool}
+	 * contract based on the exception type. Retained for backward compatibility. Will be
+	 * removed in 2.1.0.
+	 */
+	@Deprecated
+	protected Class<? extends Throwable> toolCallExceptionClass = Exception.class;
 
+	protected AbstractAsyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject) {
+		super(returnMode, toolMethod, toolObject);
+	}
+
+	/**
+	 * @deprecated use
+	 * {@link #AbstractAsyncMcpToolMethodCallback(ReturnMode, Method, Object)}. The
+	 * {@code toolCallExceptionClass} argument is ignored: exception handling now follows
+	 * the {@code @Tool} contract based on the exception type. Will be removed in 2.1.0.
+	 */
+	@Deprecated
 	protected AbstractAsyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject,
 			Class<? extends Throwable> toolCallExceptionClass) {
 		super(returnMode, toolMethod, toolObject);
@@ -76,11 +95,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			}
 
 			// Handle other Mono types - map the emitted value to CallToolResult
-			return monoResult.map(this::mapValueToCallToolResult)
-				.onErrorResume(e -> Mono.just(CallToolResult.builder()
-					.isError(true)
-					.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
-					.build()));
+			return monoResult.map(this::mapValueToCallToolResult).onErrorResume(this::toErrorResultOrPropagate);
 		}
 
 		// Handle Flux by taking the first element
@@ -99,12 +114,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			}
 
 			// Handle other Flux types by taking the first element and mapping
-			return fluxResult.next()
-				.map(this::mapValueToCallToolResult)
-				.onErrorResume(e -> Mono.just(CallToolResult.builder()
-					.isError(true)
-					.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
-					.build()));
+			return fluxResult.next().map(this::mapValueToCallToolResult).onErrorResume(this::toErrorResultOrPropagate);
 		}
 
 		// Handle other Publisher types
@@ -124,11 +134,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			}
 
 			// Handle other Publisher types by mapping the emitted value
-			return monoFromPublisher.map(this::mapValueToCallToolResult)
-				.onErrorResume(e -> Mono.just(CallToolResult.builder()
-					.isError(true)
-					.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
-					.build()));
+			return monoFromPublisher.map(this::mapValueToCallToolResult).onErrorResume(this::toErrorResultOrPropagate);
 		}
 
 		// This should not happen in async context, but handle as fallback
@@ -144,6 +150,26 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 	 */
 	protected CallToolResult mapValueToCallToolResult(Object value) {
 		return convertValueToCallToolResult(value);
+	}
+
+	/**
+	 * Resolves a reactive error either into an error {@link CallToolResult} conveyed to
+	 * the model, or into a propagated error that fails the model interaction. Mirrors the
+	 * {@code @Tool} contract: ordinary {@link RuntimeException}s are conveyed to the
+	 * model, while declared checked exceptions (carried as
+	 * {@link UndeclaredThrowableException}), {@link Error}s and protocol-level
+	 * {@link McpError}s bubble up as hard failures.
+	 * @param e the reactive error
+	 * @return an error result or a propagated error
+	 */
+	private Mono<CallToolResult> toErrorResultOrPropagate(Throwable e) {
+		if (e instanceof RuntimeException && !(e instanceof UndeclaredThrowableException) && !(e instanceof McpError)) {
+			return Mono.just(CallToolResult.builder()
+				.isError(true)
+				.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
+				.build());
+		}
+		return Mono.error(e);
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp.annotation.method.tool;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -72,18 +73,22 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 	 */
 	protected Object callMethod(Object[] methodArguments) {
 		this.toolMethod.setAccessible(true);
-
-		Object result;
 		try {
-			result = this.toolMethod.invoke(this.toolObject, methodArguments);
+			return this.toolMethod.invoke(this.toolObject, methodArguments);
 		}
 		catch (IllegalAccessException ex) {
 			throw new RuntimeException("Failed to access tool method", ex);
 		}
 		catch (InvocationTargetException ex) {
-			throw new RuntimeException("Error invoking method: " + this.toolMethod.getName(), ex.getCause());
+			Throwable cause = ex.getCause();
+			if (cause instanceof RuntimeException re) {
+				throw re;
+			}
+			if (cause instanceof Error err) {
+				throw err;
+			}
+			throw new UndeclaredThrowableException(cause);
 		}
-		return result;
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractSyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractSyncMcpToolMethodCallback.java
@@ -38,6 +38,17 @@ import org.springframework.ai.mcp.annotation.context.McpRequestContextTypes;
 public abstract class AbstractSyncMcpToolMethodCallback<T, RC extends McpRequestContextTypes<?>>
 		extends AbstractAsyncMcpToolMethodCallback<T, RC> {
 
+	protected AbstractSyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject) {
+		super(returnMode, toolMethod, toolObject);
+	}
+
+	/**
+	 * @deprecated use
+	 * {@link #AbstractSyncMcpToolMethodCallback(ReturnMode, Method, Object)}. The
+	 * {@code toolCallExceptionClass} argument is ignored: exception handling now follows
+	 * the {@code @Tool} contract based on the exception type. Will be removed in 2.1.0.
+	 */
+	@Deprecated
 	protected AbstractSyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject,
 			Class<? extends Throwable> toolCallExceptionClass) {
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallback.java
@@ -17,10 +17,12 @@
 package org.springframework.ai.mcp.annotation.method.tool;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import reactor.core.publisher.Mono;
@@ -42,9 +44,16 @@ public final class AsyncMcpToolMethodCallback
 		implements BiFunction<McpAsyncServerExchange, CallToolRequest, Mono<CallToolResult>> {
 
 	public AsyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject) {
-		super(returnMode, toolMethod, toolObject, Exception.class);
+		super(returnMode, toolMethod, toolObject);
 	}
 
+	/**
+	 * @deprecated use {@link #AsyncMcpToolMethodCallback(ReturnMode, Method, Object)}.
+	 * The {@code toolCallExceptionClass} argument is ignored: exception handling now
+	 * follows the {@code @Tool} contract based on the exception type. Will be removed in
+	 * 2.1.0.
+	 */
+	@Deprecated
 	public AsyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject,
 			Class<? extends Throwable> toolCallExceptionClass) {
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
@@ -93,11 +102,20 @@ public final class AsyncMcpToolMethodCallback
 				return this.convertToCallToolResult(result);
 
 			}
-			catch (Exception e) {
-				if (this.toolCallExceptionClass.isInstance(e)) {
-					return this.createAsyncErrorResult(e);
-				}
+			catch (UndeclaredThrowableException e) {
 				return Mono.error(e);
+			}
+			// McpError extends RuntimeException — this catch must precede the plain
+			// RuntimeException catch below, or McpError would be silently swallowed into
+			// an error CallToolResult instead of propagating as a hard failure.
+			catch (McpError e) {
+				// A protocol-level error (e.g. URL elicitation) carries MCP semantics
+				// that must reach the protocol layer, so it bubbles up rather than being
+				// conveyed to the model as an error result.
+				return Mono.error(e);
+			}
+			catch (RuntimeException e) {
+				return this.createAsyncErrorResult(e);
 			}
 		}));
 	}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallback.java
@@ -16,9 +16,11 @@
 
 package org.springframework.ai.mcp.annotation.method.tool;
 
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import reactor.core.publisher.Mono;
@@ -41,9 +43,17 @@ public final class AsyncStatelessMcpToolMethodCallback
 
 	public AsyncStatelessMcpToolMethodCallback(ReturnMode returnMode, java.lang.reflect.Method toolMethod,
 			Object toolObject) {
-		super(returnMode, toolMethod, toolObject, Exception.class);
+		super(returnMode, toolMethod, toolObject);
 	}
 
+	/**
+	 * @deprecated use
+	 * {@link #AsyncStatelessMcpToolMethodCallback(ReturnMode, java.lang.reflect.Method, Object)}.
+	 * The {@code toolCallExceptionClass} argument is ignored: exception handling now
+	 * follows the {@code @Tool} contract based on the exception type. Will be removed in
+	 * 2.1.0.
+	 */
+	@Deprecated
 	public AsyncStatelessMcpToolMethodCallback(ReturnMode returnMode, java.lang.reflect.Method toolMethod,
 			Object toolObject, Class<? extends Throwable> toolCallExceptionClass) {
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
@@ -90,11 +100,20 @@ public final class AsyncStatelessMcpToolMethodCallback
 				return this.convertToCallToolResult(result);
 
 			}
-			catch (Exception e) {
-				if (this.toolCallExceptionClass.isInstance(e)) {
-					return this.createAsyncErrorResult(e);
-				}
+			catch (UndeclaredThrowableException e) {
 				return Mono.error(e);
+			}
+			// McpError extends RuntimeException — this catch must precede the plain
+			// RuntimeException catch below, or McpError would be silently swallowed into
+			// an error CallToolResult instead of propagating as a hard failure.
+			catch (McpError e) {
+				// A protocol-level error (e.g. URL elicitation) carries MCP semantics
+				// that must reach the protocol layer, so it bubbles up rather than being
+				// conveyed to the model as an error result.
+				return Mono.error(e);
+			}
+			catch (RuntimeException e) {
+				return this.createAsyncErrorResult(e);
 			}
 		}));
 	}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallback.java
@@ -16,10 +16,12 @@
 
 package org.springframework.ai.mcp.annotation.method.tool;
 
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 
@@ -40,9 +42,17 @@ public final class SyncMcpToolMethodCallback
 		implements BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> {
 
 	public SyncMcpToolMethodCallback(ReturnMode returnMode, java.lang.reflect.Method toolMethod, Object toolObject) {
-		super(returnMode, toolMethod, toolObject, Exception.class);
+		super(returnMode, toolMethod, toolObject);
 	}
 
+	/**
+	 * @deprecated use
+	 * {@link #SyncMcpToolMethodCallback(ReturnMode, java.lang.reflect.Method, Object)}.
+	 * The {@code toolCallExceptionClass} argument is ignored: exception handling now
+	 * follows the {@code @Tool} contract based on the exception type. Will be removed in
+	 * 2.1.0.
+	 */
+	@Deprecated
 	public SyncMcpToolMethodCallback(ReturnMode returnMode, java.lang.reflect.Method toolMethod, Object toolObject,
 			Class<? extends Throwable> toolCallExceptionClass) {
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
@@ -89,11 +99,20 @@ public final class SyncMcpToolMethodCallback
 			// Return the processed result
 			return this.processResult(result);
 		}
-		catch (Exception e) {
-			if (this.toolCallExceptionClass.isInstance(e)) {
-				return this.createSyncErrorResult(e);
-			}
+		catch (UndeclaredThrowableException e) {
 			throw e;
+		}
+		// McpError extends RuntimeException — this catch must precede the plain
+		// RuntimeException catch below, or McpError would be silently swallowed into
+		// an error CallToolResult instead of propagating as a hard failure.
+		catch (McpError e) {
+			// A protocol-level error (e.g. URL elicitation) carries MCP semantics that
+			// must reach the protocol layer, so it bubbles up rather than being conveyed
+			// to the model as an error result.
+			throw e;
+		}
+		catch (RuntimeException e) {
+			return this.createSyncErrorResult(e);
 		}
 	}
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncStatelessMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncStatelessMcpToolMethodCallback.java
@@ -16,9 +16,11 @@
 
 package org.springframework.ai.mcp.annotation.method.tool;
 
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 
@@ -40,9 +42,17 @@ public final class SyncStatelessMcpToolMethodCallback
 
 	public SyncStatelessMcpToolMethodCallback(ReturnMode returnMode, java.lang.reflect.Method toolMethod,
 			Object toolObject) {
-		super(returnMode, toolMethod, toolObject, Exception.class);
+		super(returnMode, toolMethod, toolObject);
 	}
 
+	/**
+	 * @deprecated use
+	 * {@link #SyncStatelessMcpToolMethodCallback(ReturnMode, java.lang.reflect.Method, Object)}.
+	 * The {@code toolCallExceptionClass} argument is ignored: exception handling now
+	 * follows the {@code @Tool} contract based on the exception type. Will be removed in
+	 * 2.1.0.
+	 */
+	@Deprecated
 	public SyncStatelessMcpToolMethodCallback(ReturnMode returnMode, java.lang.reflect.Method toolMethod,
 			Object toolObject, Class<? extends Throwable> toolCallExceptionClass) {
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
@@ -80,11 +90,20 @@ public final class SyncStatelessMcpToolMethodCallback
 			// Return the processed result
 			return this.processResult(result);
 		}
-		catch (Exception e) {
-			if (this.toolCallExceptionClass.isInstance(e)) {
-				return this.createSyncErrorResult(e);
-			}
+		catch (UndeclaredThrowableException e) {
 			throw e;
+		}
+		// McpError extends RuntimeException — this catch must precede the plain
+		// RuntimeException catch below, or McpError would be silently swallowed into
+		// an error CallToolResult instead of propagating as a hard failure.
+		catch (McpError e) {
+			// A protocol-level error (e.g. URL elicitation) carries MCP semantics that
+			// must reach the protocol layer, so it bubbles up rather than being conveyed
+			// to the model as an error result.
+			throw e;
+		}
+		catch (RuntimeException e) {
+			return this.createSyncErrorResult(e);
 		}
 	}
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AbstractMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AbstractMcpToolProvider.java
@@ -50,6 +50,12 @@ public abstract class AbstractMcpToolProvider {
 		return method.getAnnotation(McpTool.class);
 	}
 
+	/**
+	 * @deprecated no longer consulted. Exception handling now follows the {@code @Tool}
+	 * contract based on the exception type, so the returned value has no effect. Retained
+	 * for backward compatibility. Will be removed in 2.1.0.
+	 */
+	@Deprecated
 	protected Class<? extends Throwable> doGetToolCallException() {
 		return Exception.class;
 	}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -141,7 +141,7 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 									: ReturnMode.TEXT;
 
 					BiFunction<McpAsyncServerExchange, CallToolRequest, Mono<CallToolResult>> methodCallback = new AsyncMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException());
+							returnMode, mcpToolMethod, toolObject);
 
 					AsyncToolSpecification toolSpec = AsyncToolSpecification.builder()
 						.tool(tool)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -146,7 +146,7 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 									: ReturnMode.TEXT;
 
 					BiFunction<McpTransportContext, CallToolRequest, Mono<CallToolResult>> methodCallback = new AsyncStatelessMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException());
+							returnMode, mcpToolMethod, toolObject);
 
 					AsyncToolSpecification toolSpec = AsyncToolSpecification.builder()
 						.tool(tool)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
@@ -137,7 +137,7 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 									: ReturnMode.TEXT);
 
 					BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> methodCallback = new SyncMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException());
+							returnMode, mcpToolMethod, toolObject);
 
 					var toolSpec = SyncToolSpecification.builder().tool(tool).callHandler(methodCallback).build();
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
@@ -141,7 +141,7 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 									: ReturnMode.TEXT);
 
 					BiFunction<McpTransportContext, CallToolRequest, CallToolResult> methodCallback = new SyncStatelessMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException());
+							returnMode, mcpToolMethod, toolObject);
 
 					var toolSpec = SyncToolSpecification.builder().tool(tool).callHandler(methodCallback).build();
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncCallToolRequestSupportTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncCallToolRequestSupportTests.java
@@ -94,11 +94,12 @@ public class AsyncCallToolRequestSupportTests {
 
 		Mono<CallToolResult> resultMono = callback.apply(exchange, request);
 
-		// When a method returns Mono.error(), it propagates as an error
-		StepVerifier.create(resultMono)
-			.expectErrorMatches(throwable -> throwable instanceof RuntimeException
-					&& throwable.getMessage().contains("Async tool execution failed"))
-			.verify();
+		// A plain RuntimeException emitted by the Mono is conveyed to the model as an
+		// error result, mirroring the @Tool contract.
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result.isError()).isTrue();
+			assertThat(((TextContent) result.content().get(0)).text()).contains("Async tool execution failed");
+		}).verifyComplete();
 	}
 
 	@Test

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.method.tool;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Map;
+
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.ai.mcp.annotation.McpTool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for exception handling in {@link AsyncMcpToolMethodCallback}.
+ *
+ * <p>
+ * The contract mirrors {@code @Tool}: RuntimeExceptions are conveyed to the LLM as error
+ * results; declared checked exceptions and Errors bubble up without reaching the LLM.
+ *
+ * @author Christian Tzolov
+ */
+public class AsyncMcpToolMethodCallbackExceptionHandlingTests {
+
+	@Test
+	public void runtimeExceptionIsConvertedToErrorResult() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("runtimeExceptionTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("runtime-exception-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).contains("Runtime error: test");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void runtimeExceptionSubclassIsConvertedToErrorResult() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("customRuntimeExceptionTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("custom-runtime-exception-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).contains("Custom runtime error: test");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void nullPointerExceptionIsConvertedToErrorResult() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("nullPointerTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("null-pointer-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).contains("Null pointer: test");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void illegalArgumentExceptionIsConvertedToErrorResult() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("illegalArgumentTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("illegal-argument-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).contains("Illegal argument: test");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void declaredCheckedExceptionBubblesUp() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("checkedExceptionTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("checked-exception-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result)
+			.expectErrorSatisfies(e -> assertThat(e).isInstanceOf(UndeclaredThrowableException.class)
+				.cause()
+				.isInstanceOf(BusinessException.class)
+				.hasMessageContaining("Business error: test"))
+			.verify();
+	}
+
+	@Test
+	public void errorBubblesUp() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("assertionErrorTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("assertion-error-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result)
+			.expectErrorSatisfies(
+					e -> assertThat(e).isInstanceOf(AssertionError.class).hasMessageContaining("Assertion error: test"))
+			.verify();
+	}
+
+	@Test
+	public void mcpErrorThrownDirectlyBubblesUp() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("mcpErrorTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("mcp-error-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).expectError(McpError.class).verify();
+	}
+
+	@Test
+	public void errorEmittedReactivelyBubblesUp() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("monoAssertionErrorTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("mono-assertion-error-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result)
+			.expectErrorSatisfies(
+					e -> assertThat(e).isInstanceOf(AssertionError.class).hasMessageContaining("Reactive error: test"))
+			.verify();
+	}
+
+	@Test
+	public void mcpErrorEmittedReactivelyBubblesUp() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("monoMcpErrorTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("mono-mcp-error-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).expectError(McpError.class).verify();
+	}
+
+	@Test
+	public void successfulExecutionReturnsResult() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("successTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("success-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isFalse();
+			assertThat(((TextContent) r.content().get(0)).text()).isEqualTo("Success: test");
+		}).verifyComplete();
+	}
+
+	// --- helpers ---
+
+	private AsyncMcpToolMethodCallback callbackFor(String methodName) throws Exception {
+		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
+		Method method = ExceptionTestToolProvider.class.getMethod(methodName, String.class);
+		return new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+	}
+
+	// --- exception types ---
+
+	public static class BusinessException extends Exception {
+
+		public BusinessException(String message) {
+			super(message);
+		}
+
+	}
+
+	public static class CustomRuntimeException extends RuntimeException {
+
+		public CustomRuntimeException(String message) {
+			super(message);
+		}
+
+	}
+
+	// --- tool provider ---
+
+	public static class ExceptionTestToolProvider {
+
+		@McpTool(name = "runtime-exception-tool", description = "Throws RuntimeException")
+		public Mono<String> runtimeExceptionTool(String input) {
+			throw new RuntimeException("Runtime error: " + input);
+		}
+
+		@McpTool(name = "custom-runtime-exception-tool", description = "Throws CustomRuntimeException")
+		public Mono<String> customRuntimeExceptionTool(String input) {
+			throw new CustomRuntimeException("Custom runtime error: " + input);
+		}
+
+		@McpTool(name = "null-pointer-tool", description = "Throws NullPointerException")
+		public Mono<String> nullPointerTool(String input) {
+			throw new NullPointerException("Null pointer: " + input);
+		}
+
+		@McpTool(name = "illegal-argument-tool", description = "Throws IllegalArgumentException")
+		public Mono<String> illegalArgumentTool(String input) {
+			throw new IllegalArgumentException("Illegal argument: " + input);
+		}
+
+		@McpTool(name = "checked-exception-tool", description = "Throws declared checked exception")
+		public Mono<String> checkedExceptionTool(String input) throws BusinessException {
+			throw new BusinessException("Business error: " + input);
+		}
+
+		@McpTool(name = "assertion-error-tool", description = "Throws AssertionError")
+		public Mono<String> assertionErrorTool(String input) {
+			throw new AssertionError("Assertion error: " + input);
+		}
+
+		@McpTool(name = "mono-assertion-error-tool", description = "Emits AssertionError via Mono")
+		public Mono<String> monoAssertionErrorTool(String input) {
+			return Mono.error(new AssertionError("Reactive error: " + input));
+		}
+
+		@McpTool(name = "mcp-error-tool", description = "Throws McpError directly")
+		public Mono<String> mcpErrorTool(String input) {
+			throw McpError.builder(-32000).message("Protocol error: " + input).build();
+		}
+
+		@McpTool(name = "mono-mcp-error-tool", description = "Emits McpError via Mono")
+		public Mono<String> monoMcpErrorTool(String input) {
+			return Mono.error(McpError.builder(-32000).message("Protocol error: " + input).build());
+		}
+
+		@McpTool(name = "success-tool", description = "Returns a result")
+		public Mono<String> successTool(String input) {
+			return Mono.just("Success: " + input);
+		}
+
+	}
+
+}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -168,6 +168,57 @@ public class AsyncMcpToolMethodCallbackExceptionHandlingTests {
 	}
 
 	@Test
+	public void runtimeExceptionFromMonoVoidIsConvertedToErrorResult() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("monoVoidRuntimeExceptionTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("mono-void-runtime-exception-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).contains("Void error: test");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void mcpErrorFromMonoVoidBubblesUp() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("monoVoidMcpErrorTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("mono-void-mcp-error-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).expectError(McpError.class).verify();
+	}
+
+	@Test
+	public void runtimeExceptionFromMonoCallToolResultIsConvertedToErrorResult() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("monoCallToolResultRuntimeExceptionTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("mono-call-tool-result-runtime-exception-tool",
+				Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).contains("CallToolResult error: test");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void mcpErrorFromMonoCallToolResultBubblesUp() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("monoCallToolResultMcpErrorTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("mono-call-tool-result-mcp-error-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).expectError(McpError.class).verify();
+	}
+
+	@Test
 	public void successfulExecutionReturnsResult() throws Exception {
 		AsyncMcpToolMethodCallback callback = callbackFor("successTool");
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -259,6 +310,27 @@ public class AsyncMcpToolMethodCallbackExceptionHandlingTests {
 		@McpTool(name = "success-tool", description = "Returns a result")
 		public Mono<String> successTool(String input) {
 			return Mono.just("Success: " + input);
+		}
+
+		@McpTool(name = "mono-void-runtime-exception-tool", description = "Emits RuntimeException via Mono<Void>")
+		public Mono<Void> monoVoidRuntimeExceptionTool(String input) {
+			return Mono.error(new RuntimeException("Void error: " + input));
+		}
+
+		@McpTool(name = "mono-void-mcp-error-tool", description = "Emits McpError via Mono<Void>")
+		public Mono<Void> monoVoidMcpErrorTool(String input) {
+			return Mono.error(McpError.builder(-32000).message("Protocol error: " + input).build());
+		}
+
+		@McpTool(name = "mono-call-tool-result-runtime-exception-tool",
+				description = "Emits RuntimeException via Mono<CallToolResult>")
+		public Mono<CallToolResult> monoCallToolResultRuntimeExceptionTool(String input) {
+			return Mono.error(new RuntimeException("CallToolResult error: " + input));
+		}
+
+		@McpTool(name = "mono-call-tool-result-mcp-error-tool", description = "Emits McpError via Mono<CallToolResult>")
+		public Mono<CallToolResult> monoCallToolResultMcpErrorTool(String input) {
+			return Mono.error(McpError.builder(-32000).message("Protocol error: " + input).build());
 		}
 
 	}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -17,9 +17,11 @@
 package org.springframework.ai.mcp.annotation.method.tool;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Map;
 
 import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -34,246 +36,149 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for exception handling in {@link SyncMcpToolMethodCallback}.
  *
- * These tests verify the exception handling behavior in the apply() method, specifically
- * the catch block that checks if an exception is an instance of the configured
- * toolCallExceptionClass.
+ * <p>
+ * The contract mirrors {@code @Tool}: RuntimeExceptions are conveyed to the LLM as error
+ * results; declared checked exceptions and Errors bubble up without reaching the LLM.
  *
  * @author Christian Tzolov
  */
 public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 
 	@Test
-	public void testDefaultConstructor_CatchesAllExceptions() throws Exception {
-		// Test with default constructor (uses Exception.class)
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("runtimeExceptionTool", String.class);
-		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
-
+	public void runtimeExceptionIsConvertedToErrorResult() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("runtimeExceptionTool");
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("runtime-exception-tool", Map.of("input", "test"));
+		CallToolRequest request = CallToolRequest.builder("runtime-exception-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
 
-		// The RuntimeException thrown by callMethod should be caught and converted to
-		// error result
 		CallToolResult result = callback.apply(exchange, request);
 
-		assertThat(result).isNotNull();
 		assertThat(result.isError()).isTrue();
-		assertThat(result.content()).hasSize(1);
-		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
 		assertThat(((TextContent) result.content().get(0)).text()).contains("Runtime error: test");
 	}
 
 	@Test
-	public void testExceptionClassConstructor_CatchesSpecifiedExceptions() throws Exception {
-		// Configure to catch only RuntimeException and its subclasses
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("customRuntimeExceptionTool", String.class);
-		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
-				RuntimeException.class);
-
+	public void runtimeExceptionSubclassIsConvertedToErrorResult() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("customRuntimeExceptionTool");
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("custom-runtime-exception-tool", Map.of("input", "test"));
+		CallToolRequest request = CallToolRequest.builder("custom-runtime-exception-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
 
-		// The RuntimeException wrapper from callMethod should be caught
 		CallToolResult result = callback.apply(exchange, request);
 
-		assertThat(result).isNotNull();
 		assertThat(result.isError()).isTrue();
-		assertThat(result.content()).hasSize(1);
-		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
 		assertThat(((TextContent) result.content().get(0)).text()).contains("Custom runtime error: test");
 	}
 
 	@Test
-	public void testNonMatchingExceptionClass_ThrowsException() throws Exception {
-		// Configure to catch only IllegalArgumentException
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("runtimeExceptionTool", String.class);
-
-		// Create callback that only catches IllegalArgumentException
-		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
-				IllegalArgumentException.class);
-
+	public void nullPointerExceptionIsConvertedToErrorResult() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("nullPointerTool");
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("runtime-exception-tool", Map.of("input", "test"));
+		CallToolRequest request = CallToolRequest.builder("null-pointer-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
 
-		// The RuntimeException from callMethod should NOT be caught (not an
-		// IllegalArgumentException)
-		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(RuntimeException.class)
-			.hasMessageContaining("Error invoking method");
-	}
-
-	@Test
-	public void testCheckedExceptionHandling_WithExceptionClass() throws Exception {
-		// Test handling of checked exceptions wrapped in RuntimeException
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("checkedExceptionTool", String.class);
-
-		// Configure to catch Exception (which includes RuntimeException)
-		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
-				Exception.class);
-
-		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("checked-exception-tool", Map.of("input", "test"));
-
-		// The RuntimeException wrapper should be caught
 		CallToolResult result = callback.apply(exchange, request);
 
-		assertThat(result).isNotNull();
 		assertThat(result.isError()).isTrue();
-		assertThat(result.content()).hasSize(1);
-		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
-		assertThat(((TextContent) result.content().get(0)).text()).contains("Business error: test");
-	}
-
-	@Test
-	public void testCheckedExceptionHandling_WithSpecificClass() throws Exception {
-		// Configure to catch only IllegalArgumentException (not RuntimeException)
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("checkedExceptionTool", String.class);
-
-		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
-				IllegalArgumentException.class);
-
-		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("checked-exception-tool", Map.of("input", "test"));
-
-		// The RuntimeException wrapper should NOT be caught
-		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(RuntimeException.class)
-			.hasMessageContaining("Error invoking method")
-			.hasCauseInstanceOf(BusinessException.class);
-	}
-
-	@Test
-	public void testSuccessfulExecution_NoExceptionThrown() throws Exception {
-		// Test that successful execution works normally regardless of exception class
-		// config
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("successTool", String.class);
-
-		// Configure with a specific exception class
-		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
-				IllegalArgumentException.class);
-
-		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("success-tool", Map.of("input", "test"));
-
-		CallToolResult result = callback.apply(exchange, request);
-
-		assertThat(result).isNotNull();
-		assertThat(result.isError()).isFalse();
-		assertThat(result.content()).hasSize(1);
-		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
-		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Success: test");
-	}
-
-	@Test
-	public void testNullPointerException_WithRuntimeExceptionClass() throws Exception {
-		// Configure to catch RuntimeException (which includes NullPointerException)
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("nullPointerTool", String.class);
-		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
-				RuntimeException.class);
-
-		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("null-pointer-tool", Map.of("input", "test"));
-
-		// Should catch the RuntimeException wrapper
-		CallToolResult result = callback.apply(exchange, request);
-
-		assertThat(result).isNotNull();
-		assertThat(result.isError()).isTrue();
-		assertThat(result.content()).hasSize(1);
-		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
 		assertThat(((TextContent) result.content().get(0)).text()).contains("Null pointer: test");
 	}
 
 	@Test
-	public void testIllegalArgumentException_WithSpecificHandling() throws Exception {
-		// Configure to catch only RuntimeException
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("illegalArgumentTool", String.class);
-		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
-				RuntimeException.class);
-
+	public void illegalArgumentExceptionIsConvertedToErrorResult() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("illegalArgumentTool");
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("illegal-argument-tool", Map.of("input", "test"));
+		CallToolRequest request = CallToolRequest.builder("illegal-argument-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
 
-		// Should catch the RuntimeException wrapper (which wraps
-		// IllegalArgumentException)
 		CallToolResult result = callback.apply(exchange, request);
 
-		assertThat(result).isNotNull();
 		assertThat(result.isError()).isTrue();
-		assertThat(result.content()).hasSize(1);
-		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
 		assertThat(((TextContent) result.content().get(0)).text()).contains("Illegal argument: test");
 	}
 
 	@Test
-	public void testMultipleCallsWithDifferentResults() throws Exception {
-		// Test that the same callback instance handles different scenarios correctly
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method successMethod = ExceptionTestToolProvider.class.getMethod("successTool", String.class);
-		Method exceptionMethod = ExceptionTestToolProvider.class.getMethod("runtimeExceptionTool", String.class);
-
-		// Create callbacks with Exception handling (catches all)
-		SyncMcpToolMethodCallback successCallback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, successMethod,
-				provider, Exception.class);
-		SyncMcpToolMethodCallback exceptionCallback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, exceptionMethod,
-				provider, Exception.class);
-
+	public void declaredCheckedExceptionBubblesUp() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("checkedExceptionTool");
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("checked-exception-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
 
-		// Test success case
-		CallToolRequest successRequest = new CallToolRequest("success-tool", Map.of("input", "success"));
-		CallToolResult successResult = successCallback.apply(exchange, successRequest);
-		assertThat(successResult.isError()).isFalse();
-		assertThat(((TextContent) successResult.content().get(0)).text()).isEqualTo("Success: success");
-
-		// Test exception case
-		CallToolRequest exceptionRequest = new CallToolRequest("runtime-exception-tool", Map.of("input", "error"));
-		CallToolResult exceptionResult = exceptionCallback.apply(exchange, exceptionRequest);
-		assertThat(exceptionResult.isError()).isTrue();
-		assertThat(((TextContent) exceptionResult.content().get(0)).text()).contains("Runtime error: error");
+		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(UndeclaredThrowableException.class)
+			.cause()
+			.isInstanceOf(BusinessException.class)
+			.hasMessageContaining("Business error: test");
 	}
 
 	@Test
-	public void testExceptionHierarchy_ParentClassCatchesSubclasses() throws Exception {
-		// Configure to catch Exception (parent of RuntimeException)
+	public void errorBubblesUp() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("assertionErrorTool");
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("assertion-error-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
+
+		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(AssertionError.class)
+			.hasMessageContaining("Assertion error: test");
+	}
+
+	@Test
+	public void mcpErrorBubblesUp() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("mcpErrorTool");
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("mcp-error-tool").arguments(Map.of("input", "test")).build();
+
+		// A protocol-level McpError must bubble up rather than be converted to an error
+		// CallToolResult conveyed to the model.
+		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(McpError.class);
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void deprecatedConstructorIgnoresToolCallExceptionClass() throws Exception {
 		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("customRuntimeExceptionTool", String.class);
+		Method method = ExceptionTestToolProvider.class.getMethod("checkedExceptionTool", String.class);
+		// The deprecated toolCallExceptionClass argument is retained for binary
+		// compatibility but ignored: a declared checked exception still bubbles up rather
+		// than being converted to an error result, regardless of the class passed.
 		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
-				Exception.class);
-
+				RuntimeException.class);
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("custom-runtime-exception-tool", Map.of("input", "test"));
+		CallToolRequest request = CallToolRequest.builder("checked-exception-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
 
-		// Should catch the RuntimeException (subclass of Exception)
-		CallToolResult result = callback.apply(exchange, request);
-		assertThat(result).isNotNull();
-		assertThat(result.isError()).isTrue();
+		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(UndeclaredThrowableException.class)
+			.cause()
+			.isInstanceOf(BusinessException.class);
 	}
 
 	@Test
-	public void testConstructorWithNullExceptionClass_UsesDefault() throws Exception {
-		// The constructor with 3 parameters uses Exception.class as default
-		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
-		Method method = ExceptionTestToolProvider.class.getMethod("runtimeExceptionTool", String.class);
-
-		// This constructor uses Exception.class internally
-		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
-
+	public void successfulExecutionReturnsResult() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("successTool");
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-		CallToolRequest request = new CallToolRequest("runtime-exception-tool", Map.of("input", "test"));
+		CallToolRequest request = CallToolRequest.builder("success-tool").arguments(Map.of("input", "test")).build();
 
-		// Should catch all exceptions (default is Exception.class)
 		CallToolResult result = callback.apply(exchange, request);
-		assertThat(result).isNotNull();
-		assertThat(result.isError()).isTrue();
+
+		assertThat(result.isError()).isFalse();
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Success: test");
 	}
 
-	// Custom exception classes for testing
+	// --- helpers ---
+
+	private SyncMcpToolMethodCallback callbackFor(String methodName) throws Exception {
+		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
+		Method method = ExceptionTestToolProvider.class.getMethod(methodName, String.class);
+		return new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+	}
+
+	// --- exception types ---
+
 	public static class BusinessException extends Exception {
 
 		public BusinessException(String message) {
@@ -290,37 +195,48 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 
 	}
 
-	// Test tool provider with various exception-throwing methods
-	private static class ExceptionTestToolProvider {
+	// --- tool provider ---
 
-		@McpTool(name = "runtime-exception-tool", description = "Tool that throws RuntimeException")
+	public static class ExceptionTestToolProvider {
+
+		@McpTool(name = "runtime-exception-tool", description = "Throws RuntimeException")
 		public String runtimeExceptionTool(String input) {
 			throw new RuntimeException("Runtime error: " + input);
 		}
 
-		@McpTool(name = "custom-runtime-exception-tool", description = "Tool that throws CustomRuntimeException")
+		@McpTool(name = "custom-runtime-exception-tool", description = "Throws CustomRuntimeException")
 		public String customRuntimeExceptionTool(String input) {
 			throw new CustomRuntimeException("Custom runtime error: " + input);
 		}
 
-		@McpTool(name = "checked-exception-tool", description = "Tool that throws checked exception")
-		public String checkedExceptionTool(String input) throws BusinessException {
-			throw new BusinessException("Business error: " + input);
-		}
-
-		@McpTool(name = "success-tool", description = "Tool that succeeds")
-		public String successTool(String input) {
-			return "Success: " + input;
-		}
-
-		@McpTool(name = "null-pointer-tool", description = "Tool that throws NullPointerException")
+		@McpTool(name = "null-pointer-tool", description = "Throws NullPointerException")
 		public String nullPointerTool(String input) {
 			throw new NullPointerException("Null pointer: " + input);
 		}
 
-		@McpTool(name = "illegal-argument-tool", description = "Tool that throws IllegalArgumentException")
+		@McpTool(name = "illegal-argument-tool", description = "Throws IllegalArgumentException")
 		public String illegalArgumentTool(String input) {
 			throw new IllegalArgumentException("Illegal argument: " + input);
+		}
+
+		@McpTool(name = "checked-exception-tool", description = "Throws declared checked exception")
+		public String checkedExceptionTool(String input) throws BusinessException {
+			throw new BusinessException("Business error: " + input);
+		}
+
+		@McpTool(name = "assertion-error-tool", description = "Throws AssertionError")
+		public String assertionErrorTool(String input) {
+			throw new AssertionError("Assertion error: " + input);
+		}
+
+		@McpTool(name = "mcp-error-tool", description = "Throws McpError")
+		public String mcpErrorTool(String input) {
+			throw McpError.builder(-32000).message("Protocol error: " + input).build();
+		}
+
+		@McpTool(name = "success-tool", description = "Returns a result")
+		public String successTool(String input) {
+			return "Success: " + input;
 		}
 
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
@@ -178,6 +178,42 @@ public String performLongTask(
 }
 ----
 
+==== Exception Handling
+
+Exceptions thrown by an `@McpTool` method follow the same contract as regular xref:api/tools.adoc#exception-handling[Spring AI `@Tool` methods].
+
+* A `RuntimeException` is converted to an error `CallToolResult` and conveyed to the model, which can reason about it or retry.
+* A declared checked exception or an `Error` bubbles up and fails the tool call, so it is not conveyed to the model.
+
+In other words, if you do not want a failure to reach the model, declare a checked exception in the tool method signature and throw it.
+
+[source,java]
+----
+@McpTool(name = "read-file", description = "Read a file from disk")
+public String readFile(@McpToolParam(description = "Path", required = true) String path) throws IOException {
+    // An IOException bubbles up and fails the tool call instead of being
+    // sent back to the model as an error result.
+    return Files.readString(Path.of(path));
+}
+----
+
+A `RuntimeException`, by contrast, is reported to the model as an error result so it can recover.
+
+[source,java]
+----
+@McpTool(name = "divide", description = "Divide two numbers")
+public double divide(int a, int b) {
+    if (b == 0) {
+        // Conveyed to the model as an error result.
+        throw new IllegalArgumentException("Cannot divide by zero");
+    }
+    return (double) a / b;
+}
+----
+
+NOTE: Protocol-level `McpError` exceptions (for example, those used for URL elicitation and other MCP protocol flows) always propagate to the MCP protocol layer rather than being converted to an error `CallToolResult`.
+This applies whether the `McpError` is thrown directly or emitted through a reactive return type (`Mono` or `Flux`).
+
 === @McpResource
 
 The `@McpResource` annotation provides access to resources via URI templates.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -95,7 +95,7 @@ public String lookupOrder(String orderId) {
 }
 ----
 
-If you want a checked exception to be a hard failure (the previous default behaviour when the exception type was `Exception.class`), no change is needed — it already bubbles up.
+If you want a checked exception to be a hard failure, no change is needed — it already bubbles up as an `UndeclaredThrowableException` by default.
 
 ==== Deprecated: `toolCallExceptionClass` Constructor Parameter
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -54,6 +54,74 @@ The new module provides a smooth transition from the deprecated module:
 
 NOTE: Both the deprecated module and the legacy configuration prefix will be removed in a future release.
 
+=== MCP Tool Exception Handling
+
+==== Changed: `@McpTool` Exception Handling Now Mirrors `@Tool`
+
+The exception-handling contract for `@McpTool`-annotated server methods has been aligned with `@Tool`.
+Previously, all exceptions thrown by an `@McpTool` method — including declared checked exceptions, `Error` subtypes, and protocol-level `McpError`s — were caught and silently converted into an error `CallToolResult` that was passed to the model.
+Starting with 2.0.1, exception dispatch follows the same type-based rule used by `@Tool`:
+
+[cols="1,2", options="header"]
+|===
+| Exception type | Behaviour
+| `RuntimeException` (not `McpError`) | Converted to an error `CallToolResult` and passed to the model
+| Declared checked exception | Bubbles up as `UndeclaredThrowableException` — hard failure, never reaches the model
+| `Error` subtype | Bubbles up unchanged — hard failure
+| `McpError` | Bubbles up unchanged — hard failure (protocol-level signal, e.g. URL elicitation)
+|===
+
+===== Impact
+
+`@McpTool` methods that intentionally threw a checked exception or `Error` to signal a problem, expecting the exception to be conveyed to the model as an error message, will now propagate the exception instead.
+
+===== Migration
+
+If your `@McpTool` method throws a checked exception or `Error` and you want the model to see an error message, convert it to a `RuntimeException` (or a subclass) in the method body before throwing:
+
+[source,java]
+----
+// Before — checked exception was silently converted to an error result
+@McpTool(description = "Look up an order")
+public String lookupOrder(String orderId) throws NotFoundException {
+    throw new NotFoundException("Order not found: " + orderId);
+}
+
+// After — wrap in RuntimeException to convey error to model,
+//         or remove the checked-exception declaration and let it propagate
+@McpTool(description = "Look up an order")
+public String lookupOrder(String orderId) {
+    throw new RuntimeException("Order not found: " + orderId); // reaches model as error result
+}
+----
+
+If you want a checked exception to be a hard failure (the previous default behaviour when the exception type was `Exception.class`), no change is needed — it already bubbles up.
+
+==== Deprecated: `toolCallExceptionClass` Constructor Parameter
+
+The `toolCallExceptionClass` parameter on the following classes is deprecated and will be removed in 2.1.0.
+It is ignored at runtime — exception dispatch is now type-based, not class-based.
+
+* `SyncMcpToolMethodCallback(ReturnMode, Method, Object, Class<? extends Throwable>)`
+* `AsyncMcpToolMethodCallback(ReturnMode, Method, Object, Class<? extends Throwable>)`
+* `SyncStatelessMcpToolMethodCallback(ReturnMode, Method, Object, Class<? extends Throwable>)`
+* `AsyncStatelessMcpToolMethodCallback(ReturnMode, Method, Object, Class<? extends Throwable>)`
+* `AbstractMcpToolProvider.doGetToolCallException()`
+
+===== Migration
+
+Use the three-argument constructors.
+The `toolCallExceptionClass` argument is accepted but no longer has any effect:
+
+[source,java]
+----
+// Before
+new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider, Exception.class);
+
+// After
+new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+----
+
 [[upgrading-to-2-0-0]]
 == Upgrading to 2.0.0
 
@@ -425,15 +493,6 @@ chatClient.prompt()
 ----
 
 For new code, prefer the declarative `@Tool` annotation — see xref:api/tools.adoc#defining-tools[Defining Tools].
-
-
-
-
-
-
-
-
-
 
 === JDBC Chat Memory `sequence_id` Column
 


### PR DESCRIPTION
Mirror the @Tool exception-handling contract in all @McpTool server callbacks: RuntimeExceptions are conveyed to the model as error CallToolResults; declared checked exceptions (wrapped in UndeclaredThrowableException), Error subtypes, and McpError are propagated as hard failures and never reach the model.

On the client side, McpError thrown by a remote MCP server is now re-thrown from SyncMcpToolCallback / AsyncMcpToolCallback instead of being wrapped in a ToolExecutionException, so it bypasses DefaultToolExecutionExceptionProcessor and fails the model interaction.

The toolCallExceptionClass constructor parameter and doGetToolCallException() on AbstractMcpToolProvider are deprecated (scheduled for removal in 2.1.0) and retained for binary/source compatibility; the value is ignored at runtime.

Closes #6456