### PR TITLE
Fix `StructuredOutputValidationAdvisor` dropping tool call responses

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
@@ -172,6 +172,11 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 					processedChatClientRequest = chatClientRequest.mutate().prompt(augmentedPrompt).build();
 				}
 			}
+			else {
+				// Hand the tool call request back to the outer tool-calling advisor for
+				// execution; re-invoking the model instead would discard the request.
+				break;
+			}
 		}
 		while (!isValidationSuccess && repeatCounter <= this.maxRepeatAttempts);
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
@@ -256,6 +256,63 @@ public class StructuredOutputValidationAdvisorTests {
 	}
 
 	@Test
+	void whenToolCallResponseOnFirstAttemptThenReturnedWithoutValidation() {
+		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
+			.outputType(new TypeReference<Person>() {
+			})
+			.maxRepeatAttempts(2)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse toolCallResponse = createToolCallResponse();
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return toolCallResponse;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		ChatClientResponse result = realChain.nextCall(request);
+
+		assertThat(result).isEqualTo(toolCallResponse);
+		assertThat(callCount[0]).isEqualTo(1);
+	}
+
+	@Test
+	void whenToolCallResponseFollowsValidationFailureThenReturnedForToolExecution() {
+		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
+			.outputType(new TypeReference<Person>() {
+			})
+			.maxRepeatAttempts(2)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		String invalidJson = "{\"name\":\"John Doe\"}"; // Missing required 'age' field
+		ChatClientResponse invalidResponse = createMockResponse(invalidJson);
+		ChatClientResponse toolCallResponse = createToolCallResponse();
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = terminalAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? invalidResponse : toolCallResponse;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		ChatClientResponse result = realChain.nextCall(request);
+
+		assertThat(callCount[0]).isEqualTo(2);
+		assertThat(result.chatResponse()).isNotNull();
+		assertThat(result.chatResponse().hasToolCalls()).isTrue();
+	}
+
+	@Test
 	void adviseCallAccumulatesUsageAcrossValidationRetries() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
 			.outputType(new TypeReference<Person>() {
@@ -897,6 +954,16 @@ public class StructuredOutputValidationAdvisorTests {
 		Generation generation = new Generation(assistantMessage);
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().usage(usage).build();
 		ChatResponse chatResponse = ChatResponse.builder().generations(List.of(generation)).metadata(metadata).build();
+		return ChatClientResponse.builder().chatResponse(chatResponse).build();
+	}
+
+	private ChatClientResponse createToolCallResponse() {
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("id1", "function", "getCurrentAge", "{}")))
+			.build();
+		Generation generation = new Generation(assistantMessage);
+		ChatResponse chatResponse = new ChatResponse(List.of(generation));
 		return ChatClientResponse.builder().chatResponse(chatResponse).build();
 	}
 


### PR DESCRIPTION
By default `StructuredOutputValidationAdvisor` runs at `LOWEST_PRECEDENCE - 2000`,
inside the `ToolCallingAdvisor` loop (`HIGHEST_PRECEDENCE + 300`). When structured
output validation is combined with tool calling and the model answers a validation
retry with a tool call, that response is silently discarded. The advisor re-invokes
the model with the same augmented prompt until `maxRepeatAttempts` is exhausted,
wasting the remaining retry budget on calls whose tool-call responses are thrown
away, and delaying the tool execution the model asked for.

## Root cause

The retry loop exits only when validation succeeds or the attempt budget runs out.
Tool-call responses correctly skip the validation block (per the existing "We should
not validate tool call requests" comment), but nothing ended the loop on that branch,
so the failure flag stayed set and every tool-call round was treated as another
failed attempt. On the first attempt it worked only by accident, because
`isValidationSuccess` still held its initial `true`.

## Fix

Break out of the retry loop when the model responds with a tool call, so the response
is handed back to the outer `ToolCallingAdvisor` for execution, consistent with the
first-attempt behavior. Validation still runs on every content response, and the
retry and augmentation logic is unchanged.

## Testing

`whenToolCallResponseFollowsValidationFailureThenReturnedForToolExecution` fails on
the current implementation, where the chain is invoked a third time after the tool
call (`expected: 2 but was: 3`), and passes with the fix.
`whenToolCallResponseOnFirstAttemptThenReturnedWithoutValidation` pins the
already-correct first-attempt behavior.

Both tests are deterministic and provider-free, using `DefaultAroundAdvisorChain` with
a terminal advisor (the same harness as the existing tests). Existing tests are
unaffected, and `./mvnw -pl spring-ai-client-chat clean test` passes (571 tests).
