### PR TITLE
Stop registering internal RedisClient as bean

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
@@ -69,15 +69,9 @@ public class RedisChatMemoryRepositoryAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
-	public RedisClient jedisClient(RedisChatMemoryRepositoryProperties properties) {
-		return RedisClient.builder().hostAndPort(properties.getHost(), properties.getPort()).build();
-	}
-
-	@Bean
 	@ConditionalOnMissingBean({ RedisChatMemoryRepository.class, ChatMemory.class, ChatMemoryRepository.class })
-	public RedisChatMemoryRepository redisChatMemoryRepository(RedisClient jedisClient,
-			RedisChatMemoryRepositoryProperties properties) {
+	public RedisChatMemoryRepository redisChatMemoryRepository(RedisChatMemoryRepositoryProperties properties) {
+		RedisClient jedisClient = jedisClient(properties);
 		RedisChatMemoryRepository.Builder builder = RedisChatMemoryRepository.builder().jedisClient(jedisClient);
 
 		// Apply configuration if provided
@@ -110,6 +104,10 @@ public class RedisChatMemoryRepositoryAutoConfiguration {
 		}
 
 		return builder.build();
+	}
+
+	private RedisClient jedisClient(RedisChatMemoryRepositoryProperties properties) {
+		return RedisClient.builder().hostAndPort(properties.getHost(), properties.getPort()).build();
 	}
 
 }

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
@@ -71,29 +71,9 @@ public class RedisChatMemoryRepositoryAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
-	public RedisClient jedisClient(RedisChatMemoryRepositoryProperties properties) {
-		if (StringUtils.hasText(properties.getUsername()) || StringUtils.hasText(properties.getPassword())) {
-			DefaultJedisClientConfig.Builder configBuilder = DefaultJedisClientConfig.builder();
-			if (StringUtils.hasText(properties.getUsername())) {
-				configBuilder.user(properties.getUsername());
-			}
-			if (StringUtils.hasText(properties.getPassword())) {
-				configBuilder.password(properties.getPassword());
-			}
-			JedisClientConfig clientConfig = configBuilder.build();
-			return RedisClient.builder()
-				.hostAndPort(properties.getHost(), properties.getPort())
-				.clientConfig(clientConfig)
-				.build();
-		}
-		return RedisClient.builder().hostAndPort(properties.getHost(), properties.getPort()).build();
-	}
-
-	@Bean
 	@ConditionalOnMissingBean({ RedisChatMemoryRepository.class, ChatMemory.class, ChatMemoryRepository.class })
-	public RedisChatMemoryRepository redisChatMemoryRepository(RedisClient jedisClient,
-			RedisChatMemoryRepositoryProperties properties) {
+	public RedisChatMemoryRepository redisChatMemoryRepository(RedisChatMemoryRepositoryProperties properties) {
+		RedisClient jedisClient = jedisClient(properties);
 		RedisChatMemoryRepository.Builder builder = RedisChatMemoryRepository.builder().jedisClient(jedisClient);
 
 		// Apply configuration if provided
@@ -126,6 +106,24 @@ public class RedisChatMemoryRepositoryAutoConfiguration {
 		}
 
 		return builder.build();
+	}
+
+	private RedisClient jedisClient(RedisChatMemoryRepositoryProperties properties) {
+		if (StringUtils.hasText(properties.getUsername()) || StringUtils.hasText(properties.getPassword())) {
+			DefaultJedisClientConfig.Builder configBuilder = DefaultJedisClientConfig.builder();
+			if (StringUtils.hasText(properties.getUsername())) {
+				configBuilder.user(properties.getUsername());
+			}
+			if (StringUtils.hasText(properties.getPassword())) {
+				configBuilder.password(properties.getPassword());
+			}
+			JedisClientConfig clientConfig = configBuilder.build();
+			return RedisClient.builder()
+				.hostAndPort(properties.getHost(), properties.getPort())
+				.clientConfig(clientConfig)
+				.build();
+		}
+		return RedisClient.builder().hostAndPort(properties.getHost(), properties.getPort()).build();
 	}
 
 }

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/test/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfigurationTests.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/test/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfigurationTests.java
@@ -16,19 +16,12 @@
 
 package org.springframework.ai.model.chat.memory.redis.autoconfigure;
 
-import org.apache.commons.pool2.PooledObjectFactory;
 import org.junit.jupiter.api.Test;
-import redis.clients.jedis.ConnectionFactory;
-import redis.clients.jedis.JedisClientConfig;
-import redis.clients.jedis.RedisClient;
-import redis.clients.jedis.providers.PooledConnectionProvider;
-import redis.clients.jedis.util.Pool;
 
 import org.springframework.ai.model.chat.memory.repository.redis.autoconfigure.RedisChatMemoryRepositoryAutoConfiguration;
 import org.springframework.ai.model.chat.memory.repository.redis.autoconfigure.RedisChatMemoryRepositoryProperties;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -86,10 +79,6 @@ class RedisChatMemoryAutoConfigurationTests {
 					.getBean(RedisChatMemoryRepositoryProperties.class);
 				assertThat(properties.getUsername()).isEqualTo("app-user");
 				assertThat(properties.getPassword()).isEqualTo("secret");
-
-				JedisClientConfig clientConfig = extractJedisClientConfig(context.getBean(RedisClient.class));
-				assertThat(clientConfig.getUser()).isEqualTo("app-user");
-				assertThat(clientConfig.getPassword()).isEqualTo("secret");
 			});
 	}
 
