### PR TITLE
Preserve Anthropic thinking blocks for tool replay

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -1009,10 +1009,20 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				ThinkingBlock thinkingBlock = block.asThinking();
 				thinkingContents
 					.add(AnthropicThinkingContent.thinking(thinkingBlock.thinking(), thinkingBlock.signature()));
+				Map<String, Object> thinkingProperties = new HashMap<>();
+				thinkingProperties.put("signature", thinkingBlock.signature());
+				generations.add(new Generation(AssistantMessage.builder()
+					.content(thinkingBlock.thinking())
+					.properties(thinkingProperties)
+					.build(), generationMetadata));
 			}
 			else if (block.isRedactedThinking()) {
 				RedactedThinkingBlock redactedBlock = block.asRedactedThinking();
 				thinkingContents.add(AnthropicThinkingContent.redacted(redactedBlock.data()));
+				Map<String, Object> redactedProperties = new HashMap<>();
+				redactedProperties.put("data", redactedBlock.data());
+				generations.add(new Generation(AssistantMessage.builder().properties(redactedProperties).build(),
+						generationMetadata));
 			}
 			else if (block.isWebSearchToolResult()) {
 				WebSearchToolResultBlock wsBlock = block.asWebSearchToolResult();

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -48,10 +48,12 @@ import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.MessageCreateParams;
 import com.anthropic.models.messages.RawMessageStreamEvent;
 import com.anthropic.models.messages.RedactedThinkingBlock;
+import com.anthropic.models.messages.RedactedThinkingBlockParam;
 import com.anthropic.models.messages.TextBlock;
 import com.anthropic.models.messages.TextBlockParam;
 import com.anthropic.models.messages.TextCitation;
 import com.anthropic.models.messages.ThinkingBlock;
+import com.anthropic.models.messages.ThinkingBlockParam;
 import com.anthropic.models.messages.Tool;
 import com.anthropic.models.messages.ToolChoice;
 import com.anthropic.models.messages.ToolChoiceAuto;
@@ -141,6 +143,7 @@ import org.springframework.util.MimeType;
  * @author Austin Dase
  * @author Sebastien Deleuze
  * @author Ilayaperumal Gopinathan
+ * @author Jewoo Shin
  * @since 1.0.0
  * @see AnthropicChatOptions
  * @see <a href="https://docs.anthropic.com/en/api/messages">Anthropic Messages API</a>
@@ -156,6 +159,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	private static final String BETA_CODE_EXECUTION = "code-execution-2025-08-25";
 
 	private static final String BETA_FILES_API = "files-api-2025-04-14";
+
+	static final String ANTHROPIC_THINKING_CONTENTS_PROPERTY = "anthropicThinkingContents";
 
 	private static final ToolCallingManager DEFAULT_TOOL_CALLING_MANAGER = ToolCallingManager.builder().build();
 
@@ -383,9 +388,13 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				var toolUseBlock = contentBlock.asToolUse();
 				streamingState.startToolUse(toolUseBlock.id(), toolUseBlock.name());
 			}
