### PR TITLE
Add customizers for stateless MCP servers

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
@@ -38,6 +39,8 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.Implementation;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
 
+import org.springframework.ai.mcp.customizer.McpStatelessAsyncServerCustomizer;
+import org.springframework.ai.mcp.customizer.McpStatelessSyncServerCustomizer;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -80,7 +83,8 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<SyncResourceSpecification>> resources,
 			ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
-			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment) {
+			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment,
+			Optional<McpStatelessSyncServerCustomizer> mcpStatelessServerCustomizer) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
 				serverProperties.getVersion());
@@ -159,6 +163,8 @@ public class McpServerStatelessAutoConfiguration {
 			serverBuilder.immediateExecution(true);
 		}
 
+		mcpStatelessServerCustomizer.ifPresent(customizer -> customizer.customize(serverBuilder));
+
 		return serverBuilder.build();
 	}
 
@@ -170,7 +176,8 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
 			ObjectProvider<List<AsyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
-			ObjectProvider<List<AsyncCompletionSpecification>> completions) {
+			ObjectProvider<List<AsyncCompletionSpecification>> completions,
+			Optional<McpStatelessAsyncServerCustomizer> mcpStatelessServerCustomizer) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
 				serverProperties.getVersion());
@@ -245,6 +252,8 @@ public class McpServerStatelessAutoConfiguration {
 		serverBuilder.instructions(serverProperties.getInstructions());
 
 		serverBuilder.requestTimeout(serverProperties.getRequestTimeout());
+
+		mcpStatelessServerCustomizer.ifPresent(customizer -> customizer.customize(serverBuilder));
 
 		return serverBuilder.build();
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
@@ -84,7 +83,7 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
 			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment,
-			Optional<McpStatelessSyncServerCustomizer> mcpStatelessServerCustomizer) {
+			ObjectProvider<McpStatelessSyncServerCustomizer> customizers) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
 				serverProperties.getVersion());
@@ -163,7 +162,7 @@ public class McpServerStatelessAutoConfiguration {
 			serverBuilder.immediateExecution(true);
 		}
 
-		mcpStatelessServerCustomizer.ifPresent(customizer -> customizer.customize(serverBuilder));
+		customizers.orderedStream().forEach(customizer -> customizer.customize(serverBuilder));
 
 		return serverBuilder.build();
 	}
@@ -177,7 +176,7 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<AsyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
 			ObjectProvider<List<AsyncCompletionSpecification>> completions,
-			Optional<McpStatelessAsyncServerCustomizer> mcpStatelessServerCustomizer) {
+			ObjectProvider<McpStatelessAsyncServerCustomizer> customizers) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
 				serverProperties.getVersion());
@@ -253,7 +252,7 @@ public class McpServerStatelessAutoConfiguration {
 
 		serverBuilder.requestTimeout(serverProperties.getRequestTimeout());
 
-		mcpStatelessServerCustomizer.ifPresent(customizer -> customizer.customize(serverBuilder));
+		customizers.orderedStream().forEach(customizer -> customizer.customize(serverBuilder));
 
 		return serverBuilder.build();
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
@@ -38,6 +39,8 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.Implementation;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
 
+import org.springframework.ai.mcp.customizer.McpStatelessAsyncServerCustomizer;
+import org.springframework.ai.mcp.customizer.McpStatelessSyncServerCustomizer;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -80,7 +83,8 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<SyncResourceSpecification>> resources,
 			ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
-			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment) {
+			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment,
+			Optional<McpStatelessSyncServerCustomizer> mcpStatelessServerCustomizer) {
 
 		McpSchema.Implementation serverInfo = Implementation
 			.builder(serverProperties.getName(), serverProperties.getVersion())
@@ -160,6 +164,8 @@ public class McpServerStatelessAutoConfiguration {
 			serverBuilder.immediateExecution(true);
 		}
 
+		mcpStatelessServerCustomizer.ifPresent(customizer -> customizer.customize(serverBuilder));
+
 		return serverBuilder.build();
 	}
 
