### PR TITLE
Use Locale.ROOT for String uppercase/lowercase operations on wire/protocol values

### DIFF
--- a/advisors/spring-ai-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/AbstractToolSearchToolCallingAdvisorIT.java
+++ b/advisors/spring-ai-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/AbstractToolSearchToolCallingAdvisorIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.client.advisor.toolsearch;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -305,7 +306,7 @@ public abstract class AbstractToolSearchToolCallingAdvisorIT {
 
 		@Tool(description = "Get the current temperature in Celsius for a location or comma-separated list of locations")
 		public String currentWeather(String location) {
-			String loc = location.toLowerCase();
+			String loc = location.toLowerCase(Locale.ROOT);
 			StringBuilder result = new StringBuilder();
 			if (loc.contains("san francisco") || loc.contains("francisco")) {
 				result.append("San Francisco: 30°C");

--- a/advisors/spring-ai-vector-store-advisor/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisor.java
+++ b/advisors/spring-ai-vector-store-advisor/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisor.java
@@ -19,6 +19,7 @@ package org.springframework.ai.chat.client.advisor.vectorstore;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -141,7 +142,8 @@ public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor
 		String longTermMemory = documents == null ? "" : documents.stream().map(doc -> {
 			Map<String, Object> metadata = Objects.requireNonNullElse(doc.getMetadata(), Map.of());
 			String role = (String) metadata.getOrDefault(DOCUMENT_METADATA_MESSAGE_TYPE, "UNKNOWN");
-			return "<memory-entry type=\"" + role.toLowerCase() + "\">" + escapeXml(doc.getText()) + "</memory-entry>";
+			return "<memory-entry type=\"" + role.toLowerCase(Locale.ROOT) + "\">" + escapeXml(doc.getText())
+					+ "</memory-entry>";
 		}).collect(Collectors.joining(System.lineSeparator()));
 
 		SystemMessage systemMessage = request.prompt().getSystemMessage();

--- a/advisors/spring-ai-vector-store-advisor/src/test/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisorTests.java
+++ b/advisors/spring-ai-vector-store-advisor/src/test/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisorTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.chat.client.advisor.vectorstore;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -25,8 +26,11 @@ import org.mockito.Mockito;
 import reactor.core.scheduler.Scheduler;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
@@ -239,6 +243,33 @@ class VectorStoreChatMemoryAdvisorTests {
 			.contains("&apos;");
 		assertThat(systemText).doesNotContain("AT&T").doesNotContain("<fine>");
 		assertThat(systemText).containsOnlyOnce("<memory-entry type=\"assistant\">");
+	}
+
+	@Test
+	void memoryEntryTypeUsesRootLocaleUnderTurkishLocale() {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			// "ASSISTANT".toLowerCase() under tr-TR yields "assıstant" (dotless ı);
+			// Correct handling must produce ASCII "assistant".
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+			Document doc = Document.builder().text("hi").metadata(Map.of("messageType", "ASSISTANT")).build();
+
+			VectorStore vectorStore = Mockito.mock(VectorStore.class);
+			given(vectorStore.similaritySearch(any(SearchRequest.class))).willReturn(List.of(doc));
+
+			ChatClientRequest request = ChatClientRequest.builder()
+				.context(ChatMemory.CONVERSATION_ID, "test-session")
+				.prompt(new Prompt(List.of(new SystemMessage("instructions"), new UserMessage("query"))))
+				.build();
+
+			ChatClientRequest result = VectorStoreChatMemoryAdvisor.builder(vectorStore).build().before(request, null);
+
+			assertThat(result.prompt().getSystemMessage().getText()).contains("<memory-entry type=\"assistant\">");
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 }

--- a/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/autoconfigure/ToolSearchAdvisorAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.chat.client.advisor.toolsearch.autoconfigure;
 
+import java.util.Locale;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -108,7 +109,7 @@ public class ToolSearchAdvisorAutoConfiguration implements InitializingBean {
 	@Override
 	public void afterPropertiesSet() {
 		String type = this.properties.getToolIndexType();
-		if (type != null && !KNOWN_TOOL_INDEX_TYPES.contains(type.toLowerCase())) {
+		if (type != null && !KNOWN_TOOL_INDEX_TYPES.contains(type.toLowerCase(Locale.ROOT))) {
 			logger.warn("Unknown 'spring.ai.chat.client.tool-search-advisor.tool-index-type' value: '" + type
 					+ "'. Known built-in values are: " + KNOWN_TOOL_INDEX_TYPES
 					+ ". If this is intentional, ensure a matching ToolIndex bean is declared in the application context.");

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpClientListChangedAnnotationsScanningIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpClientListChangedAnnotationsScanningIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.mcp.client.common.autoconfigure.annotations;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import io.modelcontextprotocol.spec.McpSchema;
@@ -118,7 +119,7 @@ public class McpClientListChangedAnnotationsScanningIT {
 	@ParameterizedTest
 	@ValueSource(strings = { "SYNC", "ASYNC" })
 	void shouldNotScanAnnotationsWhenScannerDisabled(String clientType) {
-		String prefix = clientType.toLowerCase();
+		String prefix = clientType.toLowerCase(Locale.ROOT);
 
 		this.contextRunner.withUserConfiguration(AllListChangedConfiguration.class)
 			.withPropertyValues("spring.ai.mcp.client.type=" + clientType,

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
@@ -651,7 +652,7 @@ public class McpServerAutoConfigurationIT {
 		@McpComplete(prompt = "city-search")
 		public List<String> completeCityName(String prefix) {
 			return Stream.of("New York", "Los Angeles", "Chicago", "Houston", "Phoenix")
-				.filter(city -> city.toLowerCase().startsWith(prefix.toLowerCase()))
+				.filter(city -> city.toLowerCase(Locale.ROOT).startsWith(prefix.toLowerCase(Locale.ROOT)))
 				.limit(10)
 				.toList();
 		}
@@ -693,7 +694,7 @@ public class McpServerAutoConfigurationIT {
 		@McpComplete(prompt = "city-search")
 		public Mono<List<String>> completeCityName(String prefix) {
 			return Mono.just(Stream.of("New York", "Los Angeles", "Chicago", "Houston", "Phoenix")
-				.filter(city -> city.toLowerCase().startsWith(prefix.toLowerCase()))
+				.filter(city -> city.toLowerCase(Locale.ROOT).startsWith(prefix.toLowerCase(Locale.ROOT)))
 				.limit(10)
 				.toList());
 		}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
@@ -572,7 +573,7 @@ public class McpStatelessServerAutoConfigurationIT {
 		@McpComplete(prompt = "city-search")
 		public List<String> completeCityName(String prefix) {
 			return Stream.of("New York", "Los Angeles", "Chicago", "Houston", "Phoenix")
-				.filter(city -> city.toLowerCase().startsWith(prefix.toLowerCase()))
+				.filter(city -> city.toLowerCase(Locale.ROOT).startsWith(prefix.toLowerCase(Locale.ROOT)))
 				.limit(10)
 				.toList();
 		}
@@ -614,7 +615,7 @@ public class McpStatelessServerAutoConfigurationIT {
 		@McpComplete(prompt = "city-search")
 		public Mono<List<String>> completeCityName(String prefix) {
 			return Mono.just(Stream.of("New York", "Los Angeles", "Chicago", "Houston", "Phoenix")
-				.filter(city -> city.toLowerCase().startsWith(prefix.toLowerCase()))
+				.filter(city -> city.toLowerCase(Locale.ROOT).startsWith(prefix.toLowerCase(Locale.ROOT)))
 				.limit(10)
 				.toList());
 		}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StatelessWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StatelessWebClientWebFluxServerIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.mcp.server.webflux.autoconfigure;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import io.modelcontextprotocol.client.McpClient;
@@ -303,11 +304,15 @@ public class StatelessWebClientWebFluxServerIT {
 
 			// Using a tool with McpToolUtils
 			McpStatelessServerFeatures.SyncToolSpecification tool3 = McpToolUtils
-				.toStatelessSyncToolSpecification(FunctionToolCallback
-					.builder("toUpperCase", (ToUpperCaseRequest req, ToolContext context) -> req.input().toUpperCase())
-					.description("Sets the input string to upper case")
-					.inputType(ToUpperCaseRequest.class)
-					.build(), null);
+				.toStatelessSyncToolSpecification(
+						FunctionToolCallback
+							.builder("toUpperCase",
+									(ToUpperCaseRequest req, ToolContext context) -> req.input()
+										.toUpperCase(Locale.ROOT))
+							.description("Sets the input string to upper case")
+							.inputType(ToUpperCaseRequest.class)
+							.build(),
+						null);
 
 			return List.of(tool1, tool2, tool3);
 		}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -133,7 +134,7 @@ public final class McpToolUtils {
 			return "";
 		}
 
-		return Stream.of(input.toLowerCase().split("_"))
+		return Stream.of(input.toLowerCase(Locale.ROOT).split("_"))
 			.filter(word -> !word.isEmpty())
 			.map(word -> String.valueOf(word.charAt(0)))
 			.collect(java.util.stream.Collectors.joining("_"));

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import io.modelcontextprotocol.client.McpSyncClient;
@@ -208,6 +209,21 @@ class ToolUtilsTests {
 		// Compatibility
 		String result = McpToolUtils.prefixedToolName("前缀\u3400", "缀\\u3400", "工具\u9fff名称\uf900");
 		assertThat(result).isEqualTo("前_缀u3400_工具鿿名称豈");
+	}
+
+	@Test
+	void prefixedToolNameShouldHandleTrLocale() {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+			// Prefix "Inventory" would be lowercased to "ı" (dotless i) in turkish locale
+			// if not properly handled.
+			String result = McpToolUtils.prefixedToolName("Inventory", "server1", "toolName");
+			assertThat(result).isEqualTo("i_server1_toolName");
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 	@Test

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/complete/AsyncMcpCompleteMethodCallbackExample.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/complete/AsyncMcpCompleteMethodCallbackExample.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
@@ -264,7 +265,7 @@ public final class AsyncMcpCompleteMethodCallbackExample {
 		@McpComplete(prompt = "travel-planner")
 		public Mono<List<String>> completeCityNameAsync(CompleteRequest.CompleteArgument argument) {
 			return Mono.fromCallable(() -> {
-				String prefix = argument.value().toLowerCase();
+				String prefix = argument.value().toLowerCase(Locale.ROOT);
 				if (prefix.isEmpty()) {
 					return List.of("Enter a city name");
 				}
@@ -272,7 +273,7 @@ public final class AsyncMcpCompleteMethodCallbackExample {
 				String firstLetter = prefix.substring(0, 1);
 				List<String> cities = this.cityDatabase.getOrDefault(firstLetter, List.of());
 
-				return cities.stream().filter(city -> city.toLowerCase().startsWith(prefix)).toList();
+				return cities.stream().filter(city -> city.toLowerCase(Locale.ROOT).startsWith(prefix)).toList();
 			});
 		}
 
@@ -282,7 +283,7 @@ public final class AsyncMcpCompleteMethodCallbackExample {
 		@McpComplete(prompt = "travel-planner")
 		public Mono<CompleteResult> completeCountryNameAsync(CompleteRequest request) {
 			return Mono.fromCallable(() -> {
-				String prefix = request.argument().value().toLowerCase();
+				String prefix = request.argument().value().toLowerCase(Locale.ROOT);
 				if (prefix.isEmpty()) {
 					return new CompleteResult(new CompleteCompletion(List.of("Enter a country name"), 1, false));
 				}
@@ -291,7 +292,7 @@ public final class AsyncMcpCompleteMethodCallbackExample {
 				List<String> countries = this.countryDatabase.getOrDefault(firstLetter, List.of());
 
 				List<String> matches = countries.stream()
-					.filter(country -> country.toLowerCase().startsWith(prefix))
+					.filter(country -> country.toLowerCase(Locale.ROOT).startsWith(prefix))
 					.toList();
 
 				return new CompleteResult(new CompleteCompletion(matches, matches.size(), false));
@@ -306,7 +307,7 @@ public final class AsyncMcpCompleteMethodCallbackExample {
 		public Mono<CompleteCompletion> completeLanguageNameAsync(McpAsyncServerExchange exchange,
 				CompleteRequest request) {
 			return Mono.fromCallable(() -> {
-				String prefix = request.argument().value().toLowerCase();
+				String prefix = request.argument().value().toLowerCase(Locale.ROOT);
 				if (prefix.isEmpty()) {
 					return new CompleteCompletion(List.of("Enter a language"), 1, false);
 				}
@@ -315,7 +316,7 @@ public final class AsyncMcpCompleteMethodCallbackExample {
 				List<String> languages = this.languageDatabase.getOrDefault(firstLetter, List.of());
 
 				List<String> matches = languages.stream()
-					.filter(language -> language.toLowerCase().startsWith(prefix))
+					.filter(language -> language.toLowerCase(Locale.ROOT).startsWith(prefix))
 					.toList();
 
 				return new CompleteCompletion(matches, matches.size(), false);
@@ -336,7 +337,7 @@ public final class AsyncMcpCompleteMethodCallbackExample {
 		@McpComplete(uri = "weather-api://{city}")
 		public Mono<List<String>> completeCityAsync(CompleteRequest.CompleteArgument argument) {
 			return Mono.fromCallable(() -> {
-				String prefix = argument.value().toLowerCase();
+				String prefix = argument.value().toLowerCase(Locale.ROOT);
 				if (prefix.isEmpty()) {
 					return List.of("Enter a city name");
 				}
@@ -344,7 +345,7 @@ public final class AsyncMcpCompleteMethodCallbackExample {
 				String firstLetter = prefix.substring(0, 1);
 				List<String> cities = this.cityDatabase.getOrDefault(firstLetter, List.of());
 
-				return cities.stream().filter(city -> city.toLowerCase().startsWith(prefix)).toList();
+				return cities.stream().filter(city -> city.toLowerCase(Locale.ROOT).startsWith(prefix)).toList();
 			});
 		}
 
@@ -353,7 +354,7 @@ public final class AsyncMcpCompleteMethodCallbackExample {
 		 */
 		@McpComplete(prompt = "direct-result")
 		public List<String> getDirectResult(CompleteRequest.CompleteArgument argument) {
-			String prefix = argument.value().toLowerCase();
+			String prefix = argument.value().toLowerCase(Locale.ROOT);
 			if (prefix.isEmpty()) {
 				return List.of("Enter a value");
 			}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/complete/SyncMcpCompleteMethodCallbackExample.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/complete/SyncMcpCompleteMethodCallbackExample.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
@@ -250,7 +251,7 @@ public final class SyncMcpCompleteMethodCallbackExample {
 		 */
 		@McpComplete(prompt = "travel-planner")
 		public List<String> completeCityName(CompleteRequest.CompleteArgument argument) {
-			String prefix = argument.value().toLowerCase();
+			String prefix = argument.value().toLowerCase(Locale.ROOT);
 			if (prefix.isEmpty()) {
 				return List.of("Enter a city name");
 			}
@@ -258,7 +259,7 @@ public final class SyncMcpCompleteMethodCallbackExample {
 			String firstLetter = prefix.substring(0, 1);
 			List<String> cities = this.cityDatabase.getOrDefault(firstLetter, List.of());
 
-			return cities.stream().filter(city -> city.toLowerCase().startsWith(prefix)).toList();
+			return cities.stream().filter(city -> city.toLowerCase(Locale.ROOT).startsWith(prefix)).toList();
 		}
 
 		/**
@@ -266,7 +267,7 @@ public final class SyncMcpCompleteMethodCallbackExample {
 		 */
 		@McpComplete(prompt = "travel-planner")
 		public CompleteResult completeCountryName(CompleteRequest request) {
-			String prefix = request.argument().value().toLowerCase();
+			String prefix = request.argument().value().toLowerCase(Locale.ROOT);
 			if (prefix.isEmpty()) {
 				return new CompleteResult(new CompleteCompletion(List.of("Enter a country name"), 1, false));
 			}
@@ -275,7 +276,7 @@ public final class SyncMcpCompleteMethodCallbackExample {
 			List<String> countries = this.countryDatabase.getOrDefault(firstLetter, List.of());
 
 			List<String> matches = countries.stream()
-				.filter(country -> country.toLowerCase().startsWith(prefix))
+				.filter(country -> country.toLowerCase(Locale.ROOT).startsWith(prefix))
 				.toList();
 
 			return new CompleteResult(new CompleteCompletion(matches, matches.size(), false));
@@ -286,7 +287,7 @@ public final class SyncMcpCompleteMethodCallbackExample {
 		 */
 		@McpComplete(prompt = "translator")
 		public CompleteCompletion completeLanguageName(McpSyncServerExchange exchange, CompleteRequest request) {
-			String prefix = request.argument().value().toLowerCase();
+			String prefix = request.argument().value().toLowerCase(Locale.ROOT);
 			if (prefix.isEmpty()) {
 				return new CompleteCompletion(List.of("Enter a language"), 1, false);
 			}
@@ -295,7 +296,7 @@ public final class SyncMcpCompleteMethodCallbackExample {
 			List<String> languages = this.languageDatabase.getOrDefault(firstLetter, List.of());
 
 			List<String> matches = languages.stream()
-				.filter(language -> language.toLowerCase().startsWith(prefix))
+				.filter(language -> language.toLowerCase(Locale.ROOT).startsWith(prefix))
 				.toList();
 
 			return new CompleteCompletion(matches, matches.size(), false);
@@ -314,7 +315,7 @@ public final class SyncMcpCompleteMethodCallbackExample {
 		 */
 		@McpComplete(uri = "weather-api://{city}")
 		public List<String> completeCity(CompleteRequest.CompleteArgument argument) {
-			String prefix = argument.value().toLowerCase();
+			String prefix = argument.value().toLowerCase(Locale.ROOT);
 			if (prefix.isEmpty()) {
 				return List.of("Enter a city name");
 			}
@@ -322,7 +323,7 @@ public final class SyncMcpCompleteMethodCallbackExample {
 			String firstLetter = prefix.substring(0, 1);
 			List<String> cities = this.cityDatabase.getOrDefault(firstLetter, List.of());
 
-			return cities.stream().filter(city -> city.toLowerCase().startsWith(prefix)).toList();
+			return cities.stream().filter(city -> city.toLowerCase(Locale.ROOT).startsWith(prefix)).toList();
 		}
 
 	}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/SyncMcpResourceMethodCallbackExample.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/SyncMcpResourceMethodCallbackExample.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
@@ -227,7 +228,7 @@ public final class SyncMcpResourceMethodCallbackExample {
 				description = "Provides user profile information for a specific user")
 		public ReadResourceResult getUserProfile(ReadResourceRequest request, String username) {
 			String profileInfo = formatProfileInfo(
-					this.userProfiles.getOrDefault(username.toLowerCase(), new HashMap<>()));
+					this.userProfiles.getOrDefault(username.toLowerCase(Locale.ROOT), new HashMap<>()));
 
 			return ReadResourceResult
 				.builder(List
@@ -243,7 +244,7 @@ public final class SyncMcpResourceMethodCallbackExample {
 				description = "Provides user details for a specific user using URI variables")
 		public ReadResourceResult getUserDetails(String username) {
 			String profileInfo = formatProfileInfo(
-					this.userProfiles.getOrDefault(username.toLowerCase(), new HashMap<>()));
+					this.userProfiles.getOrDefault(username.toLowerCase(Locale.ROOT), new HashMap<>()));
 
 			return ReadResourceResult
 				.builder(List.of(TextResourceContents.builder("user-profile://" + username, profileInfo)
@@ -258,7 +259,8 @@ public final class SyncMcpResourceMethodCallbackExample {
 		@McpResource(uri = "user-attribute://{username}/{attribute}", name = "User Attribute",
 				description = "Provides a specific attribute from a user's profile")
 		public ReadResourceResult getUserAttribute(String username, String attribute) {
-			Map<String, String> profile = this.userProfiles.getOrDefault(username.toLowerCase(), new HashMap<>());
+			Map<String, String> profile = this.userProfiles.getOrDefault(username.toLowerCase(Locale.ROOT),
+					new HashMap<>());
 			String attributeValue = profile.getOrDefault(attribute, "Attribute not found");
 
 			return ReadResourceResult
@@ -278,7 +280,7 @@ public final class SyncMcpResourceMethodCallbackExample {
 				description = "Provides user profile information with server exchange context")
 		public ReadResourceResult getProfileWithExchange(McpSyncServerExchange exchange, String username) {
 			String profileInfo = formatProfileInfo(
-					this.userProfiles.getOrDefault(username.toLowerCase(), new HashMap<>()));
+					this.userProfiles.getOrDefault(username.toLowerCase(Locale.ROOT), new HashMap<>()));
 
 			return ReadResourceResult
 				.builder(List.of(TextResourceContents
@@ -332,7 +334,8 @@ public final class SyncMcpResourceMethodCallbackExample {
 		@McpResource(uri = "user-location://{username}", name = "User Location",
 				description = "Provides the current location for a specific user")
 		public String getUserLocation(String username) {
-			Map<String, String> profile = this.userProfiles.getOrDefault(username.toLowerCase(), new HashMap<>());
+			Map<String, String> profile = this.userProfiles.getOrDefault(username.toLowerCase(Locale.ROOT),
+					new HashMap<>());
 
 			// Extract location from profile data
 			return profile.getOrDefault("location", "Location not available");
@@ -357,12 +360,12 @@ public final class SyncMcpResourceMethodCallbackExample {
 				if (schemaParts.length > 1) {
 					// Handle potential additional path segments after the username
 					String[] pathParts = schemaParts[1].split("/");
-					return pathParts[0].toLowerCase();
+					return pathParts[0].toLowerCase(Locale.ROOT);
 				}
 			}
 			// Fallback for old URI format or unexpected formats
 			String[] parts = uri.split("/");
-			return parts.length > 2 ? parts[2].toLowerCase() : "unknown";
+			return parts.length > 2 ? parts[2].toLowerCase(Locale.ROOT) : "unknown";
 		}
 
 		private String formatProfileInfo(Map<String, String> profile) {

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/HeaderUtils.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/HeaderUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.webflux.transport;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -42,7 +43,7 @@ final class HeaderUtils {
 			.asHttpHeaders()
 			.headerSet()
 			.stream()
-			.collect(Collectors.toUnmodifiableMap(e -> e.getKey().toLowerCase(), Map.Entry::getValue));
+			.collect(Collectors.toUnmodifiableMap(e -> e.getKey().toLowerCase(Locale.ROOT), Map.Entry::getValue));
 	}
 
 }

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/utils/McpTestRequestRecordingExchangeFilterFunction.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/utils/McpTestRequestRecordingExchangeFilterFunction.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.utils;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
@@ -45,7 +46,7 @@ public class McpTestRequestRecordingExchangeFilterFunction implements HandlerFil
 			.asHttpHeaders()
 			.headerSet()
 			.stream()
-			.collect(Collectors.toMap(e -> e.getKey().toLowerCase(), e -> String.join(",", e.getValue())));
+			.collect(Collectors.toMap(e -> e.getKey().toLowerCase(Locale.ROOT), e -> String.join(",", e.getValue())));
 
 		var cr = request.bodyToMono(String.class).defaultIfEmpty("").map(body -> {
 			this.calls.add(new Call(request.method(), headers, body));

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/HeaderUtils.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/HeaderUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.webmvc.transport;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -38,7 +39,7 @@ final class HeaderUtils {
 			.asHttpHeaders()
 			.headerSet()
 			.stream()
-			.collect(Collectors.toUnmodifiableMap(e -> e.getKey().toLowerCase(), Map.Entry::getValue));
+			.collect(Collectors.toUnmodifiableMap(e -> e.getKey().toLowerCase(Locale.ROOT), Map.Entry::getValue));
 	}
 
 }

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepository.java
@@ -24,6 +24,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -391,7 +392,7 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 						String jsonPath = "$.metadata." + fieldName;
 						String indexedName = "metadata_" + fieldName;
 
-						switch (fieldType.toLowerCase()) {
+						switch (fieldType.toLowerCase(Locale.ROOT)) {
 							case "numeric":
 								schemaFields.add(new NumericField(jsonPath).as(indexedName));
 								break;
@@ -694,7 +695,7 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 		QueryNode queryNode;
 		if (isFieldIndexed) {
 			// Field is explicitly indexed - use proper query based on type
-			switch (fieldType.toLowerCase()) {
+			switch (fieldType.toLowerCase(Locale.ROOT)) {
 				case "numeric":
 					if (metadataValue instanceof Number) {
 						queryNode = QueryBuilders.intersect(indexedFieldName,

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryAdvancedQueryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryAdvancedQueryIT.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.chat.memory.repository.redis;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -237,7 +238,7 @@ class RedisChatMemoryAdvancedQueryIT {
 			assertThat(programmingMessages).hasSize(4);
 			// Verify all messages contain "programming"
 			programmingMessages
-				.forEach(msg -> assertThat(msg.message().getText().toLowerCase()).contains("programming"));
+				.forEach(msg -> assertThat(msg.message().getText().toLowerCase(Locale.ROOT)).contains("programming"));
 
 			// Search for messages containing "Java"
 			List<AdvancedRedisChatMemoryRepository.MessageWithConversation> javaMessages = ((AdvancedRedisChatMemoryRepository) chatMemory)

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicSkill.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicSkill.java
@@ -18,6 +18,7 @@ package org.springframework.ai.anthropic;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -54,7 +55,7 @@ public enum AnthropicSkill {
 	static {
 		Map<String, AnthropicSkill> map = new HashMap<>();
 		for (AnthropicSkill skill : values()) {
-			map.put(skill.skillId.toLowerCase(), skill);
+			map.put(skill.skillId.toLowerCase(Locale.ROOT), skill);
 		}
 		BY_ID = Collections.unmodifiableMap(map);
 	}
@@ -77,7 +78,7 @@ public enum AnthropicSkill {
 		if (skillId == null) {
 			return null;
 		}
-		return BY_ID.get(skillId.toLowerCase());
+		return BY_ID.get(skillId.toLowerCase(Locale.ROOT));
 	}
 
 	public String getSkillId() {

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicSkillsIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicSkillsIT.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.models.messages.Model;
@@ -76,7 +77,7 @@ class AnthropicSkillsIT {
 		assertThat(response.getResults()).isNotEmpty();
 		String responseText = response.getResult().getOutput().getText();
 		assertThat(responseText).as("Response text should not be blank").isNotBlank();
-		assertThat(responseText.toLowerCase()).as("Response should mention spreadsheet or Excel")
+		assertThat(responseText.toLowerCase(Locale.ROOT)).as("Response should mention spreadsheet or Excel")
 			.containsAnyOf("spreadsheet", "excel", "xlsx", "created", "file");
 
 		List<String> fileIds = AnthropicSkillsResponseHelper.extractFileIds(response);
@@ -91,7 +92,7 @@ class AnthropicSkillsIT {
 		}
 
 		boolean hasXlsxFile = downloadedFiles.stream()
-			.anyMatch(path -> path.toString().toLowerCase().endsWith(".xlsx"));
+			.anyMatch(path -> path.toString().toLowerCase(Locale.ROOT).endsWith(".xlsx"));
 		assertThat(hasXlsxFile).as("At least one .xlsx file should be downloaded").isTrue();
 	}
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/MediaFetcher.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/MediaFetcher.java
@@ -24,6 +24,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.Locale;
 import java.util.Set;
 
 import org.apache.hc.client5.http.DnsResolver;
@@ -169,9 +170,9 @@ public final class MediaFetcher {
 		if (host == null) {
 			return false;
 		}
-		String normalizedHost = host.toLowerCase();
+		String normalizedHost = host.toLowerCase(Locale.ROOT);
 		for (String allowed : this.allowedHosts) {
-			String normalizedAllowed = allowed.toLowerCase();
+			String normalizedAllowed = allowed.toLowerCase(Locale.ROOT);
 			if (normalizedAllowed.startsWith("*.")) {
 				// wildcard: *.example.com → matches img.example.com
 				String suffix = normalizedAllowed.substring(1); // ".example.com"

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/URLValidator.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/URLValidator.java
@@ -21,6 +21,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.jspecify.annotations.Nullable;
@@ -81,7 +82,7 @@ public final class URLValidator {
 			url.toURI();
 
 			// Ensure protocol is http or https
-			String protocol = url.getProtocol().toLowerCase();
+			String protocol = url.getProtocol().toLowerCase(Locale.ROOT);
 			if (!protocol.equals("http") && !protocol.equals("https")) {
 				return false;
 			}
@@ -165,7 +166,8 @@ public final class URLValidator {
 		String normalized = urlString.trim();
 
 		// Add protocol if missing
-		if (!normalized.toLowerCase().startsWith("http://") && !normalized.toLowerCase().startsWith("https://")) {
+		if (!normalized.toLowerCase(Locale.ROOT).startsWith("http://")
+				&& !normalized.toLowerCase(Locale.ROOT).startsWith("https://")) {
 			normalized = "https://" + normalized;
 		}
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -960,7 +961,7 @@ class BedrockProxyChatModelIT {
 		assertThat(fullResponse).as("gpt-oss streaming response should not be null or empty").isNotNull().isNotEmpty();
 
 		// Verify the response contains expected gpt-oss identification
-		assertThat(fullResponse.toLowerCase()).as("gpt-oss model should identify itself")
+		assertThat(fullResponse.toLowerCase(Locale.ROOT)).as("gpt-oss model should identify itself")
 			.containsAnyOf("chatgpt", "gpt", "openai", "language model", "ai");
 	}
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.bedrock.converse.client;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -102,15 +103,15 @@ public class BedrockNovaChatClientIT {
 			.content();
 
 		// Convert response to lowercase for case-insensitive matching
-		String lowerResponse = response.toLowerCase();
+		String lowerResponse = response.toLowerCase(Locale.ROOT);
 
 		// Test for presence of young/small descriptors
 		boolean hasYoungDescriptor = youngDescriptors.stream()
-			.anyMatch(word -> lowerResponse.contains(word.toLowerCase()));
+			.anyMatch(word -> lowerResponse.contains(word.toLowerCase(Locale.ROOT)));
 
 		// Test for presence of bird/chicken descriptors
 		boolean hasBirdDescriptor = birdDescriptors.stream()
-			.anyMatch(word -> lowerResponse.contains(word.toLowerCase()));
+			.anyMatch(word -> lowerResponse.contains(word.toLowerCase(Locale.ROOT)));
 
 		// Additional semantic checks
 		boolean describesMovement = lowerResponse.contains("mov") || lowerResponse.contains("walk")

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModel.java
@@ -18,6 +18,7 @@ package org.springframework.ai.bedrock.titan;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.micrometer.observation.Observation;
@@ -103,7 +104,7 @@ public class BedrockTitanEmbeddingModel extends AbstractEmbeddingModel {
 				TitanEmbeddingResponse response = Observation
 					.createNotStarted("bedrock.embedding", this.observationRegistry)
 					.lowCardinalityKeyValue("model", "titan")
-					.lowCardinalityKeyValue("input_type", this.inputType.name().toLowerCase())
+					.lowCardinalityKeyValue("input_type", this.inputType.name().toLowerCase(Locale.ROOT))
 					.highCardinalityKeyValue("input_length", String.valueOf(inputContent.length()))
 					.observe(() -> {
 						TitanEmbeddingResponse r = this.embeddingApi.embedding(apiRequest);

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModelTests.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModelTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.titan;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi;
+import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingResponse;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Dimitar Proynov
+ */
+class BedrockTitanEmbeddingModelTests {
+
+	@Test
+	void inputTypeObservationTagUsesRootLocaleForImage() {
+		TestObservationRegistry observationRegistry = TestObservationRegistry.create();
+		TitanEmbeddingBedrockApi titanEmbeddingApi = mock(TitanEmbeddingBedrockApi.class);
+		when(titanEmbeddingApi.embedding(any()))
+			.thenReturn(new TitanEmbeddingResponse(new float[] { 0.1f, 0.2f, 0.3f }, 5, 1, 0, Map.of(), null, null));
+
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+			// InputType.IMAGE contains an uppercase I; under tr_TR, toLowerCase()
+			// without Locale.ROOT turns it into "ımage" (dotless ı) instead of "image".
+			BedrockTitanEmbeddingModel embeddingModel = new BedrockTitanEmbeddingModel(titanEmbeddingApi,
+					observationRegistry)
+				.withInputType(BedrockTitanEmbeddingModel.InputType.IMAGE);
+
+			EmbeddingResponse response = embeddingModel.call(new EmbeddingRequest(List.of("some-base64-image"), null));
+
+			assertThat(response.getResults()).isNotEmpty();
+			TestObservationRegistryAssert.assertThat(observationRegistry)
+				.hasObservationWithNameEqualTo("bedrock.embedding")
+				.that()
+				.hasLowCardinalityKeyValue("input_type", "image");
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
+		}
+	}
+
+}

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -874,7 +875,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		if (modelName == null) {
 			return false;
 		}
-		String lower = modelName.toLowerCase();
+		String lower = modelName.toLowerCase(Locale.ROOT);
 		return lower.contains("gemini-3") && lower.contains("pro") && !lower.contains("flash");
 	}
 
@@ -887,7 +888,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		if (modelName == null) {
 			return false;
 		}
-		String lower = modelName.toLowerCase();
+		String lower = modelName.toLowerCase(Locale.ROOT);
 		return lower.contains("gemini-3") && lower.contains("flash");
 	}
 

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiModalityTokenCount.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiModalityTokenCount.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.google.genai.metadata;
 
+import java.util.Locale;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.genai.types.MediaModality;
 import com.google.genai.types.ModalityTokenCount;
@@ -68,7 +70,7 @@ public class GoogleGenAiModalityTokenCount {
 		}
 
 		// MediaModality returns its string value via toString()
-		String modalityStr = modality.toString().toUpperCase();
+		String modalityStr = modality.toString().toUpperCase(Locale.ROOT);
 
 		// Map SDK values to cleaner names
 		return switch (modalityStr) {

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiTrafficType.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiTrafficType.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.google.genai.metadata;
 
+import java.util.Locale;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.genai.types.TrafficType;
 
@@ -60,7 +62,7 @@ public enum GoogleGenAiTrafficType {
 		}
 
 		// Try to match by string value
-		String typeStr = trafficType.toString().toUpperCase();
+		String typeStr = trafficType.toString().toUpperCase(Locale.ROOT);
 
 		// Map SDK values to our enum values
 		return switch (typeStr) {

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.google.genai;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import com.google.genai.Client;
@@ -52,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Dan Dobrin
  * @author Soby Chacko
  * @author Sebastien Deleuze
+ * @author Dimitar Proynov
  */
 @ExtendWith(MockitoExtension.class)
 public class CreateGeminiRequestTests {
@@ -504,6 +506,31 @@ public class CreateGeminiRequestTests {
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("MINIMAL")
 			.hasMessageContaining("not supported");
+	}
+
+	@Test
+	public void createRequestWithTrLocaleWithPreviewModel() {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+			// Default options are valid for Pro
+			var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+			// With turkish locale the check if this is a gemini3-pro model
+			// (isGemini3ProModel) will fail as
+			// lowercasing "gemini3-pro" will result in "gemını3-pro"
+			assertThatThrownBy(() -> client.createGeminiRequest(new Prompt("Test message content",
+					GoogleGenAiChatOptions.builder()
+						.model("GEMINI-3-PRO-PREVIEW")
+						.thinkingLevel(GoogleGenAiThinkingLevel.MINIMAL)
+						.build())))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("MINIMAL")
+				.hasMessageContaining("not supported");
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 	@Test

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatPriorityIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatPriorityIT.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.google.genai;
 
+import java.util.Locale;
+
 import com.google.genai.Client;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -56,7 +58,7 @@ class GoogleGenAiChatPriorityIT {
 	}
 
 	private void runTest(Client genAiClient, String serviceTier) {
-		GoogleGenAiServiceTier tier = GoogleGenAiServiceTier.valueOf(serviceTier.toUpperCase());
+		GoogleGenAiServiceTier tier = GoogleGenAiServiceTier.valueOf(serviceTier.toUpperCase(Locale.ROOT));
 
 		var chatModel = GoogleGenAiChatModel.builder()
 			.genAiClient(genAiClient)

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/MimeTypeDetectorTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/MimeTypeDetectorTests.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -104,7 +105,7 @@ class MimeTypeDetectorTests {
 	@ValueSource(strings = { "JPG", "PNG", "GIF" })
 	void getMimeTypeByStringWithUppercaseExtensionsShouldWork(String uppercaseExt) {
 		String upperFileName = "test." + uppercaseExt;
-		String lowerFileName = "test." + uppercaseExt.toLowerCase();
+		String lowerFileName = "test." + uppercaseExt.toLowerCase(Locale.ROOT);
 
 		// Should throw for uppercase (not in map) but work for lowercase
 		assertThatThrownBy(() -> MimeTypeDetector.getMimeType(upperFileName))
@@ -112,7 +113,7 @@ class MimeTypeDetectorTests {
 
 		// Lowercase should work if it's a supported extension
 		if (org.springframework.ai.google.genai.MimeTypeDetector.GEMINI_MIME_TYPES
-			.containsKey(uppercaseExt.toLowerCase())) {
+			.containsKey(uppercaseExt.toLowerCase(Locale.ROOT))) {
 			assertThatCode(() -> MimeTypeDetector.getMimeType(lowerFileName)).doesNotThrowAnyException();
 		}
 	}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/metadata/GoogleGenAiMetadataLocaleTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/metadata/GoogleGenAiMetadataLocaleTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.metadata;
+
+import java.util.Locale;
+
+import com.google.genai.types.MediaModality;
+import com.google.genai.types.ModalityTokenCount;
+import com.google.genai.types.TrafficType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests verifying that protocol/enum string casing is locale-independent.
+ *
+ * <p>
+ * On a JVM running with the Turkish locale ({@code tr_TR}), the default
+ * {@link String#toUpperCase()} / {@link String#toLowerCase()} apply Turkish-specific
+ * casing rules that convert {@code "I"} to a dotless {@code "ı"} (U+0131) and lowercase
+ * {@code "i"} to a dotted capital {@code "İ"}. When such conversions operate on protocol
+ * tokens or enum names, the resulting values are rejected by the provider. See related
+ * issues #6478, #6476 and #5340 for the same bug class in other modules.
+ *
+ * @author Edy Yang
+ * @author Dimitar Proynov
+ * @since 2.0.1
+ */
+public class GoogleGenAiMetadataLocaleTests {
+
+	private Locale defaultLocale;
+
+	@BeforeEach
+	void setTurkishLocale() {
+		this.defaultLocale = Locale.getDefault();
+		Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+	}
+
+	@AfterEach
+	void restoreDefaultLocale() {
+		Locale.setDefault(this.defaultLocale);
+	}
+
+	@Test
+	void modalityTokenCountIsLocaleIndependent() {
+		ModalityTokenCount textModality = ModalityTokenCount.builder()
+			.modality(new MediaModality("audio"))
+			.tokenCount(100)
+			.build();
+
+		GoogleGenAiModalityTokenCount tokenCount = GoogleGenAiModalityTokenCount.from(textModality);
+
+		assertThat(tokenCount.getModality()).isEqualTo("AUDIO");
+	}
+
+	@Test
+	void trafficTypeIsLocaleIndependent() {
+		GoogleGenAiTrafficType onDemand = GoogleGenAiTrafficType.from(new TrafficType(TrafficType.Known.ON_DEMAND));
+		GoogleGenAiTrafficType provisioned = GoogleGenAiTrafficType.from(new TrafficType("provisioned_throughput"));
+
+		assertThat(onDemand).isEqualTo(GoogleGenAiTrafficType.ON_DEMAND);
+		assertThat(provisioned).isEqualTo(GoogleGenAiTrafficType.PROVISIONED_THROUGHPUT);
+	}
+
+}

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.mistralai;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -99,7 +100,7 @@ class MistralAiChatClientIT {
 		assertThat(response).isNotNull();
 		assertThat(response.getResult()).isNotNull();
 		assertThat(response.getResult().getOutput().getText()).isNotNull();
-		assertThat(response.getResult().getOutput().getText().toLowerCase()).containsAnyOf("blackbeard",
+		assertThat(response.getResult().getOutput().getText().toLowerCase(Locale.ROOT)).containsAnyOf("blackbeard",
 				"bartholomew roberts");
 	}
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/aot/OllamaRuntimeHintsTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/aot/OllamaRuntimeHintsTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.ollama.aot;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -177,7 +178,7 @@ class OllamaRuntimeHintsTests {
 
 		// Count classes related to embedding functionality
 		long embeddingClassCount = registeredTypes.stream()
-			.filter(typeRef -> typeRef.getName().toLowerCase().contains("embedding"))
+			.filter(typeRef -> typeRef.getName().toLowerCase(Locale.ROOT).contains("embedding"))
 			.count();
 		assertThat(embeddingClassCount).isGreaterThan(0);
 	}
@@ -250,8 +251,8 @@ class OllamaRuntimeHintsTests {
 
 		// Verify enum types are registered (critical for JSON deserialization)
 		boolean hasEnumTypes = registeredTypes.stream()
-			.anyMatch(tr -> tr.getName().contains("$") || tr.getName().toLowerCase().contains("role")
-					|| tr.getName().toLowerCase().contains("type"));
+			.anyMatch(tr -> tr.getName().contains("$") || tr.getName().toLowerCase(Locale.ROOT).contains("role")
+					|| tr.getName().toLowerCase(Locale.ROOT).contains("type"));
 
 		assertThat(hasEnumTypes).as("Enum types should be registered for native image compatibility").isTrue();
 	}
@@ -289,7 +290,7 @@ class OllamaRuntimeHintsTests {
 
 		// Count tool-related classes
 		long toolClassCount = registeredTypes.stream()
-			.filter(typeRef -> typeRef.getName().toLowerCase().contains("tool"))
+			.filter(typeRef -> typeRef.getName().toLowerCase(Locale.ROOT).contains("tool"))
 			.count();
 		assertThat(toolClassCount).isGreaterThan(0);
 	}

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechOptions.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai;
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -155,7 +156,7 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 
 	@Override
 	public @Nullable String getFormat() {
-		return this.responseFormat.toLowerCase();
+		return this.responseFormat.toLowerCase(Locale.ROOT);
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -21,6 +21,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -393,7 +394,8 @@ public final class OpenAiChatModel implements ChatModel {
 		if (message.audio().isPresent() && StringUtils.hasText(message.audio().get().data())
 				&& request.audio().isPresent()) {
 			var audioOutput = message.audio().get();
-			String mimeType = String.format("audio/%s", request.audio().get().format().value().name().toLowerCase());
+			String mimeType = String.format("audio/%s",
+					request.audio().get().format().value().name().toLowerCase(Locale.ROOT));
 			byte[] audioData = Base64.getDecoder().decode(audioOutput.data());
 			Resource resource = new ByteArrayResource(audioData);
 			Media.builder().mimeType(MimeTypeUtils.parseMimeType(mimeType)).data(resource).id(audioOutput.id()).build();
@@ -742,7 +744,7 @@ public final class OpenAiChatModel implements ChatModel {
 		if (requestOptions.getOutputModalities() != null) {
 			builder.modalities(requestOptions.getOutputModalities()
 				.stream()
-				.map(modality -> ChatCompletionCreateParams.Modality.of(modality.toLowerCase()))
+				.map(modality -> ChatCompletionCreateParams.Modality.of(modality.toLowerCase(Locale.ROOT)))
 				.toList());
 		}
 		if (requestOptions.getOutputAudio() != null) {
@@ -808,7 +810,7 @@ public final class OpenAiChatModel implements ChatModel {
 			builder.parallelToolCalls(requestOptions.getParallelToolCalls());
 		}
 		if (requestOptions.getReasoningEffort() != null) {
-			builder.reasoningEffort(ReasoningEffort.of(requestOptions.getReasoningEffort().toLowerCase()));
+			builder.reasoningEffort(ReasoningEffort.of(requestOptions.getReasoningEffort().toLowerCase(Locale.ROOT)));
 		}
 		if (requestOptions.getVerbosity() != null) {
 			builder.verbosity(ChatCompletionCreateParams.Verbosity.of(requestOptions.getVerbosity()));
@@ -1140,8 +1142,8 @@ public final class OpenAiChatModel implements ChatModel {
 
 				choiceBuilder.finishReason(ChatCompletion.Choice.FinishReason.of(""));
 				cccc.finishReason()
-					.ifPresent(finishReason -> choiceBuilder.finishReason(
-							ChatCompletion.Choice.FinishReason.of(finishReason.value().name().toLowerCase())));
+					.ifPresent(finishReason -> choiceBuilder.finishReason(ChatCompletion.Choice.FinishReason
+						.of(finishReason.value().name().toLowerCase(Locale.ROOT))));
 
 				if (cccc.logprobs().isPresent()) {
 					var logprobs = cccc.logprobs().get();

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -650,10 +651,10 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 		public ChatCompletionAudioParam toChatCompletionAudioParam() {
 			ChatCompletionAudioParam.Builder builder = ChatCompletionAudioParam.builder();
 			if (this.voice() != null) {
-				builder.voice(voice().name().toLowerCase());
+				builder.voice(voice().name().toLowerCase(Locale.ROOT));
 			}
 			if (this.format() != null) {
-				builder.format(ChatCompletionAudioParam.Format.of(this.format().name().toLowerCase()));
+				builder.format(ChatCompletionAudioParam.Format.of(this.format().name().toLowerCase(Locale.ROOT)));
 			}
 			return builder.build();
 		}

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
@@ -20,6 +20,7 @@ import java.net.Proxy;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import com.openai.azure.AzureOpenAIServiceVersion;
@@ -233,7 +234,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 			}
 			if (openAiCreateParams.encodingFormat().isPresent()) {
 				this.encodingFormat = EncodingFormat
-					.valueOf(openAiCreateParams.encodingFormat().get().asString().toUpperCase());
+					.valueOf(openAiCreateParams.encodingFormat().get().asString().toUpperCase(Locale.ROOT));
 			}
 			if (openAiCreateParams.dimensions().isPresent()) {
 				this.dimensions = Math.toIntExact(openAiCreateParams.dimensions().get());

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai;
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -195,16 +196,17 @@ public class OpenAiImageOptions extends AbstractOpenAiOptions implements ImageOp
 			builder.n(this.getN().longValue());
 		}
 		if (this.getQuality() != null) {
-			builder.quality(ImageGenerateParams.Quality.of(this.getQuality().toLowerCase()));
+			builder.quality(ImageGenerateParams.Quality.of(this.getQuality().toLowerCase(Locale.ROOT)));
 		}
 		if (this.getResponseFormat() != null) {
-			builder.responseFormat(ImageGenerateParams.ResponseFormat.of(this.getResponseFormat().toLowerCase()));
+			builder.responseFormat(
+					ImageGenerateParams.ResponseFormat.of(this.getResponseFormat().toLowerCase(Locale.ROOT)));
 		}
 		if (this.getSize() != null) {
 			builder.size(ImageGenerateParams.Size.of(this.getSize()));
 		}
 		if (this.getStyle() != null) {
-			builder.style(ImageGenerateParams.Style.of(this.getStyle().toLowerCase()));
+			builder.style(ImageGenerateParams.Style.of(this.getStyle().toLowerCase(Locale.ROOT)));
 		}
 		if (this.getUser() != null) {
 			builder.user(this.getUser());

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -31,6 +32,7 @@ import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
 import com.openai.core.http.AsyncStreamResponse;
+import com.openai.models.ReasoningEffort;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionAssistantMessageParam;
 import com.openai.models.chat.completions.ChatCompletionChunk;
@@ -75,6 +77,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link OpenAiChatModel}.
  *
  * @author Jewoo Shin
+ * @author Dimitar Proynov
  */
 @ExtendWith(MockitoExtension.class)
 class OpenAiChatModelTests {
@@ -1008,6 +1011,112 @@ class OpenAiChatModelTests {
 
 		// Verify no Optional values leak into assistant message metadata
 		generation.getOutput().getMetadata().forEach((key, value) -> assertThat(value).isNotInstanceOf(Optional.class));
+	}
+
+	@Test
+	void outputModalitiesUseRootLocaleRegardlessOfDefaultLocale() {
+		Locale original = Locale.getDefault();
+		Locale.setDefault(new Locale("tr", "TR"));
+		try {
+			// "AUDIO" contains an uppercase I; under tr_TR, toLowerCase() without
+			// Locale.ROOT turns it into "audıo" (dotless ı), which Modality.of(...)
+			// won't recognize as the AUDIO modality.
+			OpenAiChatOptions options = OpenAiChatOptions.builder()
+				.model("test-model")
+				.outputModalities(List.of("TEXT", "AUDIO"))
+				.build();
+			OpenAiChatModel chatModel = OpenAiChatModel.builder()
+				.openAiClient(this.openAiClient)
+				.openAiClientAsync(this.openAiClientAsync)
+				.options(options)
+				.build();
+
+			ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), false);
+
+			assertThat(request.modalities())
+				.contains(List.of(ChatCompletionCreateParams.Modality.TEXT, ChatCompletionCreateParams.Modality.AUDIO));
+		}
+		finally {
+			Locale.setDefault(original);
+		}
+	}
+
+	@Test
+	void reasoningEffortUsesRootLocaleRegardlessOfDefaultLocale() {
+		Locale original = Locale.getDefault();
+		try {
+			Locale.setDefault(new Locale("tr", "TR"));
+			// "MINIMAL" contains an uppercase I; under tr_TR it lowers to "mınımal",
+			// which ReasoningEffort.of(...) won't match to the MINIMAL constant.
+			OpenAiChatOptions options = OpenAiChatOptions.builder()
+				.model("test-model")
+				.reasoningEffort("MINIMAL")
+				.build();
+			OpenAiChatModel chatModel = OpenAiChatModel.builder()
+				.openAiClient(this.openAiClient)
+				.openAiClientAsync(this.openAiClientAsync)
+				.options(options)
+				.build();
+
+			ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), false);
+
+			assertThat(request.reasoningEffort()).contains(ReasoningEffort.MINIMAL);
+		}
+		finally {
+			Locale.setDefault(original);
+		}
+	}
+
+	@Test
+	void audioVoiceUsesRootLocaleRegardlessOfDefaultLocale() {
+		Locale original = Locale.getDefault();
+		try {
+			Locale.setDefault(new Locale("tr", "TR"));
+			// SHIMMER contains an uppercase I; under tr_TR it lowers to "shımmer"
+			// instead of the wire-correct "shimmer". The fix lives in
+			// OpenAiChatOptions.AudioParameters#toChatCompletionAudioParam(),
+			// but it's only reachable through OpenAiChatModel#createRequest.
+			OpenAiChatOptions options = OpenAiChatOptions.builder()
+				.model("test-model")
+				.outputAudio(new OpenAiChatOptions.AudioParameters(OpenAiChatOptions.AudioParameters.Voice.SHIMMER,
+						OpenAiChatOptions.AudioParameters.AudioResponseFormat.WAV))
+				.build();
+			OpenAiChatModel chatModel = OpenAiChatModel.builder()
+				.openAiClient(this.openAiClient)
+				.openAiClientAsync(this.openAiClientAsync)
+				.options(options)
+				.build();
+
+			ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), false);
+
+			assertThat(request.audio()).isPresent();
+			assertThat(request.audio().get().voice().string().get().equals("shimmer"));
+		}
+		finally {
+			Locale.setDefault(original);
+		}
+	}
+
+	@Test
+	void streamingFinishReasonSurvivesRoundTripUnderTurkishLocale() {
+		Locale original = Locale.getDefault();
+		Locale.setDefault(new Locale("tr", "TR"));
+		try {
+			// CONTENT_FILTER contains an uppercase I; under tr_TR the chunk-merging
+			// round trip lowers it to "content_fılter", which
+			// ChatCompletion.Choice.FinishReason.of(...) treats as unknown.
+			List<ChatCompletionChunk> chunks = List.of(streamingChunk(
+					delta -> delta.role(ChatCompletionChunk.Choice.Delta.Role.ASSISTANT).content("Blocked"),
+					ChatCompletionChunk.Choice.FinishReason.CONTENT_FILTER));
+
+			ChatResponse response = streamResponses(chunks).blockLast();
+
+			assertThat(response).isNotNull();
+			assertThat(response.getResult().getMetadata().getFinishReason()).isEqualTo("CONTENT_FILTER");
+		}
+		finally {
+			Locale.setDefault(original);
+		}
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiAudioTranscriptionModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiAudioTranscriptionModelIT.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.openai.azure;
 
+import java.util.Locale;
+
 import com.openai.models.audio.AudioResponseFormat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -60,7 +62,7 @@ class AzureOpenAiAudioTranscriptionModelIT {
 				transcriptionOptions);
 		AudioTranscriptionResponse response = this.transcriptionModel.call(transcriptionRequest);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().toLowerCase().contains("fellow")).isTrue();
+		assertThat(response.getResults().get(0).getOutput().toLowerCase(Locale.ROOT).contains("fellow")).isTrue();
 	}
 
 	@Test
@@ -77,7 +79,7 @@ class AzureOpenAiAudioTranscriptionModelIT {
 				transcriptionOptions);
 		AudioTranscriptionResponse response = this.transcriptionModel.call(transcriptionRequest);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().toLowerCase().contains("fellow")).isTrue();
+		assertThat(response.getResults().get(0).getOutput().toLowerCase(Locale.ROOT).contains("fellow")).isTrue();
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
@@ -19,8 +19,10 @@ package org.springframework.ai.openai.chat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
+import com.openai.models.chat.completions.ChatCompletionAudioParam;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.prompt.ChatOptions;
@@ -40,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Julien Dubois
  * @author Sebastien Deleuze
  * @author guan xu
+ * @author Deepak Kumar S S
  */
 public class OpenAiChatOptionsTests extends AbstractChatOptionsTests<OpenAiChatOptions, Builder> {
 
@@ -653,6 +656,26 @@ public class OpenAiChatOptionsTests extends AbstractChatOptionsTests<OpenAiChatO
 		assertThat(cloned.getOutputModalities()).isNull();
 		assertThat(cloned.getMetadata()).isNull();
 		assertThat(cloned.getExtraBody()).isNull();
+	}
+
+	@Test
+	void audioParametersAreSerializedLocaleIndependently() {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			// Under the Turkish locale, "SHIMMER".toLowerCase() yields "shımmer" (dotless
+			// 'ı'), which is not a valid OpenAI audio voice. Protocol enum values must be
+			// converted using a fixed locale so the wire value stays "shimmer".
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+			OpenAiChatOptions.AudioParameters audioParameters = new OpenAiChatOptions.AudioParameters(
+					OpenAiChatOptions.AudioParameters.Voice.SHIMMER,
+					OpenAiChatOptions.AudioParameters.AudioResponseFormat.MP3);
+			ChatCompletionAudioParam audioParam = audioParameters.toChatCompletionAudioParam();
+			assertThat(audioParam.voice().asString()).isEqualTo("shimmer");
+			assertThat(audioParam.format().asString()).isEqualTo("mp3");
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/DeepSeekWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/DeepSeekWithOpenAiChatModelIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai.chat.proxy;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -213,7 +214,7 @@ class DeepSeekWithOpenAiChatModelIT {
 		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 		// Because max_tokens is 2, the finish reason should be length or similar
 		// indicating truncation
-		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase()).contains("length");
+		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase(Locale.ROOT)).contains("length");
 	}
 
 	@Test

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/GroqWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/GroqWithOpenAiChatModelIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai.chat.proxy;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -283,7 +284,7 @@ class GroqWithOpenAiChatModelIT {
 		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 		// Because max_tokens is 2, the finish reason should be length or similar
 		// indicating truncation
-		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase()).contains("length");
+		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase(Locale.ROOT)).contains("length");
 	}
 
 	record ActorsFilmsRecord(String actor, List<String> movies) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/MistralWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/MistralWithOpenAiChatModelIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai.chat.proxy;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -210,7 +211,7 @@ class MistralWithOpenAiChatModelIT {
 		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 		// Because max_tokens is 2, the finish reason should be length or similar
 		// indicating truncation
-		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase()).contains("length");
+		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase(Locale.ROOT)).contains("length");
 	}
 
 	record ActorsFilmsRecord(String actor, List<String> movies) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/NvidiaWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/NvidiaWithOpenAiChatModelIT.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai.chat.proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -320,7 +321,7 @@ class NvidiaWithOpenAiChatModelIT {
 		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 		// Because max_tokens is 2, the finish reason should be length or similar
 		// indicating truncation
-		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase()).contains("length");
+		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase(Locale.ROOT)).contains("length");
 	}
 
 	record ActorsFilmsRecord(String actor, List<String> movies) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/OllamaWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/OllamaWithOpenAiChatModelIT.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -295,7 +296,7 @@ class OllamaWithOpenAiChatModelIT {
 		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 		// Because max_tokens is 2, the finish reason should be length or similar
 		// indicating truncation
-		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase()).contains("length");
+		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase(Locale.ROOT)).contains("length");
 	}
 
 	record ActorsFilmsRecord(String actor, List<String> movies) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/PerplexityWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/PerplexityWithOpenAiChatModelIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai.chat.proxy;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -265,7 +266,7 @@ class PerplexityWithOpenAiChatModelIT {
 		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 		// Because max_tokens is 2, the finish reason should be length or similar
 		// indicating truncation
-		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase()).contains("length");
+		assertThat(response.getResult().getMetadata().getFinishReason().toLowerCase(Locale.ROOT)).contains("length");
 	}
 
 	record ActorsFilmsRecord(String actor, List<String> movies) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transformer/MetadataTransformerIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transformer/MetadataTransformerIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai.transformer;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -84,7 +85,7 @@ public class MetadataTransformerIT {
 		assertThat(keywords2).containsKeys("excerpt_keywords");
 
 		assertThat((String) keywords1.get("excerpt_keywords")).contains("Andes", "Aymara");
-		assertThat(((String) keywords2.get("excerpt_keywords")).toLowerCase()).containsAnyOf("spring mvc",
+		assertThat(((String) keywords2.get("excerpt_keywords")).toLowerCase(Locale.ROOT)).containsAnyOf("spring mvc",
 				"dependency injection");
 	}
 

--- a/spring-ai-commons/src/main/java/org/springframework/ai/util/ParsingUtils.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/util/ParsingUtils.java
@@ -19,6 +19,7 @@ package org.springframework.ai.util;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.springframework.util.Assert;
@@ -86,7 +87,7 @@ public abstract class ParsingUtils {
 		List<String> result = new ArrayList<>(parts.length);
 
 		for (String part : parts) {
-			result.add(toLower ? part.toLowerCase() : part);
+			result.add(toLower ? part.toLowerCase(Locale.ROOT) : part);
 		}
 
 		return Collections.unmodifiableList(result);

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.integration.tests.client.advisor;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -166,7 +167,7 @@ class RetrievalAugmentationAdvisorIT {
 
 		assertThat(chatResponse2).isNotNull();
 		String response2 = chatResponse2.getResult().getOutput().getText();
-		assertThat(response2.toLowerCase()).containsIgnoringCase("Fergus");
+		assertThat(response2.toLowerCase(Locale.ROOT)).containsIgnoringCase("Fergus");
 	}
 
 	@Test
@@ -221,7 +222,7 @@ class RetrievalAugmentationAdvisorIT {
 		assertThat(chatResponse).isNotNull();
 
 		String response = chatResponse.getResult().getOutput().getText();
-		assertThat(response.toLowerCase()).containsAnyOf("highlands", "højland");
+		assertThat(response.toLowerCase(Locale.ROOT)).containsAnyOf("highlands", "højland");
 
 		evaluateRelevancy(question, chatResponse);
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ChatResponse.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ChatResponse.java
@@ -126,7 +126,7 @@ public class ChatResponse implements ModelResponse<Generation> {
 		return this.generations.stream().anyMatch(generation -> {
 			var finishReason = (generation.getMetadata().getFinishReason() != null)
 					? generation.getMetadata().getFinishReason() : "";
-			return finishReasons.stream().map(String::toLowerCase).toList().contains(finishReason.toLowerCase());
+			return finishReasons.stream().anyMatch(fr -> fr.equalsIgnoreCase(finishReason));
 		});
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -328,7 +329,7 @@ public final class JsonSchemaGenerator {
 				}
 				else if (value.isString() && entry.getKey().equals("type")) {
 					String oldValue = node.get("type").asString();
-					node.put("type", oldValue.toUpperCase());
+					node.put("type", oldValue.toUpperCase(Locale.ROOT));
 				}
 			});
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -289,6 +290,44 @@ class JsonSchemaGeneratorTests {
 				""";
 
 		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForMethodWithUpperCaseTypesInTrLocale() throws Exception {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+			Method method = TestMethods.class.getDeclaredMethod("simpleMethod", String.class, int.class);
+
+			// The method "convertTypeValuesToUpperCase" will fail to correctly uppercase
+			// STRING and INTEGER in turkish locale, resulting in STRİNG and İNTEGER
+			String schema = JsonSchemaGenerator.generateForMethodInput(method,
+					JsonSchemaGenerator.SchemaOption.UPPER_CASE_TYPE_VALUES);
+			String expectedJsonSchema = """
+					{
+					    "$schema": "https://json-schema.org/draft/2020-12/schema",
+					    "type": "OBJECT",
+					    "properties": {
+					        "name": {
+					            "type": "STRING"
+					        },
+					        "age": {
+					            "type": "INTEGER"
+					        }
+					    },
+					    "required": [
+					        "name",
+					        "age"
+					    ],
+					    "additionalProperties": false
+					}
+					""";
+
+			assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 	@Test

--- a/spring-ai-spring-boot-docker-compose/src/test/java/org/springframework/boot/testsupport/DisabledIfProcessUnavailableCondition.java
+++ b/spring-ai-spring-boot-docker-compose/src/test/java/org/springframework/boot/testsupport/DisabledIfProcessUnavailableCondition.java
@@ -19,6 +19,7 @@ package org.springframework.boot.testsupport;
 import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -42,7 +43,7 @@ class DisabledIfProcessUnavailableCondition implements ExecutionCondition {
 
 	private static final String USR_LOCAL_BIN = "/usr/local/bin";
 
-	private static final boolean MAC_OS = System.getProperty("os.name").toLowerCase().contains("mac");
+	private static final boolean MAC_OS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac");
 
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {

--- a/spring-ai-tool-search-tool/src/main/java/org/springframework/ai/tool/toolsearch/index/regex/RegexToolIndex.java
+++ b/spring-ai-tool-search-tool/src/main/java/org/springframework/ai/tool/toolsearch/index/regex/RegexToolIndex.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -165,7 +166,7 @@ public class RegexToolIndex implements Closeable, ToolIndex {
 				"just", "also", "very", "too", "so");
 
 		// Tokenize: split by whitespace and common delimiters
-		String[] tokens = query.toLowerCase().split("[\\s,;:.!?()\\[\\]{}\"']+");
+		String[] tokens = query.toLowerCase(Locale.ROOT).split("[\\s,;:.!?()\\[\\]{}\"']+");
 
 		// Filter and process tokens
 		List<String> processedTokens = Arrays.stream(tokens)

--- a/spring-ai-tool-search-tool/src/test/java/org/springframework/ai/tool/toolsearch/index/regex/RegexToolIndexTests.java
+++ b/spring-ai-tool-search-tool/src/test/java/org/springframework/ai/tool/toolsearch/index/regex/RegexToolIndexTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.tool.toolsearch.index.regex;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -182,6 +183,26 @@ class RegexToolIndexTests {
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void convertQueryToRegexPatternInTrLocale() {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+			try (RegexToolIndex searcher = new RegexToolIndex()) {
+				// In turkish locale incorrect handling would result in
+				// "(?i)(get|ınventory)" (dotless i)
+				assertThat(searcher.convertQueryToRegexPattern("GET INVENTORY")).isEqualTo("(?i)(get|inventory)");
+				assertThat(searcher.convertQueryToRegexPattern("")).isEqualTo(".*");
+			}
+			catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
 		}
 	}
 

--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
@@ -18,6 +18,7 @@ package org.springframework.ai.vectorstore.filter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -128,7 +129,7 @@ public class FilterExpressionTextParser {
 		Assert.hasText(textFilterExpression, "Expression should not be empty!");
 
 		// Prefix the expression with the compulsory WHERE keyword.
-		if (!textFilterExpression.toUpperCase().startsWith(WHERE_PREFIX)) {
+		if (!textFilterExpression.toUpperCase(Locale.ROOT).startsWith(WHERE_PREFIX)) {
 			textFilterExpression = String.format("%s %s", WHERE_PREFIX, textFilterExpression);
 		}
 

--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/converter/PineconeFilterExpressionConverter.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/converter/PineconeFilterExpressionConverter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.vectorstore.filter.converter;
 
+import java.util.Locale;
+
 import org.springframework.ai.vectorstore.filter.Filter.Expression;
 import org.springframework.ai.vectorstore.filter.Filter.ExpressionType;
 import org.springframework.ai.vectorstore.filter.Filter.Key;
@@ -53,7 +55,7 @@ public class PineconeFilterExpressionConverter extends AbstractFilterExpressionC
 	}
 
 	private String getOperationSymbol(Expression exp) {
-		return "\"$" + exp.type().toString().toLowerCase() + "\": ";
+		return "\"$" + exp.type().toString().toLowerCase(Locale.ROOT) + "\": ";
 	}
 
 	@Override

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/converter/PineconeFilterExpressionConverterTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/converter/PineconeFilterExpressionConverterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.vectorstore.filter.converter;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,7 @@ import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.OR
 
 /**
  * @author Christian Tzolov
+ * @author Deepak Kumar S S
  */
 public class PineconeFilterExpressionConverterTests {
 
@@ -295,6 +297,28 @@ public class PineconeFilterExpressionConverterTests {
 		});
 		assertThat(map).hasSize(1);
 		assertThat(map).containsKey("x\" : { \"$or\": [ {} ] }, \"y");
+	}
+
+	@Test
+	void operatorSymbolsAreSerializedLocaleIndependently() {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			// Under the Turkish locale, "IN".toLowerCase() yields "ın" (dotless 'ı'),
+			// which is not a valid Pinecone operator. Operator symbols must be converted
+			// with a fixed locale so they stay "$in" / "$nin".
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+			String in = this.converter
+				.convertExpression(new Expression(IN, new Key("genre"), new Value(List.of("comedy", "drama"))));
+			assertThat(in).isEqualTo("{\"genre\": {\"$in\": [\"comedy\",\"drama\"]}}");
+
+			String nin = this.converter
+				.convertExpression(new Expression(NIN, new Key("city"), new Value(List.of("Sofia", "Plovdiv"))));
+			assertThat(nin).isEqualTo("{\"city\": {\"$nin\": [\"Sofia\",\"Plovdiv\"]}}");
+		}
+		finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 }

--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -397,8 +398,10 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 					String.format("Index %s does not exist in table %s", this.schema.index(), this.schema.table));
 		}
 
-		return Similarity
-			.valueOf(indexMetadata.get().getOptions().getOrDefault("similarity_function", "COSINE").toUpperCase());
+		return Similarity.valueOf(indexMetadata.get()
+			.getOptions()
+			.getOrDefault("similarity_function", "COSINE")
+			.toUpperCase(Locale.ROOT));
 
 	}
 
@@ -450,9 +453,8 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 	}
 
 	private String createSimilaritySearchCql(SearchRequest request, CqlVector<Float> cqlVector, int topK) {
-
 		Select stmt = QueryBuilder.selectFrom(this.schema.keyspace(), this.schema.table())
-			.function("similarity_" + this.similarity.toString().toLowerCase(),
+			.function("similarity_" + this.similarity.toString().toLowerCase(Locale.ROOT),
 					Selector.column(this.schema.embedding()), QueryBuilder.literal(cqlVector));
 
 		for (var c : this.schema.partitionKeys()) {

--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -920,7 +921,8 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 				// Add individual terms with OR operator
 				for (String term : terms) {
 					// Skip stopwords if configured
-					if (this.stopwords.contains(term.toLowerCase())) {
+					// Use toLowerCase(Locale.getDefault()) to pass checkstyle
+					if (this.stopwords.contains(term.toLowerCase(Locale.getDefault()))) {
 						continue;
 					}
 					queryBuilder.append(" | ").append(term);

--- a/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreDistanceMetricIT.java
+++ b/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreDistanceMetricIT.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.vectorstore.redis;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -145,7 +146,7 @@ class RedisVectorStoreDistanceMetricIT {
 			// distance)
 			boolean foundDbDoc = false;
 			for (Document doc : dbResults) {
-				if (doc.getText().toLowerCase().contains("databases")
+				if (doc.getText().toLowerCase(Locale.ROOT).contains("databases")
 						&& "DB".equals(doc.getMetadata().get("category"))) {
 					foundDbDoc = true;
 					break;


### PR DESCRIPTION

On Turkish locale the operation "I".toLowerCase() results in "ı", which breaks string comparisons. Similarly, the "i".toUpperCase() results in "İ".

This change uses .toUpperCase(Locale.ROOT) and  .toLowerCase(Locale.ROOT) to address all such code occurrences where protocol/wire values are uppercased/lowercased, including test code, to achieve a stable build with "tr-TR" locale JVMs.

RegexToolIndex and RedisVectorStore use Locale.getDefault to pass a future implementation of checkstyle check that will prevent this bug in the future, as they operate on user-supplied text,

Closes https://github.com/spring-projects/spring-ai/issues/6478 , https://github.com/spring-projects/spring-ai/issues/5340

Signed-off-by: Dimitar Proynov <dimitar.proynov@broadcom.com>