### PR TITLE
Fix unhandled content_block_stop event in Anthropic streaming

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -265,7 +265,11 @@ public final class AnthropicApi {
 			})
 			.flatMap(mono -> mono)
 			.map(event -> this.streamHelper.eventToChatCompletionResponse(event, chatCompletionReference))
-			.filter(chatCompletionResponse -> chatCompletionResponse.type() != null);
+			// content_block_stop carries no content and has no response chunk
+			// equivalent, but it must still reach the stream helper to reset the
+			// aggregated content before the message_delta event.
+			.filter(chatCompletionResponse -> chatCompletionResponse.type() != null
+					&& !EventType.CONTENT_BLOCK_STOP.name().equals(chatCompletionResponse.type()));
 	}
 
 	// Files API Methods

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
@@ -218,6 +218,12 @@ public class StreamHelper {
 				contentBlockReference.get().withUsage(totalUsage);
 			}
 		}
+		else if (event.type().equals(EventType.CONTENT_BLOCK_STOP)) {
+			// Emitted at the end of every content block outside of tool use. It carries
+			// no content but must reset the aggregated content so that the following
+			// message_delta event does not re-emit the last delta.
+			contentBlockReference.get().withType(event.type().name()).withContent(List.of());
+		}
 		else if (event.type().equals(EventType.MESSAGE_STOP)) {
 			// Don't return the latest Content block as it was before. Instead, return it
 			// with an updated event type and general information like: model, message

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicApiChatCompletionStreamTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicApiChatCompletionStreamTests.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.api;
+
+import java.io.IOException;
+import java.util.List;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.anthropic.api.AnthropicApi.AnthropicMessage;
+import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionRequest;
+import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionResponse;
+import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock;
+import org.springframework.ai.anthropic.api.AnthropicApi.EventType;
+import org.springframework.ai.anthropic.api.AnthropicApi.Role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AnthropicApi#chatCompletionStream} event handling against a mock
+ * server, without requiring real API calls.
+ *
+ * @author Nikita Kibitkin
+ */
+class AnthropicApiChatCompletionStreamTests {
+
+	private MockWebServer mockWebServer;
+
+	private AnthropicApi anthropicApi;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		this.mockWebServer = new MockWebServer();
+		this.mockWebServer.start();
+		this.anthropicApi = AnthropicApi.builder()
+			.apiKey("test-api-key")
+			.baseUrl(this.mockWebServer.url("/").toString())
+			.build();
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		this.mockWebServer.shutdown();
+	}
+
+	// GH-6372
+	@Test
+	void contentBlockStopEventShouldNotProduceResponseChunk() {
+		String sseBody = """
+				event: message_start
+				data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":10,"output_tokens":1}}}
+
+				event: content_block_start
+				data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+				event: ping
+				data: {"type":"ping"}
+
+				event: content_block_delta
+				data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+				event: content_block_delta
+				data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}
+
+				event: content_block_stop
+				data: {"type":"content_block_stop","index":0}
+
+				event: message_delta
+				data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":12}}
+
+				event: message_stop
+				data: {"type":"message_stop"}
+
+				""";
+
+		this.mockWebServer.enqueue(new MockResponse().setBody(sseBody)
+			.setHeader("Content-Type", "text/event-stream")
+			.setHeader("Cache-Control", "no-cache"));
+
+		List<ChatCompletionResponse> responses = this.anthropicApi.chatCompletionStream(streamRequest())
+			.collectList()
+			.block();
+
+		assertThat(responses).isNotEmpty();
+		assertThat(responses)
+			.noneSatisfy(response -> assertThat(response.type()).isEqualTo(EventType.CONTENT_BLOCK_STOP.name()));
+
+		String aggregatedText = responses.stream()
+			.flatMap(response -> response.content().stream())
+			.filter(contentBlock -> contentBlock.text() != null)
+			.map(ContentBlock::text)
+			.reduce("", String::concat);
+		assertThat(aggregatedText).isEqualTo("Hello world");
+	}
+
+	// GH-6372
+	@Test
+	void contentBlockStopEventShouldStillFinalizeToolUseAggregation() {
+		String sseBody = """
+				event: message_start
+				data: {"type":"message_start","message":{"id":"msg_456","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":10,"output_tokens":1}}}
+
+				event: content_block_start
+				data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"getWeather","input":{}}}
+
+				event: content_block_delta
+				data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"location\\":"}}
+
+				event: content_block_delta
+				data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"Paris\\"}"}}
+
+				event: content_block_stop
+				data: {"type":"content_block_stop","index":0}
+
+				event: message_delta
+				data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":30}}
+
+				event: message_stop
+				data: {"type":"message_stop"}
+
+				""";
+
+		this.mockWebServer.enqueue(new MockResponse().setBody(sseBody)
+			.setHeader("Content-Type", "text/event-stream")
+			.setHeader("Cache-Control", "no-cache"));
+
+		List<ChatCompletionResponse> responses = this.anthropicApi.chatCompletionStream(streamRequest())
+			.collectList()
+			.block();
+
+		assertThat(responses).isNotEmpty();
+		assertThat(responses)
+			.noneSatisfy(response -> assertThat(response.type()).isEqualTo(EventType.CONTENT_BLOCK_STOP.name()));
+
+		// The message_delta chunk must still carry the aggregated tool call, as tool
+		// execution downstream is triggered by its stop reason.
+		ChatCompletionResponse messageDeltaResponse = responses.stream()
+			.filter(response -> EventType.MESSAGE_DELTA.name().equals(response.type()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(messageDeltaResponse.stopReason()).isEqualTo("tool_use");
+		assertThat(messageDeltaResponse.content()).hasSize(1);
+		assertThat(messageDeltaResponse.content().get(0).type()).isEqualTo(ContentBlock.Type.TOOL_USE);
+		assertThat(messageDeltaResponse.content().get(0).name()).isEqualTo("getWeather");
+		assertThat(messageDeltaResponse.content().get(0).input()).containsEntry("location", "Paris");
+	}
+
+	private ChatCompletionRequest streamRequest() {
+		return ChatCompletionRequest.builder()
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_5)
+			.messages(List.of(new AnthropicMessage(List.of(new ContentBlock("Hi")), Role.USER)))
+			.maxTokens(100)
+			.stream(true)
+			.build();
+	}
+
+}


### PR DESCRIPTION
Fixes #6372

For non-tool streams the content_block_stop event passes through the tool-merge reduce untouched, and StreamHelper.eventToChatCompletionResponse has no branch for it, so every text content block logs "Unhandled event type: CONTENT_BLOCK_STOP" and emits an empty ChatResponse chunk to consumers. main/2.0 is not affected, so this targets 1.1.x only.

The event cannot simply be dropped before conversion: resetting the aggregated builder content is its load-bearing side effect, without it the message_delta chunk re-emits the last text delta. So StreamHelper now handles content_block_stop explicitly (resets content, no warning) and the converted chunk is dropped in the existing terminal filter of chatCompletionStream. Same behavior as the 2.0 module, tool-use aggregation unchanged.

Testing: new AnthropicApiChatCompletionStreamTests (MockWebServer, no live API) covers a text stream (no CONTENT_BLOCK_STOP chunk, deltas intact; verified to fail without the fix) and a tool-use stream (aggregated tool call still reaches the message_delta chunk). Module tests, spring-javaformat and checkstyle clean.