### PR TITLE
Fix MCP annotated specs with early server initialization

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerSpecificationFactoryAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
 
 import java.util.List;
+import java.util.Set;
 
 import io.modelcontextprotocol.server.McpServerFeatures;
 
@@ -29,6 +30,7 @@ import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration.ServerMcpAnnotatedBeans;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -46,6 +48,12 @@ import org.springframework.context.annotation.Configuration;
 @Conditional(McpServerAutoConfiguration.NonStatelessServerCondition.class)
 public class McpServerSpecificationFactoryAutoConfiguration {
 
+	private static void initializeBeans(ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations,
+			ConfigurableListableBeanFactory beanFactory,
+			Class<? extends java.lang.annotation.Annotation> annotationType) {
+		beansWithMcpMethodAnnotations.initializeBeans(beanFactory, Set.of(annotationType));
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
@@ -53,8 +61,9 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpServerFeatures.SyncResourceSpecification> resourceSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
 
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpResource.class);
 			List<McpServerFeatures.SyncResourceSpecification> syncResourceSpecifications = SyncMcpAnnotationProviders
 				.resourceSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
 			return syncResourceSpecifications;
@@ -62,8 +71,9 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpServerFeatures.SyncResourceTemplateSpecification> resourceTemplateSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
 
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpResource.class);
 			List<McpServerFeatures.SyncResourceTemplateSpecification> syncResourceTemplateSpecifications = SyncMcpAnnotationProviders
 				.resourceTemplateSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
 			return syncResourceTemplateSpecifications;
@@ -71,21 +81,24 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpServerFeatures.SyncPromptSpecification> promptSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpPrompt.class);
 			return SyncMcpAnnotationProviders
 				.promptSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpPrompt.class));
 		}
 
 		@Bean
 		public List<McpServerFeatures.SyncCompletionSpecification> completionSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpComplete.class);
 			return SyncMcpAnnotationProviders
 				.completeSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpComplete.class));
 		}
 
 		@Bean
 		public List<McpServerFeatures.SyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpTool.class);
 			List<Object> beansByAnnotation = beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class);
 			return SyncMcpAnnotationProviders.toolSpecifications(beansByAnnotation);
 		}
@@ -98,36 +111,41 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpServerFeatures.AsyncResourceSpecification> resourceSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpResource.class);
 			return AsyncMcpAnnotationProviders
 				.resourceSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
 		}
 
 		@Bean
 		public List<McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplateSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
 
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpResource.class);
 			return AsyncMcpAnnotationProviders
 				.resourceTemplateSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
 		}
 
 		@Bean
 		public List<McpServerFeatures.AsyncPromptSpecification> promptSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpPrompt.class);
 			return AsyncMcpAnnotationProviders
 				.promptSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpPrompt.class));
 		}
 
 		@Bean
 		public List<McpServerFeatures.AsyncCompletionSpecification> completionSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpComplete.class);
 			return AsyncMcpAnnotationProviders
 				.completeSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpComplete.class));
 		}
 
 		@Bean
 		public List<McpServerFeatures.AsyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, ConfigurableListableBeanFactory beanFactory) {
+			initializeBeans(beansWithMcpMethodAnnotations, beanFactory, McpTool.class);
 			return AsyncMcpAnnotationProviders
 				.toolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
 		}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
