### PR TITLE
Fix `OllamaChatModel` prompt options not inheriting configured model

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -504,7 +504,7 @@ public class OllamaChatModel implements ChatModel {
 
 		private @Nullable OllamaApi ollamaApi;
 
-		private OllamaChatOptions options = OllamaChatOptions.builder().build();
+		private @Nullable OllamaChatOptions options;
 
 		private @Nullable ToolCallingManager toolCallingManager;
 
@@ -558,7 +558,9 @@ public class OllamaChatModel implements ChatModel {
 
 		public OllamaChatModel build() {
 			Assert.state(this.ollamaApi != null, "OllamaApi must not be null");
-			return new OllamaChatModel(this.ollamaApi, this.options,
+			OllamaChatOptions resolvedOptions = this.options != null ? this.options
+					: OllamaChatOptions.builder().build();
+			return new OllamaChatModel(this.ollamaApi, resolvedOptions,
 					Objects.requireNonNullElse(this.toolCallingManager, DEFAULT_TOOL_CALLING_MANAGER),
 					this.observationRegistry, this.modelManagementOptions, this.retryTemplate);
 		}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
@@ -115,7 +115,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		UserMessage userMessage = new UserMessage("Tell me about 5 famous pirates from the Golden Age of Piracy.");
 
 		// portable/generic options
-		var portableOptions = OllamaChatOptions.builder().temperature(0.7).build();
+		var portableOptions = OllamaChatOptions.builder().model(MODEL).temperature(0.7).build();
 
 		Prompt prompt = new Prompt(List.of(systemMessage, userMessage), portableOptions);
 
@@ -123,7 +123,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		verifyMostFamousPiratePresence(response);
 
 		// ollama specific options
-		var ollamaOptions = OllamaChatOptions.builder().lowVRAM(true).build();
+		var ollamaOptions = OllamaChatOptions.builder().model(MODEL).lowVRAM(true).build();
 
 		response = this.chatModel.call(new Prompt(List.of(systemMessage, userMessage), ollamaOptions));
 		verifyMostFamousPiratePresence(response);
@@ -277,7 +277,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 				""");
 		Map<String, Object> model = Map.of("country", "denmark");
 		var prompt = userPromptTemplate.create(model,
-				OllamaChatOptions.builder().format(outputConverter.getJsonSchemaMap()).build());
+				OllamaChatOptions.builder().model(MODEL).format(outputConverter.getJsonSchemaMap()).build());
 
 		var chatResponse = this.chatModel.call(prompt);
 
@@ -292,7 +292,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 	@Test
 	void jsonStructuredOutputWithOutputSchemaOption() {
 		var jsonSchemaAsText = ResourceUtils.getText("classpath:country-json-schema.json");
-		var chatOptions = OllamaChatOptions.builder().outputSchema(jsonSchemaAsText).build();
+		var chatOptions = OllamaChatOptions.builder().model(MODEL).outputSchema(jsonSchemaAsText).build();
 		var prompt = new Prompt("Tell me about Canada.", chatOptions);
 
 		var chatResponse = this.chatModel.call(prompt);
@@ -402,7 +402,10 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		ChatMemory chatMemory = MessageWindowChatMemory.builder().build();
 		String conversationId = UUID.randomUUID().toString();
 
-		var chatOptions = OllamaChatOptions.builder().toolCallbacks(ToolCallbacks.from(new MathTools())).build();
+		var chatOptions = OllamaChatOptions.builder()
+			.model(MODEL)
+			.toolCallbacks(ToolCallbacks.from(new MathTools()))
+			.build();
 		Prompt prompt = new Prompt(
 				List.of(new SystemMessage("You are a helpful assistant."), new UserMessage("What is 6 * 8?")),
 				chatOptions);


### PR DESCRIPTION
  When prompt-level `OllamaChatOptions` were provided without an explicit
  model, the options defaulted to `OllamaModel.MISTRAL` regardless of the
  model configured on `OllamaChatModel`. This caused requests to fail with
  `404 - model 'mistral' not found` in environments where only a different
  model is available.

  Align `OllamaChatModel.Builder` with `OpenAiChatModel.Builder` by making
  the `options` field `@Nullable` and resolving it in `build()` rather than
  eagerly initialising it with a hardcoded default. Update `OllamaChatModelIT`
  tests that pass prompt-level options to explicitly set the test model,
  which is the correct practice when overriding specific options at the
  prompt level.