### PR TITLE
Expose Anthropic thinking replay carrier

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicAssistantMessage.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicAssistantMessage.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.content.Media;
+import org.springframework.util.Assert;
+
+/**
+ * Anthropic assistant message that carries thinking content required for request replay.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.1
+ */
+public final class AnthropicAssistantMessage extends AssistantMessage {
+
+	static final String ANTHROPIC_THINKING_CONTENTS_PROPERTY = "anthropicThinkingContents";
+
+	private final List<AnthropicThinkingContent> thinkingContents;
+
+	private AnthropicAssistantMessage(@Nullable String content, Map<String, Object> properties,
+			List<ToolCall> toolCalls, List<Media> media, List<AnthropicThinkingContent> thinkingContents) {
+		super(content, anthropicThinkingProperties(properties, thinkingContents), List.copyOf(toolCalls),
+				List.copyOf(media));
+		this.thinkingContents = List.copyOf(thinkingContents);
+	}
+
+	/**
+	 * Return the Anthropic thinking content attached to this assistant message.
+	 * @return the thinking content
+	 */
+	public List<AnthropicThinkingContent> getThinkingContents() {
+		return this.thinkingContents;
+	}
+
+	/**
+	 * Whether this assistant message carries Anthropic thinking content.
+	 * @return true if thinking content is present
+	 */
+	public boolean hasThinkingContents() {
+		return !this.thinkingContents.isEmpty();
+	}
+
+	@Override
+	public String toString() {
+		return "AnthropicAssistantMessage [messageType=" + getMessageType() + ", toolCalls=" + getToolCalls()
+				+ ", thinkingContents=" + this.thinkingContents.size() + "]";
+	}
+
+	/**
+	 * Create a new builder for {@link AnthropicAssistantMessage}.
+	 * @return a new builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	static Map<String, Object> anthropicThinkingProperties(Map<String, Object> properties,
+			List<AnthropicThinkingContent> thinkingContents) {
+		Assert.notNull(properties, "properties must not be null");
+		Assert.notNull(thinkingContents, "thinkingContents must not be null");
+		if (thinkingContents.isEmpty()) {
+			return properties;
+		}
+		Map<String, Object> messageProperties = new HashMap<>(properties);
+		messageProperties.put(ANTHROPIC_THINKING_CONTENTS_PROPERTY, List.copyOf(thinkingContents));
+		return messageProperties;
+	}
+
+	/**
+	 * Builder for {@link AnthropicAssistantMessage}.
+	 */
+	public static class Builder extends AssistantMessage.Builder<Builder> {
+
+		private List<AnthropicThinkingContent> thinkingContents = List.of();
+
+		/**
+		 * Set the Anthropic thinking content carried by the assistant message.
+		 * @param thinkingContents the thinking content
+		 * @return the builder
+		 */
+		public Builder thinkingContents(List<AnthropicThinkingContent> thinkingContents) {
+			Assert.notNull(thinkingContents, "thinkingContents must not be null");
+			this.thinkingContents = thinkingContents;
+			return this;
+		}
+
+		@Override
+		public AnthropicAssistantMessage build() {
+			return new AnthropicAssistantMessage(this.content, this.properties, this.toolCalls, this.media,
+					this.thinkingContents);
+		}
+
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -48,12 +48,10 @@ import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.MessageCreateParams;
 import com.anthropic.models.messages.RawMessageStreamEvent;
 import com.anthropic.models.messages.RedactedThinkingBlock;
-import com.anthropic.models.messages.RedactedThinkingBlockParam;
 import com.anthropic.models.messages.TextBlock;
 import com.anthropic.models.messages.TextBlockParam;
 import com.anthropic.models.messages.TextCitation;
 import com.anthropic.models.messages.ThinkingBlock;
-import com.anthropic.models.messages.ThinkingBlockParam;
 import com.anthropic.models.messages.Tool;
 import com.anthropic.models.messages.ToolChoice;
 import com.anthropic.models.messages.ToolChoiceAuto;
@@ -159,8 +157,6 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	private static final String BETA_CODE_EXECUTION = "code-execution-2025-08-25";
 
 	private static final String BETA_FILES_API = "files-api-2025-04-14";
-
-	static final String ANTHROPIC_THINKING_CONTENTS_PROPERTY = "anthropicThinkingContents";
 
 	private static final ToolCallingManager DEFAULT_TOOL_CALLING_MANAGER = ToolCallingManager.builder().build();
 
@@ -1489,14 +1485,19 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			}
 			return assistantMessageBuilder.build();
 		}
