### PR TITLE
Add `numberOfRerankedResults` to Bedrock KB store

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-bedrock-knowledgebase/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/autoconfigure/BedrockKnowledgeBaseVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-bedrock-knowledgebase/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/autoconfigure/BedrockKnowledgeBaseVectorStoreAutoConfiguration.java
@@ -128,6 +128,10 @@ public class BedrockKnowledgeBaseVectorStoreAutoConfiguration {
 			builder.rerankingModelArn(properties.getRerankingModelArn());
 		}
 
+		if (properties.getNumberOfRerankedResults() != null) {
+			builder.numberOfRerankedResults(properties.getNumberOfRerankedResults());
+		}
+
 		return builder.build();
 	}
 

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-bedrock-knowledgebase/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/autoconfigure/BedrockKnowledgeBaseVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-bedrock-knowledgebase/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/autoconfigure/BedrockKnowledgeBaseVectorStoreProperties.java
@@ -102,6 +102,13 @@ public class BedrockKnowledgeBaseVectorStoreProperties {
 	 */
 	private @Nullable String rerankingModelArn;
 
+	/**
+	 * The number of results to return after reranking. Only takes effect when
+	 * reranking-model-arn is set. Default: null (uses the service default)
+	 */
+	@Min(1)
+	private @Nullable Integer numberOfRerankedResults;
+
 	public @Nullable String getKnowledgeBaseId() {
 		return this.knowledgeBaseId;
 	}
@@ -148,6 +155,14 @@ public class BedrockKnowledgeBaseVectorStoreProperties {
 
 	public void setRerankingModelArn(@Nullable String rerankingModelArn) {
 		this.rerankingModelArn = rerankingModelArn;
+	}
+
+	public @Nullable Integer getNumberOfRerankedResults() {
+		return this.numberOfRerankedResults;
+	}
+
+	public void setNumberOfRerankedResults(@Nullable Integer numberOfRerankedResults) {
+		this.numberOfRerankedResults = numberOfRerankedResults;
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/bedrock-knowledge-base.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/bedrock-knowledge-base.adoc
@@ -89,6 +89,7 @@ You can use the following properties in your Spring Boot configuration to custom
 |`spring.ai.vectorstore.bedrock-knowledge-base.similarity-threshold` | Minimum similarity score (0.0 to 1.0) | 0.0
 |`spring.ai.vectorstore.bedrock-knowledge-base.search-type` | Search type: SEMANTIC or HYBRID | null (KB default)
 |`spring.ai.vectorstore.bedrock-knowledge-base.reranking-model-arn` | ARN of Bedrock reranking model | null (disabled)
+|`spring.ai.vectorstore.bedrock-knowledge-base.number-of-reranked-results` | Number of results returned after reranking (1 to 100) | null (service default)
 
 |===
 
@@ -116,7 +117,11 @@ You can improve search relevance by enabling a Bedrock reranking model:
 [source,properties]
 ----
 spring.ai.vectorstore.bedrock-knowledge-base.reranking-model-arn=arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0
+spring.ai.vectorstore.bedrock-knowledge-base.number-of-reranked-results=3
 ----
+
+The `number-of-reranked-results` property controls how many results the reranking model returns (1 to 100).
+It only takes effect when `reranking-model-arn` is set.
 
 Available reranking models:
 

--- a/vector-stores/spring-ai-bedrock-knowledgebase-store/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/BedrockKnowledgeBaseVectorStore.java
+++ b/vector-stores/spring-ai-bedrock-knowledgebase-store/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/BedrockKnowledgeBaseVectorStore.java
@@ -75,6 +75,8 @@ public final class BedrockKnowledgeBaseVectorStore implements VectorStore {
 
 	private final @Nullable String rerankingModelArn;
 
+	private final @Nullable Integer numberOfRerankedResults;
+
 	private final BedrockKnowledgeBaseFilterExpressionConverter filterConverter;
 
 	private BedrockKnowledgeBaseVectorStore(final Builder builder) {
@@ -84,6 +86,7 @@ public final class BedrockKnowledgeBaseVectorStore implements VectorStore {
 		this.defaultSimilarityThreshold = builder.similarityThreshold;
 		this.searchType = builder.searchType;
 		this.rerankingModelArn = builder.rerankingModelArn;
+		this.numberOfRerankedResults = builder.numberOfRerankedResults;
 		this.filterConverter = builder.filterConverter != null ? builder.filterConverter
 				: new BedrockKnowledgeBaseFilterExpressionConverter();
 	}
@@ -185,9 +188,13 @@ public final class BedrockKnowledgeBaseVectorStore implements VectorStore {
 			.builder()
 			.modelArn(this.rerankingModelArn)
 			.build();
-		VectorSearchBedrockRerankingConfiguration bedrockConfig = VectorSearchBedrockRerankingConfiguration.builder()
-			.modelConfiguration(modelConfig)
-			.build();
+		VectorSearchBedrockRerankingConfiguration.Builder bedrockConfigBuilder = VectorSearchBedrockRerankingConfiguration
+			.builder()
+			.modelConfiguration(modelConfig);
+		if (this.numberOfRerankedResults != null) {
+			bedrockConfigBuilder.numberOfRerankedResults(this.numberOfRerankedResults);
+		}
+		VectorSearchBedrockRerankingConfiguration bedrockConfig = bedrockConfigBuilder.build();
 		return VectorSearchRerankingConfiguration.builder()
 			.type(type)
 			.bedrockRerankingConfiguration(bedrockConfig)
@@ -338,6 +345,8 @@ public final class BedrockKnowledgeBaseVectorStore implements VectorStore {
 
 		private @Nullable String rerankingModelArn;
 
+		private @Nullable Integer numberOfRerankedResults;
+
 		private @Nullable BedrockKnowledgeBaseFilterExpressionConverter filterConverter;
 
 		private Builder(final BedrockAgentRuntimeClient client, final String knowledgeBaseId) {
@@ -387,6 +396,20 @@ public final class BedrockKnowledgeBaseVectorStore implements VectorStore {
 		 */
 		public Builder rerankingModelArn(@Nullable final String modelArn) {
 			this.rerankingModelArn = modelArn;
+			return this;
+		}
+
+		/**
+		 * Sets the number of results to return after reranking. Only applied when
+		 * reranking is enabled via {@link #rerankingModelArn(String)}.
+		 * @param numberOfRerankedResults the number of reranked results (1 to 100)
+		 * @return this builder
+		 * @since 2.0.1
+		 */
+		public Builder numberOfRerankedResults(@Nullable final Integer numberOfRerankedResults) {
+			Assert.isTrue(numberOfRerankedResults == null || numberOfRerankedResults > 0,
+					"numberOfRerankedResults must be positive");
+			this.numberOfRerankedResults = numberOfRerankedResults;
 			return this;
 		}
 

--- a/vector-stores/spring-ai-bedrock-knowledgebase-store/src/test/java/org/springframework/ai/vectorstore/bedrockknowledgebase/BedrockKnowledgeBaseVectorStoreTest.java
+++ b/vector-stores/spring-ai-bedrock-knowledgebase-store/src/test/java/org/springframework/ai/vectorstore/bedrockknowledgebase/BedrockKnowledgeBaseVectorStoreTest.java
@@ -41,6 +41,8 @@ import software.amazon.awssdk.services.bedrockagentruntime.model.RetrievalResult
 import software.amazon.awssdk.services.bedrockagentruntime.model.RetrieveRequest;
 import software.amazon.awssdk.services.bedrockagentruntime.model.RetrieveResponse;
 import software.amazon.awssdk.services.bedrockagentruntime.model.SearchType;
+import software.amazon.awssdk.services.bedrockagentruntime.model.VectorSearchRerankingConfiguration;
+import software.amazon.awssdk.services.bedrockagentruntime.model.VectorSearchRerankingConfigurationType;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentMetadata;
@@ -588,6 +590,102 @@ class BedrockKnowledgeBaseVectorStoreTest {
 
 			assertThat(captor.getValue().retrievalConfiguration().vectorSearchConfiguration().overrideSearchType())
 				.isEqualTo(SearchType.SEMANTIC);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Reranking Tests")
+	class RerankingTests {
+
+		private static final String RERANKING_MODEL_ARN = "arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0";
+
+		@Test
+		void shouldPassRerankingConfigWithNumberOfRerankedResultsToApi() {
+			// Given
+			BedrockKnowledgeBaseVectorStore storeWithReranking = BedrockKnowledgeBaseVectorStore
+				.builder(BedrockKnowledgeBaseVectorStoreTest.this.mockClient, TEST_KB_ID)
+				.rerankingModelArn(RERANKING_MODEL_ARN)
+				.numberOfRerankedResults(3)
+				.build();
+
+			when(BedrockKnowledgeBaseVectorStoreTest.this.mockClient.retrieve(any(RetrieveRequest.class)))
+				.thenReturn(RetrieveResponse.builder().retrievalResults(List.of()).build());
+
+			// When
+			storeWithReranking.similaritySearch(SearchRequest.builder().query("test").build());
+
+			// Then
+			ArgumentCaptor<RetrieveRequest> captor = ArgumentCaptor.forClass(RetrieveRequest.class);
+			verify(BedrockKnowledgeBaseVectorStoreTest.this.mockClient).retrieve(captor.capture());
+
+			VectorSearchRerankingConfiguration rerankingConfig = captor.getValue()
+				.retrievalConfiguration()
+				.vectorSearchConfiguration()
+				.rerankingConfiguration();
+			assertThat(rerankingConfig).isNotNull();
+			assertThat(rerankingConfig.type())
+				.isEqualTo(VectorSearchRerankingConfigurationType.BEDROCK_RERANKING_MODEL);
+			assertThat(rerankingConfig.bedrockRerankingConfiguration().modelConfiguration().modelArn())
+				.isEqualTo(RERANKING_MODEL_ARN);
+			assertThat(rerankingConfig.bedrockRerankingConfiguration().numberOfRerankedResults()).isEqualTo(3);
+		}
+
+		@Test
+		void shouldOmitNumberOfRerankedResultsWhenNotSet() {
+			// Given
+			BedrockKnowledgeBaseVectorStore storeWithReranking = BedrockKnowledgeBaseVectorStore
+				.builder(BedrockKnowledgeBaseVectorStoreTest.this.mockClient, TEST_KB_ID)
+				.rerankingModelArn(RERANKING_MODEL_ARN)
+				.build();
+
+			when(BedrockKnowledgeBaseVectorStoreTest.this.mockClient.retrieve(any(RetrieveRequest.class)))
+				.thenReturn(RetrieveResponse.builder().retrievalResults(List.of()).build());
+
+			// When
+			storeWithReranking.similaritySearch(SearchRequest.builder().query("test").build());
+
+			// Then
+			ArgumentCaptor<RetrieveRequest> captor = ArgumentCaptor.forClass(RetrieveRequest.class);
+			verify(BedrockKnowledgeBaseVectorStoreTest.this.mockClient).retrieve(captor.capture());
+
+			VectorSearchRerankingConfiguration rerankingConfig = captor.getValue()
+				.retrievalConfiguration()
+				.vectorSearchConfiguration()
+				.rerankingConfiguration();
+			assertThat(rerankingConfig).isNotNull();
+			assertThat(rerankingConfig.bedrockRerankingConfiguration().numberOfRerankedResults()).isNull();
+		}
+
+		@Test
+		void shouldIgnoreNumberOfRerankedResultsWithoutRerankingModelArn() {
+			// Given
+			BedrockKnowledgeBaseVectorStore storeWithoutReranking = BedrockKnowledgeBaseVectorStore
+				.builder(BedrockKnowledgeBaseVectorStoreTest.this.mockClient, TEST_KB_ID)
+				.numberOfRerankedResults(3)
+				.build();
+
+			when(BedrockKnowledgeBaseVectorStoreTest.this.mockClient.retrieve(any(RetrieveRequest.class)))
+				.thenReturn(RetrieveResponse.builder().retrievalResults(List.of()).build());
+
+			// When
+			storeWithoutReranking.similaritySearch(SearchRequest.builder().query("test").build());
+
+			// Then
+			ArgumentCaptor<RetrieveRequest> captor = ArgumentCaptor.forClass(RetrieveRequest.class);
+			verify(BedrockKnowledgeBaseVectorStoreTest.this.mockClient).retrieve(captor.capture());
+
+			assertThat(captor.getValue().retrievalConfiguration().vectorSearchConfiguration().rerankingConfiguration())
+				.isNull();
+		}
+
+		@Test
+		void shouldRejectInvalidNumberOfRerankedResults() {
+			assertThatThrownBy(() -> BedrockKnowledgeBaseVectorStore
+				.builder(BedrockKnowledgeBaseVectorStoreTest.this.mockClient, TEST_KB_ID)
+				.numberOfRerankedResults(0)
+				.build()).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("numberOfRerankedResults must be positive");
 		}
 
 	}


### PR DESCRIPTION
Expose the `numberOfRerankedResults` field of the Bedrock Agent Runtime Retrieve API in `BedrockKnowledgeBaseVectorStore`, so users can control how many results the Bedrock reranking model returns.

The value is configurable via the store builder and the new `spring.ai.vectorstore.bedrock-knowledge-base.number-of-reranked-results` auto-configuration property. It is only applied when a reranking model ARN is configured, since the reranking configuration is only attached to the Retrieve request in that case.

Closes #6569

**Expected Behavior**

`BedrockKnowledgeBaseVectorStore` should allow configuring how many results the Bedrock reranking model returns, by exposing the `numberOfRerankedResults` field of `VectorSearchBedrockRerankingConfiguration` from the Bedrock Agent Runtime Retrieve API.

```
BedrockKnowledgeBaseVectorStore store = BedrockKnowledgeBaseVectorStore
    .builder(bedrockAgentRuntimeClient, "kb-id")
    .rerankingModelArn("arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0")
    .numberOfRerankedResults(3)
    .build();
```

And via Spring Boot auto-configuration:

```
spring.ai.vectorstore.bedrock-knowledge-base.reranking-model-arn=arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0
spring.ai.vectorstore.bedrock-knowledge-base.number-of-reranked-results=3
```

**Current Behavior**

The reranking support introduced with the store only exposes the reranking model ARN. `BedrockKnowledgeBaseVectorStore#buildRerankingConfig()` sets `modelConfiguration` but never `numberOfRerankedResults`, so the Retrieve call always uses the service default. The class is final and builds the request internally, so there is no way to set this value without forking the store or bypassing the `VectorStore` abstraction and calling the AWS SDK directly.

**Context**

We use this store in a RAG pipeline with a Bedrock reranking model: retrieve a larger candidate set (top-k), then have the reranker narrow it down to a small high-relevance set before it reaches the prompt. That is exactly what `numberOfRerankedResults` controls, and the field is already available in the bedrockagentruntime SDK version pinned by Spring AI. Trimming client-side after retrieval does not change what the reranker returns, and using `getNativeClient()` gives up the VectorStore abstraction and filter expression support.

**Changes**
  - `numberOfRerankedResults` builder option on `BedrockKnowledgeBaseVectorStore`, applied to the reranking configuration only when `rerankingModelArn` is set
  - New `spring.ai.vectorstore.bedrock-knowledge-base.number-of-reranked-results` property (validated with @Min(1)) wired in the auto-configuration
  - Unit tests covering: value passed to the API, omitted when unset, ignored without a reranking model ARN, rejection of non-positive values
  - Reference documentation updates for the new property