### PR TITLE
Propagate custom headers for OpenAI embeddings

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
@@ -30,6 +30,7 @@ import com.openai.models.embeddings.EmbeddingModel;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.embedding.EmbeddingOptions;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Configuration information for the Embedding Model implementation using the OpenAI Java
@@ -116,6 +117,9 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 		}
 		if (this.getDimensions() != null) {
 			builder.dimensions(this.getDimensions());
+		}
+		if (!CollectionUtils.isEmpty(this.getCustomHeaders())) {
+			this.getCustomHeaders().forEach(builder::putAdditionalHeader);
 		}
 		return builder.build();
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/embedding/OpenAiEmbeddingOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/embedding/OpenAiEmbeddingOptionsTests.java
@@ -81,6 +81,18 @@ class OpenAiEmbeddingOptionsTests {
 	}
 
 	@Test
+	void customHeadersArePropagatedToEmbeddingCreateParams() {
+		OpenAiEmbeddingOptions options = OpenAiEmbeddingOptions.builder()
+			.model("text-embedding-3-small")
+			.customHeaders(Map.of("x-budget-id", "BUDGET_123"))
+			.build();
+
+		EmbeddingCreateParams params = options.toOpenAiCreateParams(List.of("test input"));
+
+		assertThat(params._additionalHeaders().values("x-budget-id")).containsExactly("BUDGET_123");
+	}
+
+	@Test
 	void testOptionsBuilderMergeCustomHeaders() {
 		OpenAiEmbeddingOptions defaultOptions = OpenAiEmbeddingOptions.builder()
 			.customHeaders(Map.of("default-header", "default-value"))


### PR DESCRIPTION
OpenAiEmbeddingOptions#toOpenAiCreateParams built the request from model/input/user/encodingFormat/dimensions only, silently dropping per-call customHeaders. As a result, a shared embedding client could not forward per-request headers (e.g. distributed-tracing identifiers or LLM-gateway headers) to the OpenAI API.

This mirrors the fix already applied to chat (OpenAiChatModel#createRequest, propagating per-call headers via putAdditionalHeader) and images (#6083), applying the same pattern to the embedding path.

Fixes #6574

🤖 Generated with [Claude Code](https://claude.com/claude-code)