### PR TITLE
Add name attribute to McpToolParam

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpToolParam.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpToolParam.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface McpToolParam {
+
+	/**
+	 * The external name of the tool argument exposed in the MCP input schema.
+	 * When empty, the Java parameter or field name is used.
+	 */
+	String name() default "";
 
 	/**
 	 * Whether the tool argument is required.

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpToolParamUtils.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpToolParamUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation;
+
+import java.lang.reflect.Parameter;
+
+import com.github.victools.jsonschema.generator.MemberScope;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Utilities for resolving external MCP tool argument names from {@link McpToolParam}.
+ */
+public abstract class McpToolParamUtils {
+
+	private McpToolParamUtils() {
+	}
+
+	public static String resolveExternalName(Parameter parameter) {
+		McpToolParam annotation = parameter.getAnnotation(McpToolParam.class);
+		if (annotation != null && StringUtils.hasText(annotation.name())) {
+			return annotation.name();
+		}
+		return parameter.getName();
+	}
+
+	public static @Nullable String resolveExternalPropertyName(MemberScope<?, ?> member) {
+		McpToolParam annotation = member.getAnnotationConsideringFieldAndGetter(McpToolParam.class);
+		if (annotation != null && StringUtils.hasText(annotation.name())) {
+			return annotation.name();
+		}
+		return null;
+	}
+
+}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -31,6 +31,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.ai.mcp.annotation.McpMeta;
 import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpToolParamUtils;
 import org.springframework.ai.mcp.annotation.context.McpAsyncRequestContext;
 import org.springframework.ai.mcp.annotation.context.McpRequestContextTypes;
 import org.springframework.ai.mcp.annotation.context.McpSyncRequestContext;
@@ -131,7 +132,7 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 				return exchangeOrContext;
 			}
 
-			Object rawArgument = toolInputArguments.get(parameter.getName());
+			Object rawArgument = toolInputArguments.get(McpToolParamUtils.resolveExternalName(parameter));
 			return buildTypedArgument(rawArgument, parameter.getParameterizedType());
 		}).toArray();
 	}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
@@ -49,6 +49,7 @@ import tools.jackson.databind.node.ObjectNode;
 import org.springframework.ai.mcp.annotation.McpMeta;
 import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.ai.mcp.annotation.McpToolParamUtils;
 import org.springframework.ai.mcp.annotation.context.McpAsyncRequestContext;
 import org.springframework.ai.mcp.annotation.context.McpSyncRequestContext;
 import org.springframework.ai.model.KotlinModule;
@@ -153,7 +154,7 @@ public final class McpJsonSchemaGenerator {
 
 		for (int i = 0; i < method.getParameterCount(); i++) {
 			Parameter parameter = method.getParameters()[i];
-			String parameterName = parameter.getName();
+			String parameterName = McpToolParamUtils.resolveExternalName(parameter);
 			Type parameterType = method.getGenericParameterTypes()[i];
 
 			// Skip parameters annotated with @McpProgressToken

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpSpringAiSchemaModule.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpSpringAiSchemaModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,17 @@
 package org.springframework.ai.mcp.annotation.method.tool.utils;
 
 import com.github.victools.jsonschema.generator.MemberScope;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.ai.mcp.annotation.McpToolParamUtils;
 import org.springframework.ai.util.json.schema.AbstractSpringAiSchemaModule;
 import org.springframework.util.StringUtils;
 
 /**
  * JSON Schema Generator Module for Spring AI MCP.
- * <p>
+ *
  * This module provides a set of customizations to the JSON Schema generator to support
  * the Spring AI MCP framework. It allows extracting descriptions from
  * {@code @McpToolParam(description = ...)} annotations and to determine whether a
@@ -42,7 +44,13 @@ public final class McpSpringAiSchemaModule extends AbstractSpringAiSchemaModule 
 	}
 
 	@Override
-	protected @Nullable String resolveToolParamDescription(MemberScope<?, ?> member) {
+	public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+		super.applyToConfigBuilder(builder);
+		builder.forFields().withPropertyNameOverrideResolver(McpToolParamUtils::resolveExternalPropertyName);
+	}
+
+	@Override
+	protected @Nullable String resolveToolParamDescription(MemberScope member) {
 		var annotation = member.getAnnotationConsideringFieldAndGetter(McpToolParam.class);
 		if (annotation != null && StringUtils.hasText(annotation.description())) {
 			return annotation.description();
@@ -51,7 +59,7 @@ public final class McpSpringAiSchemaModule extends AbstractSpringAiSchemaModule 
 	}
 
 	@Override
-	protected @Nullable Boolean resolveToolParamRequired(MemberScope<?, ?> member) {
+	protected @Nullable Boolean resolveToolParamRequired(MemberScope member) {
 		var annotation = member.getAnnotationConsideringFieldAndGetter(McpToolParam.class);
 		return annotation != null ? annotation.required() : null;
 	}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackTests.java
@@ -47,6 +47,21 @@ import static org.mockito.Mockito.mock;
 public class SyncMcpToolMethodCallbackTests {
 
 	@Test
+	public void testToolWithCustomParameterName() throws Exception {
+		TestToolProvider provider = new TestToolProvider();
+		Method method = TestToolProvider.class.getMethod("getWeather", String.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("get-weather", Map.of("city_name", "Paris"));
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result.isError()).isFalse();
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Paris");
+	}
+
+	@Test
 	public void testSimpleToolCallback() throws Exception {
 		TestToolProvider provider = new TestToolProvider();
 		Method method = TestToolProvider.class.getMethod("simpleTool", String.class);
@@ -596,6 +611,11 @@ public class SyncMcpToolMethodCallbackTests {
 		@McpTool(name = "object-tool", description = "Tool with object parameter")
 		public String processObject(TestObject obj) {
 			return "Object: " + obj.name + " - " + obj.value;
+		}
+
+		@McpTool(name = "get-weather", description = "Get weather for a city")
+		public String getWeather(@McpToolParam(name = "city_name") String cityName) {
+			return cityName;
 		}
 
 		@McpTool(name = "optional-params-tool", description = "Tool with optional parameters")

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
@@ -20,6 +20,8 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.mcp.annotation.McpToolParam;
 import tools.jackson.databind.JsonNode;
 
 import org.springframework.ai.util.JsonHelper;
@@ -149,6 +151,26 @@ class McpJsonSchemaGeneratorTests {
 
 		assertThat(schemaNode.get("type").asString()).isEqualTo("object");
 		assertThat(schemaNode.has("properties")).isTrue();
+	}
+
+	
+	@Test
+	void generateSchemaUsesCustomMcpToolParamName() throws Exception {
+		Method method = CustomNameMethods.class.getDeclaredMethod("getWeather", String.class);
+
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = jsonHelper.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/properties/city_name").has("type")).isTrue();
+		assertThat(schemaNode.at("/properties/cityName").isMissingNode()).isTrue();
+		assertThat(schemaNode.get("required").get(0).asString()).isEqualTo("city_name");
+	}
+
+	static class CustomNameMethods {
+
+		public void getWeather(@McpToolParam(name = "city_name") String cityName) {
+		}
+
 	}
 
 	static class TestMethods {


### PR DESCRIPTION
MCP tool input schemas and runtime argument binding always used the Java reflection parameter name, so callers could not expose snake_case or other external naming conventions while keeping idiomatic camelCase parameter names in tool methods.

This adds an optional name attribute to McpToolParam and uses it when generating top-level tool input schemas and when resolving incoming tool arguments. Nested object fields annotated with McpToolParam also honour the custom name through the schema module property resolver.

Fixes #6544

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc