### PR TITLE
Support customizing MCP server `serverInfo` via an overridable `Implementation` bean

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
@@ -99,20 +99,23 @@ public class McpServerAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
+	public McpSchema.Implementation serverInfo(McpServerProperties serverProperties) {
+		return new Implementation(serverProperties.getName(), serverProperties.getVersion());
+	}
+
+	@Bean
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
 	public McpSyncServer mcpSyncServer(McpServerTransportProviderBase transportProvider,
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,
-			McpServerChangeNotificationProperties changeNotificationProperties,
+			McpSchema.Implementation serverInfo, McpServerChangeNotificationProperties changeNotificationProperties,
 			ObjectProvider<List<SyncToolSpecification>> tools,
 			ObjectProvider<List<SyncResourceSpecification>> resources,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
 			ObjectProvider<List<SyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
 			Environment environment) {
-
-		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
-				serverProperties.getVersion());
 
 		// Create the server with both tool and resource capabilities
 		SyncSpecification<?> serverBuilder;
@@ -202,15 +205,12 @@ public class McpServerAutoConfiguration {
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
 	public McpAsyncServer mcpAsyncServer(McpServerTransportProviderBase transportProvider,
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,
-			McpServerChangeNotificationProperties changeNotificationProperties,
+			McpSchema.Implementation serverInfo, McpServerChangeNotificationProperties changeNotificationProperties,
 			ObjectProvider<List<AsyncToolSpecification>> tools,
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
 			ObjectProvider<List<AsyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpAsyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumer) {
-
-		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
-				serverProperties.getVersion());
 
 		// Create the server with both tool and resource capabilities
 		AsyncSpecification<?> serverBuilder;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -73,17 +73,20 @@ public class McpServerStatelessAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
+	public McpSchema.Implementation serverInfo(McpServerProperties serverProperties) {
+		return new Implementation(serverProperties.getName(), serverProperties.getVersion());
+	}
+
+	@Bean
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
 	public McpStatelessSyncServer mcpStatelessSyncServer(McpStatelessServerTransport statelessTransport,
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,
-			ObjectProvider<List<SyncToolSpecification>> tools,
+			McpSchema.Implementation serverInfo, ObjectProvider<List<SyncToolSpecification>> tools,
 			ObjectProvider<List<SyncResourceSpecification>> resources,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
 			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment) {
-
-		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
-				serverProperties.getVersion());
 
 		// Create the server with both tool and resource capabilities
 		StatelessSyncSpecification serverBuilder = McpServer.sync(statelessTransport).serverInfo(serverInfo);
@@ -153,13 +156,10 @@ public class McpServerStatelessAutoConfiguration {
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
 	public McpStatelessAsyncServer mcpStatelessAsyncServer(McpStatelessServerTransport statelessTransport,
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,
-			ObjectProvider<List<AsyncToolSpecification>> tools,
+			McpSchema.Implementation serverInfo, ObjectProvider<List<AsyncToolSpecification>> tools,
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
 			ObjectProvider<List<AsyncCompletionSpecification>> completions) {
-
-		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
-				serverProperties.getVersion());
 
 		// Create the server with both tool and resource capabilities
 		StatelessAsyncSpecification serverBuilder = McpServer.async(statelessTransport).serverInfo(serverInfo);

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -400,6 +400,26 @@ public class McpStatelessServerAutoConfigurationIT {
 
 	}
 
+	@Test
+	void customServerInfoBeanOverridesDefault() {
+		this.contextRunner.withUserConfiguration(CustomServerInfoConfiguration.class).run(context -> {
+			assertThat(context).hasSingleBean(McpStatelessSyncServer.class);
+			McpSchema.Implementation serverInfo = context.getBean(McpSchema.Implementation.class);
+			assertThat(serverInfo.name()).isEqualTo("custom");
+			assertThat(serverInfo.title()).isEqualTo("Custom Title");
+		});
+	}
+
+	@Configuration
+	static class CustomServerInfoConfiguration {
+
+		@Bean
+		McpSchema.Implementation serverInfo() {
+			return McpSchema.Implementation.builder("custom", "9.9.9").title("Custom Title").build();
+		}
+
+	}
+
 	@Configuration
 	static class TestRootsHandlerConfiguration {
 


### PR DESCRIPTION
The MCP server autoconfigurations build `serverInfo` inline as `new Implementation(name, version)` in all four server beans (`mcpSyncServer`, `mcpAsyncServer`, `mcpStatelessSyncServer`, `mcpStatelessAsyncServer`), so a display title or icons can't be advertised in the `initialize` handshake and there is no seam to customize it — the server customizers were removed in the autoconfig modularization.

This adds an overridable `@ConditionalOnMissingBean McpSchema.Implementation serverInfo` bean to both `McpServerAutoConfiguration` and `McpServerStatelessAutoConfiguration`; all four server beans inject it. Default behavior is unchanged (`Implementation(name, version)`); a user can now supply their own `Implementation` bean (e.g. with `.title(...)` / `.icons(...)`) to customize what the server advertises — consistently across stateful/stateless and sync/async.

Includes a test in `McpStatelessServerAutoConfigurationIT` asserting a user `Implementation` bean overrides the default; a matching test for the stateful autoconfig can follow if preferred.