+			else if (contentBlock.isThinking()) {
+				streamingState.startThinking();
+			}
 			else if (contentBlock.isRedactedThinking()) {
 				// Emit redacted thinking block immediately
 				RedactedThinkingBlock redactedBlock = contentBlock.asRedactedThinking();
+				streamingState.addThinkingContent(AnthropicThinkingContent.redacted(redactedBlock.data()));
 				Map<String, Object> redactedProperties = new HashMap<>();
 				redactedProperties.put("data", redactedBlock.data());
 				AssistantMessage assistantMessage = AssistantMessage.builder().properties(redactedProperties).build();
@@ -428,6 +437,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			// Thinking chunk — emit with thinking metadata
 			if (delta.isThinking()) {
 				String thinkingText = delta.asThinking().thinking();
+				streamingState.appendThinking(thinkingText);
 				Map<String, Object> thinkingProperties = new HashMap<>();
 				thinkingProperties.put("thinking", Boolean.TRUE);
 				AssistantMessage assistantMessage = AssistantMessage.builder()
@@ -440,6 +450,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			// Thinking signature — emit with signature metadata
 			if (delta.isSignature()) {
 				String signature = delta.asSignature().signature();
+				streamingState.setThinkingSignature(signature);
 				Map<String, Object> signatureProperties = new HashMap<>();
 				signatureProperties.put("signature", signature);
 				AssistantMessage assistantMessage = AssistantMessage.builder().properties(signatureProperties).build();
@@ -463,6 +474,9 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			if (streamingState.isTrackingToolUse()) {
 				streamingState.finishToolUse();
 			}
+			else if (streamingState.isTrackingThinking()) {
+				streamingState.finishThinking();
+			}
 			return null;
 		}
 
@@ -473,13 +487,10 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			ChatGenerationMetadata metadata = ChatGenerationMetadata.builder().finishReason(stopReason).build();
 
 			// Build assistant message with any accumulated tool calls
-			AssistantMessage.Builder assistantMessageBuilder = AssistantMessage.builder().content("");
 			List<ToolCall> toolCalls = streamingState.getCompletedToolCalls();
-			if (!toolCalls.isEmpty()) {
-				assistantMessageBuilder.toolCalls(toolCalls);
-			}
-
-			Generation generation = new Generation(assistantMessageBuilder.build(), metadata);
+			AssistantMessage assistantMessage = buildAssistantMessage("", toolCalls,
+					streamingState.getThinkingContents());
+			Generation generation = new Generation(assistantMessage, metadata);
 
 			// Combine input tokens from message_start with output tokens from
 			// message_delta
@@ -738,16 +749,25 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			}
 			else if (message.getMessageType() == MessageType.ASSISTANT) {
 				AssistantMessage assistantMessage = (AssistantMessage) message;
-				if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
-					List<ContentBlockParam> toolUseBlocks = assistantMessage.getToolCalls()
+				List<AnthropicThinkingContent> thinkingContents = getAnthropicThinkingContents(assistantMessage);
+				if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls()) || !thinkingContents.isEmpty()) {
+					List<ContentBlockParam> contentBlocks = new ArrayList<>();
+					String text = getAssistantTextForRequest(assistantMessage, thinkingContents);
+					if (text != null && !text.isEmpty()) {
+						contentBlocks.add(ContentBlockParam.ofText(TextBlockParam.builder().text(text).build()));
+					}
+					thinkingContents.stream()
+						.map(AnthropicThinkingContent::toContentBlockParam)
+						.forEach(contentBlocks::add);
+					assistantMessage.getToolCalls()
 						.stream()
 						.map(toolCall -> ContentBlockParam.ofToolUse(ToolUseBlockParam.builder()
 							.id(toolCall.id())
 							.name(toolCall.name())
 							.input(buildToolInput(toolCall.arguments()))
 							.build()))
-						.toList();
-					builder.addAssistantMessageOfBlockParams(toolUseBlocks);
+						.forEach(contentBlocks::add);
+					builder.addAssistantMessageOfBlockParams(contentBlocks);
 				}
 				else {
 					String text = message.getText();
@@ -960,6 +980,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		// Collect text and tool calls from content blocks
 		StringBuilder textContent = new StringBuilder();
 		List<ToolCall> toolCalls = new ArrayList<>();
+		List<AnthropicThinkingContent> thinkingContents = new ArrayList<>();
 
 		for (ContentBlock block : message.content()) {
 			if (block.isText()) {
@@ -985,23 +1006,13 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				toolCalls.add(new ToolCall(toolUseBlock.id(), "function", toolUseBlock.name(), arguments));
 			}
 			else if (block.isThinking()) {
-				// ThinkingBlock: stored as a separate Generation with the thinking
-				// text as content and signature in metadata properties.
 				ThinkingBlock thinkingBlock = block.asThinking();
-				Map<String, Object> thinkingProperties = new HashMap<>();
-				thinkingProperties.put("signature", thinkingBlock.signature());
-				generations.add(new Generation(AssistantMessage.builder()
-					.content(thinkingBlock.thinking())
-					.properties(thinkingProperties)
-					.build(), generationMetadata));
+				thinkingContents
+					.add(AnthropicThinkingContent.thinking(thinkingBlock.thinking(), thinkingBlock.signature()));
 			}
 			else if (block.isRedactedThinking()) {
-				// RedactedThinkingBlock: safety-redacted reasoning with a data marker.
 				RedactedThinkingBlock redactedBlock = block.asRedactedThinking();
-				Map<String, Object> redactedProperties = new HashMap<>();
-				redactedProperties.put("data", redactedBlock.data());
-				generations.add(new Generation(AssistantMessage.builder().properties(redactedProperties).build(),
-						generationMetadata));
+				thinkingContents.add(AnthropicThinkingContent.redacted(redactedBlock.data()));
 			}
 			else if (block.isWebSearchToolResult()) {
 				WebSearchToolResultBlock wsBlock = block.asWebSearchToolResult();
@@ -1020,13 +1031,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			}
 		}
 
-		AssistantMessage.Builder assistantMessageBuilder = AssistantMessage.builder().content(textContent.toString());
-
-		if (!toolCalls.isEmpty()) {
-			assistantMessageBuilder.toolCalls(toolCalls);
-		}
-
-		generations.add(new Generation(assistantMessageBuilder.build(), generationMetadata));
+		generations.add(new Generation(buildAssistantMessage(textContent.toString(), toolCalls, thinkingContents),
+				generationMetadata));
 
 		return generations;
 	}
@@ -1467,6 +1473,121 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		}
 	}
 
