### PR TITLE
Migrate to Mistral Moderation 2 (mistral-moderation-2603)

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiModerationApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiModerationApi.java
@@ -35,7 +35,9 @@ import org.springframework.web.client.RestClient;
  *
  * @author Ricken Bazolo
  * @author Jason Smith
- * @see <a href= "https://docs.mistral.ai/capabilities/guardrailing/">Moderation</a>
+ * @author Nicolas Krier
+ * @see <a href= "https://docs.mistral.ai/studio-api/conversations/moderation">Moderation
+ * and Guardrailing</a>
  */
 public class MistralAiModerationApi {
 
@@ -45,15 +47,14 @@ public class MistralAiModerationApi {
 
 	public MistralAiModerationApi(String baseUrl, String apiKey, RestClient.Builder restClientBuilder,
 			ResponseErrorHandler responseErrorHandler) {
-
-		Consumer<HttpHeaders> jsonContentHeaders = headers -> {
+		Consumer<HttpHeaders> defaultHeaders = headers -> {
 			headers.setBearerAuth(apiKey);
 			headers.setContentType(MediaType.APPLICATION_JSON);
 		};
 
 		this.restClient = restClientBuilder.clone()
 			.baseUrl(baseUrl)
-			.defaultHeaders(jsonContentHeaders)
+			.defaultHeaders(defaultHeaders)
 			.defaultStatusHandler(responseErrorHandler)
 			.build();
 	}
@@ -125,9 +126,7 @@ public class MistralAiModerationApi {
 	 */
 	public enum Model {
 
-		// @formatter:off
 		MISTRAL_MODERATION("mistral-moderation-latest");
-		// @formatter:on
 
 		private final String value;
 
@@ -142,19 +141,13 @@ public class MistralAiModerationApi {
 	}
 
 	// @formatter:off
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public record MistralAiModerationRequest(
 		@JsonProperty("input") String prompt,
 		@JsonProperty("model") String model
 	) {
 
-		@SuppressWarnings("NullAway") // Not null per API documentation, likely a merge related issue
-		public MistralAiModerationRequest(String prompt) {
-			this(prompt, null);
-		}
 	}
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public record MistralAiModerationResponse(
 			@JsonProperty("id") String id,
 			@JsonProperty("model") String model,
@@ -162,44 +155,55 @@ public class MistralAiModerationApi {
 
 	}
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public record MistralAiModerationResult(
 			@JsonProperty("categories") Categories categories,
 			@JsonProperty("category_scores") CategoryScores categoryScores) {
 
 		public boolean flagged() {
-			return this.categories != null && (Boolean.TRUE.equals(this.categories.sexual()) || Boolean.TRUE.equals(this.categories.hateAndDiscrimination()) || Boolean.TRUE.equals(this.categories.violenceAndThreats())
-					|| Boolean.TRUE.equals(this.categories.selfHarm()) || Boolean.TRUE.equals(this.categories.dangerousAndCriminalContent()) || Boolean.TRUE.equals(this.categories.health())
-					|| Boolean.TRUE.equals(this.categories.financial()) || Boolean.TRUE.equals(this.categories.law()) || Boolean.TRUE.equals(this.categories.pii()));
+			return (Boolean.TRUE.equals(this.categories.sexual())
+					|| Boolean.TRUE.equals(this.categories.hateAndDiscrimination())
+					|| Boolean.TRUE.equals(this.categories.violenceAndThreats())
+					|| Boolean.TRUE.equals(this.categories.selfHarm())
+					|| Boolean.TRUE.equals(this.categories.dangerous())
+					|| Boolean.TRUE.equals(this.categories.criminal())
+					|| Boolean.TRUE.equals(this.categories.health())
+					|| Boolean.TRUE.equals(this.categories.financial())
+					|| Boolean.TRUE.equals(this.categories.law())
+					|| Boolean.TRUE.equals(this.categories.pii())
+					|| Boolean.TRUE.equals(this.categories.jailbreaking()));
 		}
 
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public record Categories(
-			@JsonProperty("sexual") Boolean sexual,
-			@JsonProperty("hate_and_discrimination") Boolean hateAndDiscrimination,
-			@JsonProperty("violence_and_threats") Boolean violenceAndThreats,
-			@JsonProperty("selfharm") Boolean selfHarm,
-			@JsonProperty("dangerous_and_criminal_content") Boolean dangerousAndCriminalContent,
-			@JsonProperty("health") Boolean health,
-			@JsonProperty("financial") Boolean financial,
-			@JsonProperty("law") Boolean law,
-			@JsonProperty("pii") Boolean pii)  {
+			@JsonProperty("sexual") @Nullable Boolean sexual,
+			@JsonProperty("hate_and_discrimination") @Nullable Boolean hateAndDiscrimination,
+			@JsonProperty("violence_and_threats") @Nullable Boolean violenceAndThreats,
+			@JsonProperty("selfharm") @Nullable Boolean selfHarm,
+			@JsonProperty("dangerous") @Nullable Boolean dangerous,
+			@JsonProperty("criminal") @Nullable Boolean criminal,
+			@JsonProperty("health") @Nullable Boolean health,
+			@JsonProperty("financial") @Nullable Boolean financial,
+			@JsonProperty("law") @Nullable Boolean law,
+			@JsonProperty("pii") @Nullable Boolean pii,
+			@JsonProperty("jailbreaking") @Nullable Boolean jailbreaking) {
 
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public record CategoryScores(
-			@JsonProperty("sexual") Double sexual,
-			@JsonProperty("hate_and_discrimination") Double hateAndDiscrimination,
-			@JsonProperty("violence_and_threats") Double violenceAndThreats,
-			@JsonProperty("selfharm") Double selfHarm,
-			@JsonProperty("dangerous_and_criminal_content") Double dangerousAndCriminalContent,
-			@JsonProperty("health") Double health,
-			@JsonProperty("financial") Double financial,
-			@JsonProperty("law") Double law,
-			@JsonProperty("pii") Double pii)  {
+			@JsonProperty("sexual") @Nullable Double sexual,
+			@JsonProperty("hate_and_discrimination") @Nullable Double hateAndDiscrimination,
+			@JsonProperty("violence_and_threats") @Nullable Double violenceAndThreats,
+			@JsonProperty("selfharm") @Nullable Double selfHarm,
+			@JsonProperty("dangerous") @Nullable Double dangerous,
+			@JsonProperty("criminal") @Nullable Double criminal,
+			@JsonProperty("health") @Nullable Double health,
+			@JsonProperty("financial") @Nullable Double financial,
+			@JsonProperty("law") @Nullable Double law,
+			@JsonProperty("pii") @Nullable Double pii,
+			@JsonProperty("jailbreaking") @Nullable Double jailbreaking) {
 
 	}
 	// @formatter:on

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationModel.java
@@ -16,9 +16,8 @@
 
 package org.springframework.ai.mistralai.moderation;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -34,7 +33,6 @@ import org.springframework.ai.moderation.CategoryScores;
 import org.springframework.ai.moderation.Generation;
 import org.springframework.ai.moderation.Moderation;
 import org.springframework.ai.moderation.ModerationModel;
-import org.springframework.ai.moderation.ModerationOptions;
 import org.springframework.ai.moderation.ModerationPrompt;
 import org.springframework.ai.moderation.ModerationResponse;
 import org.springframework.ai.moderation.ModerationResult;
@@ -47,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Ricken Bazolo
  * @author Jason Smith
  * @author Sebastien Deleuze
+ * @author Nicolas Krier
  */
 public class MistralAiModerationModel implements ModerationModel {
 
@@ -70,20 +69,11 @@ public class MistralAiModerationModel implements ModerationModel {
 
 	@Override
 	public ModerationResponse call(ModerationPrompt moderationPrompt) {
-
 		return RetryUtils.execute(this.retryTemplate, () -> {
-
 			var instructions = moderationPrompt.getInstructions().getText();
-
-			ModerationOptions requestOptions = moderationPrompt.getOptions();
-			String model = this.options.getModel();
-
-			if (requestOptions != null) {
-				model = ModelOptionsUtils.mergeOption(requestOptions.getModel(), this.options.getModel());
-			}
-
+			var model = ModelOptionsUtils.mergeOption(moderationPrompt.getOptions().getModel(),
+					this.options.getModel());
 			var moderationRequest = new MistralAiModerationRequest(instructions, model);
-
 			var moderationResponseEntity = this.mistralAiModerationApi.moderate(moderationRequest);
 
 			return convertResponse(moderationResponseEntity, moderationRequest);
@@ -93,6 +83,7 @@ public class MistralAiModerationModel implements ModerationModel {
 	private ModerationResponse convertResponse(ResponseEntity<MistralAiModerationResponse> moderationResponseEntity,
 			MistralAiModerationRequest mistralAiModerationRequest) {
 		var moderationApiResponse = moderationResponseEntity.getBody();
+
 		if (moderationApiResponse == null) {
 			if (logger.isWarnEnabled()) {
 				logger.warn("No moderation response returned for request: " + mistralAiModerationRequest);
@@ -100,50 +91,9 @@ public class MistralAiModerationModel implements ModerationModel {
 			return new ModerationResponse(null);
 		}
 
-		List<ModerationResult> moderationResults = new ArrayList<>();
-		if (moderationApiResponse.results() != null) {
-
-			for (MistralAiModerationResult result : moderationApiResponse.results()) {
-				Categories categories = null;
-				CategoryScores categoryScores = null;
-				if (result.categories() != null) {
-					var cats = result.categories();
-					categories = Categories.builder()
-						.sexual(Boolean.TRUE.equals(cats.sexual()))
-						.pii(Boolean.TRUE.equals(cats.pii()))
-						.law(Boolean.TRUE.equals(cats.law()))
-						.financial(Boolean.TRUE.equals(cats.financial()))
-						.health(Boolean.TRUE.equals(cats.health()))
-						.dangerousAndCriminalContent(Boolean.TRUE.equals(cats.dangerousAndCriminalContent()))
-						.violence(Boolean.TRUE.equals(cats.violenceAndThreats()))
-						.hate(Boolean.TRUE.equals(cats.hateAndDiscrimination()))
-						.selfHarm(Boolean.TRUE.equals(cats.selfHarm()))
-						.build();
-				}
-				if (result.categoryScores() != null) {
-					var scores = result.categoryScores();
-					categoryScores = CategoryScores.builder()
-						.sexual(Objects.requireNonNullElse(scores.sexual(), 0.0))
-						.pii(Objects.requireNonNullElse(scores.pii(), 0.0))
-						.law(Objects.requireNonNullElse(scores.law(), 0.0))
-						.financial(Objects.requireNonNullElse(scores.financial(), 0.0))
-						.health(Objects.requireNonNullElse(scores.health(), 0.0))
-						.dangerousAndCriminalContent(
-								Objects.requireNonNullElse(scores.dangerousAndCriminalContent(), 0.0))
-						.violence(Objects.requireNonNullElse(scores.violenceAndThreats(), 0.0))
-						.hate(Objects.requireNonNullElse(scores.hateAndDiscrimination(), 0.0))
-						.selfHarm(Objects.requireNonNullElse(scores.selfHarm(), 0.0))
-						.build();
-				}
-				var moderationResult = ModerationResult.builder()
-					.categories(Objects.requireNonNull(categories))
-					.categoryScores(Objects.requireNonNull(categoryScores))
-					.flagged(result.flagged())
-					.build();
-				moderationResults.add(moderationResult);
-			}
-
-		}
+		var moderationResults = Stream.of(moderationApiResponse.results())
+			.map(MistralAiModerationModel::convertModerationResult)
+			.toList();
 
 		var moderation = Moderation.builder()
 			.id(moderationApiResponse.id())
@@ -152,6 +102,44 @@ public class MistralAiModerationModel implements ModerationModel {
 			.build();
 
 		return new ModerationResponse(new Generation(moderation));
+	}
+
+	private static ModerationResult convertModerationResult(MistralAiModerationResult mistralAiModerationResult) {
+		var sourceCategories = mistralAiModerationResult.categories();
+		var targetCategories = Categories.builder()
+			.sexual(Boolean.TRUE.equals(sourceCategories.sexual()))
+			.pii(Boolean.TRUE.equals(sourceCategories.pii()))
+			.law(Boolean.TRUE.equals(sourceCategories.law()))
+			.financial(Boolean.TRUE.equals(sourceCategories.financial()))
+			.health(Boolean.TRUE.equals(sourceCategories.health()))
+			.criminal(Boolean.TRUE.equals(sourceCategories.criminal()))
+			.dangerous(Boolean.TRUE.equals(sourceCategories.dangerous()))
+			.jailbreaking(Boolean.TRUE.equals(sourceCategories.jailbreaking()))
+			.violence(Boolean.TRUE.equals(sourceCategories.violenceAndThreats()))
+			.hate(Boolean.TRUE.equals(sourceCategories.hateAndDiscrimination()))
+			.selfHarm(Boolean.TRUE.equals(sourceCategories.selfHarm()))
+			.build();
+
+		var sourceCategoryScores = mistralAiModerationResult.categoryScores();
+		var targetCategoryScores = CategoryScores.builder()
+			.sexual(Objects.requireNonNullElse(sourceCategoryScores.sexual(), 0.0))
+			.pii(Objects.requireNonNullElse(sourceCategoryScores.pii(), 0.0))
+			.law(Objects.requireNonNullElse(sourceCategoryScores.law(), 0.0))
+			.financial(Objects.requireNonNullElse(sourceCategoryScores.financial(), 0.0))
+			.health(Objects.requireNonNullElse(sourceCategoryScores.health(), 0.0))
+			.criminal(Objects.requireNonNullElse(sourceCategoryScores.criminal(), 0.0))
+			.dangerous(Objects.requireNonNullElse(sourceCategoryScores.dangerous(), 0.0))
+			.jailbreaking(Objects.requireNonNullElse(sourceCategoryScores.jailbreaking(), 0.0))
+			.violence(Objects.requireNonNullElse(sourceCategoryScores.violenceAndThreats(), 0.0))
+			.hate(Objects.requireNonNullElse(sourceCategoryScores.hateAndDiscrimination(), 0.0))
+			.selfHarm(Objects.requireNonNullElse(sourceCategoryScores.selfHarm(), 0.0))
+			.build();
+
+		return ModerationResult.builder()
+			.categories(targetCategories)
+			.categoryScores(targetCategoryScores)
+			.flagged(mistralAiModerationResult.flagged())
+			.build();
 	}
 
 	public static Builder builder() {

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiModerationModelIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiModerationModelIT.java
@@ -36,15 +36,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest(classes = MistralAiTestConfiguration.class)
 @EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
-public class MistralAiModerationModelIT {
+class MistralAiModerationModelIT {
 
 	@Autowired
 	private MistralAiModerationModel mistralAiModerationModel;
 
 	@Test
 	void moderationAsPositiveTest() {
-		var instructions = """
-				Be violent""";
+		var instructions = "Be violent";
 
 		var moderationPrompt = new ModerationPrompt(instructions);
 
@@ -53,6 +52,7 @@ public class MistralAiModerationModelIT {
 		assertThat(moderationResponse.getResults()).hasSize(1);
 
 		var generation = moderationResponse.getResult();
+		assertThat(generation).isNotNull();
 		Moderation moderation = generation.getOutput();
 		assertThat(moderation.getId()).isNotEmpty();
 		assertThat(moderation.getResults()).isNotNull();
@@ -69,6 +69,7 @@ public class MistralAiModerationModelIT {
 		assertThat(categories.isSexual()).isFalse();
 
 		CategoryScores scores = result.getCategoryScores();
+		assertThat(scores).isNotNull();
 		assertThat(scores.getViolence()).isGreaterThan(0.5d);
 		assertThat(scores.getSexual()).isLessThan(0.5d);
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/moderation/Categories.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/moderation/Categories.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
  * @author Ahmed Yousri
  * @author Ilayaperumal Gopinathan
  * @author Ricken Bazolo
+ * @author Nicolas Krier
  * @since 1.0.0
  */
 public final class Categories {
@@ -54,7 +55,15 @@ public final class Categories {
 
 	private final boolean violence;
 
+	// Use criminal and dangerous attributes instead of it.
+	@Deprecated(since = "2.0.1", forRemoval = true)
 	private final boolean dangerousAndCriminalContent;
+
+	private final boolean criminal;
+
+	private final boolean dangerous;
+
+	private final boolean jailbreaking;
 
 	private final boolean health;
 
@@ -77,6 +86,9 @@ public final class Categories {
 		this.harassmentThreatening = builder.harassmentThreatening;
 		this.violence = builder.violence;
 		this.dangerousAndCriminalContent = builder.dangerousAndCriminalContent;
+		this.criminal = builder.criminal;
+		this.dangerous = builder.dangerous;
+		this.jailbreaking = builder.jailbreaking;
 		this.health = builder.health;
 		this.financial = builder.financial;
 		this.law = builder.law;
@@ -131,8 +143,22 @@ public final class Categories {
 		return this.violence;
 	}
 
+	// Use criminal and dangerous getters instead of it.
+	@Deprecated(since = "2.0.1", forRemoval = true)
 	public boolean isDangerousAndCriminalContent() {
 		return this.dangerousAndCriminalContent;
+	}
+
+	public boolean isCriminal() {
+		return this.criminal;
+	}
+
+	public boolean isDangerous() {
+		return this.dangerous;
+	}
+
+	public boolean isJailbreaking() {
+		return this.jailbreaking;
 	}
 
 	public boolean isHealth() {
@@ -164,7 +190,9 @@ public final class Categories {
 				&& this.hateThreatening == that.hateThreatening && this.violenceGraphic == that.violenceGraphic
 				&& this.selfHarmIntent == that.selfHarmIntent && this.selfHarmInstructions == that.selfHarmInstructions
 				&& this.harassmentThreatening == that.harassmentThreatening && this.violence == that.violence
-				&& this.dangerousAndCriminalContent == that.dangerousAndCriminalContent && this.health == that.health
+				&& this.dangerousAndCriminalContent == that.dangerousAndCriminalContent
+				&& this.criminal == that.criminal && this.dangerous == that.dangerous
+				&& this.jailbreaking == that.jailbreaking && this.health == that.health
 				&& this.financial == that.financial && this.law == that.law && this.pii == that.pii;
 	}
 
@@ -172,8 +200,8 @@ public final class Categories {
 	public int hashCode() {
 		return Objects.hash(this.sexual, this.hate, this.harassment, this.selfHarm, this.sexualMinors,
 				this.hateThreatening, this.violenceGraphic, this.selfHarmIntent, this.selfHarmInstructions,
-				this.harassmentThreatening, this.violence, this.dangerousAndCriminalContent, this.health,
-				this.financial, this.law, this.pii);
+				this.harassmentThreatening, this.violence, this.dangerousAndCriminalContent, this.criminal,
+				this.dangerous, this.jailbreaking, this.health, this.financial, this.law, this.pii);
 	}
 
 	@Override
@@ -183,7 +211,8 @@ public final class Categories {
 				+ this.hateThreatening + ", violenceGraphic=" + this.violenceGraphic + ", selfHarmIntent="
 				+ this.selfHarmIntent + ", selfHarmInstructions=" + this.selfHarmInstructions
 				+ ", harassmentThreatening=" + this.harassmentThreatening + ", violence=" + this.violence
-				+ ", dangerousAndCriminalContent=" + this.dangerousAndCriminalContent + ", health=" + this.health
+				+ ", dangerousAndCriminalContent=" + this.dangerousAndCriminalContent + ", criminal=" + this.criminal
+				+ ", dangerous=" + this.dangerous + ", jailbreaking=" + this.jailbreaking + ", health=" + this.health
 				+ ", financial=" + this.financial + ", law=" + this.law + ", pii=" + this.pii + '}';
 	}
 
@@ -211,7 +240,15 @@ public final class Categories {
 
 		private boolean violence;
 
+		// Use criminal and dangerous attributes instead of it.
+		@Deprecated(since = "2.0.1", forRemoval = true)
 		private boolean dangerousAndCriminalContent;
+
+		private boolean criminal;
+
+		private boolean dangerous;
+
+		private boolean jailbreaking;
 
 		private boolean health;
 
@@ -276,8 +313,25 @@ public final class Categories {
 			return this;
 		}
 
+		// Use criminal and dangerous building methods instead of it.
+		@Deprecated(since = "2.0.1", forRemoval = true)
 		public Builder dangerousAndCriminalContent(boolean dangerousAndCriminalContent) {
 			this.dangerousAndCriminalContent = dangerousAndCriminalContent;
+			return this;
+		}
+
+		public Builder criminal(boolean criminal) {
+			this.criminal = criminal;
+			return this;
+		}
+
+		public Builder dangerous(boolean dangerous) {
+			this.dangerous = dangerous;
+			return this;
+		}
+
+		public Builder jailbreaking(boolean jailbreaking) {
+			this.jailbreaking = jailbreaking;
 			return this;
 		}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/moderation/CategoryScores.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/moderation/CategoryScores.java
@@ -29,6 +29,7 @@ import org.jspecify.annotations.Nullable;
  * @author Ilayaperumal Gopinathan
  * @author Ricken Bazolo
  * @author Jonghoon Park
+ * @author Nicolas Krier
  * @since 1.0.0
  */
 public final class CategoryScores {
@@ -55,7 +56,15 @@ public final class CategoryScores {
 
 	private final double violence;
 
+	// Use criminal and dangerous attributes instead of it.
+	@Deprecated(since = "2.0.1", forRemoval = true)
 	private final double dangerousAndCriminalContent;
+
+	private final double criminal;
+
+	private final double dangerous;
+
+	private final double jailbreaking;
 
 	private final double health;
 
@@ -78,6 +87,9 @@ public final class CategoryScores {
 		this.harassmentThreatening = builder.harassmentThreatening;
 		this.violence = builder.violence;
 		this.dangerousAndCriminalContent = builder.dangerousAndCriminalContent;
+		this.criminal = builder.criminal;
+		this.dangerous = builder.dangerous;
+		this.jailbreaking = builder.jailbreaking;
 		this.health = builder.health;
 		this.financial = builder.financial;
 		this.law = builder.law;
@@ -132,8 +144,22 @@ public final class CategoryScores {
 		return this.violence;
 	}
 
+	// Use criminal and dangerous getters instead of it.
+	@Deprecated(since = "2.0.1", forRemoval = true)
 	public double getDangerousAndCriminalContent() {
 		return this.dangerousAndCriminalContent;
+	}
+
+	public double getCriminal() {
+		return this.criminal;
+	}
+
+	public double getDangerous() {
+		return this.dangerous;
+	}
+
+	public double getJailbreaking() {
+		return this.jailbreaking;
 	}
 
 	public double getHealth() {
@@ -171,6 +197,9 @@ public final class CategoryScores {
 				&& Double.compare(that.harassmentThreatening, this.harassmentThreatening) == 0
 				&& Double.compare(that.violence, this.violence) == 0
 				&& Double.compare(that.dangerousAndCriminalContent, this.dangerousAndCriminalContent) == 0
+				&& Double.compare(that.criminal, this.criminal) == 0
+				&& Double.compare(that.dangerous, this.dangerous) == 0
+				&& Double.compare(that.jailbreaking, this.jailbreaking) == 0
 				&& Double.compare(that.health, this.health) == 0 && Double.compare(that.financial, this.financial) == 0
 				&& Double.compare(that.law, this.law) == 0 && Double.compare(that.pii, this.pii) == 0;
 	}
@@ -179,8 +208,8 @@ public final class CategoryScores {
 	public int hashCode() {
 		return Objects.hash(this.sexual, this.hate, this.harassment, this.selfHarm, this.sexualMinors,
 				this.hateThreatening, this.violenceGraphic, this.selfHarmIntent, this.selfHarmInstructions,
-				this.harassmentThreatening, this.violence, this.dangerousAndCriminalContent, this.health,
-				this.financial, this.law, this.pii);
+				this.harassmentThreatening, this.violence, this.dangerousAndCriminalContent, this.criminal,
+				this.dangerous, this.jailbreaking, this.health, this.financial, this.law, this.pii);
 	}
 
 	@Override
@@ -190,7 +219,8 @@ public final class CategoryScores {
 				+ this.hateThreatening + ", violenceGraphic=" + this.violenceGraphic + ", selfHarmIntent="
 				+ this.selfHarmIntent + ", selfHarmInstructions=" + this.selfHarmInstructions
 				+ ", harassmentThreatening=" + this.harassmentThreatening + ", violence=" + this.violence
-				+ ", dangerousAndCriminalContent=" + this.dangerousAndCriminalContent + ", health=" + this.health
+				+ ", dangerousAndCriminalContent=" + this.dangerousAndCriminalContent + ", criminal=" + this.criminal
+				+ ", dangerous=" + this.dangerous + ", jailbreaking=" + this.jailbreaking + ", health=" + this.health
 				+ ", financial=" + this.financial + ", law=" + this.law + ", pii=" + this.pii + '}';
 	}
 
@@ -218,7 +248,15 @@ public final class CategoryScores {
 
 		private double violence;
 
+		// Use criminal and dangerous attributes instead of it.
+		@Deprecated(since = "2.0.1", forRemoval = true)
 		private double dangerousAndCriminalContent;
+
+		private double criminal;
+
+		private double dangerous;
+
+		private double jailbreaking;
 
 		private double health;
 
@@ -283,8 +321,25 @@ public final class CategoryScores {
 			return this;
 		}
 
+		// Use criminal and dangerous building methods instead of it.
+		@Deprecated(since = "2.0.1", forRemoval = true)
 		public Builder dangerousAndCriminalContent(double dangerousAndCriminalContent) {
 			this.dangerousAndCriminalContent = dangerousAndCriminalContent;
+			return this;
+		}
+
+		public Builder criminal(double criminal) {
+			this.criminal = criminal;
+			return this;
+		}
+
+		public Builder dangerous(double dangerous) {
+			this.dangerous = dangerous;
+			return this;
+		}
+
+		public Builder jailbreaking(double jailbreaking) {
+			this.jailbreaking = jailbreaking;
 			return this;
 		}
 


### PR DESCRIPTION
## Description

- Update moderation categories and category scores,
- Improve null safety based on OpenAPI Specifications,
- Polish integration tests.

## Explanations

`mistral-moderation-2411` has been retired the 30th of June 2026 and is replaced by `mistral-moderation-2603`. Here are the corresponding documentation links:
- [Mistral AI's OAS](https://github.com/mistralai/platform-docs-public/blob/main/openapi.yaml),
- [Legacy Models section](https://docs.mistral.ai/models/overview#legacy-models),
- [Moderation & Guardrailing](https://docs.mistral.ai/studio-api/conversations/moderation).

Regarding nullability, the following elements of the OAS are relevant:
- [ChatModerationRequest](https://github.com/mistralai/platform-docs-public/blob/main/openapi.yaml#L12149-L12193),
- [ModerationResponse](https://github.com/mistralai/platform-docs-public/blob/main/openapi.yaml#L14450-L14480).

## Related work

#6565