### PR TITLE
Allow empty and null `ToolContext` in tool method invocation

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -1080,6 +1080,8 @@ public class DefaultChatClient implements ChatClient {
 		public ChatClientRequestSpec toolContext(Map<String, Object> toolContext) {
 			Assert.notNull(toolContext, "context cannot be null");
 			Assert.noNullElements(toolContext.keySet(), "context keys cannot contain null elements");
+			Assert.noNullElements(toolContext.values(), "context values cannot contain null elements; "
+					+ "to represent an optional entry, omit the key rather than setting it to null");
 			toolContext.keySet().forEach(key -> Assert.hasText(key, "context key cannot be null or empty"));
 			this.toolContext.putAll(toolContext);
 			return this;

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -1080,7 +1080,6 @@ public class DefaultChatClient implements ChatClient {
 		public ChatClientRequestSpec toolContext(Map<String, Object> toolContext) {
 			Assert.notNull(toolContext, "context cannot be null");
 			Assert.noNullElements(toolContext.keySet(), "context keys cannot contain null elements");
-			Assert.noNullElements(toolContext.values(), "context values cannot contain null elements");
 			toolContext.keySet().forEach(key -> Assert.hasText(key, "context key cannot be null or empty"));
 			this.toolContext.putAll(toolContext);
 			return this;

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1990,14 +1990,34 @@ class DefaultChatClientTests {
 	}
 
 	@Test
-	void whenToolContextValueIsNullThenSucceed() {
+	void whenToolContextValueIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		Map<String, Object> toolContext = new HashMap<>();
 		toolContext.put("key", null);
-		spec = spec.toolContext(toolContext);
+		assertThatThrownBy(() -> spec.toolContext(toolContext)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("context values cannot contain null elements")
+			.hasMessageContaining("omit the key rather than setting it to null");
+	}
+
+	@Test
+	void whenToolContextMultipleValuesWithOneNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+		Map<String, Object> toolContext = new HashMap<>();
+		toolContext.put("tenantId", "ACME");
+		toolContext.put("orderNumber", null);
+		assertThatThrownBy(() -> spec.toolContext(toolContext)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("context values cannot contain null elements");
+	}
+
+	@Test
+	void whenToolContextEmptyMapThenSucceed() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+		spec = spec.toolContext(new HashMap<>());
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
-		assertThat(defaultSpec.getToolContext()).containsEntry("key", null);
+		assertThat(defaultSpec.getToolContext()).isEmpty();
 	}
 
 	@Test
@@ -2058,13 +2078,13 @@ class DefaultChatClientTests {
 	}
 
 	@Test
-	void whenToolSpecContextValueIsNullThenSucceed() {
+	void whenToolSpecContextValueIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		Map<String, Object> ctx = new HashMap<>();
 		ctx.put("key", null);
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().toolContext(ctx);
-		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
-		assertThat(defaultSpec.getToolContext()).containsEntry("key", null);
+		assertThatThrownBy(() -> chatClient.prompt().toolContext(ctx)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("context values cannot contain null elements")
+			.hasMessageContaining("omit the key rather than setting it to null");
 	}
 
 	@Test

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1990,13 +1990,14 @@ class DefaultChatClientTests {
 	}
 
 	@Test
-	void whenToolContextValueIsNullThenThrow() {
+	void whenToolContextValueIsNullThenSucceed() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		Map<String, Object> toolContext = new HashMap<>();
 		toolContext.put("key", null);
-		assertThatThrownBy(() -> spec.toolContext(toolContext)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("context values cannot contain null elements");
+		spec = spec.toolContext(toolContext);
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getToolContext()).containsEntry("key", null);
 	}
 
 	@Test
@@ -2057,12 +2058,13 @@ class DefaultChatClientTests {
 	}
 
 	@Test
-	void whenToolSpecContextValueIsNullThenThrow() {
+	void whenToolSpecContextValueIsNullThenSucceed() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
 		Map<String, Object> ctx = new HashMap<>();
 		ctx.put("key", null);
-		assertThatThrownBy(() -> chatClient.prompt().toolContext(ctx)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("context values cannot contain null elements");
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().toolContext(ctx);
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getToolContext()).containsEntry("key", null);
 	}
 
 	@Test

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
@@ -38,8 +38,6 @@ import org.springframework.ai.tool.metadata.ToolMetadata;
 import org.springframework.ai.util.JsonHelper;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.CollectionUtils;
 
 /**
  * A {@link ToolCallback} implementation to invoke methods as tools.
@@ -104,8 +102,6 @@ public final class MethodToolCallback implements ToolCallback {
 			logger.debug("Starting execution of tool: " + this.toolDefinition.name());
 		}
 
-		this.validateToolContextSupport(toolContext);
-
 		Map<String, Object> toolArguments = this.extractToolArguments(toolInput);
 		Assert.state(toolArguments != null, "toolArguments must not be null");
 
@@ -122,15 +118,6 @@ public final class MethodToolCallback implements ToolCallback {
 		return this.toolCallResultConverter.convert(result, returnType);
 	}
 
-	private void validateToolContextSupport(@Nullable ToolContext toolContext) {
-		var isNonEmptyToolContextProvided = toolContext != null && !CollectionUtils.isEmpty(toolContext.getContext());
-		var isToolContextAcceptedByMethod = Stream.of(this.toolMethod.getParameterTypes())
-			.anyMatch(type -> ClassUtils.isAssignable(ToolContext.class, type));
-		if (isToolContextAcceptedByMethod && !isNonEmptyToolContextProvided) {
-			throw new IllegalArgumentException("ToolContext is required by the method as an argument");
-		}
-	}
-
 	private @Nullable Map<String, Object> extractToolArguments(String toolInput) {
 		try {
 			return jsonHelper.fromJson(toolInput, new ParameterizedTypeReference<>() {
@@ -143,12 +130,11 @@ public final class MethodToolCallback implements ToolCallback {
 		}
 	}
 
-	// Based on the implementation in MethodToolCallback.
 	@SuppressWarnings("null")
 	private Object[] buildMethodArguments(Map<String, Object> toolInputArguments, @Nullable ToolContext toolContext) {
 		return Stream.of(this.toolMethod.getParameters()).map(parameter -> {
 			if (parameter.getType().isAssignableFrom(ToolContext.class)) {
-				return toolContext;
+				return toolContext != null ? toolContext : new ToolContext(Map.of());
 			}
 			Object rawArgument = toolInputArguments.get(parameter.getName());
 			return buildTypedArgument(rawArgument, parameter.getParameterizedType());

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackToolContextTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackToolContextTests.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.method;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.execution.ToolExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link MethodToolCallback} ToolContext handling (issue #6545).
+ *
+ * <p>
+ * Covers: null context, empty context, non-empty context, multiple values, null values,
+ * case sensitivity, methods that don't accept ToolContext, and exception paths.
+ */
+class MethodToolCallbackToolContextTests {
+
+	private ContextAwareTools toolObject;
+
+	private MethodToolCallback contextCallback;
+
+	private MethodToolCallback noContextCallback;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		this.toolObject = new ContextAwareTools();
+
+		Method contextMethod = ContextAwareTools.class.getMethod("withContext", String.class, ToolContext.class);
+		ToolDefinition contextDef = DefaultToolDefinition.builder()
+			.name("withContext")
+			.description("Tool that reads ToolContext")
+			.inputSchema("{\"type\":\"object\",\"properties\":{\"input\":{\"type\":\"string\"}}}")
+			.build();
+		this.contextCallback = MethodToolCallback.builder()
+			.toolDefinition(contextDef)
+			.toolMethod(contextMethod)
+			.toolObject(this.toolObject)
+			.build();
+
+		Method noContextMethod = ContextAwareTools.class.getMethod("withoutContext", String.class);
+		ToolDefinition noContextDef = DefaultToolDefinition.builder()
+			.name("withoutContext")
+			.description("Tool that ignores ToolContext")
+			.inputSchema("{\"type\":\"object\",\"properties\":{\"input\":{\"type\":\"string\"}}}")
+			.build();
+		this.noContextCallback = MethodToolCallback.builder()
+			.toolDefinition(noContextDef)
+			.toolMethod(noContextMethod)
+			.toolObject(this.toolObject)
+			.build();
+	}
+
+	// -------------------------------------------------------------------------
+	// null ToolContext
+	// -------------------------------------------------------------------------
+
+	@Test
+	void nullToolContextYieldsEmptyContextInsideTool() {
+		// call(toolInput) overload passes null — tool must receive an empty ToolContext
+		String result = this.contextCallback.call("{\"input\": \"ping\"}");
+		assertThat(result).contains("size=0");
+	}
+
+	@Test
+	void nullToolContextExplicitlyPassedYieldsEmptyContextInsideTool() {
+		String result = this.contextCallback.call("{\"input\": \"ping\"}", null);
+		assertThat(result).contains("size=0");
+	}
+
+	// -------------------------------------------------------------------------
+	// empty ToolContext (the primary bug from issue #6545)
+	// -------------------------------------------------------------------------
+
+	@Test
+	void emptyToolContextIsAccepted() {
+		ToolContext empty = new ToolContext(new HashMap<>());
+		String result = this.contextCallback.call("{\"input\": \"ping\"}", empty);
+		assertThat(result).contains("size=0");
+	}
+
+	@Test
+	void emptyToolContextViaMapOfIsAccepted() {
+		ToolContext empty = new ToolContext(Map.of());
+		String result = this.contextCallback.call("{\"input\": \"test\"}", empty);
+		assertThat(result).contains("size=0");
+	}
+
+	// -------------------------------------------------------------------------
+	// non-empty ToolContext — backward compatibility
+	// -------------------------------------------------------------------------
+
+	@Test
+	void singleEntryContextPassedThrough() {
+		ToolContext ctx = new ToolContext(Map.of("tenantId", "t-1"));
+		String result = this.contextCallback.call("{\"input\": \"hi\"}", ctx);
+		assertThat(result).contains("tenantId=t-1").contains("size=1");
+	}
+
+	@Test
+	void multipleEntriesAllPassedThrough() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("tenantId", "t-1");
+		map.put("requestId", "r-42");
+		map.put("locale", "en-US");
+		ToolContext ctx = new ToolContext(map);
+
+		String result = this.contextCallback.call("{\"input\": \"hi\"}", ctx);
+		assertThat(result).contains("size=3").contains("tenantId=t-1").contains("requestId=r-42");
+	}
+
+	// -------------------------------------------------------------------------
+	// null values inside the context map
+	// -------------------------------------------------------------------------
+
+	@Test
+	void contextWithNullValueIsPassedToTool() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("orderNumber", null);
+		map.put("userId", "u-99");
+		ToolContext ctx = new ToolContext(map);
+
+		String result = this.contextCallback.call("{\"input\": \"order\"}", ctx);
+		// Tool receives both keys; orderNumber value is null
+		assertThat(result).contains("size=2").contains("hasOrder=false").contains("userId=u-99");
+	}
+
+	// -------------------------------------------------------------------------
+	// case sensitivity of context keys
+	// -------------------------------------------------------------------------
+
+	@Test
+	void contextKeysCaseIsPreserved() {
+		ToolContext ctx = new ToolContext(Map.of("UserId", "upper", "userid", "lower"));
+		String result = this.contextCallback.call("{\"input\": \"case\"}", ctx);
+		assertThat(result).contains("size=2");
+	}
+
+	// -------------------------------------------------------------------------
+	// methods that do NOT accept ToolContext
+	// -------------------------------------------------------------------------
+
+	@Test
+	void nullContextIgnoredForMethodWithoutContextParam() {
+		String result = this.noContextCallback.call("{\"input\": \"hello\"}", null);
+		assertThat(result).contains("hello");
+	}
+
+	@Test
+	void emptyContextIgnoredForMethodWithoutContextParam() {
+		ToolContext empty = new ToolContext(Map.of());
+		String result = this.noContextCallback.call("{\"input\": \"world\"}", empty);
+		assertThat(result).contains("world");
+	}
+
+	@Test
+	void nonEmptyContextIgnoredForMethodWithoutContextParam() {
+		ToolContext ctx = new ToolContext(Map.of("key", "value"));
+		String result = this.noContextCallback.call("{\"input\": \"ignored\"}", ctx);
+		assertThat(result).contains("ignored");
+	}
+
+	// -------------------------------------------------------------------------
+	// exception path — tool throws, context does not affect exception wrapping
+	// -------------------------------------------------------------------------
+
+	@Test
+	void toolExceptionWithEmptyContextIsWrappedCorrectly() throws Exception {
+		ThrowingTools throwing = new ThrowingTools();
+		Method method = ThrowingTools.class.getMethod("alwaysFails", String.class, ToolContext.class);
+		ToolDefinition def = DefaultToolDefinition.builder()
+			.name("alwaysFails")
+			.description("Always throws")
+			.inputSchema("{\"type\":\"object\",\"properties\":{\"input\":{\"type\":\"string\"}}}")
+			.build();
+		MethodToolCallback failCallback = MethodToolCallback.builder()
+			.toolDefinition(def)
+			.toolMethod(method)
+			.toolObject(throwing)
+			.build();
+
+		ToolContext empty = new ToolContext(Map.of());
+		assertThatThrownBy(() -> failCallback.call("{\"input\": \"boom\"}", empty))
+			.isInstanceOf(ToolExecutionException.class)
+			.hasMessageContaining("deliberate failure for: boom");
+	}
+
+	@Test
+	void toolExceptionWithNullContextIsWrappedCorrectly() throws Exception {
+		ThrowingTools throwing = new ThrowingTools();
+		Method method = ThrowingTools.class.getMethod("alwaysFails", String.class, ToolContext.class);
+		ToolDefinition def = DefaultToolDefinition.builder()
+			.name("alwaysFails")
+			.description("Always throws")
+			.inputSchema("{\"type\":\"object\",\"properties\":{\"input\":{\"type\":\"string\"}}}")
+			.build();
+		MethodToolCallback failCallback = MethodToolCallback.builder()
+			.toolDefinition(def)
+			.toolMethod(method)
+			.toolObject(throwing)
+			.build();
+
+		assertThatThrownBy(() -> failCallback.call("{\"input\": \"boom\"}", null))
+			.isInstanceOf(ToolExecutionException.class)
+			.hasMessageContaining("deliberate failure for: boom");
+	}
+
+	// -------------------------------------------------------------------------
+	// Tool classes
+	// -------------------------------------------------------------------------
+
+	public static class ContextAwareTools {
+
+		@Tool(description = "Tool that reads ToolContext")
+		public String withContext(String input, ToolContext toolContext) {
+			Map<String, Object> ctx = toolContext.getContext();
+			StringBuilder sb = new StringBuilder();
+			sb.append("input=").append(input).append(" size=").append(ctx.size());
+			boolean hasOrder = ctx.containsKey("orderNumber") && ctx.get("orderNumber") != null;
+			sb.append(" hasOrder=").append(hasOrder);
+			ctx.forEach((k, v) -> {
+				if (!"orderNumber".equals(k)) {
+					sb.append(" ").append(k).append("=").append(v);
+				}
+			});
+			return sb.toString();
+		}
+
+		@Tool(description = "Tool that ignores ToolContext")
+		public String withoutContext(String input) {
+			return "echo:" + input;
+		}
+
+	}
+
+	public static class ThrowingTools {
+
+		@Tool(description = "Always throws")
+		public String alwaysFails(String input, ToolContext toolContext) {
+			throw new RuntimeException("deliberate failure for: " + input);
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackToolContextTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackToolContextTests.java
@@ -135,22 +135,6 @@ class MethodToolCallbackToolContextTests {
 	}
 
 	// -------------------------------------------------------------------------
-	// null values inside the context map
-	// -------------------------------------------------------------------------
-
-	@Test
-	void contextWithNullValueIsPassedToTool() {
-		Map<String, Object> map = new HashMap<>();
-		map.put("orderNumber", null);
-		map.put("userId", "u-99");
-		ToolContext ctx = new ToolContext(map);
-
-		String result = this.contextCallback.call("{\"input\": \"order\"}", ctx);
-		// Tool receives both keys; orderNumber value is null
-		assertThat(result).contains("size=2").contains("hasOrder=false").contains("userId=u-99");
-	}
-
-	// -------------------------------------------------------------------------
 	// case sensitivity of context keys
 	// -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Fixes #6545

Two related but independent bugs prevent callers from expressing an optional or absent tool context:

**Bug 1 — `MethodToolCallback` (spring-ai-model)**

`validateToolContextSupport()` treated an *empty* `ToolContext` the same as a *missing* one, and threw `IllegalArgumentException` in both cases. This forced callers to inject fake placeholder entries (e.g. `Map.of("foo", "bar")`) just to satisfy the guard, even when no real context was needed:

```java
// Workaround required before this fix:
Map<String, Object> toolContext = new HashMap<>();
if (orderNumber != null) {
    toolContext.put("orderNumber", orderNumber);
} else {
    toolContext.put("foo", "bar"); // fake entry to prevent exception
}
```

**Bug 2 — `DefaultChatClient` (spring-ai-client-chat)**

`ChatClientRequestSpec.toolContext()` rejected maps that contained `null` values via `Assert.noNullElements()`, making it impossible to represent optional context entries as `null`.

## Changes

### `spring-ai-model` — `MethodToolCallback`

- Remove `validateToolContextSupport()`. Empty context is valid; the tool method decides which keys it requires.
- In `buildMethodArguments()`, convert a `null` `ToolContext` to `new ToolContext(Map.of())` so tool methods that declare the parameter never receive `null`, preventing NPE without throwing.
- Remove now-unused imports `ClassUtils` and `CollectionUtils`.

### `spring-ai-client-chat` — `DefaultChatClient`

- Remove the `Assert.noNullElements()` guard on context map **values** only.
- The following guards are **preserved unchanged**:
  - `null` map reference → still rejected
  - `null` keys → still rejected
  - blank/empty string keys → still rejected

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Method declares `ToolContext` + `null` context | throws | tool receives `ToolContext(Map.of())` |
| Method declares `ToolContext` + empty context | throws | tool receives the empty context |
| Method declares `ToolContext` + non-empty context | works | works (unchanged) |
| Method does not declare `ToolContext` + any context | silently ignored | silently ignored (unchanged) |
| `toolContext(map)` with `null` value | throws | accepted |
| `toolContext(null)` map reference | throws | throws (unchanged) |
| `toolContext(map)` with `null` key | throws | throws (unchanged) |

## Tests

**New: `MethodToolCallbackToolContextTests`** — 13 tests covering:
- `null` context (implicit via `call(input)`) → tool receives empty `ToolContext`
- explicit `null` context → tool receives empty `ToolContext`
- empty `HashMap` and `Map.of()` are accepted
- single and multiple context entries pass through unchanged (backward compatibility)
- `null` value in context map is forwarded to the tool
- key case is preserved
- method without `ToolContext` param: `null` / empty / non-empty context are all silently ignored (original behaviour preserved)
- exception path with empty and `null` context wraps correctly in `ToolExecutionException`

**Updated: `DefaultChatClientTests`** — 2 tests renamed from `*ThenThrow` to `*ThenSucceed` to reflect the new allowed behaviour for `null` map values.

## Test results

| Module | Tests | Failures |
|---|---|---|
| `spring-ai-model` | 829 | 0 |
| `spring-ai-client-chat` | 569 | 0 |