+	private static AssistantMessage buildAssistantMessage(String content, List<ToolCall> toolCalls,
+			List<AnthropicThinkingContent> thinkingContents) {
+		if (thinkingContents.isEmpty()) {
+			AssistantMessage.Builder<?> assistantMessageBuilder = AssistantMessage.builder().content(content);
+			if (!toolCalls.isEmpty()) {
+				assistantMessageBuilder.toolCalls(toolCalls);
+			}
+			return assistantMessageBuilder.build();
+		}
+		return new AnthropicAssistantMessage(content, toolCalls, thinkingContents);
+	}
+
+	private static List<AnthropicThinkingContent> getAnthropicThinkingContents(AssistantMessage assistantMessage) {
+		if (assistantMessage instanceof AnthropicAssistantMessage anthropicAssistantMessage) {
+			return anthropicAssistantMessage.getThinkingContents();
+		}
+		Object contents = assistantMessage.getMetadata().get(ANTHROPIC_THINKING_CONTENTS_PROPERTY);
+		if (contents instanceof List<?> list) {
+			List<AnthropicThinkingContent> thinkingContents = new ArrayList<>();
+			for (Object item : list) {
+				if (item instanceof AnthropicThinkingContent thinkingContent) {
+					thinkingContents.add(thinkingContent);
+				}
+				else {
+					return List.of();
+				}
+			}
+			return thinkingContents;
+		}
+		return List.of();
+	}
+
+	private static @Nullable String getAssistantTextForRequest(AssistantMessage assistantMessage,
+			List<AnthropicThinkingContent> thinkingContents) {
+		String text = assistantMessage.getText();
+		if (text == null || text.isEmpty() || thinkingContents.isEmpty() || !assistantMessage.hasToolCalls()) {
+			return text;
+		}
+		StringBuilder replayedThinkingText = new StringBuilder();
+		for (AnthropicThinkingContent thinkingContent : thinkingContents) {
+			if (thinkingContent.thinking() != null) {
+				replayedThinkingText.append(thinkingContent.thinking());
+			}
+		}
+		if (!replayedThinkingText.isEmpty() && text.startsWith(replayedThinkingText.toString())) {
+			return text.substring(replayedThinkingText.length());
+		}
+		return text;
+	}
+
+	private static Map<String, Object> anthropicThinkingProperties(List<AnthropicThinkingContent> thinkingContents) {
+		if (thinkingContents.isEmpty()) {
+			return Map.of();
+		}
+		return Map.of(ANTHROPIC_THINKING_CONTENTS_PROPERTY, List.copyOf(thinkingContents));
+	}
+
+	static final class AnthropicAssistantMessage extends AssistantMessage {
+
+		private final List<AnthropicThinkingContent> thinkingContents;
+
+		private AnthropicAssistantMessage(String content, List<ToolCall> toolCalls,
+				List<AnthropicThinkingContent> thinkingContents) {
+			super(content, anthropicThinkingProperties(thinkingContents), List.copyOf(toolCalls), List.of());
+			this.thinkingContents = List.copyOf(thinkingContents);
+		}
+
+		List<AnthropicThinkingContent> getThinkingContents() {
+			return this.thinkingContents;
+		}
+
+		boolean hasThinkingContents() {
+			return !this.thinkingContents.isEmpty();
+		}
+
+		@Override
+		public String toString() {
+			return "AnthropicAssistantMessage [messageType=" + getMessageType() + ", toolCalls=" + getToolCalls()
+					+ ", textContent=" + getText() + ", thinkingContents=" + this.thinkingContents.size() + "]";
+		}
+
+	}
+
+	record AnthropicThinkingContent(@Nullable String thinking, @Nullable String signature,
+			@Nullable String redactedData) {
+
+		static AnthropicThinkingContent thinking(String thinking, String signature) {
+			return new AnthropicThinkingContent(thinking, signature, null);
+		}
+
+		static AnthropicThinkingContent redacted(String data) {
+			return new AnthropicThinkingContent(null, null, data);
+		}
+
+		ContentBlockParam toContentBlockParam() {
+			if (this.redactedData != null) {
+				return ContentBlockParam
+					.ofRedactedThinking(RedactedThinkingBlockParam.builder().data(this.redactedData).build());
+			}
+			String thinking = this.thinking;
+			String signature = this.signature;
+			Assert.notNull(thinking, "thinking must not be null");
+			Assert.notNull(signature, "signature must not be null");
+			return ContentBlockParam
+				.ofThinking(ThinkingBlockParam.builder().thinking(thinking).signature(signature).build());
+		}
+
+		@Override
+		public String toString() {
+			String type = this.redactedData != null ? "redacted_thinking" : "thinking";
+			return "AnthropicThinkingContent[type=" + type + "]";
+		}
+
+	}
+
 	/**
 	 * Holds state accumulated during streaming for building complete responses. This
 	 * includes message metadata (ID, model, input tokens) and tool call accumulation
@@ -1488,6 +1609,14 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		private final StringBuilder currentToolJsonAccumulator = new StringBuilder();
 
 		private final List<ToolCall> completedToolCalls = new ArrayList<>();
+
+		private final AtomicReference<Boolean> currentThinking = new AtomicReference<>(false);
+
+		private final StringBuilder currentThinkingAccumulator = new StringBuilder();
+
+		private final AtomicReference<@Nullable String> currentThinkingSignature = new AtomicReference<>();
+
+		private final List<AnthropicThinkingContent> thinkingContents = new ArrayList<>();
 
 		private final List<Citation> accumulatedCitations = new ArrayList<>();
 
@@ -1532,6 +1661,35 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			this.currentToolJsonAccumulator.setLength(0);
 		}
 
+		void startThinking() {
+			this.currentThinking.set(true);
+			this.currentThinkingAccumulator.setLength(0);
+			this.currentThinkingSignature.set(null);
+		}
+
+		void appendThinking(String thinking) {
+			this.currentThinkingAccumulator.append(thinking);
+		}
+
+		void setThinkingSignature(String signature) {
+			this.currentThinkingSignature.set(signature);
+		}
+
+		void finishThinking() {
+			if (this.currentThinking.get()) {
+				String signature = this.currentThinkingSignature.get();
+				this.thinkingContents.add(AnthropicThinkingContent.thinking(this.currentThinkingAccumulator.toString(),
+						signature != null ? signature : ""));
+			}
+			this.currentThinking.set(false);
+			this.currentThinkingAccumulator.setLength(0);
+			this.currentThinkingSignature.set(null);
+		}
+
+		void addThinkingContent(AnthropicThinkingContent thinkingContent) {
+			this.thinkingContents.add(thinkingContent);
+		}
+
 		/**
 		 * Appends partial JSON to the current tool's input accumulator.
 		 * @param partialJson the partial JSON string
@@ -1563,11 +1721,19 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			return !this.currentToolId.get().isEmpty();
 		}
 
+		boolean isTrackingThinking() {
+			return Boolean.TRUE.equals(this.currentThinking.get());
+		}
+
 		/**
 		 * Returns the list of completed tool calls accumulated during streaming.
 		 */
 		List<ToolCall> getCompletedToolCalls() {
 			return new ArrayList<>(this.completedToolCalls);
+		}
+
+		List<AnthropicThinkingContent> getThinkingContents() {
+			return new ArrayList<>(this.thinkingContents);
 		}
 
 		void addCitation(Citation citation) {

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
@@ -71,6 +71,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.RateLimit;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingManager;
@@ -262,6 +263,14 @@ class AnthropicChatModelTests {
 		Prompt prompt = new Prompt("What's the weather?", options);
 
 		ChatResponse response = this.chatModel.call(prompt);
+		assertThat(response.getResults()).hasSize(2);
+		Generation thinkingGeneration = response.getResults().get(0);
+		assertThat(thinkingGeneration.getOutput().getText()).isEqualTo("thinking text");
+		assertThat(thinkingGeneration.getOutput().getMetadata()).containsEntry("signature", "thinking-signature");
+		Generation toolCallGeneration = response.getResults().get(1);
+		assertThat(toolCallGeneration.getOutput()).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
+		assertThat(toolCallGeneration.getOutput().getToolCalls()).hasSize(1);
+
 		ToolExecutionResult toolExecutionResult = ToolCallingManager.builder()
 			.build()
 			.executeToolCalls(prompt, response);
@@ -292,6 +301,13 @@ class AnthropicChatModelTests {
 		Prompt prompt = new Prompt("What's the weather?", options);
 
 		ChatResponse response = this.chatModel.call(prompt);
+		assertThat(response.getResults()).hasSize(2);
+		Generation redactedGeneration = response.getResults().get(0);
+		assertThat(redactedGeneration.getOutput().getMetadata()).containsEntry("data", "redacted-data");
+		Generation toolCallGeneration = response.getResults().get(1);
+		assertThat(toolCallGeneration.getOutput()).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
+		assertThat(toolCallGeneration.getOutput().getToolCalls()).hasSize(1);
+
 		ToolExecutionResult toolExecutionResult = ToolCallingManager.builder()
 			.build()
 			.executeToolCalls(prompt, response);
@@ -308,17 +324,22 @@ class AnthropicChatModelTests {
 	}
 
 	@Test
-	void thinkingOnlyResponseKeepsFinalTextAsResult() {
+	void thinkingOnlyResponseExposesThinkingGenerationAndKeepsReplayState() {
 		Message mockResponse = createMockMessageWithThinkingAndText("thinking text", "thinking-signature",
 				"Final answer.");
 		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(mockResponse);
 
 		ChatResponse response = this.chatModel.call(new Prompt("Explain it"));
 
-		assertThat(response.getResult().getOutput().getText()).isEqualTo("Final answer.");
-		assertThat(response.getResult().getOutput()).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
-		AnthropicChatModel.AnthropicAssistantMessage output = (AnthropicChatModel.AnthropicAssistantMessage) response
-			.getResult()
+		assertThat(response.getResults()).hasSize(2);
+		Generation thinkingGeneration = response.getResults().get(0);
+		assertThat(thinkingGeneration.getOutput().getText()).isEqualTo("thinking text");
+		assertThat(thinkingGeneration.getOutput().getMetadata()).containsEntry("signature", "thinking-signature");
+
+		Generation finalGeneration = response.getResults().get(1);
+		assertThat(finalGeneration.getOutput().getText()).isEqualTo("Final answer.");
+		assertThat(finalGeneration.getOutput()).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
+		AnthropicChatModel.AnthropicAssistantMessage output = (AnthropicChatModel.AnthropicAssistantMessage) finalGeneration
 			.getOutput();
 		assertThat(output.hasThinkingContents()).isTrue();
 	}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import com.anthropic.client.AnthropicClient;
@@ -38,10 +39,16 @@ import com.anthropic.models.messages.MessageDeltaUsage;
 import com.anthropic.models.messages.MessageParam;
 import com.anthropic.models.messages.Model;
 import com.anthropic.models.messages.OutputConfig;
+import com.anthropic.models.messages.RawContentBlockDeltaEvent;
+import com.anthropic.models.messages.RawContentBlockStartEvent;
+import com.anthropic.models.messages.RawContentBlockStopEvent;
 import com.anthropic.models.messages.RawMessageDeltaEvent;
+import com.anthropic.models.messages.RawMessageStartEvent;
 import com.anthropic.models.messages.RawMessageStreamEvent;
+import com.anthropic.models.messages.RedactedThinkingBlock;
 import com.anthropic.models.messages.StopReason;
 import com.anthropic.models.messages.TextBlock;
+import com.anthropic.models.messages.ThinkingBlock;
 import com.anthropic.models.messages.ToolResultBlockParam;
 import com.anthropic.models.messages.ToolUseBlock;
 import com.anthropic.models.messages.Usage;
@@ -64,13 +71,20 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.RateLimit;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.definition.ToolDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -79,6 +93,7 @@ import static org.mockito.Mockito.verify;
  *
  * @author Soby Chacko
  * @author Sebastien Deleuze
+ * @author Jewoo Shin
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -232,6 +247,125 @@ class AnthropicChatModelTests {
 		assertThat(toolCall.id()).isEqualTo("toolu_123");
 		assertThat(toolCall.name()).isEqualTo("getCurrentWeather");
 		assertThat(toolCall.arguments()).contains("San Francisco");
+	}
+
+	@Test
+	void thinkingBlockIsReplayedBeforeToolUseBlock() {
+		Message toolUseResponse = createMockMessageWithThinkingAndToolUse("thinking text", "thinking-signature",
+				"toolu_123", "getCurrentWeather", JsonValue.from(java.util.Map.of("location", "Paris")));
+		Message finalResponse = createMockMessage("Done.", StopReason.END_TURN);
+		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(toolUseResponse, finalResponse);
+
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.toolCallbacks(List.of(new TestToolCallback("getCurrentWeather")))
+			.build();
+		Prompt prompt = new Prompt("What's the weather?", options);
+
+		ChatResponse response = this.chatModel.call(prompt);
+		ToolExecutionResult toolExecutionResult = ToolCallingManager.builder()
+			.build()
+			.executeToolCalls(prompt, response);
+		this.chatModel.call(new Prompt(toolExecutionResult.conversationHistory(), options));
+
+		ArgumentCaptor<MessageCreateParams> captor = ArgumentCaptor.forClass(MessageCreateParams.class);
+		verify(this.messageService, times(2)).create(captor.capture());
+
+		List<ContentBlockParam> replayedAssistantBlocks = assistantBlockParams(captor.getAllValues().get(1));
+		assertThat(replayedAssistantBlocks).hasSize(2);
+		assertThat(replayedAssistantBlocks.get(0).isThinking()).isTrue();
+		assertThat(replayedAssistantBlocks.get(0).asThinking().thinking()).isEqualTo("thinking text");
+		assertThat(replayedAssistantBlocks.get(0).asThinking().signature()).isEqualTo("thinking-signature");
+		assertThat(replayedAssistantBlocks.get(1).isToolUse()).isTrue();
+		assertThat(toolResultBlocks(captor.getAllValues().get(1))).hasSize(1);
+	}
+
+	@Test
+	void redactedThinkingBlockIsReplayedBeforeToolUseBlock() {
+		Message toolUseResponse = createMockMessageWithRedactedThinkingAndToolUse("redacted-data", "toolu_123",
+				"getCurrentWeather", JsonValue.from(java.util.Map.of("location", "Paris")));
+		Message finalResponse = createMockMessage("Done.", StopReason.END_TURN);
+		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(toolUseResponse, finalResponse);
+
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.toolCallbacks(List.of(new TestToolCallback("getCurrentWeather")))
+			.build();
+		Prompt prompt = new Prompt("What's the weather?", options);
+
+		ChatResponse response = this.chatModel.call(prompt);
+		ToolExecutionResult toolExecutionResult = ToolCallingManager.builder()
+			.build()
+			.executeToolCalls(prompt, response);
+		this.chatModel.call(new Prompt(toolExecutionResult.conversationHistory(), options));
+
+		ArgumentCaptor<MessageCreateParams> captor = ArgumentCaptor.forClass(MessageCreateParams.class);
+		verify(this.messageService, times(2)).create(captor.capture());
+
+		List<ContentBlockParam> replayedAssistantBlocks = assistantBlockParams(captor.getAllValues().get(1));
+		assertThat(replayedAssistantBlocks).hasSize(2);
+		assertThat(replayedAssistantBlocks.get(0).isRedactedThinking()).isTrue();
+		assertThat(replayedAssistantBlocks.get(0).asRedactedThinking().data()).isEqualTo("redacted-data");
+		assertThat(replayedAssistantBlocks.get(1).isToolUse()).isTrue();
+	}
+
+	@Test
+	void thinkingOnlyResponseKeepsFinalTextAsResult() {
+		Message mockResponse = createMockMessageWithThinkingAndText("thinking text", "thinking-signature",
+				"Final answer.");
+		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(mockResponse);
+
+		ChatResponse response = this.chatModel.call(new Prompt("Explain it"));
+
+		assertThat(response.getResult().getOutput().getText()).isEqualTo("Final answer.");
+		assertThat(response.getResult().getOutput()).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
+		AnthropicChatModel.AnthropicAssistantMessage output = (AnthropicChatModel.AnthropicAssistantMessage) response
+			.getResult()
+			.getOutput();
+		assertThat(output.hasThinkingContents()).isTrue();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void streamingThinkingBlockIsReplayedBeforeToolUseBlock() {
+		List<RawMessageStreamEvent> events = List.of(messageStartEvent(), thinkingStartEvent(),
+				thinkingDeltaEvent("thinking "), thinkingDeltaEvent("text"), signatureDeltaEvent("thinking-signature"),
+				contentBlockStopEvent(0), toolUseStartEvent("toolu_123", "getCurrentWeather"),
+				inputJsonDeltaEvent("{\"location\":\"Paris\"}"), contentBlockStopEvent(1),
+				messageDeltaEvent(StopReason.TOOL_USE));
+		StreamResponse<RawMessageStreamEvent> streamResponse = mock(StreamResponse.class);
+		given(streamResponse.stream()).willReturn(events.stream());
+
+		HttpResponseFor<StreamResponse<RawMessageStreamEvent>> rawResponse = mock(HttpResponseFor.class);
+		given(rawResponse.parse()).willReturn(streamResponse);
+		given(rawResponse.headers()).willReturn(Headers.builder().build());
+
+		given(this.anthropicClientAsync.messages()).willReturn(this.messageServiceAsync);
+		given(this.messageServiceAsync.withRawResponse()).willReturn(this.messageServiceAsyncWithRawResponse);
+		given(this.messageServiceAsyncWithRawResponse.createStreaming(any(MessageCreateParams.class)))
+			.willReturn(CompletableFuture.completedFuture(rawResponse));
+		Message finalResponse = createMockMessage("Done.", StopReason.END_TURN);
+		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(finalResponse);
+
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.toolCallbacks(List.of(new TestToolCallback("getCurrentWeather")))
+			.build();
+		Prompt prompt = new Prompt("What's the weather?", options);
+		AtomicReference<ChatResponse> aggregatedResponse = new AtomicReference<>();
+
+		new MessageAggregator().aggregate(this.chatModel.stream(prompt), aggregatedResponse::set).collectList().block();
+		ToolExecutionResult toolExecutionResult = ToolCallingManager.builder()
+			.build()
+			.executeToolCalls(prompt, aggregatedResponse.get());
+		this.chatModel.call(new Prompt(toolExecutionResult.conversationHistory(), options));
+
+		ArgumentCaptor<MessageCreateParams> captor = ArgumentCaptor.forClass(MessageCreateParams.class);
+		verify(this.messageService).create(captor.capture());
+
+		List<ContentBlockParam> replayedAssistantBlocks = assistantBlockParams(captor.getValue());
+		assertThat(replayedAssistantBlocks).hasSize(2);
+		assertThat(replayedAssistantBlocks.get(0).isThinking()).isTrue();
+		assertThat(replayedAssistantBlocks.get(0).asThinking().thinking()).isEqualTo("thinking text");
+		assertThat(replayedAssistantBlocks.get(0).asThinking().signature()).isEqualTo("thinking-signature");
+		assertThat(replayedAssistantBlocks.get(1).isToolUse()).isTrue();
 	}
 
 	@Test
@@ -450,6 +584,15 @@ class AnthropicChatModelTests {
 			.build();
 	}
 
+	private static List<ContentBlockParam> assistantBlockParams(MessageCreateParams request) {
+		for (MessageParam message : request.messages()) {
+			if (message.role() == MessageParam.Role.ASSISTANT && message.content().isBlockParams()) {
+				return message.content().asBlockParams();
+			}
+		}
+		return List.of();
+	}
+
 	private static List<ToolResultBlockParam> toolResultBlocks(MessageCreateParams request) {
 		List<ToolResultBlockParam> blocks = new java.util.ArrayList<>();
 		for (MessageParam message : request.messages()) {
@@ -468,6 +611,91 @@ class AnthropicChatModelTests {
 		List<ToolResultBlockParam> blocks = toolResultBlocks(request);
 		assertThat(blocks).isNotEmpty();
 		return blocks.get(blocks.size() - 1);
+	}
+
+	private Message createMockMessageWithThinkingAndText(String thinking, String signature, String text) {
+		ThinkingBlock thinkingBlock = mock(ThinkingBlock.class);
+		given(thinkingBlock.thinking()).willReturn(thinking);
+		given(thinkingBlock.signature()).willReturn(signature);
+
+		ContentBlock thinkingContentBlock = mock(ContentBlock.class);
+		given(thinkingContentBlock.isText()).willReturn(false);
+		given(thinkingContentBlock.isToolUse()).willReturn(false);
+		given(thinkingContentBlock.isThinking()).willReturn(true);
+		given(thinkingContentBlock.asThinking()).willReturn(thinkingBlock);
+
+		TextBlock textBlock = mock(TextBlock.class);
+		given(textBlock.text()).willReturn(text);
+
+		ContentBlock textContentBlock = mock(ContentBlock.class);
+		given(textContentBlock.isText()).willReturn(true);
+		given(textContentBlock.asText()).willReturn(textBlock);
+
+		return createMockMessage(List.of(thinkingContentBlock, textContentBlock), StopReason.END_TURN, 10L, 20L);
+	}
+
+	private Message createMockMessageWithThinkingAndToolUse(String thinking, String signature, String toolId,
+			String toolName, JsonValue input) {
+		ThinkingBlock thinkingBlock = mock(ThinkingBlock.class);
+		given(thinkingBlock.thinking()).willReturn(thinking);
+		given(thinkingBlock.signature()).willReturn(signature);
+
+		ContentBlock thinkingContentBlock = mock(ContentBlock.class);
+		given(thinkingContentBlock.isText()).willReturn(false);
+		given(thinkingContentBlock.isToolUse()).willReturn(false);
+		given(thinkingContentBlock.isThinking()).willReturn(true);
+		given(thinkingContentBlock.asThinking()).willReturn(thinkingBlock);
+
+		ContentBlock toolUseContentBlock = toolUseContentBlock(toolId, toolName, input);
+
+		return createMockMessage(List.of(thinkingContentBlock, toolUseContentBlock), StopReason.TOOL_USE, 15L, 25L);
+	}
+
+	private Message createMockMessageWithRedactedThinkingAndToolUse(String data, String toolId, String toolName,
+			JsonValue input) {
+		RedactedThinkingBlock redactedThinkingBlock = mock(RedactedThinkingBlock.class);
+		given(redactedThinkingBlock.data()).willReturn(data);
+
+		ContentBlock redactedThinkingContentBlock = mock(ContentBlock.class);
+		given(redactedThinkingContentBlock.isText()).willReturn(false);
+		given(redactedThinkingContentBlock.isToolUse()).willReturn(false);
+		given(redactedThinkingContentBlock.isThinking()).willReturn(false);
+		given(redactedThinkingContentBlock.isRedactedThinking()).willReturn(true);
+		given(redactedThinkingContentBlock.asRedactedThinking()).willReturn(redactedThinkingBlock);
+
+		ContentBlock toolUseContentBlock = toolUseContentBlock(toolId, toolName, input);
+
+		return createMockMessage(List.of(redactedThinkingContentBlock, toolUseContentBlock), StopReason.TOOL_USE, 15L,
+				25L);
+	}
+
+	private ContentBlock toolUseContentBlock(String toolId, String toolName, JsonValue input) {
+		ToolUseBlock toolUseBlock = mock(ToolUseBlock.class);
+		given(toolUseBlock.id()).willReturn(toolId);
+		given(toolUseBlock.name()).willReturn(toolName);
+		given(toolUseBlock._input()).willReturn(input);
+
+		ContentBlock contentBlock = mock(ContentBlock.class);
+		given(contentBlock.isText()).willReturn(false);
+		given(contentBlock.isToolUse()).willReturn(true);
+		given(contentBlock.asToolUse()).willReturn(toolUseBlock);
+		return contentBlock;
+	}
+
+	private Message createMockMessage(List<ContentBlock> contentBlocks, StopReason stopReason, long inputTokens,
+			long outputTokens) {
+		Usage usage = mock(Usage.class);
+		given(usage.inputTokens()).willReturn(inputTokens);
+		given(usage.outputTokens()).willReturn(outputTokens);
+
+		Message message = mock(Message.class);
+		given(message.id()).willReturn("msg_123");
+		given(message.model()).willReturn(Model.CLAUDE_SONNET_4_5);
+		given(message.content()).willReturn(contentBlocks);
+		given(message.stopReason()).willReturn(Optional.of(stopReason));
+		given(message.usage()).willReturn(usage);
+
+		return message;
 	}
 
 	private Message createMockMessage(String text, StopReason stopReason) {
@@ -517,6 +745,71 @@ class AnthropicChatModelTests {
 		given(message.usage()).willReturn(usage);
 
 		return message;
+	}
+
+	private RawMessageStreamEvent messageStartEvent() {
+		Usage usage = mock(Usage.class);
+		given(usage.inputTokens()).willReturn(10L);
+
+		Message message = mock(Message.class);
+		given(message.id()).willReturn("msg_stream");
+		given(message.model()).willReturn(Model.CLAUDE_SONNET_4_5);
+		given(message.usage()).willReturn(usage);
+
+		return RawMessageStreamEvent.ofMessageStart(RawMessageStartEvent.builder().message(message).build());
+	}
+
+	private RawMessageStreamEvent thinkingStartEvent() {
+		ThinkingBlock thinkingBlock = mock(ThinkingBlock.class);
+		return RawMessageStreamEvent
+			.ofContentBlockStart(RawContentBlockStartEvent.builder().contentBlock(thinkingBlock).index(0L).build());
+	}
+
+	private RawMessageStreamEvent toolUseStartEvent(String id, String name) {
+		ToolUseBlock toolUseBlock = mock(ToolUseBlock.class);
+		given(toolUseBlock.id()).willReturn(id);
+		given(toolUseBlock.name()).willReturn(name);
+
+		return RawMessageStreamEvent
+			.ofContentBlockStart(RawContentBlockStartEvent.builder().contentBlock(toolUseBlock).index(1L).build());
+	}
+
+	private RawMessageStreamEvent thinkingDeltaEvent(String thinking) {
+		return RawMessageStreamEvent
+			.ofContentBlockDelta(RawContentBlockDeltaEvent.builder().thinkingDelta(thinking).index(0L).build());
+	}
+
+	private RawMessageStreamEvent signatureDeltaEvent(String signature) {
+		return RawMessageStreamEvent
+			.ofContentBlockDelta(RawContentBlockDeltaEvent.builder().signatureDelta(signature).index(0L).build());
+	}
+
+	private RawMessageStreamEvent inputJsonDeltaEvent(String partialJson) {
+		return RawMessageStreamEvent
+			.ofContentBlockDelta(RawContentBlockDeltaEvent.builder().inputJsonDelta(partialJson).index(1L).build());
+	}
+
+	private RawMessageStreamEvent contentBlockStopEvent(long index) {
+		return RawMessageStreamEvent.ofContentBlockStop(RawContentBlockStopEvent.builder().index(index).build());
+	}
+
+	private RawMessageStreamEvent messageDeltaEvent(StopReason stopReason) {
+		return RawMessageStreamEvent.ofMessageDelta(RawMessageDeltaEvent.builder()
+			.delta(RawMessageDeltaEvent.Delta.builder()
+				.container(Optional.empty())
+				.stopDetails(Optional.empty())
+				.stopReason(stopReason)
+				.stopSequence(Optional.empty())
+				.build())
+			.usage(MessageDeltaUsage.builder()
+				.cacheCreationInputTokens(Optional.empty())
+				.cacheReadInputTokens(Optional.empty())
+				.inputTokens(Optional.empty())
+				.outputTokens(5L)
+				.outputTokensDetails(Optional.empty())
+				.serverToolUse(Optional.empty())
+				.build())
+			.build());
 	}
 
 	@Test
@@ -639,6 +932,26 @@ class AnthropicChatModelTests {
 		assertThat(rateLimit.getRequestsRemaining()).isEqualTo(99L);
 		assertThat(rateLimit.getTokensLimit()).isEqualTo(50000L);
 		assertThat(rateLimit.getTokensRemaining()).isEqualTo(49000L);
+	}
+
+	static class TestToolCallback implements ToolCallback {
+
+		private final ToolDefinition toolDefinition;
+
+		TestToolCallback(String name) {
+			this.toolDefinition = DefaultToolDefinition.builder().name(name).inputSchema("{}").build();
+		}
+
+		@Override
+		public ToolDefinition getToolDefinition() {
+			return this.toolDefinition;
+		}
+
+		@Override
+		public String call(String toolInput) {
+			return "Mission accomplished!";
+		}
+
 	}
 
 }


### PR DESCRIPTION
This is the Anthropic direct-provider counterpart to #6414's Bedrock replay fix.

When an Anthropic response contains `thinking` or `redacted_thinking` blocks before `tool_use`, Spring AI now keeps that provider-specific replay state on the assistant message selected by the tool-calling loop. Follow-up Anthropic requests re-emit those thinking blocks before the corresponding tool-use blocks when tool results continue the same assistant turn.

The change stays scoped to the Anthropic provider and does not introduce a generic reasoning API.
