### PR TITLE
Fix `TokenCountBatchingStrategy` dropping equal documents

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/embedding/TokenCountBatchingStrategy.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/embedding/TokenCountBatchingStrategy.java
@@ -17,9 +17,7 @@
 package org.springframework.ai.embedding;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.knuddels.jtokkit.api.EncodingType;
 
@@ -140,10 +138,9 @@ public class TokenCountBatchingStrategy implements BatchingStrategy {
 		List<List<Document>> batches = new ArrayList<>();
 		int currentSize = 0;
 		List<Document> currentBatch = new ArrayList<>();
-		// Make sure the documentTokens' entry order is preserved by making it a
-		// LinkedHashMap.
-		Map<Document, Integer> documentTokens = new LinkedHashMap<>();
 
+		// Do not collect the documents into a Map keyed by Document: equal documents
+		// would collapse to a single entry and be silently dropped from the batches.
 		for (Document document : documents) {
 			int tokenCount = this.tokenCountEstimator
 				.estimate(document.getFormattedContent(this.contentFormatter, this.metadataMode));
@@ -151,16 +148,11 @@ public class TokenCountBatchingStrategy implements BatchingStrategy {
 				throw new IllegalArgumentException(
 						"Tokens in a single document exceeds the maximum number of allowed input tokens");
 			}
-			documentTokens.put(document, tokenCount);
-		}
-
-		for (Map.Entry<Document, Integer> entry : documentTokens.entrySet()) {
-			Document document = entry.getKey();
-			currentSize += entry.getValue();
+			currentSize += tokenCount;
 			if (currentSize > this.maxInputTokenCount) {
 				batches.add(currentBatch);
 				currentBatch = new ArrayList<>();
-				currentSize = entry.getValue();
+				currentSize = tokenCount;
 			}
 			currentBatch.add(document);
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/embedding/TokenCountBatchingStrategyTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/embedding/TokenCountBatchingStrategyTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.embedding;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import com.knuddels.jtokkit.api.EncodingType;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,30 @@ public class TokenCountBatchingStrategyTests {
 		TokenCountBatchingStrategy tokenCountBatchingStrategy = new TokenCountBatchingStrategy();
 		assertThatThrownBy(() -> tokenCountBatchingStrategy.batch(List.of(new Document(contentAsString))))
 			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void batchKeepsEqualDocuments() {
+		TokenCountBatchingStrategy strategy = new TokenCountBatchingStrategy();
+		Document first = new Document("shared-id", "same text content", Map.of());
+		Document second = new Document("shared-id", "same text content", Map.of());
+
+		List<List<Document>> batches = strategy.batch(List.of(first, second));
+
+		int totalDocs = batches.stream().mapToInt(List::size).sum();
+		assertThat(totalDocs).isEqualTo(2);
+		assertThat(batches.get(0)).containsExactly(first, second);
+	}
+
+	@Test
+	void batchKeepsRepeatedDocumentInstance() {
+		TokenCountBatchingStrategy strategy = new TokenCountBatchingStrategy();
+		Document document = new Document("doc-id", "Hello world", Map.of());
+
+		List<List<Document>> batches = strategy.batch(List.of(document, document));
+
+		int totalDocs = batches.stream().mapToInt(List::size).sum();
+		assertThat(totalDocs).isEqualTo(2);
 	}
 
 }


### PR DESCRIPTION
`TokenCountBatchingStrategy.batch` collected per-document token counts into a
`Map<Document, Integer>` before forming batches. Since `Document.equals()`
compares id, text, media, metadata and score, equal documents  for example
identical chunks produced by a content-based id generator, or the same
instance appearing twice  collapsed into one map entry and were silently
dropped from the returned batches.

`batch` is a partitioning operation and must preserve every input document:
its only caller, `EmbeddingModel.embed`, maps the returned embeddings back to
the input documents by position and asserts
`embeddings.size() == documents.size()`. With a dropped duplicate, ingestion
fails with "Embeddings must have the same number as that of the documents",
pointing away from the real cause.

This estimates and accumulates token counts in a single pass over the input
list, removing the intermediate map, so batching no longer depends on document
equality. The batch-boundary accounting and the single-oversized-document
check are unchanged.

## Testing

Added `batchKeepsEqualDocuments` and `batchKeepsRepeatedDocumentInstance`;
both fail on the previous implementation (a single document is returned) and
pass with the fix. The existing tests, including the batch-boundary token
accounting test, are unaffected.

`./mvnw -pl spring-ai-model clean test` passes (818 tests).

Fixes #6560