-		return new AnthropicAssistantMessage(content, toolCalls, thinkingContents);
+		return AnthropicAssistantMessage.builder()
+			.content(content)
+			.toolCalls(toolCalls)
+			.thinkingContents(thinkingContents)
+			.build();
 	}
 
 	private static List<AnthropicThinkingContent> getAnthropicThinkingContents(AssistantMessage assistantMessage) {
 		if (assistantMessage instanceof AnthropicAssistantMessage anthropicAssistantMessage) {
 			return anthropicAssistantMessage.getThinkingContents();
 		}
-		Object contents = assistantMessage.getMetadata().get(ANTHROPIC_THINKING_CONTENTS_PROPERTY);
+		Object contents = assistantMessage.getMetadata()
+			.get(AnthropicAssistantMessage.ANTHROPIC_THINKING_CONTENTS_PROPERTY);
 		if (contents instanceof List<?> list) {
 			List<AnthropicThinkingContent> thinkingContents = new ArrayList<>();
 			for (Object item : list) {
@@ -1510,71 +1511,6 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			return thinkingContents;
 		}
 		return List.of();
-	}
-
-	private static Map<String, Object> anthropicThinkingProperties(List<AnthropicThinkingContent> thinkingContents) {
-		if (thinkingContents.isEmpty()) {
-			return Map.of();
-		}
-		return Map.of(ANTHROPIC_THINKING_CONTENTS_PROPERTY, List.copyOf(thinkingContents));
-	}
-
-	static final class AnthropicAssistantMessage extends AssistantMessage {
-
-		private final List<AnthropicThinkingContent> thinkingContents;
-
-		private AnthropicAssistantMessage(String content, List<ToolCall> toolCalls,
-				List<AnthropicThinkingContent> thinkingContents) {
-			super(content, anthropicThinkingProperties(thinkingContents), List.copyOf(toolCalls), List.of());
-			this.thinkingContents = List.copyOf(thinkingContents);
-		}
-
-		List<AnthropicThinkingContent> getThinkingContents() {
-			return this.thinkingContents;
-		}
-
-		boolean hasThinkingContents() {
-			return !this.thinkingContents.isEmpty();
-		}
-
-		@Override
-		public String toString() {
-			return "AnthropicAssistantMessage [messageType=" + getMessageType() + ", toolCalls=" + getToolCalls()
-					+ ", textContent=" + getText() + ", thinkingContents=" + this.thinkingContents.size() + "]";
-		}
-
-	}
-
-	record AnthropicThinkingContent(@Nullable String thinking, @Nullable String signature,
-			@Nullable String redactedData) {
-
-		static AnthropicThinkingContent thinking(String thinking, String signature) {
-			return new AnthropicThinkingContent(thinking, signature, null);
-		}
-
-		static AnthropicThinkingContent redacted(String data) {
-			return new AnthropicThinkingContent(null, null, data);
-		}
-
-		ContentBlockParam toContentBlockParam() {
-			if (this.redactedData != null) {
-				return ContentBlockParam
-					.ofRedactedThinking(RedactedThinkingBlockParam.builder().data(this.redactedData).build());
-			}
-			String thinking = this.thinking;
-			String signature = this.signature;
-			Assert.notNull(thinking, "thinking must not be null");
-			Assert.notNull(signature, "signature must not be null");
-			return ContentBlockParam
-				.ofThinking(ThinkingBlockParam.builder().thinking(thinking).signature(signature).build());
-		}
-
-		@Override
-		public String toString() {
-			String type = this.redactedData != null ? "redacted_thinking" : "thinking";
-			return "AnthropicThinkingContent[type=" + type + "]";
-		}
-
 	}
 
 	/**

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicThinkingContent.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicThinkingContent.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import java.util.Objects;
+
+import com.anthropic.models.messages.ContentBlockParam;
+import com.anthropic.models.messages.RedactedThinkingBlockParam;
+import com.anthropic.models.messages.ThinkingBlockParam;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * Anthropic thinking content preserved for request replay.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.1
+ */
+public final class AnthropicThinkingContent {
+
+	private final @Nullable String thinking;
+
+	private final @Nullable String signature;
+
+	private final @Nullable String redactedData;
+
+	private AnthropicThinkingContent(@Nullable String thinking, @Nullable String signature,
+			@Nullable String redactedData) {
+		this.thinking = thinking;
+		this.signature = signature;
+		this.redactedData = redactedData;
+	}
+
+	/**
+	 * Create a thinking content block.
+	 * @param thinking the thinking text
+	 * @param signature the thinking signature
+	 * @return a thinking content instance
+	 */
+	public static AnthropicThinkingContent thinking(String thinking, String signature) {
+		Assert.notNull(thinking, "thinking must not be null");
+		Assert.notNull(signature, "signature must not be null");
+		return new AnthropicThinkingContent(thinking, signature, null);
+	}
+
+	/**
+	 * Create a redacted thinking content block.
+	 * @param data the redacted thinking data
+	 * @return a redacted thinking content instance
+	 */
+	public static AnthropicThinkingContent redacted(String data) {
+		Assert.notNull(data, "data must not be null");
+		return new AnthropicThinkingContent(null, null, data);
+	}
+
+	/**
+	 * Return the thinking text, if this is a thinking content block.
+	 * @return the thinking text or null
+	 */
+	public @Nullable String getThinking() {
+		return this.thinking;
+	}
+
+	/**
+	 * Return the thinking signature, if this is a thinking content block.
+	 * @return the thinking signature or null
+	 */
+	public @Nullable String getSignature() {
+		return this.signature;
+	}
+
+	/**
+	 * Return the redacted thinking data, if this is a redacted thinking content block.
+	 * @return the redacted thinking data or null
+	 */
+	public @Nullable String getRedactedData() {
+		return this.redactedData;
+	}
+
+	ContentBlockParam toContentBlockParam() {
+		if (this.redactedData != null) {
+			return ContentBlockParam
+				.ofRedactedThinking(RedactedThinkingBlockParam.builder().data(this.redactedData).build());
+		}
+		String thinking = this.thinking;
+		String signature = this.signature;
+		Assert.notNull(thinking, "thinking must not be null");
+		Assert.notNull(signature, "signature must not be null");
+		return ContentBlockParam
+			.ofThinking(ThinkingBlockParam.builder().thinking(thinking).signature(signature).build());
+	}
+
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof AnthropicThinkingContent that)) {
+			return false;
+		}
+		return Objects.equals(this.thinking, that.thinking) && Objects.equals(this.signature, that.signature)
+				&& Objects.equals(this.redactedData, that.redactedData);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.thinking, this.signature, this.redactedData);
+	}
+
+	@Override
+	public String toString() {
+		String type = this.redactedData != null ? "redacted_thinking" : "thinking";
+		return "AnthropicThinkingContent[type=" + type + "]";
+	}
+
+}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
@@ -268,8 +268,13 @@ class AnthropicChatModelTests {
 		assertThat(thinkingGeneration.getOutput().getText()).isEqualTo("thinking text");
 		assertThat(thinkingGeneration.getOutput().getMetadata()).containsEntry("signature", "thinking-signature");
 		Generation toolCallGeneration = response.getResults().get(1);
-		assertThat(toolCallGeneration.getOutput()).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
-		assertThat(toolCallGeneration.getOutput().getToolCalls()).hasSize(1);
+		assertThat(toolCallGeneration.getOutput()).isInstanceOf(AnthropicAssistantMessage.class);
+		AnthropicAssistantMessage output = (AnthropicAssistantMessage) toolCallGeneration.getOutput();
+		assertThat(output.getToolCalls()).hasSize(1);
+		assertThat(output.getThinkingContents()).hasSize(1);
+		AnthropicThinkingContent thinkingContent = output.getThinkingContents().get(0);
+		assertThat(thinkingContent.getThinking()).isEqualTo("thinking text");
+		assertThat(thinkingContent.getSignature()).isEqualTo("thinking-signature");
 
 		ToolExecutionResult toolExecutionResult = ToolCallingManager.builder()
 			.build()
@@ -305,8 +310,12 @@ class AnthropicChatModelTests {
 		Generation redactedGeneration = response.getResults().get(0);
 		assertThat(redactedGeneration.getOutput().getMetadata()).containsEntry("data", "redacted-data");
 		Generation toolCallGeneration = response.getResults().get(1);
-		assertThat(toolCallGeneration.getOutput()).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
-		assertThat(toolCallGeneration.getOutput().getToolCalls()).hasSize(1);
+		assertThat(toolCallGeneration.getOutput()).isInstanceOf(AnthropicAssistantMessage.class);
+		AnthropicAssistantMessage output = (AnthropicAssistantMessage) toolCallGeneration.getOutput();
+		assertThat(output.getToolCalls()).hasSize(1);
+		assertThat(output.getThinkingContents()).hasSize(1);
+		AnthropicThinkingContent thinkingContent = output.getThinkingContents().get(0);
+		assertThat(thinkingContent.getRedactedData()).isEqualTo("redacted-data");
 
 		ToolExecutionResult toolExecutionResult = ToolCallingManager.builder()
 			.build()
@@ -338,10 +347,25 @@ class AnthropicChatModelTests {
 
 		Generation finalGeneration = response.getResults().get(1);
 		assertThat(finalGeneration.getOutput().getText()).isEqualTo("Final answer.");
-		assertThat(finalGeneration.getOutput()).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
-		AnthropicChatModel.AnthropicAssistantMessage output = (AnthropicChatModel.AnthropicAssistantMessage) finalGeneration
-			.getOutput();
+		assertThat(finalGeneration.getOutput()).isInstanceOf(AnthropicAssistantMessage.class);
+		AnthropicAssistantMessage output = (AnthropicAssistantMessage) finalGeneration.getOutput();
 		assertThat(output.hasThinkingContents()).isTrue();
+	}
+
+	@Test
+	void anthropicAssistantMessageToStringRedactsThinkingContents() {
+		AnthropicAssistantMessage message = AnthropicAssistantMessage.builder()
+			.content("visible content")
+			.thinkingContents(List.of(AnthropicThinkingContent.thinking("secret-thinking", "secret-signature"),
+					AnthropicThinkingContent.redacted("secret-redacted")))
+			.build();
+
+		assertThat(message.toString()).contains("thinkingContents=2")
+			.doesNotContain("secret-thinking", "secret-signature", "secret-redacted");
+		assertThat(message.getThinkingContents().get(0).toString())
+			.isEqualTo("AnthropicThinkingContent[type=thinking]");
+		assertThat(message.getThinkingContents().get(1).toString())
+			.isEqualTo("AnthropicThinkingContent[type=redacted_thinking]");
 	}
 
 	@Test


### PR DESCRIPTION
This aligns the Anthropic thinking replay carrier with the Bedrock provider-specific carrier proposed in #6414.

Anthropic thinking and redacted thinking blocks are already preserved for tool replay, but the carrier types are currently package-private nested types inside `AnthropicChatModel`. This extracts them as public provider-specific Spring AI value types so users can inspect whether thinking state was preserved on the tool-call assistant turn.

The change stays within the Anthropic provider module. It does not add a generic `AssistantMessage` reasoning API, does not change the core tool-calling loop, and keeps the existing Anthropic `thinking` / `redacted_thinking` response surface intact.

Validation:

```bash
./mvnw -pl models/spring-ai-anthropic -am test -Dtest=AnthropicChatModelTests -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.build.cache.enabled=false
./mvnw -pl models/spring-ai-anthropic -Dmaven.build.cache.enabled=false package
```

See #6414.
