### PR TITLE
Restore Jedis 7.0 compatibility for Redis integrations

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
@@ -16,7 +16,8 @@
 
 package org.springframework.ai.model.chat.memory.repository.redis.autoconfigure;
 
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.UnifiedJedis;
 
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
@@ -38,10 +39,11 @@ import org.springframework.util.StringUtils;
  * @author Brian Sam-Bodden
  * @author Yanming Zhou
  * @author guan xu
+ * @author Jewoo Shin
  * @since 2.0.1
  */
 @AutoConfiguration(before = ChatMemoryAutoConfiguration.class)
-@ConditionalOnClass({ RedisChatMemoryRepository.class, RedisClient.class })
+@ConditionalOnClass({ RedisChatMemoryRepository.class, JedisPooled.class })
 public class RedisChatMemoryRepositoryAutoConfiguration {
 
 	/**
@@ -70,13 +72,13 @@ public class RedisChatMemoryRepositoryAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public RedisClient jedisClient(RedisChatMemoryRepositoryProperties properties) {
-		return RedisClient.builder().hostAndPort(properties.getHost(), properties.getPort()).build();
+	public UnifiedJedis jedisClient(RedisChatMemoryRepositoryProperties properties) {
+		return new JedisPooled(properties.getHost(), properties.getPort());
 	}
 
 	@Bean
 	@ConditionalOnMissingBean({ RedisChatMemoryRepository.class, ChatMemory.class, ChatMemoryRepository.class })
-	public RedisChatMemoryRepository redisChatMemoryRepository(RedisClient jedisClient,
+	public RedisChatMemoryRepository redisChatMemoryRepository(UnifiedJedis jedisClient,
 			RedisChatMemoryRepositoryProperties properties) {
 		RedisChatMemoryRepository.Builder builder = RedisChatMemoryRepository.builder().jedisClient(jedisClient);
 

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfigurationIT.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfigurationIT.java
@@ -24,7 +24,9 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.repository.redis.RedisChatMemoryRepository;
+import org.springframework.ai.model.chat.memory.autoconfigure.ChatMemoryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -86,6 +88,17 @@ class RedisChatMemoryRepositoryAutoConfigurationIT {
 			ChatMemoryRepository repository = context.getBean(ChatMemoryRepository.class);
 
 			assertThat(repository).isSameAs(redisChatMemory);
+		});
+	}
+
+	@Test
+	void redisRepositoryBacksOffDefaultInMemoryRepository() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(ChatMemoryAutoConfiguration.class)).run(context -> {
+			RedisChatMemoryRepository redisChatMemory = context.getBean(RedisChatMemoryRepository.class);
+			ChatMemoryRepository repository = context.getBean(ChatMemoryRepository.class);
+
+			assertThat(repository).isSameAs(redisChatMemory);
+			assertThat(context).doesNotHaveBean(InMemoryChatMemoryRepository.class);
 		});
 	}
 

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.ai.model.chat.memory.redis.autoconfigure;
 
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.chat.memory.repository.redis.RedisChatMemoryRepository;
 import org.springframework.ai.model.chat.memory.autoconfigure.ChatMemoryAutoConfiguration;
@@ -33,12 +33,13 @@ import org.springframework.context.annotation.Bean;
  * @author Brian Sam-Bodden
  * @author Yanming Zhou
  * @author Sebastien Deleuze
+ * @author Jewoo Shin
  * @deprecated Use {@link RedisChatMemoryRepositoryAutoConfiguration} instead.
  */
 @Deprecated(since = "2.0.1", forRemoval = true)
 @SuppressWarnings("removal")
 @AutoConfiguration(before = ChatMemoryAutoConfiguration.class)
-@ConditionalOnClass({ RedisChatMemoryRepository.class, RedisClient.class })
+@ConditionalOnClass({ RedisChatMemoryRepository.class, JedisPooled.class })
 public class RedisChatMemoryAutoConfiguration {
 
 	/**

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheAutoConfiguration.java
@@ -17,8 +17,10 @@
 package org.springframework.ai.vectorstore.redis.cache.semantic.autoconfigure;
 
 import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.UnifiedJedis;
 
 import org.springframework.ai.chat.cache.semantic.SemanticCache;
 import org.springframework.ai.chat.cache.semantic.SemanticCacheAdvisor;
@@ -43,9 +45,10 @@ import org.springframework.util.StringUtils;
  * @author Brian Sam-Bodden
  * @author Eddú Meléndez
  * @author Yanming Zhou
+ * @author Jewoo Shin
  */
 @AutoConfiguration
-@ConditionalOnClass({ DefaultSemanticCache.class, RedisClient.class, CallAdvisor.class, StreamAdvisor.class,
+@ConditionalOnClass({ DefaultSemanticCache.class, JedisPooled.class, CallAdvisor.class, StreamAdvisor.class,
 		TransformersEmbeddingModel.class })
 @EnableConfigurationProperties(RedisSemanticCacheProperties.class)
 @ConditionalOnProperty(name = "spring.ai.vectorstore.redis.semantic-cache.enabled", havingValue = "true",
@@ -75,15 +78,15 @@ public class RedisSemanticCacheAutoConfiguration {
 	}
 
 	/**
-	 * Creates a RedisClient client for Redis connections, honoring the SSL, password,
-	 * client name, and timeout settings from the {@link JedisConnectionFactory}.
+	 * Creates a Redis client for Redis connections, honoring the SSL, password, client
+	 * name, and timeout settings from the {@link JedisConnectionFactory}.
 	 * @param jedisConnectionFactory the Jedis connection factory
-	 * @return the RedisClient client
+	 * @return the Redis client
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(EmbeddingModel.class)
-	public RedisClient jedisClient(final JedisConnectionFactory jedisConnectionFactory) {
+	public UnifiedJedis jedisClient(final JedisConnectionFactory jedisConnectionFactory) {
 		String host = jedisConnectionFactory.getHostName();
 		int port = jedisConnectionFactory.getPort();
 
@@ -94,7 +97,7 @@ public class RedisSemanticCacheAutoConfiguration {
 			.password(jedisConnectionFactory.getPassword())
 			.build();
 
-		return RedisClient.builder().hostAndPort(host, port).clientConfig(clientConfig).build();
+		return new JedisPooled(new HostAndPort(host, port), clientConfig);
 	}
 
 	/**
@@ -107,7 +110,7 @@ public class RedisSemanticCacheAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(EmbeddingModel.class)
-	public SemanticCache semanticCache(final RedisClient jedisClient, final EmbeddingModel embeddingModel,
+	public SemanticCache semanticCache(final UnifiedJedis jedisClient, final EmbeddingModel embeddingModel,
 			final RedisSemanticCacheProperties properties) {
 		DefaultSemanticCache.Builder builder = DefaultSemanticCache.builder()
 			.jedisClient(jedisClient)

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
@@ -18,8 +18,10 @@ package org.springframework.ai.vectorstore.redis.autoconfigure;
 
 import io.micrometer.observation.ObservationRegistry;
 import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.UnifiedJedis;
 
 import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
@@ -45,9 +47,10 @@ import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
  * @author Jihoon Kim
  * @author Brian Sam-Bodden
  * @author Yanming Zhou
+ * @author Jewoo Shin
  */
 @AutoConfiguration
-@ConditionalOnClass({ RedisClient.class, JedisConnectionFactory.class, RedisVectorStore.class, EmbeddingModel.class })
+@ConditionalOnClass({ JedisPooled.class, JedisConnectionFactory.class, RedisVectorStore.class, EmbeddingModel.class })
 @EnableConfigurationProperties(RedisVectorStoreProperties.class)
 @ConditionalOnProperty(name = SpringAIVectorStoreTypes.TYPE, havingValue = SpringAIVectorStoreTypes.REDIS,
 		matchIfMissing = true)
@@ -81,7 +84,7 @@ public class RedisVectorStoreAutoConfiguration {
 			final ObjectProvider<VectorStoreObservationConvention> convention,
 			final BatchingStrategy batchingStrategy) {
 
-		RedisClient jedisClient = jedisClient(jedisConnectionFactory);
+		UnifiedJedis jedisClient = jedisClient(jedisConnectionFactory);
 		RedisVectorStore.Builder builder = RedisVectorStore.builder(jedisClient, embeddingModel)
 			.initializeSchema(properties.isInitializeSchema())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
@@ -108,7 +111,7 @@ public class RedisVectorStoreAutoConfiguration {
 			.hnswEfRuntime(properties.getHnsw().getEfRuntime());
 	}
 
-	private RedisClient jedisClient(final JedisConnectionFactory jedisConnectionFactory) {
+	private UnifiedJedis jedisClient(final JedisConnectionFactory jedisConnectionFactory) {
 
 		String host = jedisConnectionFactory.getHostName();
 		int port = jedisConnectionFactory.getPort();
@@ -120,7 +123,7 @@ public class RedisVectorStoreAutoConfiguration {
 			.password(jedisConnectionFactory.getPassword())
 			.build();
 
-		return RedisClient.builder().hostAndPort(host, port).clientConfig(clientConfig).build();
+		return new JedisPooled(new HostAndPort(host, port), clientConfig);
 	}
 
 }

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryConfig.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryConfig.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.UnifiedJedis;
 
 import org.springframework.util.Assert;
 
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
  *
  * @author Brian Sam-Bodden
  * @author Yanming Zhou
+ * @author Jewoo Shin
  */
 public final class RedisChatMemoryConfig {
 
@@ -45,7 +46,7 @@ public final class RedisChatMemoryConfig {
 	public static final int DEFAULT_MAX_RESULTS = 1000;
 
 	/** The Redis client */
-	private final RedisClient jedisClient;
+	private final UnifiedJedis jedisClient;
 
 	/** The index name for Redis Search */
 	private final String indexName;
@@ -76,7 +77,7 @@ public final class RedisChatMemoryConfig {
 	private final List<Map<String, String>> metadataFields;
 
 	private RedisChatMemoryConfig(final Builder builder) {
-		Assert.notNull(builder.jedisClient, "RedisClient client must not be null");
+		Assert.notNull(builder.jedisClient, "Redis client must not be null");
 		Assert.hasText(builder.indexName, "Index name must not be empty");
 		Assert.hasText(builder.keyPrefix, "Key prefix must not be empty");
 
@@ -94,7 +95,7 @@ public final class RedisChatMemoryConfig {
 		return new Builder();
 	}
 
-	public RedisClient getJedisClient() {
+	public UnifiedJedis getJedisClient() {
 		return this.jedisClient;
 	}
 
@@ -144,7 +145,7 @@ public final class RedisChatMemoryConfig {
 	public static class Builder {
 
 		/** The Redis client */
-		private @Nullable RedisClient jedisClient;
+		private @Nullable UnifiedJedis jedisClient;
 
 		/** The index name */
 		private String indexName = DEFAULT_INDEX_NAME;
@@ -172,7 +173,7 @@ public final class RedisChatMemoryConfig {
 		 * @param jedisClient the Redis client to use
 		 * @return the builder instance
 		 */
-		public Builder jedisClient(final RedisClient jedisClient) {
+		public Builder jedisClient(final UnifiedJedis jedisClient) {
 			this.jedisClient = jedisClient;
 			return this;
 		}

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepository.java
@@ -35,8 +35,8 @@ import com.google.gson.JsonObject;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
-import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.AbstractPipeline;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.json.Path2;
 import redis.clients.jedis.search.Document;
 import redis.clients.jedis.search.FTCreateParams;
@@ -73,6 +73,7 @@ import org.springframework.util.MimeType;
  *
  * @author Brian Sam-Bodden
  * @author Yanming Zhou
+ * @author Jewoo Shin
  */
 public final class RedisChatMemoryRepository implements ChatMemoryRepository, AdvancedRedisChatMemoryRepository {
 
@@ -84,7 +85,7 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 
 	private final RedisChatMemoryConfig config;
 
-	private final RedisClient jedisClient;
+	private final UnifiedJedis jedisClient;
 
 	public RedisChatMemoryRepository(RedisChatMemoryConfig config) {
 		Assert.notNull(config, "Config must not be null");
@@ -118,7 +119,7 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 		long nextTimestamp = getNextTimestampForConversation(conversationId);
 		final AtomicLong timestampSequence = new AtomicLong(nextTimestamp);
 
-		try (Pipeline pipeline = this.jedisClient.pipelined()) {
+		try (AbstractPipeline pipeline = this.jedisClient.pipelined()) {
 			for (Message message : messages) {
 				long timestamp = timestampSequence.getAndIncrement();
 				String key = createKey(conversationId, timestamp);
@@ -366,7 +367,7 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 		Query query = new Query(queryNode.toString());
 		SearchResult result = this.jedisClient.ftSearch(this.config.getIndexName(), query);
 
-		try (Pipeline pipeline = this.jedisClient.pipelined()) {
+		try (AbstractPipeline pipeline = this.jedisClient.pipelined()) {
 			result.getDocuments().forEach(doc -> pipeline.del(doc.getId()));
 			pipeline.sync();
 		}
@@ -974,7 +975,7 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 	 */
 	public static class Builder {
 
-		private @Nullable RedisClient jedisClient;
+		private @Nullable UnifiedJedis jedisClient;
 
 		private String indexName = RedisChatMemoryConfig.DEFAULT_INDEX_NAME;
 
@@ -991,11 +992,11 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 		private List<Map<String, String>> metadataFields = Collections.emptyList();
 
 		/**
-		 * Sets the RedisClient client.
-		 * @param jedisClient the RedisClient client to use
+		 * Sets the Redis client.
+		 * @param jedisClient the Redis client to use
 		 * @return this builder
 		 */
-		public Builder jedisClient(final RedisClient jedisClient) {
+		public Builder jedisClient(final UnifiedJedis jedisClient) {
 			this.jedisClient = jedisClient;
 			return this;
 		}

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryAdvancedQueryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryAdvancedQueryIT.java
@@ -25,7 +25,7 @@ import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
@@ -535,7 +535,7 @@ class RedisChatMemoryAdvancedQueryIT {
 			String uniqueIndexName = "test-adv-app-" + System.currentTimeMillis();
 
 			return RedisChatMemoryRepository.builder()
-				.jedisClient(RedisClient.builder()
+				.jedisClient(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build())
 				.indexName(uniqueIndexName)

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryErrorHandlingIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryErrorHandlingIT.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 import org.springframework.ai.chat.messages.Message;
@@ -60,11 +60,11 @@ class RedisChatMemoryErrorHandlingIT {
 
 	private RedisChatMemoryRepository chatMemory;
 
-	private RedisClient jedisClient;
+	private JedisPooled jedisClient;
 
 	@BeforeEach
 	void setUp() {
-		this.jedisClient = RedisClient.builder()
+		this.jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 		this.chatMemory = RedisChatMemoryRepository.builder()
@@ -173,8 +173,8 @@ class RedisChatMemoryErrorHandlingIT {
 			// Using a connection to an invalid Redis server should throw a connection
 			// exception
 			assertThatExceptionOfType(JedisConnectionException.class).isThrownBy(() -> {
-				// Create a RedisClient with a connection timeout to make the test faster
-				RedisClient badConnection = RedisClient.builder().hostAndPort("localhost", 54321).build();
+				// Create a JedisPooled with a connection timeout to make the test faster
+				JedisPooled badConnection = JedisPooled.builder().hostAndPort("localhost", 54321).build();
 				// Attempt an operation that would require Redis connection
 				badConnection.ping();
 			});
@@ -320,7 +320,7 @@ class RedisChatMemoryErrorHandlingIT {
 		@Bean
 		RedisChatMemoryRepository chatMemory() {
 			return RedisChatMemoryRepository.builder()
-				.jedisClient(RedisClient.builder()
+				.jedisClient(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build())
 				.indexName("test-error-" + RedisChatMemoryConfig.DEFAULT_INDEX_NAME)

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryIT.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -53,13 +53,13 @@ class RedisChatMemoryIT {
 
 	private RedisChatMemoryRepository chatMemory;
 
-	private RedisClient jedisClient;
+	private JedisPooled jedisClient;
 
 	@BeforeEach
 	void setUp() {
-		// Create RedisClient directly with container properties for more reliable
+		// Create JedisPooled directly with container properties for more reliable
 		// connection
-		this.jedisClient = RedisClient.builder()
+		this.jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 		this.chatMemory = RedisChatMemoryRepository.builder()
@@ -219,7 +219,7 @@ class RedisChatMemoryIT {
 		@Bean
 		RedisChatMemoryRepository chatMemory() {
 			return RedisChatMemoryRepository.builder()
-				.jedisClient(RedisClient.builder()
+				.jedisClient(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build())
 				.indexName("test-" + RedisChatMemoryConfig.DEFAULT_INDEX_NAME)

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryMediaIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryMediaIT.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -61,12 +61,12 @@ class RedisChatMemoryMediaIT {
 
 	private RedisChatMemoryRepository chatMemory;
 
-	private RedisClient jedisClient;
+	private JedisPooled jedisClient;
 
 	@BeforeEach
 	void setUp() {
-		// Create RedisClient directly with container properties for reliable connection
-		this.jedisClient = RedisClient.builder()
+		// Create JedisPooled directly with container properties for reliable connection
+		this.jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 		this.chatMemory = RedisChatMemoryRepository.builder()
@@ -673,7 +673,7 @@ class RedisChatMemoryMediaIT {
 		@Bean
 		RedisChatMemoryRepository chatMemory() {
 			return RedisChatMemoryRepository.builder()
-				.jedisClient(RedisClient.builder()
+				.jedisClient(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build())
 				.indexName("test-media-" + RedisChatMemoryConfig.DEFAULT_INDEX_NAME)

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryMessageTypesIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryMessageTypesIT.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -61,11 +61,11 @@ class RedisChatMemoryMessageTypesIT {
 
 	private RedisChatMemoryRepository chatMemory;
 
-	private RedisClient jedisClient;
+	private JedisPooled jedisClient;
 
 	@BeforeEach
 	void setUp() {
-		this.jedisClient = RedisClient.builder()
+		this.jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 		this.chatMemory = RedisChatMemoryRepository.builder()
@@ -666,7 +666,7 @@ class RedisChatMemoryMessageTypesIT {
 		@Bean
 		RedisChatMemoryRepository chatMemory() {
 			return RedisChatMemoryRepository.builder()
-				.jedisClient(RedisClient.builder()
+				.jedisClient(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build())
 				.indexName("test-" + RedisChatMemoryConfig.DEFAULT_INDEX_NAME)

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepositoryIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -54,13 +54,13 @@ class RedisChatMemoryRepositoryIT {
 
 	private ChatMemoryRepository chatMemoryRepository;
 
-	private RedisClient jedisClient;
+	private JedisPooled jedisClient;
 
 	@BeforeEach
 	void setUp() {
-		// Create RedisClient directly with container properties for more reliable
+		// Create JedisPooled directly with container properties for more reliable
 		// connection
-		this.jedisClient = RedisClient.builder()
+		this.jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 
@@ -184,7 +184,7 @@ class RedisChatMemoryRepositoryIT {
 		@Bean
 		ChatMemoryRepository chatMemoryRepository() {
 			return RedisChatMemoryRepository.builder()
-				.jedisClient(RedisClient.builder()
+				.jedisClient(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build())
 				.indexName("test-" + RedisChatMemoryConfig.DEFAULT_INDEX_NAME)

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryWithSchemaIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryWithSchemaIT.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -53,11 +53,11 @@ class RedisChatMemoryWithSchemaIT {
 
 	private RedisChatMemoryRepository chatMemory;
 
-	private RedisClient jedisClient;
+	private JedisPooled jedisClient;
 
 	@BeforeEach
 	void setUp() {
-		this.jedisClient = RedisClient.builder()
+		this.jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 
@@ -197,7 +197,7 @@ class RedisChatMemoryWithSchemaIT {
 			String uniqueIndexName = "test-schema-app-" + System.currentTimeMillis();
 
 			return RedisChatMemoryRepository.builder()
-				.jedisClient(RedisClient.builder()
+				.jedisClient(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build())
 				.indexName(uniqueIndexName)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -496,11 +496,11 @@ ChatMemory chatMemory = MessageWindowChatMemory.builder()
     .build();
 ----
 
-If you'd rather create the `RedisChatMemoryRepository` manually, you can do so by providing a `RedisClient` client:
+If you'd rather create the `RedisChatMemoryRepository` manually, you can do so by providing a `UnifiedJedis` client:
 
 [source,java]
 ----
-RedisClient jedisClient = RedisClient.builder().hostAndPort("localhost", 6379).build();
+UnifiedJedis jedisClient = JedisPooled.builder().hostAndPort("localhost", 6379).build();
 
 ChatMemoryRepository chatMemoryRepository = RedisChatMemoryRepository.builder()
     .jedisClient(jedisClient)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
@@ -198,13 +198,13 @@ dependencies {
 }
 ----
 
-Create a `RedisClient` bean:
+Create a `UnifiedJedis` bean:
 
 [source,java]
 ----
 @Bean
-public RedisClient jedisClient() {
-    return RedisClient.builder().hostAndPort("<host>", 6379).build();
+public UnifiedJedis jedisClient() {
+    return JedisPooled.builder().hostAndPort("<host>", 6379).build();
 }
 ----
 
@@ -213,7 +213,7 @@ Then create the `RedisVectorStore` bean using the builder pattern:
 [source,java]
 ----
 @Bean
-public VectorStore vectorStore(RedisClient jedisClient, EmbeddingModel embeddingModel) {
+public VectorStore vectorStore(UnifiedJedis jedisClient, EmbeddingModel embeddingModel) {
     return RedisVectorStore.builder(jedisClient, embeddingModel)
         .indexName("custom-index")                // Optional: defaults to "spring-ai-index"
         .prefix("custom-prefix")                  // Optional: defaults to "embedding:"
@@ -250,15 +250,15 @@ The `metadataFields` above registers filterable metadata fields: `country` of ty
 
 == Accessing the Native Client
 
-The Redis Vector Store implementation provides access to the underlying native Redis client (`RedisClient`) through the `getNativeClient()` method:
+The Redis Vector Store implementation provides access to the underlying native Redis client (`UnifiedJedis`) through the `getNativeClient()` method:
 
 [source,java]
 ----
 RedisVectorStore vectorStore = context.getBean(RedisVectorStore.class);
-Optional<RedisClient> nativeClient = vectorStore.getNativeClient();
+Optional<UnifiedJedis> nativeClient = vectorStore.getNativeClient();
 
 if (nativeClient.isPresent()) {
-    RedisClient jedisClient = nativeClient.get();
+    UnifiedJedis jedisClient = nativeClient.get();
     // Use the native client for Redis-specific operations
 }
 ----
@@ -551,12 +551,12 @@ For more control, you can manually configure the semantic cache components:
 public class SemanticCacheConfig {
 
     @Bean
-    public RedisClient jedisClient() {
-        return RedisClient.builder().hostAndPort("localhost", 6379).build();
+    public UnifiedJedis jedisClient() {
+        return JedisPooled.builder().hostAndPort("localhost", 6379).build();
     }
 
     @Bean
-    public SemanticCache semanticCache(RedisClient jedisClient, EmbeddingModel embeddingModel) {
+    public SemanticCache semanticCache(UnifiedJedis jedisClient, EmbeddingModel embeddingModel) {
         return DefaultSemanticCache.builder()
             .jedisClient(jedisClient)
             .embeddingModel(embeddingModel)

--- a/vector-stores/spring-ai-redis-semantic-cache/README.md
+++ b/vector-stores/spring-ai-redis-semantic-cache/README.md
@@ -46,7 +46,7 @@ For Spring Boot applications, you can use the starter:
 
 ```java
 // Create Redis client
-RedisClient jedisClient = RedisClient.builder().hostAndPort("localhost", 6379).build();
+UnifiedJedis jedisClient = JedisPooled.builder().hostAndPort("localhost", 6379).build();
 
 // Create the embedding model
 EmbeddingModel embeddingModel = new OpenAiEmbeddingModel(apiKey);

--- a/vector-stores/spring-ai-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/DefaultSemanticCache.java
+++ b/vector-stores/spring-ai-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/DefaultSemanticCache.java
@@ -40,8 +40,8 @@ import com.google.gson.JsonSerializer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
-import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.AbstractPipeline;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.search.Query;
 import redis.clients.jedis.search.SearchResult;
 
@@ -68,6 +68,7 @@ import org.springframework.util.Assert;
  * @author Brian Sam-Bodden
  * @author Soby Chacko
  * @author Yanming Zhou
+ * @author Jewoo Shin
  */
 public final class DefaultSemanticCache implements SemanticCache {
 
@@ -439,9 +440,9 @@ public final class DefaultSemanticCache implements SemanticCache {
 
 	@Override
 	public void clear() {
-		Optional<RedisClient> nativeClient = this.vectorStore.getNativeClient();
+		Optional<UnifiedJedis> nativeClient = this.vectorStore.getNativeClient();
 		if (nativeClient.isPresent()) {
-			RedisClient redisClient = nativeClient.get();
+			UnifiedJedis redisClient = nativeClient.get();
 
 			// Delete documents in batches to avoid memory issues
 			boolean moreRecords = true;
@@ -453,11 +454,11 @@ public final class DefaultSemanticCache implements SemanticCache {
 				SearchResult searchResult = redisClient.ftSearch(this.indexName, query);
 
 				if (searchResult.getTotalResults() > 0) {
-					try (Pipeline pipeline = redisClient.pipelined()) {
+					try (AbstractPipeline pipeline = redisClient.pipelined()) {
 						for (redis.clients.jedis.search.Document doc : searchResult.getDocuments()) {
 							pipeline.jsonDel(doc.getId());
 						}
-						pipeline.syncAndReturnAll();
+						pipeline.sync();
 					}
 				}
 				else {
@@ -488,7 +489,7 @@ public final class DefaultSemanticCache implements SemanticCache {
 
 		private String prefix = DEFAULT_PREFIX;
 
-		private @Nullable RedisClient jedisClient;
+		private @Nullable UnifiedJedis jedisClient;
 
 		// Builder methods with validation
 		public Builder vectorStore(VectorStore vectorStore) {
@@ -522,7 +523,7 @@ public final class DefaultSemanticCache implements SemanticCache {
 			return this;
 		}
 
-		public Builder jedisClient(RedisClient jedisClient) {
+		public Builder jedisClient(UnifiedJedis jedisClient) {
 			this.jedisClient = jedisClient;
 			return this;
 		}

--- a/vector-stores/spring-ai-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/RedisVectorStoreHelper.java
+++ b/vector-stores/spring-ai-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/RedisVectorStoreHelper.java
@@ -16,7 +16,7 @@
 
 package org.springframework.ai.vectorstore.redis.cache.semantic;
 
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.UnifiedJedis;
 
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.redis.RedisVectorStore;
@@ -28,6 +28,7 @@ import org.springframework.ai.vectorstore.redis.RedisVectorStore.MetadataField;
  *
  * @author Brian Sam-Bodden
  * @author Yanming Zhou
+ * @author Jewoo Shin
  */
 public final class RedisVectorStoreHelper {
 
@@ -45,7 +46,7 @@ public final class RedisVectorStoreHelper {
 	 * @param embeddingModel The embedding model to use for vectorization
 	 * @return A configured RedisVectorStore instance
 	 */
-	public static RedisVectorStore createVectorStore(RedisClient jedisClient, EmbeddingModel embeddingModel) {
+	public static RedisVectorStore createVectorStore(UnifiedJedis jedisClient, EmbeddingModel embeddingModel) {
 		return createVectorStore(jedisClient, embeddingModel, DEFAULT_INDEX_NAME, DEFAULT_PREFIX);
 	}
 
@@ -57,7 +58,7 @@ public final class RedisVectorStoreHelper {
 	 * @param prefix The key prefix to use for Redis documents
 	 * @return A configured RedisVectorStore instance
 	 */
-	public static RedisVectorStore createVectorStore(RedisClient jedisClient, EmbeddingModel embeddingModel,
+	public static RedisVectorStore createVectorStore(UnifiedJedis jedisClient, EmbeddingModel embeddingModel,
 			String indexName, String prefix) {
 		RedisVectorStore vectorStore = RedisVectorStore.builder(jedisClient, embeddingModel)
 			.indexName(indexName)

--- a/vector-stores/spring-ai-redis-semantic-cache/src/test/java/org/springframework/ai/chat/cache/semantic/SemanticCacheAdvisorIT.java
+++ b/vector-stores/spring-ai-redis-semantic-cache/src/test/java/org/springframework/ai/chat/cache/semantic/SemanticCacheAdvisorIT.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -249,7 +249,7 @@ class SemanticCacheAdvisorIT {
 		assertThat(similarResponse.getResult().getOutput().getText()).containsIgnoringCase("Paris");
 
 		// Test with stricter threshold
-		RedisClient jedisClient = RedisClient.builder()
+		JedisPooled jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 		SemanticCache strictCache = DefaultSemanticCache.builder()
@@ -298,9 +298,9 @@ class SemanticCacheAdvisorIT {
 		assertThat(cached).isPresent();
 
 		// Verify TTL is set in Redis
-		Optional<RedisClient> nativeClient = this.semanticCache.getStore().getNativeClient();
+		Optional<JedisPooled> nativeClient = this.semanticCache.getStore().getNativeClient();
 		assertThat(nativeClient).isPresent();
-		RedisClient redisClient = nativeClient.get();
+		JedisPooled redisClient = nativeClient.get();
 
 		Set<String> keys = redisClient.keys("semantic-cache:*");
 		assertThat(keys).hasSize(1);
@@ -325,10 +325,10 @@ class SemanticCacheAdvisorIT {
 		String webQuestion = "What are the best programming languages for web development?";
 
 		// Create isolated caches for different users
-		RedisClient jedisClient1 = RedisClient.builder()
+		JedisPooled jedisClient1 = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
-		RedisClient jedisClient2 = RedisClient.builder()
+		JedisPooled jedisClient2 = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 
@@ -402,7 +402,7 @@ class SemanticCacheAdvisorIT {
 	@Test
 	void testMultipleSimilarQueries() {
 		// Test with a more lenient threshold for semantic similarity
-		RedisClient jedisClient = RedisClient.builder()
+		JedisPooled jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 
@@ -456,7 +456,7 @@ class SemanticCacheAdvisorIT {
 	void testRedisVectorSearchBehavior() {
 		// This test demonstrates the difference between KNN and VECTOR_RANGE search
 		String indexName = "test-vector-search-" + System.currentTimeMillis();
-		RedisClient jedisClient = RedisClient.builder()
+		JedisPooled jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 
@@ -581,7 +581,7 @@ class SemanticCacheAdvisorIT {
 	void testKnnSearchWithClientSideThreshold() {
 		// This test demonstrates client-side threshold filtering with KNN search
 		String indexName = "test-knn-threshold-" + System.currentTimeMillis();
-		RedisClient jedisClient = RedisClient.builder()
+		JedisPooled jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build();
 
@@ -914,7 +914,7 @@ class SemanticCacheAdvisorIT {
 
 		// Test with custom configuration (different similarity threshold)
 		this.contextRunner.run(context -> {
-			RedisClient jedisClient = RedisClient.builder()
+			JedisPooled jedisClient = JedisPooled.builder()
 				.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 				.build();
 			EmbeddingModel embModel = context.getBean(EmbeddingModel.class);
@@ -959,7 +959,7 @@ class SemanticCacheAdvisorIT {
 
 		@Bean
 		public SemanticCache semanticCache(EmbeddingModel embeddingModel) {
-			RedisClient jedisClient = RedisClient.builder()
+			JedisPooled jedisClient = JedisPooled.builder()
 				.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 				.build();
 

--- a/vector-stores/spring-ai-redis-store/README.md
+++ b/vector-stores/spring-ai-redis-store/README.md
@@ -27,7 +27,7 @@ The standard similarity search returns the k-nearest neighbors:
 
 ```java
 // Create Redis client
-RedisClient jedisClient = RedisClient.builder().hostAndPort("localhost", 6379).build();
+UnifiedJedis jedisClient = JedisPooled.builder().hostAndPort("localhost", 6379).build();
 
 // Create the vector store
 RedisVectorStore vectorStore = RedisVectorStore.builder(jedisClient, embeddingModel)
@@ -78,7 +78,7 @@ Text search supports:
 Configure text search behavior at construction time:
 
 ```java
-RedisClient jedisClient = RedisClient.builder().hostAndPort("localhost", 6379).build();
+UnifiedJedis jedisClient = JedisPooled.builder().hostAndPort("localhost", 6379).build();
 RedisVectorStore vectorStore = RedisVectorStore.builder(jedisClient, embeddingModel)
     .textScorer(TextScorer.TFIDF)                    // Text scoring algorithm
     .inOrder(true)                                   // Match terms in order
@@ -103,7 +103,7 @@ List<Document> rangeResults = vectorStore.searchByRange(
 You can also set a default range threshold at construction time:
 
 ```java
-RedisClient jedisClient = RedisClient.builder().hostAndPort("localhost", 6379).build();
+UnifiedJedis jedisClient = JedisPooled.builder().hostAndPort("localhost", 6379).build();
 RedisVectorStore vectorStore = RedisVectorStore.builder(jedisClient, embeddingModel)
     .defaultRangeThreshold(0.8)  // Set default threshold
     .build();
@@ -117,7 +117,7 @@ List<Document> results = vectorStore.searchByRange("query");
 The Redis Vector Store supports multiple configuration options:
 
 ```java
-RedisClient jedisClient = RedisClient.builder().hostAndPort("localhost", 6379).build();
+UnifiedJedis jedisClient = JedisPooled.builder().hostAndPort("localhost", 6379).build();
 RedisVectorStore vectorStore = RedisVectorStore.builder(jedisClient, embeddingModel)
     .indexName("custom-index")        // Redis index name
     .prefix("custom-prefix")          // Redis key prefix

--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
@@ -34,7 +34,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.json.Path2;
 import redis.clients.jedis.search.FTCreateParams;
 import redis.clients.jedis.search.IndexDataType;
@@ -239,6 +239,7 @@ import org.springframework.util.StringUtils;
  * @author Jihoon Kim
  * @author chabinhwang
  * @author Yanming Zhou
+ * @author Jewoo Shin
  * @see EmbeddingModel
  * @since 1.0.0
  */
@@ -278,7 +279,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 
 	private static final TextScorer DEFAULT_TEXT_SCORER = TextScorer.BM25;
 
-	private final RedisClient jedisClient;
+	private final UnifiedJedis jedisClient;
 
 	private final boolean initializeSchema;
 
@@ -318,7 +319,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 	protected RedisVectorStore(Builder builder) {
 		super(builder);
 
-		Assert.notNull(builder.jedisClient, "RedisClient must not be null");
+		Assert.notNull(builder.jedisClient, "Redis client must not be null");
 
 		this.jedisClient = builder.jedisClient;
 		this.indexName = builder.indexName;
@@ -344,7 +345,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		this.filterExpressionConverter = new RedisFilterExpressionConverter(this.metadataFields);
 	}
 
-	public RedisClient getJedisClient() {
+	public UnifiedJedis getJedisClient() {
 		return this.jedisClient;
 	}
 
@@ -354,7 +355,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 
 	@Override
 	public void doAdd(List<Document> documents) {
-		try (Pipeline pipeline = this.jedisClient.pipelined()) {
+		try (Pipeline pipeline = (Pipeline) this.jedisClient.pipelined()) {
 
 			List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 					this.batchingStrategy);
@@ -390,7 +391,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 
 	@Override
 	public void doDelete(List<String> idList) {
-		try (Pipeline pipeline = this.jedisClient.pipelined()) {
+		try (Pipeline pipeline = (Pipeline) this.jedisClient.pipelined()) {
 			for (String id : idList) {
 				pipeline.jsonDel(key(id));
 			}
@@ -422,7 +423,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 					break;
 				}
 
-				try (Pipeline pipeline = this.jedisClient.pipelined()) {
+				try (Pipeline pipeline = (Pipeline) this.jedisClient.pipelined()) {
 					for (redis.clients.jedis.search.Document doc : docs) {
 						String redisKey = doc.getId();
 						String id = redisKey.startsWith(this.prefix) ? redisKey.substring(this.prefix.length())
@@ -1246,7 +1247,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		return normalized;
 	}
 
-	public static Builder builder(RedisClient jedis, EmbeddingModel embeddingModel) {
+	public static Builder builder(UnifiedJedis jedis, EmbeddingModel embeddingModel) {
 		return new Builder(jedis, embeddingModel);
 	}
 
@@ -1312,7 +1313,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 
 	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
-		private final RedisClient jedisClient;
+		private final UnifiedJedis jedisClient;
 
 		private String indexName = DEFAULT_INDEX_NAME;
 
@@ -1346,9 +1347,9 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 
 		private Set<String> stopwords = new HashSet<>();
 
-		private Builder(RedisClient jedisClient, EmbeddingModel embeddingModel) {
+		private Builder(UnifiedJedis jedisClient, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
-			Assert.notNull(jedisClient, "RedisClient must not be null");
+			Assert.notNull(jedisClient, "Redis client must not be null");
 			this.jedisClient = jedisClient;
 		}
 

--- a/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreDistanceMetricIT.java
+++ b/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreDistanceMetricIT.java
@@ -26,7 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.UnifiedJedis;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingModel;
@@ -61,7 +62,7 @@ class RedisVectorStoreDistanceMetricIT {
 	@BeforeEach
 	void cleanDatabase() {
 		// Clean Redis completely before each test
-		try (RedisClient jedisClient = RedisClient.builder()
+		try (JedisPooled jedisClient = JedisPooled.builder()
 			.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 			.build()) {
 			jedisClient.flushAll();
@@ -73,7 +74,7 @@ class RedisVectorStoreDistanceMetricIT {
 		// Create a vector store with COSINE distance metric
 		this.contextRunner.run(context -> {
 			// Get the base Jedis client for creating a custom store
-			RedisClient jedisClient = RedisClient.builder()
+			JedisPooled jedisClient = JedisPooled.builder()
 				.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 				.build();
 			EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
@@ -96,7 +97,7 @@ class RedisVectorStoreDistanceMetricIT {
 		// Create a vector store with L2 distance metric
 		this.contextRunner.run(context -> {
 			// Get the base Jedis client for creating a custom store
-			RedisClient jedisClient = RedisClient.builder()
+			JedisPooled jedisClient = JedisPooled.builder()
 				.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 				.build();
 			EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
@@ -161,7 +162,7 @@ class RedisVectorStoreDistanceMetricIT {
 		// Create a vector store with IP distance metric
 		this.contextRunner.run(context -> {
 			// Get the base Jedis client for creating a custom store
-			RedisClient jedisClient = RedisClient.builder()
+			JedisPooled jedisClient = JedisPooled.builder()
 				.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 				.build();
 			EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
@@ -185,7 +186,7 @@ class RedisVectorStoreDistanceMetricIT {
 			redisVectorStore.afterPropertiesSet();
 
 			// Verify index exists
-			RedisClient jedisClient = redisVectorStore.getJedisClient();
+			UnifiedJedis jedisClient = redisVectorStore.getJedisClient();
 			Set<String> indexes = jedisClient.ftList();
 
 			// The index name is set in the builder, so we should verify it exists
@@ -249,7 +250,7 @@ class RedisVectorStoreDistanceMetricIT {
 		@Bean
 		public RedisVectorStore vectorStore(EmbeddingModel embeddingModel) {
 			return RedisVectorStore
-				.builder(RedisClient.builder()
+				.builder(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build(), embeddingModel)
 				.indexName("default-test-index")

--- a/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreIT.java
+++ b/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreIT.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentMetadata;
@@ -334,7 +334,7 @@ class RedisVectorStoreIT extends BaseVectorStoreTests {
 	void getNativeClientTest() {
 		this.contextRunner.run(context -> {
 			RedisVectorStore vectorStore = context.getBean(RedisVectorStore.class);
-			Optional<RedisClient> nativeClient = vectorStore.getNativeClient();
+			Optional<JedisPooled> nativeClient = vectorStore.getNativeClient();
 			assertThat(nativeClient).isPresent();
 		});
 	}
@@ -344,10 +344,10 @@ class RedisVectorStoreIT extends BaseVectorStoreTests {
 
 		@Bean
 		public RedisVectorStore vectorStore(EmbeddingModel embeddingModel) {
-			// Create RedisClient directly with container properties for more reliable
+			// Create JedisPooled directly with container properties for more reliable
 			// connection
 			return RedisVectorStore
-				.builder(RedisClient.builder()
+				.builder(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build(), embeddingModel)
 				.metadataFields(MetadataField.tag("meta1"), MetadataField.tag("meta2"), MetadataField.tag("country"),

--- a/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreObservationIT.java
+++ b/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreObservationIT.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingModel;
@@ -123,10 +123,10 @@ public class RedisVectorStoreObservationIT {
 
 		@Bean
 		public RedisVectorStore vectorStore(EmbeddingModel embeddingModel, ObservationRegistry observationRegistry) {
-			// Create RedisClient directly with container properties for more reliable
+			// Create JedisPooled directly with container properties for more reliable
 			// connection
 			return RedisVectorStore
-				.builder(RedisClient.builder()
+				.builder(JedisPooled.builder()
 					.hostAndPort(redisContainer.getHost(), redisContainer.getFirstMappedPort())
 					.build(), embeddingModel)
 				.observationRegistry(observationRegistry)


### PR DESCRIPTION
Redis chat memory currently references `RedisClient`, which is only available in newer Jedis versions. Spring Boot 4.0.x manages Jedis 7.0.0, so the Redis chat memory starter can fail during auto-configuration before `RedisChatMemoryRepository` is created.

This changes the Redis integrations to use `UnifiedJedis` as the client-facing type and creates default clients with `JedisPooled`, which is available in Jedis 7.0.0. Newer Jedis clients that extend `UnifiedJedis` can still be provided by users.

The same compatibility adjustment is applied across Redis chat memory, Redis vector store, Redis semantic cache, tests, and docs.

Validated with Jedis 7.0.0 by running dependency resolution and package verification for the affected Redis modules and auto-configurations.

Fixes #6584