@@ -171,7 +177,8 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
 			ObjectProvider<List<AsyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
-			ObjectProvider<List<AsyncCompletionSpecification>> completions) {
+			ObjectProvider<List<AsyncCompletionSpecification>> completions,
+			Optional<McpStatelessAsyncServerCustomizer> mcpStatelessServerCustomizer) {
 
 		McpSchema.Implementation serverInfo = Implementation
 			.builder(serverProperties.getName(), serverProperties.getVersion())
@@ -247,6 +254,8 @@ public class McpServerStatelessAutoConfiguration {
 		serverBuilder.instructions(serverProperties.getInstructions());
 
 		serverBuilder.requestTimeout(serverProperties.getRequestTimeout());
+
+		mcpStatelessServerCustomizer.ifPresent(customizer -> customizer.customize(serverBuilder));
 
 		return serverBuilder.build();
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
@@ -84,7 +83,7 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
 			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment,
-			Optional<McpStatelessSyncServerCustomizer> mcpStatelessServerCustomizer) {
+			ObjectProvider<McpStatelessSyncServerCustomizer> customizers) {
 
 		McpSchema.Implementation serverInfo = Implementation
 			.builder(serverProperties.getName(), serverProperties.getVersion())
@@ -164,7 +163,7 @@ public class McpServerStatelessAutoConfiguration {
 			serverBuilder.immediateExecution(true);
 		}
 
-		mcpStatelessServerCustomizer.ifPresent(customizer -> customizer.customize(serverBuilder));
+		customizers.orderedStream().forEach(customizer -> customizer.customize(serverBuilder));
 
 		return serverBuilder.build();
 	}
@@ -178,7 +177,7 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<AsyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
 			ObjectProvider<List<AsyncCompletionSpecification>> completions,
-			Optional<McpStatelessAsyncServerCustomizer> mcpStatelessServerCustomizer) {
+			ObjectProvider<McpStatelessAsyncServerCustomizer> customizers) {
 
 		McpSchema.Implementation serverInfo = Implementation
 			.builder(serverProperties.getName(), serverProperties.getVersion())
@@ -255,7 +254,7 @@ public class McpServerStatelessAutoConfiguration {
 
 		serverBuilder.requestTimeout(serverProperties.getRequestTimeout());
 
-		mcpStatelessServerCustomizer.ifPresent(customizer -> customizer.customize(serverBuilder));
+		customizers.orderedStream().forEach(customizer -> customizer.customize(serverBuilder));
 
 		return serverBuilder.build();
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpStatelessAsyncServer;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncCompletionSpecification;
@@ -51,6 +52,8 @@ import org.springframework.ai.mcp.annotation.McpPrompt;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.ai.mcp.customizer.McpStatelessAsyncServerCustomizer;
+import org.springframework.ai.mcp.customizer.McpStatelessSyncServerCustomizer;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.StatelessServerSpecificationFactoryAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
@@ -210,6 +213,26 @@ public class McpStatelessServerAutoConfigurationIT {
 			assertThat(context.getBean(McpSchema.ServerCapabilities.Builder.class))
 				.isInstanceOf(CustomCapabilitiesBuilder.class);
 		});
+	}
+
+	@Test
+	void syncServerCustomizerConfiguration() {
+		this.contextRunner.withUserConfiguration(SyncServerCustomizerConfiguration.class).run(context -> {
+			assertThat(context).hasSingleBean(McpStatelessSyncServer.class);
+			RecordingSyncServerCustomizer customizer = context.getBean(RecordingSyncServerCustomizer.class);
+			assertThat(customizer.invoked).isTrue();
+		});
+	}
+
+	@Test
+	void asyncServerCustomizerConfiguration() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.type=ASYNC")
+			.withUserConfiguration(AsyncServerCustomizerConfiguration.class)
+			.run(context -> {
+				assertThat(context).hasSingleBean(McpStatelessAsyncServer.class);
+				RecordingAsyncServerCustomizer customizer = context.getBean(RecordingAsyncServerCustomizer.class);
+				assertThat(customizer.invoked).isTrue();
+			});
 	}
 
 	@Test