@@ -443,6 +443,24 @@ public class McpServerAutoConfigurationIT {
 			});
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	void asyncServerSpecificationConfigurationWithEarlyServerConsumer() {
+		this.contextRunner
+			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
+					McpServerSpecificationFactoryAutoConfiguration.class, EarlyAsyncServerConsumerConfiguration.class,
+					AsyncTestMcpSpecsConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.server.type=async")
+			.run(context -> {
+				McpAsyncServer asyncServer = context.getBean(McpAsyncServer.class);
+
+				CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "tools");
+				assertThat(tools).hasSize(1);
+				assertThat(tools.get(0).tool().name()).isEqualTo("add");
+			});
+	}
+
 	@Configuration
 	static class TestResourceConfiguration {
 
@@ -610,6 +628,36 @@ public class McpServerAutoConfigurationIT {
 		@Bean
 		McpServerTransport customTransport() {
 			return new CustomServerTransport();
+		}
+
+	}
+
+	@Configuration
+	static class EarlyAsyncServerConsumerConfiguration {
+
+		@Bean
+		EarlyAsyncServerConsumer earlyAsyncServerConsumer(McpAsyncServer mcpAsyncServer) {
+			return new EarlyAsyncServerConsumer(mcpAsyncServer);
+		}
+
+	}
+
+	static class EarlyAsyncServerConsumer {
+
+		private final McpAsyncServer mcpAsyncServer;
+
+		EarlyAsyncServerConsumer(McpAsyncServer mcpAsyncServer) {
+			this.mcpAsyncServer = mcpAsyncServer;
+		}
+
+	}
+
+	@Configuration
+	static class AsyncTestMcpSpecsConfiguration {
+
+		@Bean
+		AsyncTestMcpSpecsComponent asyncTestMcpSpecsComponent() {
+			return new AsyncTestMcpSpecsComponent();
 		}
 
 	}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeans.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeans.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
 /**
  * Container for Beans that have method with MCP annotations
  *
@@ -36,10 +38,30 @@ public abstract class AbstractMcpAnnotatedBeans {
 	private final Map<Class<? extends Annotation>, List<Object>> beansByAnnotation = new HashMap<>();
 
 	public void addMcpAnnotatedBean(Object bean, Set<Class<? extends Annotation>> annotations) {
-		this.beansWithCustomAnnotations.add(bean);
-		annotations
-			.forEach(annotationType -> this.beansByAnnotation.computeIfAbsent(annotationType, k -> new ArrayList<>())
-				.add(bean));
+		if (!containsBean(this.beansWithCustomAnnotations, bean)) {
+			this.beansWithCustomAnnotations.add(bean);
+		}
+		annotations.forEach(annotationType -> {
+			List<Object> beans = this.beansByAnnotation.computeIfAbsent(annotationType, k -> new ArrayList<>());
+			if (!containsBean(beans, bean)) {
+				beans.add(bean);
+			}
+		});
+	}
+
+	public void initializeBeans(ConfigurableListableBeanFactory beanFactory,
+			Set<Class<? extends Annotation>> targetAnnotations) {
+		AnnotatedMethodDiscovery discovery = new AnnotatedMethodDiscovery(targetAnnotations);
+		for (String beanName : beanFactory.getBeanDefinitionNames()) {
+			Class<?> beanClass = beanFactory.getType(beanName);
+			if (beanClass == null) {
+				continue;
+			}
+			Set<Class<? extends Annotation>> foundAnnotations = discovery.scan(beanClass);
+			if (!foundAnnotations.isEmpty()) {
+				addMcpAnnotatedBean(beanFactory.getBean(beanName), foundAnnotations);
+			}
+		}
 	}
 
 	public List<Object> getAllAnnotatedBeans() {
@@ -52,6 +74,10 @@ public abstract class AbstractMcpAnnotatedBeans {
 
 	public int getCount() {
 		return this.beansWithCustomAnnotations.size();
+	}
+
+	private boolean containsBean(List<Object> beans, Object bean) {
+		return beans.stream().anyMatch(existingBean -> existingBean == bean);
 	}
 
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeansTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeansTests.java
@@ -97,6 +97,20 @@ class AbstractMcpAnnotatedBeansTests {
 	}
 
 	@Test
+	void testAddSameBeanWithAdditionalAnnotation() {
+		Object bean = new Object();
+
+		this.annotatedBeans.addMcpAnnotatedBean(bean, Collections.singleton(Deprecated.class));
+		this.annotatedBeans.addMcpAnnotatedBean(bean, Set.of(Deprecated.class, Override.class));
+
+		assertEquals(1, this.annotatedBeans.getCount());
+		assertEquals(1, this.annotatedBeans.getBeansByAnnotation(Deprecated.class).size());
+		assertEquals(1, this.annotatedBeans.getBeansByAnnotation(Override.class).size());
+		assertTrue(this.annotatedBeans.getBeansByAnnotation(Deprecated.class).contains(bean));
+		assertTrue(this.annotatedBeans.getBeansByAnnotation(Override.class).contains(bean));
+	}
+
+	@Test
 	void testGetCount() {
 		assertEquals(0, this.annotatedBeans.getCount());
 


### PR DESCRIPTION
## Description

Fixes #6535.

When an application bean injects `McpAsyncServer` early, the server specification beans can be created before regular MCP annotated beans have been initialized by the annotation-scanning `BeanPostProcessor`. In that ordering, the specification factory snapshots an empty `ServerMcpAnnotatedBeans` registry and the async server starts without the annotated `@McpTool` methods.

This change initializes beans that declare the relevant MCP annotations before converting the registry into server specifications. The registry now also de-duplicates by bean identity while still allowing the same bean to be registered under additional annotation types later.

## Testing

- `./mvnw -Dmaven.build.cache.enabled=false -pl mcp/mcp-annotations,auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common -am -Dtest=AbstractMcpAnnotatedBeansTests,AbstractAnnotatedMethodBeanPostProcessorTests,McpServerAutoConfigurationIT#syncServerSpecificationConfiguration+asyncServerSpecificationConfiguration+asyncServerSpecificationConfigurationWithEarlyServerConsumer -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -Dmaven.build.cache.enabled=false -pl mcp/mcp-annotations,auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common -am test`
- `git diff --check`