### PR TITLE
Close native resources in `TransformersEmbeddingModel`

### DIFF
--- a/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/TransformersEmbeddingModel.java
+++ b/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/TransformersEmbeddingModel.java
@@ -80,7 +80,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @since 1.0.0
  */
-public class TransformersEmbeddingModel extends AbstractEmbeddingModel implements InitializingBean {
+public class TransformersEmbeddingModel extends AbstractEmbeddingModel implements InitializingBean, AutoCloseable {
 
 	// ONNX tokenizer for the all-MiniLM-L6-v2 generative
 	public static final String DEFAULT_ONNX_TOKENIZER_URI = "https://raw.githubusercontent.com/spring-projects/spring-ai/main/models/spring-ai-transformers/src/main/resources/onnx/all-MiniLM-L6-v2/tokenizer.json";
@@ -251,6 +251,26 @@ public class TransformersEmbeddingModel extends AbstractEmbeddingModel implement
 				"The generative output names don't contain expected: " + this.modelOutputName
 						+ ". Consider one of the available model outputs: "
 						+ onnxModelOutputs.stream().collect(Collectors.joining(", ")));
+	}
+
+	/**
+	 * Release the native ONNX runtime session and tokenizer acquired in
+	 * {@link #afterPropertiesSet()}. Spring registers this as the bean destroy method
+	 * automatically (inferred {@code close()} method), and the model can also be used
+	 * with try-with-resources.
+	 */
+	@Override
+	public void close() throws OrtException {
+		try {
+			if (this.tokenizer != null) {
+				this.tokenizer.close();
+			}
+		}
+		finally {
+			if (this.session != null) {
+				this.session.close();
+			}
+		}
 	}
 
 	private Resource getCachedResource(Resource resource) {

--- a/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/TransformersEmbeddingModelTests.java
+++ b/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/TransformersEmbeddingModelTests.java
@@ -19,13 +19,19 @@ package org.springframework.ai.transformers;
 import java.text.DecimalFormat;
 import java.util.List;
 
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+import ai.onnxruntime.OrtSession;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Christian Tzolov
@@ -97,6 +103,25 @@ public class TransformersEmbeddingModelTests {
 		assertThat(embeddingModel.dimensions()).isEqualTo(384);
 		// cached
 		assertThat(embeddingModel.dimensions()).isEqualTo(384);
+	}
+
+	@Test
+	void closeReleasesNativeResources() throws Exception {
+		TransformersEmbeddingModel embeddingModel = new TransformersEmbeddingModel();
+		HuggingFaceTokenizer tokenizer = mock(HuggingFaceTokenizer.class);
+		OrtSession session = mock(OrtSession.class);
+		ReflectionTestUtils.setField(embeddingModel, "tokenizer", tokenizer);
+		ReflectionTestUtils.setField(embeddingModel, "session", session);
+
+		embeddingModel.close();
+
+		verify(tokenizer).close();
+		verify(session).close();
+	}
+
+	@Test
+	void closeBeforeInitializationIsSafe() {
+		assertThatNoException().isThrownBy(() -> new TransformersEmbeddingModel().close());
 	}
 
 }


### PR DESCRIPTION
### Problem

`TransformersEmbeddingModel` acquires two native resources in `afterPropertiesSet()` — an `OrtSession` (ONNX runtime session that holds the model in native memory) and a `HuggingFaceTokenizer` (a DJL `NativeResource`) — but the class only implements `InitializingBean` and never releases them. When the bean is destroyed, that native memory is leaked. In practice this shows up with:

- the Spring TestContext framework caching and closing many application contexts in a single JVM (each one leaks roughly the model size in native memory);
- context restarts (e.g. devtools);
- creating the model outside of Spring.

The auto-configured bean (`TransformersEmbeddingModelAutoConfiguration`) is a plain `@Bean` with no destroy method, so there was previously no path to release these resources at all.

### Fix

Implement `AutoCloseable` and release the tokenizer and session in `close()`. For the auto-configured bean, Spring infers `close()` as the destroy method, so the resources are freed on context shutdown; the model can also be used with try-with-resources. Sibling resource-holding beans follow the same pattern (e.g. `GoogleGenAiChatModel` implements `DisposableBean`; `CassandraVectorStore` and `CouchbaseSearchVectorStore` implement `AutoCloseable`).

### Tests

`TransformersEmbeddingModelTests` gains a unit test verifying `close()` releases both native resources, plus one asserting `close()` is safe before initialization.