@@ -426,6 +449,48 @@ public class McpStatelessServerAutoConfigurationIT {
 	static class CustomCapabilitiesBuilder extends McpSchema.ServerCapabilities.Builder {
 
 		// Custom implementation for testing
+
+	}
+
+	@Configuration
+	static class SyncServerCustomizerConfiguration {
+
+		@Bean
+		RecordingSyncServerCustomizer syncServerCustomizer() {
+			return new RecordingSyncServerCustomizer();
+		}
+
+	}
+
+	static class RecordingSyncServerCustomizer implements McpStatelessSyncServerCustomizer {
+
+		private boolean invoked;
+
+		@Override
+		public void customize(McpServer.StatelessSyncSpecification serverBuilder) {
+			this.invoked = true;
+		}
+
+	}
+
+	@Configuration
+	static class AsyncServerCustomizerConfiguration {
+
+		@Bean
+		RecordingAsyncServerCustomizer asyncServerCustomizer() {
+			return new RecordingAsyncServerCustomizer();
+		}
+
+	}
+
+	static class RecordingAsyncServerCustomizer implements McpStatelessAsyncServerCustomizer {
+
+		private boolean invoked;
+
+		@Override
+		public void customize(McpServer.StatelessAsyncSpecification serverBuilder) {
+			this.invoked = true;
+		}
 
 	}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -64,6 +64,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -233,6 +234,16 @@ public class McpStatelessServerAutoConfigurationIT {
 				RecordingAsyncServerCustomizer customizer = context.getBean(RecordingAsyncServerCustomizer.class);
 				assertThat(customizer.invoked).isTrue();
 			});
+	}
+
+	@Test
+	void multipleSyncServerCustomizersInvokedInOrder() {
+		this.contextRunner.withUserConfiguration(OrderedSyncServerCustomizersConfiguration.class).run(context -> {
+			assertThat(context).hasSingleBean(McpStatelessSyncServer.class);
+			@SuppressWarnings("unchecked")
+			List<String> invocations = context.getBean("customizerInvocations", List.class);
+			assertThat(invocations).containsExactly("first", "second");
+		});
 	}
 
 	@Test
@@ -469,6 +480,28 @@ public class McpStatelessServerAutoConfigurationIT {
 		@Override
 		public void customize(McpServer.StatelessSyncSpecification serverBuilder) {
 			this.invoked = true;
+		}
+
+	}
+
+	@Configuration
+	static class OrderedSyncServerCustomizersConfiguration {
+
+		@Bean
+		List<String> customizerInvocations() {
+			return new CopyOnWriteArrayList<>();
+		}
+
+		@Bean
+		@Order(1)
+		McpStatelessSyncServerCustomizer firstCustomizer(List<String> customizerInvocations) {
+			return serverBuilder -> customizerInvocations.add("first");
+		}
+
+		@Bean
+		@Order(2)
+		McpStatelessSyncServerCustomizer secondCustomizer(List<String> customizerInvocations) {
+			return serverBuilder -> customizerInvocations.add("second");
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpStatelessAsyncServer;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncCompletionSpecification;
@@ -52,6 +53,8 @@ import org.springframework.ai.mcp.annotation.McpPrompt;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.ai.mcp.customizer.McpStatelessAsyncServerCustomizer;
+import org.springframework.ai.mcp.customizer.McpStatelessSyncServerCustomizer;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.StatelessServerSpecificationFactoryAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
@@ -211,6 +214,26 @@ public class McpStatelessServerAutoConfigurationIT {
 			assertThat(context.getBean(McpSchema.ServerCapabilities.Builder.class))
 				.isInstanceOf(CustomCapabilitiesBuilder.class);
 		});
+	}
+
+	@Test
+	void syncServerCustomizerConfiguration() {
+		this.contextRunner.withUserConfiguration(SyncServerCustomizerConfiguration.class).run(context -> {
+			assertThat(context).hasSingleBean(McpStatelessSyncServer.class);
+			RecordingSyncServerCustomizer customizer = context.getBean(RecordingSyncServerCustomizer.class);
+			assertThat(customizer.invoked).isTrue();
+		});
+	}
+
+	@Test
+	void asyncServerCustomizerConfiguration() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.type=ASYNC")
+			.withUserConfiguration(AsyncServerCustomizerConfiguration.class)
+			.run(context -> {
+				assertThat(context).hasSingleBean(McpStatelessAsyncServer.class);
+				RecordingAsyncServerCustomizer customizer = context.getBean(RecordingAsyncServerCustomizer.class);
+				assertThat(customizer.invoked).isTrue();
+			});
 	}
 
 	@Test
