### PR TITLE
Fix group precedence in `MilvusFilterExpressionConverter`

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverter.java
@@ -17,7 +17,6 @@
 package org.springframework.ai.vectorstore.milvus;
 
 import org.springframework.ai.vectorstore.filter.Filter.Expression;
-import org.springframework.ai.vectorstore.filter.Filter.ExpressionType;
 import org.springframework.ai.vectorstore.filter.Filter.Group;
 import org.springframework.ai.vectorstore.filter.Filter.Key;
 import org.springframework.ai.vectorstore.filter.converter.AbstractFilterExpressionConverter;
@@ -70,8 +69,13 @@ public class MilvusFilterExpressionConverter extends AbstractFilterExpressionCon
 	}
 
 	@Override
-	protected void doGroup(Group group, StringBuilder context) {
-		this.convertOperand(new Expression(ExpressionType.AND, group.content(), group.content()), context); // trick
+	protected void doStartGroup(Group group, StringBuilder context) {
+		context.append("(");
+	}
+
+	@Override
+	protected void doEndGroup(Group group, StringBuilder context) {
+		context.append(")");
 	}
 
 	@Override

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverterTests.java
@@ -98,7 +98,18 @@ public class MilvusFilterExpressionConverterTests {
 						new Expression(EQ, new Key("country"), new Value("BG")))),
 				new Expression(NIN, new Key("city"), new Value(List.of("Sofia", "Plovdiv")))));
 		assertThat(vectorExpr).isEqualTo(
-				"metadata[\"year\"] >= 2020 || metadata[\"country\"] == \"BG\" && metadata[\"year\"] >= 2020 || metadata[\"country\"] == \"BG\" && metadata[\"city\"] not in [\"Sofia\",\"Plovdiv\"]");
+				"(metadata[\"year\"] >= 2020 || metadata[\"country\"] == \"BG\") && metadata[\"city\"] not in [\"Sofia\",\"Plovdiv\"]");
+	}
+
+	@Test
+	public void testGroupAsRightOperand() {
+		// city == "Sofia" AND (year >= 2020 OR country == "BG")
+		String vectorExpr = this.converter
+			.convertExpression(new Expression(AND, new Expression(EQ, new Key("city"), new Value("Sofia")),
+					new Group(new Expression(OR, new Expression(GTE, new Key("year"), new Value(2020)),
+							new Expression(EQ, new Key("country"), new Value("BG"))))));
+		assertThat(vectorExpr).isEqualTo(
+				"metadata[\"city\"] == \"Sofia\" && (metadata[\"year\"] >= 2020 || metadata[\"country\"] == \"BG\")");
 	}
 
 	@Test


### PR DESCRIPTION
The `doGroup` override in `MilvusFilterExpressionConverter` converted a parenthesized filter group into `content && content`, duplicating the group body and dropping the parentheses that expressed the grouping.

Because Milvus binds `&&` tighter than `||`, a filter such as:

```
(year >= 2020 OR country == 'BG') AND city != 'Sofia'
```

was emitted without parentheses:

```
metadata["year"] >= 2020 || metadata["country"] == "BG" && metadata["year"] >= 2020 || metadata["country"] == "BG" && metadata["city"] != "Sofia"
```

so the trailing `AND` no longer applied to the whole group, and the query silently matched the wrong documents.

This replaces the override with the conventional `doStartGroup`/`doEndGroup` hooks that wrap the group content in parentheses, consistent with the other filter expression converters (for example `PgVectorFilterExpressionConverter`) and with the base `AbstractFilterExpressionConverter` contract. Making the grouping explicit also means the result no longer relies on Milvus's operator precedence.

The existing `testGroup` assertion codified the incorrect output and has been corrected; a `testGroupAsRightOperand` test was added to cover a group used as the right-hand operand.