@@ -106,10 +95,6 @@ class RedisChatMemoryAutoConfigurationTests {
 					.getBean(RedisChatMemoryRepositoryProperties.class);
 				assertThat(properties.getUsername()).isEqualTo("app-user");
 				assertThat(properties.getPassword()).isEqualTo("secret");
-
-				JedisClientConfig clientConfig = extractJedisClientConfig(context.getBean(RedisClient.class));
-				assertThat(clientConfig.getUser()).isEqualTo("app-user");
-				assertThat(clientConfig.getPassword()).isEqualTo("secret");
 			});
 	}
 
@@ -121,8 +106,6 @@ class RedisChatMemoryAutoConfigurationTests {
 					"spring.ai.chat.memory.redis.initialize-schema=false")
 			.run(context -> {
 				assertThat(context.getBean(RedisChatMemoryRepositoryProperties.class).getPassword())
-					.isEqualTo("secret");
-				assertThat(extractJedisClientConfig(context.getBean(RedisClient.class)).getPassword())
 					.isEqualTo("secret");
 			});
 	}
@@ -136,8 +119,6 @@ class RedisChatMemoryAutoConfigurationTests {
 					"spring.ai.chat.memory.repository.redis.initialize-schema=false")
 			.run(context -> {
 				assertThat(context.getBean(RedisChatMemoryRepositoryProperties.class).getPassword())
-					.isEqualTo("secret");
-				assertThat(extractJedisClientConfig(context.getBean(RedisClient.class)).getPassword())
 					.isEqualTo("secret");
 			});
 	}
@@ -153,20 +134,7 @@ class RedisChatMemoryAutoConfigurationTests {
 					.getBean(RedisChatMemoryRepositoryProperties.class);
 				assertThat(properties.getUsername()).isNull();
 				assertThat(properties.getPassword()).isNull();
-
-				JedisClientConfig clientConfig = extractJedisClientConfig(context.getBean(RedisClient.class));
-				assertThat(clientConfig.getUser()).isNull();
-				assertThat(clientConfig.getPassword()).isNull();
 			});
-	}
-
-	private static JedisClientConfig extractJedisClientConfig(RedisClient redisClient) {
-		Object provider = ReflectionTestUtils.getField(redisClient, "provider");
-		assertThat(provider).isInstanceOf(PooledConnectionProvider.class);
-		Pool<?> pool = ((PooledConnectionProvider) provider).getPool();
-		PooledObjectFactory<?> factory = pool.getFactory();
-		assertThat(factory).isInstanceOf(ConnectionFactory.class);
-		return (JedisClientConfig) ReflectionTestUtils.getField(factory, "clientConfig");
 	}
 
 }

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheAutoConfiguration.java
@@ -75,40 +75,18 @@ public class RedisSemanticCacheAutoConfiguration {
 	}
 
 	/**
-	 * Creates a RedisClient client for Redis connections, honoring the SSL, password,
-	 * client name, and timeout settings from the {@link JedisConnectionFactory}.
-	 * @param jedisConnectionFactory the Jedis connection factory
-	 * @return the RedisClient client
-	 */
-	@Bean
-	@ConditionalOnMissingBean
-	@ConditionalOnBean(EmbeddingModel.class)
-	public RedisClient jedisClient(final JedisConnectionFactory jedisConnectionFactory) {
-		String host = jedisConnectionFactory.getHostName();
-		int port = jedisConnectionFactory.getPort();
-
-		JedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
-			.ssl(jedisConnectionFactory.isUseSsl())
-			.clientName(jedisConnectionFactory.getClientName())
-			.timeoutMillis(jedisConnectionFactory.getTimeout())
-			.password(jedisConnectionFactory.getPassword())
-			.build();
-
-		return RedisClient.builder().hostAndPort(host, port).clientConfig(clientConfig).build();
-	}
-
-	/**
 	 * Creates the semantic cache instance.
-	 * @param jedisClient the Jedis client
 	 * @param embeddingModel the embedding model
 	 * @param properties the semantic cache properties
+	 * @param jedisConnectionFactory the Jedis connection factory
 	 * @return the configured semantic cache
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(EmbeddingModel.class)
-	public SemanticCache semanticCache(final RedisClient jedisClient, final EmbeddingModel embeddingModel,
-			final RedisSemanticCacheProperties properties) {
+	public SemanticCache semanticCache(final EmbeddingModel embeddingModel,
+			final RedisSemanticCacheProperties properties, final JedisConnectionFactory jedisConnectionFactory) {
+		RedisClient jedisClient = jedisClient(jedisConnectionFactory);
 		DefaultSemanticCache.Builder builder = DefaultSemanticCache.builder()
 			.jedisClient(jedisClient)
 			.embeddingModel(embeddingModel);
@@ -136,6 +114,20 @@ public class RedisSemanticCacheAutoConfiguration {
 	@ConditionalOnBean(SemanticCache.class)
 	public SemanticCacheAdvisor semanticCacheAdvisor(final SemanticCache semanticCache) {
 		return new SemanticCacheAdvisor(semanticCache);
+	}
+
+	private RedisClient jedisClient(final JedisConnectionFactory jedisConnectionFactory) {
+		String host = jedisConnectionFactory.getHostName();
+		int port = jedisConnectionFactory.getPort();
+
+		JedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+			.ssl(jedisConnectionFactory.isUseSsl())
+			.clientName(jedisConnectionFactory.getClientName())
+			.timeoutMillis(jedisConnectionFactory.getTimeout())
+			.password(jedisConnectionFactory.getPassword())
+			.build();
+
+		return RedisClient.builder().hostAndPort(host, port).clientConfig(clientConfig).build();
 	}
 
 }


### PR DESCRIPTION
Align `chat-memory-repository-redis` and `vector-store-redis-semantic-cache` with `vector-store-redis`, keep `JedisClient` isolated with each other module.