@@ -427,6 +450,48 @@ public class McpStatelessServerAutoConfigurationIT {
 	static class CustomCapabilitiesBuilder extends McpSchema.ServerCapabilities.Builder {
 
 		// Custom implementation for testing
+
+	}
+
+	@Configuration
+	static class SyncServerCustomizerConfiguration {
+
+		@Bean
+		RecordingSyncServerCustomizer syncServerCustomizer() {
+			return new RecordingSyncServerCustomizer();
+		}
+
+	}
+
+	static class RecordingSyncServerCustomizer implements McpStatelessSyncServerCustomizer {
+
+		private boolean invoked;
+
+		@Override
+		public void customize(McpServer.StatelessSyncSpecification serverBuilder) {
+			this.invoked = true;
+		}
+
+	}
+
+	@Configuration
+	static class AsyncServerCustomizerConfiguration {
+
+		@Bean
+		RecordingAsyncServerCustomizer asyncServerCustomizer() {
+			return new RecordingAsyncServerCustomizer();
+		}
+
+	}
+
+	static class RecordingAsyncServerCustomizer implements McpStatelessAsyncServerCustomizer {
+
+		private boolean invoked;
+
+		@Override
+		public void customize(McpServer.StatelessAsyncSpecification serverBuilder) {
+			this.invoked = true;
+		}
 
 	}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -65,6 +65,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -234,6 +235,16 @@ public class McpStatelessServerAutoConfigurationIT {
 				RecordingAsyncServerCustomizer customizer = context.getBean(RecordingAsyncServerCustomizer.class);
 				assertThat(customizer.invoked).isTrue();
 			});
+	}
+
+	@Test
+	void multipleSyncServerCustomizersInvokedInOrder() {
+		this.contextRunner.withUserConfiguration(OrderedSyncServerCustomizersConfiguration.class).run(context -> {
+			assertThat(context).hasSingleBean(McpStatelessSyncServer.class);
+			@SuppressWarnings("unchecked")
+			List<String> invocations = context.getBean("customizerInvocations", List.class);
+			assertThat(invocations).containsExactly("first", "second");
+		});
 	}
 
 	@Test
@@ -470,6 +481,28 @@ public class McpStatelessServerAutoConfigurationIT {
 		@Override
 		public void customize(McpServer.StatelessSyncSpecification serverBuilder) {
 			this.invoked = true;
+		}
+
+	}
+
+	@Configuration
+	static class OrderedSyncServerCustomizersConfiguration {
+
+		@Bean
+		List<String> customizerInvocations() {
+			return new CopyOnWriteArrayList<>();
+		}
+
+		@Bean
+		@Order(1)
+		McpStatelessSyncServerCustomizer firstCustomizer(List<String> customizerInvocations) {
+			return serverBuilder -> customizerInvocations.add("first");
+		}
+
+		@Bean
+		@Order(2)
+		McpStatelessSyncServerCustomizer secondCustomizer(List<String> customizerInvocations) {
+			return serverBuilder -> customizerInvocations.add("second");
 		}
 
 	}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpStatelessAsyncServerCustomizer.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpStatelessAsyncServerCustomizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.customizer;
