### PR TITLE
Re-extract cached resource when its source content changes

### DIFF
--- a/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/ResourceCacheService.java
+++ b/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/ResourceCacheService.java
@@ -107,7 +107,7 @@ public class ResourceCacheService {
 			}
 
 			File cachedFile = getCachedFile(originalResource);
-			if (!cachedFile.exists()) {
+			if (!cachedFile.exists() || isCachedFileStale(originalResource, cachedFile)) {
 				FileCopyUtils.copy(StreamUtils.copyToByteArray(originalResource.getInputStream()), cachedFile);
 				logger.info("Caching the " + originalResource.toString() + " resource to: " + cachedFile);
 			}
@@ -115,6 +115,40 @@ public class ResourceCacheService {
 		}
 		catch (Exception e) {
 			throw new IllegalStateException("Failed to cache the resource: " + originalResource.getDescription(), e);
+		}
+	}
+
+	/**
+	 * Determine whether an existing cached file is out of date with respect to the
+	 * original resource. Because the cache key is derived only from the resource
+	 * location, a resource replaced in place (for example an ONNX model bundled in a
+	 * rebuilt fat jar) keeps the same cache path and would otherwise be served from a
+	 * stale copy. A cached file is treated as stale when its size differs from the
+	 * original resource, or when the original resource has been modified more recently
+	 * than the cached copy.
+	 * @param originalResource the source resource being cached
+	 * @param cachedFile the existing cached copy on the local file system
+	 * @return {@code true} if the cached file should be refreshed from the original
+	 * resource
+	 */
+	private boolean isCachedFileStale(Resource originalResource, File cachedFile) {
+		try {
+			long originalLength = originalResource.contentLength();
+			if (originalLength >= 0 && originalLength != cachedFile.length()) {
+				return true;
+			}
+		}
+		catch (IOException ex) {
+			// Content length is not available for this resource; fall back to the
+			// modification time check below.
+		}
+		try {
+			long originalLastModified = originalResource.lastModified();
+			return originalLastModified > 0 && originalLastModified > cachedFile.lastModified();
+		}
+		catch (IOException ex) {
+			// Modification time is not available either; keep the existing cached copy.
+			return false;
 		}
 	}
 

--- a/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/ResourceCacheServiceTests.java
+++ b/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/ResourceCacheServiceTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.transformers;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.util.StreamUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -99,6 +101,37 @@ public class ResourceCacheServiceTests {
 			.describedAs(
 					"As both resources come from the same parent segments they should be cached in a single common parent.");
 		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(2);
+	}
+
+	@Test
+	public void reCachesResourceWhenSourceContentChanges(@TempDir File sourceDir) throws IOException {
+		var cache = new ResourceCacheService(this.tempDir);
+
+		cache.setExcludedUriSchemas(List.of()); // erase the excluded schema names,
+		// including 'file'.
+
+		// Simulate a resource bundled in a fat jar (e.g. an ONNX model) that is later
+		// replaced in place by a rebuilt jar shipping a different version. The cache key
+		// is
+		// derived from the resource location, so the location stays the same across
+		// builds.
+		File source = new File(sourceDir, "model.onnx");
+		Files.writeString(source.toPath(), "first-model-payload");
+		var originalResourceUri = source.toURI().toString();
+
+		var firstCached = cache.getCachedResource(originalResourceUri);
+		assertThat(StreamUtils.copyToString(firstCached.getInputStream(), StandardCharsets.UTF_8))
+			.isEqualTo("first-model-payload");
+
+		// Replace the source content (a different size, as a differently sized model
+		// would
+		// produce) at the same location.
+		Files.writeString(source.toPath(), "second-model");
+
+		var secondCached = cache.getCachedResource(originalResourceUri);
+		assertThat(StreamUtils.copyToString(secondCached.getInputStream(), StandardCharsets.UTF_8))
+			.describedAs("The cached copy must be refreshed after the source resource is replaced in place")
+			.isEqualTo("second-model");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes gh-6219

`ResourceCacheService` copies a resource into the local cache only when the target file does not yet exist, so a resource that is replaced in place keeps its previously extracted (stale) copy forever.

When a `classpath:` resource is packaged inside a fat jar its URI scheme resolves to `jar` rather than `classpath`, so it is not excluded from caching and gets extracted to the temp cache. The cache path is derived only from the resource location, which is stable across builds. Rebuilding the jar with a different `model.onnx` therefore reuses the old extracted file, and `TransformersEmbeddingModel` keeps serving the previous model's embedding dimensions until the temp directory is deleted by hand (e.g. a 768-dim model is used to query a 384-dim index).

This refreshes the cached copy when the original resource's content length differs from the cached file, or when the original has been modified more recently than the cached copy. Both are cheap metadata reads; when either is unavailable the existing cached copy is kept, preserving current behavior for resources that cannot report size/last-modified.

A regression test reproduces an in-place source change and asserts the cache is refreshed. It fails without the fix and passes with it.