### PR TITLE
Fix Azure OpenAI authentication failure behind a TLS-inspecting proxy

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/setup/AzureInternalOpenAiHelper.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/setup/AzureInternalOpenAiHelper.java
@@ -16,10 +16,16 @@
 
 package org.springframework.ai.openai.setup;
 
-import com.azure.identity.AuthenticationUtil;
+import java.time.OffsetDateTime;
+import java.util.function.Supplier;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.openai.credential.BearerTokenCredential;
 import com.openai.credential.Credential;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Specific configuration for authenticating on Azure. This is in a separate class to
@@ -33,12 +39,50 @@ import com.openai.credential.Credential;
  */
 final class AzureInternalOpenAiHelper {
 
+	private static final String COGNITIVE_SERVICES_SCOPE = "https://cognitiveservices.azure.com/.default";
+
 	private AzureInternalOpenAiHelper() {
 	}
 
 	static Credential getAzureCredential() {
-		return BearerTokenCredential.create(AuthenticationUtil.getBearerTokenSupplier(
-				new DefaultAzureCredentialBuilder().build(), "https://cognitiveservices.azure.com/.default"));
+		return getAzureCredential(new DefaultAzureCredentialBuilder().build());
+	}
+
+	static Credential getAzureCredential(TokenCredential credential) {
+		TokenRequestContext request = new TokenRequestContext().addScopes(COGNITIVE_SERVICES_SCOPE);
+		// Not via AuthenticationUtil.getBearerTokenSupplier: that sends a
+		// request to https://www.example.com on every call to harvest the
+		// Authorization header, which fails behind TLS-inspecting proxies.
+		return BearerTokenCredential.create(new CachingTokenSupplier(credential, request));
+	}
+
+	/**
+	 * Caches the token because {@link BearerTokenCredential} calls this supplier on each
+	 * request, so the credential is queried only on first use and when it nears expiry.
+	 */
+	private static final class CachingTokenSupplier implements Supplier<String> {
+
+		private final TokenCredential credential;
+
+		private final TokenRequestContext request;
+
+		private @Nullable AccessToken cachedToken;
+
+		CachingTokenSupplier(TokenCredential credential, TokenRequestContext request) {
+			this.credential = credential;
+			this.request = request;
+		}
+
+		@Override
+		public synchronized String get() {
+			@Nullable AccessToken token = this.cachedToken;
+			if (token == null || OffsetDateTime.now().plusMinutes(5).isAfter(token.getExpiresAt())) {
+				token = this.credential.getTokenSync(this.request);
+				this.cachedToken = token;
+			}
+			return token.getToken();
+		}
+
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/setup/AzureInternalOpenAiHelperTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/setup/AzureInternalOpenAiHelperTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.setup;
+
+import java.time.OffsetDateTime;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import com.openai.credential.BearerTokenCredential;
+import com.openai.credential.Credential;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class AzureInternalOpenAiHelperTests {
+
+	@Test
+	void getAzureCredentialResolvesTokenDirectlyFromCredential() {
+		AccessToken accessToken = new AccessToken("test-token", OffsetDateTime.now().plusHours(1));
+		TokenCredential credential = mock(TokenCredential.class);
+		given(credential.getTokenSync(any(TokenRequestContext.class))).willReturn(accessToken);
+
+		Credential azureCredential = AzureInternalOpenAiHelper.getAzureCredential(credential);
+
+		assertThat(azureCredential).isInstanceOf(BearerTokenCredential.class);
+		assertThat(((BearerTokenCredential) azureCredential).token()).isEqualTo("test-token");
+	}
+
+	@Test
+	void getAzureCredentialRequestsCognitiveServicesScope() {
+		AccessToken accessToken = new AccessToken("test-token", OffsetDateTime.now().plusHours(1));
+		TokenCredential credential = mock(TokenCredential.class);
+		given(credential.getTokenSync(any(TokenRequestContext.class))).willReturn(accessToken);
+
+		((BearerTokenCredential) AzureInternalOpenAiHelper.getAzureCredential(credential)).token();
+
+		ArgumentCaptor<TokenRequestContext> captor = ArgumentCaptor.forClass(TokenRequestContext.class);
+		verify(credential).getTokenSync(captor.capture());
+		assertThat(captor.getValue().getScopes()).containsExactly("https://cognitiveservices.azure.com/.default");
+	}
+
+	@Test
+	void getAzureCredentialCachesTokenAcrossCalls() {
+		AccessToken accessToken = new AccessToken("test-token", OffsetDateTime.now().plusHours(1));
+		TokenCredential credential = mock(TokenCredential.class);
+		given(credential.getTokenSync(any(TokenRequestContext.class))).willReturn(accessToken);
+
+		BearerTokenCredential azureCredential = (BearerTokenCredential) AzureInternalOpenAiHelper
+			.getAzureCredential(credential);
+		azureCredential.token();
+		azureCredential.token();
+		azureCredential.token();
+
+		verify(credential, times(1)).getTokenSync(any(TokenRequestContext.class));
+	}
+
+	@Test
+	void getAzureCredentialRefreshesTokenNearExpiry() {
+		TokenCredential credential = mock(TokenCredential.class);
+		given(credential.getTokenSync(any(TokenRequestContext.class))).willReturn(
+				new AccessToken("first", OffsetDateTime.now().plusMinutes(1)),
+				new AccessToken("second", OffsetDateTime.now().plusHours(1)));
+
+		BearerTokenCredential azureCredential = (BearerTokenCredential) AzureInternalOpenAiHelper
+			.getAzureCredential(credential);
+
+		assertThat(azureCredential.token()).isEqualTo("first");
+		assertThat(azureCredential.token()).isEqualTo("second");
+		verify(credential, times(2)).getTokenSync(any(TokenRequestContext.class));
+	}
+
+}


### PR DESCRIPTION
Azure OpenAI token authentication (Azure CLI or managed identity, rather than an
API key) currently builds its bearer-token supplier with
`AuthenticationUtil.getBearerTokenSupplier(...)`. That supplier issues a live
HTTPS `GET https://www.example.com` on every invocation, purely to run the
credential through a `BearerTokenAuthenticationPolicy` and read the resulting
`Authorization` header back off the request. The `openai-java` client invokes
the supplier while preparing each request, so this hop happens on every call.

The example.com request is unnecessary and fails in environments where such a
connection is not permitted  for example behind a TLS-inspecting proxy that
requires custom certificates, where it surfaces as
`SSLHandshakeException: ... PKIX path building failed`. Importing certificates
into every application's JVM is an impractical workaround.

This reads the token directly from the credential instead. Since the
`azure-identity` credentials do not cache tokens themselves — that is the SDK
pipeline's role — the supplier is a small `CachingTokenSupplier` that caches the
acquired token and refreshes it shortly before expiry, preserving the token
caching the previous pipeline provided. No dependency is added (both types come
with the Azure SDK), the acquired token is unchanged, and it continues to work
with any `DefaultAzureCredential` chain (managed identity, workload identity,
Azure CLI, etc.).

## Testing

Added unit tests in `AzureInternalOpenAiHelperTests`:
- the token is resolved from the credential (no HTTP client in the path),
- the `https://cognitiveservices.azure.com/.default` scope is requested,
- the cached token is reused across calls (the credential is queried once),
- the token is refreshed as it nears expiry.

`./mvnw -pl models/spring-ai-openai test` passes; formatting is clean.

Closes #6549