+
+import io.modelcontextprotocol.server.McpServer;
+
+/**
+ * Interface for customizing stateless asynchronous MCP server configurations.
+ *
+ * @author Niklas Herder
+ * @since 2.0.1
+ * @see io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification
+ */
+public interface McpStatelessAsyncServerCustomizer {
+
+	void customize(McpServer.StatelessAsyncSpecification serverBuilder);
+
+}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpStatelessAsyncServerCustomizer.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpStatelessAsyncServerCustomizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.customizer;
+
+import io.modelcontextprotocol.server.McpServer;
+
+/**
+ * Interface for customizing stateless asynchronous MCP server configurations.
+ *
+ * @author Niklas Herder
+ * @since 2.0.2
+ * @see io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification
+ */
+public interface McpStatelessAsyncServerCustomizer {
+
+	void customize(McpServer.StatelessAsyncSpecification serverBuilder);
+
+}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpStatelessSyncServerCustomizer.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpStatelessSyncServerCustomizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.customizer;
+
+import io.modelcontextprotocol.server.McpServer;
+
+/**
+ * Interface for customizing stateless synchronous MCP server configurations.
+ *
+ * @author Niklas Herder
+ * @since 2.0.1
+ * @see io.modelcontextprotocol.server.McpServer.StatelessSyncSpecification
+ */
+public interface McpStatelessSyncServerCustomizer {
+
+	void customize(McpServer.StatelessSyncSpecification serverBuilder);
+
+}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpStatelessSyncServerCustomizer.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpStatelessSyncServerCustomizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.customizer;
+
+import io.modelcontextprotocol.server.McpServer;
+
+/**
+ * Interface for customizing stateless synchronous MCP server configurations.
+ *
+ * @author Niklas Herder
+ * @since 2.0.2
+ * @see io.modelcontextprotocol.server.McpServer.StatelessSyncSpecification
+ */
+public interface McpStatelessSyncServerCustomizer {
+
+	void customize(McpServer.StatelessSyncSpecification serverBuilder);
+
+}


### PR DESCRIPTION
## What

Stateful MCP servers can be tuned with `McpSyncServerCustomizer` / `McpAsyncServerCustomizer` beans, which `McpServerAutoConfiguration` applies to the server builder before `build()`. The stateless (stateless/streamable transport) servers had no equivalent hook.

This adds, symmetric with the stateful side:

- `McpStatelessSyncServerCustomizer` and `McpStatelessAsyncServerCustomizer` in `org.springframework.ai.mcp.customizer`.
- Application of these beans in `McpServerStatelessAutoConfiguration` (`mcpStatelessSyncServer` / `mcpStatelessAsyncServer`) via `ObjectProvider` + `orderedStream()`, just before `build()` — so any number of customizers are applied, honouring `@Order`, consistent with the other `ObjectProvider` collaborators already injected into those methods.

## Why

Without a customizer, the only way to change anything on the stateless server builder — e.g. `serverInfo` (server name/version/title/icons for branding), capabilities, or request timeout — is to `spring.autoconfigure.exclude` `McpServerStatelessAutoConfiguration` and re-declare the entire server bean, duplicating all of the autoconfiguration's wiring. The stateful autoconfig already avoids this via customizer beans; this brings the stateless autoconfig in line.

`ObjectProvider` is used rather than `Optional`: `Optional<T>` supports only zero-or-one bean (a second customizer fails startup with `NoUniqueBeanDefinitionException`, with no ordering), whereas `ObjectProvider<T>.orderedStream()` applies all customizers honouring `@Order` — the idiomatic Boot customizer convention. See the [comment below](https://github.com/spring-projects/spring-ai/pull/6539#issuecomment-4866736114) for a note on the stateful side, which still uses `Optional`.

## Notes

- The servlet `immediateExecution(true)` default in the stateless sync path is left inline and runs before the customizers, so a user customizer can still override it.
- Tests added in `McpStatelessServerAutoConfigurationIT`: a user-provided customizer of each type is invoked during server construction, and multiple `@Order`ed customizers are all invoked in order. Full `spring-ai-autoconfigure-mcp-server-common` module build (incl. checkstyle + spring-javaformat) is green; 26/26 tests pass.

Replaces #6538, which changed all transports via a shared `serverInfo` bean; this is the narrower, convention-aligned approach.
