### PR TITLE
Add partition scoping to Milvus vector store

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/src/main/java/org/springframework/ai/vectorstore/milvus/autoconfigure/MilvusVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/src/main/java/org/springframework/ai/vectorstore/milvus/autoconfigure/MilvusVectorStoreAutoConfiguration.java
@@ -46,6 +46,7 @@ import org.springframework.context.annotation.Bean;
  * @author Eddú Meléndez
  * @author Soby Chacko
  * @author Ilayaperumal Gopinathan
+ * @author Taewoong Kim
  */
 @AutoConfiguration
 @ConditionalOnClass({ MilvusVectorStore.class, EmbeddingModel.class })
@@ -78,6 +79,7 @@ public class MilvusVectorStoreAutoConfiguration {
 			.initializeSchema(properties.isInitializeSchema())
 			.databaseName(properties.getDatabaseName())
 			.collectionName(properties.getCollectionName())
+			.partitionName(properties.getPartitionName())
 			.embeddingDimension(properties.getEmbeddingDimension())
 			.indexType(IndexType.valueOf(properties.getIndexType().name()))
 			.metricType(MetricType.valueOf(properties.getMetricType().name()))

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/src/main/java/org/springframework/ai/vectorstore/milvus/autoconfigure/MilvusVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/src/main/java/org/springframework/ai/vectorstore/milvus/autoconfigure/MilvusVectorStoreProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.vectorstore.milvus.autoconfigure;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.vectorstore.milvus.MilvusVectorStore;
 import org.springframework.ai.vectorstore.properties.CommonVectorStoreProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -26,6 +28,7 @@ import org.springframework.util.Assert;
  *
  * @author Christian Tzolov
  * @author Ilayaperumal Gopinathan
+ * @author Taewoong Kim
  */
 @ConfigurationProperties(MilvusVectorStoreProperties.CONFIG_PREFIX)
 public class MilvusVectorStoreProperties extends CommonVectorStoreProperties {
@@ -41,6 +44,12 @@ public class MilvusVectorStoreProperties extends CommonVectorStoreProperties {
 	 * Milvus collection name to store the vectors.
 	 */
 	private String collectionName = MilvusVectorStore.DEFAULT_COLLECTION_NAME;
+
+	/**
+	 * Existing Milvus partition name used to scope insert, delete, and search operations.
+	 * When unset or blank, Milvus default behavior is used.
+	 */
+	private @Nullable String partitionName;
 
 	/**
 	 * The dimension of the vectors to be stored in the Milvus collection.
@@ -103,6 +112,14 @@ public class MilvusVectorStoreProperties extends CommonVectorStoreProperties {
 	public void setCollectionName(String collectionName) {
 		Assert.hasText(collectionName, "Collection name should not be empty.");
 		this.collectionName = collectionName;
+	}
+
+	public @Nullable String getPartitionName() {
+		return this.partitionName;
+	}
+
+	public void setPartitionName(@Nullable String partitionName) {
+		this.partitionName = partitionName;
 	}
 
 	public int getEmbeddingDimension() {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/src/test/java/org/springframework/ai/vectorstore/milvus/autoconfigure/MilvusVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/src/test/java/org/springframework/ai/vectorstore/milvus/autoconfigure/MilvusVectorStoreAutoConfigurationIT.java
@@ -18,8 +18,15 @@ package org.springframework.ai.vectorstore.milvus.autoconfigure;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import io.micrometer.observation.tck.TestObservationRegistry;
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.common.clientenum.ConsistencyLevelEnum;
+import io.milvus.param.dml.QueryParam;
+import io.milvus.param.partition.CreatePartitionParam;
+import io.milvus.param.partition.LoadPartitionsParam;
+import io.milvus.response.QueryResultsWrapper;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -48,9 +55,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Soby Chacko
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Taewoong Kim
  */
 @Testcontainers
 public class MilvusVectorStoreAutoConfigurationIT {
+
+	private static final String DEFAULT_PARTITION_NAME = "_default";
 
 	@Container
 	private static MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.6.18");
@@ -165,6 +175,86 @@ public class MilvusVectorStoreAutoConfigurationIT {
 	}
 
 	@Test
+	public void addSearchAndDeleteWithPartitionName() {
+		String collectionName = "partitionCollection" + UUID.randomUUID().toString().replace("-", "");
+		String partitionName = "tenant_partition";
+		this.contextRunner
+			.withPropertyValues("spring.ai.vectorstore.milvus.metric-type=COSINE",
+					"spring.ai.vectorstore.milvus.index-type=IVF_FLAT",
+					"spring.ai.vectorstore.milvus.embedding-dimension=384",
+					"spring.ai.vectorstore.milvus.collection-name=" + collectionName,
+					"spring.ai.vectorstore.milvus.partition-name=" + partitionName,
+					"spring.ai.vectorstore.milvus.initialize-schema=true",
+					"spring.ai.vectorstore.milvus.client.host=" + milvus.getHost(),
+					"spring.ai.vectorstore.milvus.client.port=" + milvus.getMappedPort(19530))
+			.run(context -> {
+				MilvusServiceClient milvusClient = context.getBean(MilvusServiceClient.class);
+				createAndLoadPartition(milvusClient, collectionName, partitionName);
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+				VectorStore defaultPartitionVectorStore = MilvusVectorStore
+					.builder(milvusClient, context.getBean(EmbeddingModel.class))
+					.collectionName(collectionName)
+					.build();
+				Document partitionDocument = new Document("Spring AI partition support", Map.of("tenant", "a"));
+				Document defaultPartitionDocument = new Document("Spring AI partition support",
+						Map.of("tenant", "default"));
+
+				defaultPartitionVectorStore.add(List.of(defaultPartitionDocument));
+				vectorStore.add(List.of(partitionDocument));
+
+				assertThat(countDocuments(milvusClient, collectionName, partitionName, partitionDocument.getId()))
+					.isEqualTo(1);
+				assertThat(
+						countDocuments(milvusClient, collectionName, DEFAULT_PARTITION_NAME, partitionDocument.getId()))
+					.isZero();
+				assertThat(countDocuments(milvusClient, collectionName, DEFAULT_PARTITION_NAME,
+						defaultPartitionDocument.getId()))
+					.isEqualTo(1);
+
+				List<Document> results = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("Spring AI partition support")
+					.topK(5)
+					.similarityThresholdAll()
+					.build());
+				assertThat(results).extracting(Document::getId)
+					.contains(partitionDocument.getId())
+					.doesNotContain(defaultPartitionDocument.getId());
+
+				vectorStore.delete(List.of(partitionDocument.getId()));
+
+				assertThat(countDocuments(milvusClient, collectionName, partitionName, partitionDocument.getId()))
+					.isZero();
+				assertThat(
+						countDocuments(milvusClient, collectionName, DEFAULT_PARTITION_NAME, partitionDocument.getId()))
+					.isZero();
+				assertThat(countDocuments(milvusClient, collectionName, DEFAULT_PARTITION_NAME,
+						defaultPartitionDocument.getId()))
+					.isEqualTo(1);
+
+				results = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("Spring AI partition support")
+					.topK(5)
+					.similarityThresholdAll()
+					.build());
+				assertThat(results).isEmpty();
+			});
+	}
+
+	private long countDocuments(MilvusServiceClient milvusClient, String collectionName, String partitionName,
+			String documentId) {
+		var query = milvusClient.query(QueryParam.newBuilder()
+			.withDatabaseName(MilvusVectorStore.DEFAULT_DATABASE_NAME)
+			.withCollectionName(collectionName)
+			.withConsistencyLevel(ConsistencyLevelEnum.STRONG)
+			.addPartitionName(partitionName)
+			.addOutField(MilvusVectorStore.DOC_ID_FIELD_NAME)
+			.withExpr(MilvusVectorStore.DOC_ID_FIELD_NAME + " == \"" + documentId + "\"")
+			.build());
+		assertThat(query.getException()).isNull();
+		return new QueryResultsWrapper(query.getData()).getRowCount();
+	}
+
+	@Test
 	public void autoConfigurationDisabledWhenTypeIsNone() {
 		this.contextRunner.withPropertyValues("spring.ai.vectorstore.type=none").run(context -> {
 			assertThat(context.getBeansOfType(MilvusVectorStoreProperties.class)).isEmpty();
@@ -196,6 +286,22 @@ public class MilvusVectorStoreAutoConfigurationIT {
 				assertThat(context.getBeansOfType(VectorStore.class)).isNotEmpty();
 				assertThat(context.getBean(VectorStore.class)).isInstanceOf(MilvusVectorStore.class);
 			});
+	}
+
+	private void createAndLoadPartition(MilvusServiceClient milvusClient, String collectionName, String partitionName) {
+		var createPartition = milvusClient.createPartition(CreatePartitionParam.newBuilder()
+			.withDatabaseName(MilvusVectorStore.DEFAULT_DATABASE_NAME)
+			.withCollectionName(collectionName)
+			.withPartitionName(partitionName)
+			.build());
+		assertThat(createPartition.getException()).isNull();
+
+		var loadPartitions = milvusClient.loadPartitions(LoadPartitionsParam.newBuilder()
+			.withDatabaseName(MilvusVectorStore.DEFAULT_DATABASE_NAME)
+			.withCollectionName(collectionName)
+			.addPartitionName(partitionName)
+			.build());
+		assertThat(loadPartitions.getException()).isNull();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
@@ -236,6 +236,7 @@ You can use the following properties in your Spring Boot configuration to custom
 
 |spring.ai.vectorstore.milvus.database-name |  The name of the Milvus database to use.  | default
 |spring.ai.vectorstore.milvus.collection-name | Milvus collection name to store the vectors  | vector_store
+|spring.ai.vectorstore.milvus.partition-name | Existing Milvus partition name used to scope insert, delete, and search operations. When unset or blank, Milvus default behavior is used. | -
 |spring.ai.vectorstore.milvus.initialize-schema | whether to initialize Milvus' backend | false
 |spring.ai.vectorstore.milvus.embedding-dimension | The dimension of the vectors to be stored in the Milvus collection.  | 1536
 |spring.ai.vectorstore.milvus.index-type | The type of the index to be created for the Milvus collection.  | IVF_FLAT

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
@@ -58,6 +58,7 @@ import io.milvus.response.QueryResultsWrapper.RowRecord;
 import io.milvus.response.SearchResultsWrapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentMetadata;
@@ -189,6 +190,8 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 
 	private final String collectionName;
 
+	private final @Nullable String partitionName;
+
 	private final int embeddingDimension;
 
 	private final IndexType indexType;
@@ -219,6 +222,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		this.initializeSchema = builder.initializeSchema;
 		this.databaseName = builder.databaseName;
 		this.collectionName = builder.collectionName;
+		this.partitionName = builder.partitionName;
 		this.embeddingDimension = builder.embeddingDimension;
 		this.indexType = builder.indexType;
 		this.metricType = builder.metricType;
@@ -275,11 +279,14 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		fields.add(new InsertParam.Field(this.metadataFieldName, metadataArray));
 		fields.add(new InsertParam.Field(this.embeddingFieldName, embeddingArray));
 
-		InsertParam insertParam = InsertParam.newBuilder()
+		InsertParam.Builder insertParamBuilder = InsertParam.newBuilder()
 			.withDatabaseName(this.databaseName)
 			.withCollectionName(this.collectionName)
-			.withFields(fields)
-			.build();
+			.withFields(fields);
+		if (StringUtils.hasText(this.partitionName)) {
+			insertParamBuilder.withPartitionName(this.partitionName);
+		}
+		InsertParam insertParam = insertParamBuilder.build();
 
 		R<MutationResult> status = this.milvusClient.insert(insertParam);
 		if (status.getException() != null) {
@@ -300,11 +307,14 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 					.map(MilvusFilterExpressionConverter::toFilterExpressionLiteral)
 					.collect(Collectors.joining(",")));
 
-		R<MutationResult> status = this.milvusClient.delete(DeleteParam.newBuilder()
+		DeleteParam.Builder deleteParamBuilder = DeleteParam.newBuilder()
 			.withDatabaseName(this.databaseName)
 			.withCollectionName(this.collectionName)
-			.withExpr(deleteExpression)
-			.build());
+			.withExpr(deleteExpression);
+		if (StringUtils.hasText(this.partitionName)) {
+			deleteParamBuilder.withPartitionName(this.partitionName);
+		}
+		R<MutationResult> status = this.milvusClient.delete(deleteParamBuilder.build());
 
 		long deleteCount = status.getData().getDeleteCnt();
 		if (logger.isWarnEnabled() && deleteCount != idList.size()) {
@@ -319,11 +329,14 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		try {
 			String nativeFilterExpression = this.filterExpressionConverter.convertExpression(filterExpression);
 
-			R<MutationResult> status = this.milvusClient.delete(DeleteParam.newBuilder()
+			DeleteParam.Builder deleteParamBuilder = DeleteParam.newBuilder()
 				.withDatabaseName(this.databaseName)
 				.withCollectionName(this.collectionName)
-				.withExpr(nativeFilterExpression)
-				.build());
+				.withExpr(nativeFilterExpression);
+			if (StringUtils.hasText(this.partitionName)) {
+				deleteParamBuilder.withPartitionName(this.partitionName);
+			}
+			R<MutationResult> status = this.milvusClient.delete(deleteParamBuilder.build());
 
 			if (status.getStatus() != Status.Success.getCode()) {
 				throw new IllegalStateException("Failed to delete documents by filter: " + status.getMessage());
@@ -376,6 +389,10 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 
 		if (StringUtils.hasText(nativeFilterExpressions)) {
 			searchParamBuilder.withExpr(nativeFilterExpressions);
+		}
+
+		if (StringUtils.hasText(this.partitionName)) {
+			searchParamBuilder.addPartitionName(this.partitionName);
 		}
 
 		if (StringUtils.hasText(searchParamsJson)) {
@@ -633,6 +650,8 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 
 		private String collectionName = DEFAULT_COLLECTION_NAME;
 
+		private @Nullable String partitionName;
+
 		private int embeddingDimension = INVALID_EMBEDDING_DIMENSION;
 
 		private IndexType indexType = IndexType.IVF_FLAT;
@@ -719,6 +738,18 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 */
 		public Builder collectionName(String collectionName) {
 			this.collectionName = collectionName;
+			return this;
+		}
+
+		/**
+		 * Configures the Milvus partition name for insert, delete, and search operations.
+		 * @param partitionName the existing partition name to use ({@code null} or blank
+		 * keeps the default Milvus behavior)
+		 * @return this builder instance
+		 * @since 2.0.1
+		 */
+		public Builder partitionName(@Nullable String partitionName) {
+			this.partitionName = partitionName;
 			return this;
 		}
 

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreTest.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreTest.java
@@ -26,6 +26,7 @@ import io.milvus.grpc.SearchResultData;
 import io.milvus.grpc.SearchResults;
 import io.milvus.param.R;
 import io.milvus.param.dml.DeleteParam;
+import io.milvus.param.dml.InsertParam;
 import io.milvus.param.dml.SearchParam;
 import io.milvus.response.QueryResultsWrapper.RowRecord;
 import io.milvus.response.SearchResultsWrapper;
@@ -57,9 +58,12 @@ import static org.mockito.Mockito.when;
  *
  * @author waileong
  * @author Soby Chacko
+ * @author Taewoong Kim
  */
 @ExtendWith(MockitoExtension.class)
 class MilvusVectorStoreTest {
+
+	private static final String PARTITION_NAME = "tenant_partition";
 
 	@Mock
 	private MilvusServiceClient milvusClient;
@@ -167,6 +171,88 @@ class MilvusVectorStoreTest {
 			assertThat(capturedParam.getTopK()).isEqualTo(request.getTopK());
 			assertThat(capturedParam.getExpr()).isEqualTo("metadata[\"age\"] > 30"); // filter
 			assertThat(capturedParam.getParams()).isEqualTo("{}");
+			assertThat(capturedParam.getPartitionNames()).isEmpty();
+		}
+	}
+
+	@Test
+	void shouldApplyPartitionNameWhenAddingDocuments() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+			.partitionName(PARTITION_NAME)
+			.build();
+
+		when(this.embeddingModel.embed(any(), any(), any())).thenReturn(List.of(new float[] { 1.0f, 2.0f, 3.0f }));
+		when(this.milvusClient.insert(any(InsertParam.class)))
+			.thenReturn(R.success(MutationResult.getDefaultInstance()));
+
+		this.vectorStore.doAdd(List.of(new Document("Spring AI partition test")));
+
+		ArgumentCaptor<InsertParam> captor = ArgumentCaptor.forClass(InsertParam.class);
+		verify(this.milvusClient).insert(captor.capture());
+		assertThat(captor.getValue().getPartitionName()).isEqualTo(PARTITION_NAME);
+	}
+
+	@Test
+	void shouldIgnoreBlankPartitionNameWhenAddingDocuments() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel).partitionName(" ").build();
+
+		when(this.embeddingModel.embed(any(), any(), any())).thenReturn(List.of(new float[] { 1.0f, 2.0f, 3.0f }));
+		when(this.milvusClient.insert(any(InsertParam.class)))
+			.thenReturn(R.success(MutationResult.getDefaultInstance()));
+
+		this.vectorStore.doAdd(List.of(new Document("Spring AI partition test")));
+
+		ArgumentCaptor<InsertParam> captor = ArgumentCaptor.forClass(InsertParam.class);
+		verify(this.milvusClient).insert(captor.capture());
+		assertThat(captor.getValue().getPartitionName()).isEmpty();
+	}
+
+	@Test
+	void shouldApplyPartitionNameWhenDeletingByIdList() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+			.partitionName(PARTITION_NAME)
+			.build();
+		MutationResult mutationResult = MutationResult.newBuilder().setDeleteCnt(1).build();
+		when(this.milvusClient.delete(any(DeleteParam.class))).thenReturn(R.success(mutationResult));
+
+		this.vectorStore.doDelete(List.of("doc-1"));
+
+		ArgumentCaptor<DeleteParam> captor = ArgumentCaptor.forClass(DeleteParam.class);
+		verify(this.milvusClient).delete(captor.capture());
+		assertThat(captor.getValue().getPartitionName()).isEqualTo(PARTITION_NAME);
+	}
+
+	@Test
+	void shouldApplyPartitionNameWhenDeletingByFilterExpression() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+			.partitionName(PARTITION_NAME)
+			.build();
+		MutationResult mutationResult = MutationResult.newBuilder().setDeleteCnt(1).build();
+		when(this.milvusClient.delete(any(DeleteParam.class))).thenReturn(R.success(mutationResult));
+
+		this.vectorStore.delete("tenant == 'a'");
+
+		ArgumentCaptor<DeleteParam> captor = ArgumentCaptor.forClass(DeleteParam.class);
+		verify(this.milvusClient).delete(captor.capture());
+		assertThat(captor.getValue().getPartitionName()).isEqualTo(PARTITION_NAME);
+	}
+
+	@Test
+	void shouldApplyPartitionNameWhenPerformingSimilaritySearch() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+			.partitionName(PARTITION_NAME)
+			.build();
+
+		try (MockedStatic<EmbeddingUtils> mockedEmbeddingUtils = mockStatic(EmbeddingUtils.class);
+				MockedConstruction<SearchResultsWrapper> mockedSearchResultsWrapper = mockConstruction(
+						SearchResultsWrapper.class,
+						(mock, context) -> when(mock.getRowRecords(0)).thenReturn(List.of()))) {
+
+			SearchRequest request = SearchRequest.builder().query("sample query").topK(5).build();
+
+			SearchParam capturedParam = performSimilaritySearch(mockedEmbeddingUtils, request);
+
+			assertThat(capturedParam.getPartitionNames()).containsExactly(PARTITION_NAME);
 		}
 	}
 
@@ -227,6 +313,7 @@ class MilvusVectorStoreTest {
 		// values.
 		assertThat(captor.getValue().getExpr()).isEqualTo(
 				"doc_id in [\"plain-id\",\"x' || doc_id != 'x\",\"with\\\"dquote\",\"back\\\\slash\\nnewline\"]");
+		assertThat(captor.getValue().getPartitionName()).isEmpty();
 	}
 
 	private SearchParam performSimilaritySearch(MockedStatic<EmbeddingUtils> mockedEmbeddingUtils,


### PR DESCRIPTION
Refs #797

`MilvusVectorStore` currently has no way to pass a Milvus partition name, so applications that organize data across Milvus partitions cannot scope insert, search, or delete operations to a specific partition.

This PR adds an optional `partitionName` builder option and the `spring.ai.vectorstore.milvus.partition-name` property. When set, the partition is applied to insert, delete, and search operations. Existing behavior is unchanged when the partition name is not set.

I also started `milvusdb/milvus:v2.5.4` locally and verified that, with matching documents in the default partition and a configured partition, `spring.ai.vectorstore.milvus.partition-name` limits search and delete to the configured partition.