### PR TITLE
Cache Pinecone `Index` connection in `PineconeVectorStore`

### DIFF
--- a/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
@@ -25,8 +25,8 @@ import java.util.Optional;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
+import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
-import io.pinecone.proto.QueryRequest;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 import org.apache.commons.logging.Log;
@@ -79,6 +79,8 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 
 	private final Pinecone pinecone;
 
+	private volatile @Nullable Index index;
+
 	private static final Log logger = LogFactory.getLog(PineconeVectorStore.class);
 
 	/**
@@ -97,6 +99,28 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 		this.pineconeDistanceMetadataFieldName = builder.distanceMetadataFieldName;
 
 		this.pinecone = new Pinecone.Builder(builder.apiKey).build();
+	}
+
+	/**
+	 * Returns a cached index connection, resolved lazily on first use. The Pinecone
+	 * client's {@code getIndexConnection} performs a blocking control-plane call
+	 * ({@code describeIndex}) on every invocation, so the connection is created once and
+	 * reused across operations. It is intentionally not closed on shutdown, as the
+	 * connection is held in the client's shared, static connection map and closing it
+	 * would affect other stores using the same index.
+	 */
+	private Index getIndex() {
+		Index localIndex = this.index;
+		if (localIndex == null) {
+			synchronized (this) {
+				localIndex = this.index;
+				if (localIndex == null) {
+					localIndex = this.pinecone.getIndexConnection(this.pineconeIndexName);
+					this.index = localIndex;
+				}
+			}
+		}
+		return localIndex;
 	}
 
 	/**
@@ -143,7 +167,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 			upsertVectors.add(io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices(document.getId(),
 					EmbeddingUtils.toList(embeddings.get(i)), null, null, metadataToStruct(document)));
 		}
-		this.pinecone.getIndexConnection(this.pineconeIndexName).upsert(upsertVectors, namespace);
+		getIndex().upsert(upsertVectors, namespace);
 	}
 
 	/**
@@ -189,7 +213,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 	 * @param namespace The namespace of the document IDs.
 	 */
 	public void delete(List<String> documentIds, String namespace) {
-		this.pinecone.getIndexConnection(this.pineconeIndexName).delete(documentIds, false, namespace, null);
+		getIndex().delete(documentIds, false, namespace, null);
 	}
 
 	/**
@@ -208,22 +232,11 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 
 		float[] queryEmbedding = this.embeddingModel.embed(request.getQuery());
 
-		var queryRequestBuilder = QueryRequest.newBuilder()
-			.addAllVector(EmbeddingUtils.toList(queryEmbedding))
-			.setTopK(request.getTopK())
-			.setIncludeMetadata(true)
-			.setNamespace(namespace);
-
-		if (StringUtils.hasText(nativeExpressionFilters)) {
-			queryRequestBuilder.setFilter(metadataFiltersToStruct(nativeExpressionFilters));
-		}
-
 		Struct filterStruct = StringUtils.hasText(nativeExpressionFilters)
 				? metadataFiltersToStruct(nativeExpressionFilters) : null;
 
-		QueryResponseWithUnsignedIndices queryResponse = this.pinecone.getIndexConnection(this.pineconeIndexName)
-			.queryByVector(request.getTopK(), EmbeddingUtils.toList(queryEmbedding), namespace, filterStruct, false,
-					true);
+		QueryResponseWithUnsignedIndices queryResponse = getIndex().queryByVector(request.getTopK(),
+				EmbeddingUtils.toList(queryEmbedding), namespace, filterStruct, false, true);
 
 		return queryResponse.getMatchesList()
 			.stream()

--- a/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStoreTests.java
+++ b/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStoreTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.pinecone;
+
+import java.util.List;
+
+import io.pinecone.clients.Index;
+import io.pinecone.clients.Pinecone;
+import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+/**
+ * Unit tests for {@link PineconeVectorStore}.
+ *
+ * @author Timur Rakhmatullin
+ */
+class PineconeVectorStoreTests {
+
+	private static final String INDEX_NAME = "test-index";
+
+	private EmbeddingModel embeddingModel;
+
+	private Pinecone pinecone;
+
+	private Index index;
+
+	private PineconeVectorStore vectorStore;
+
+	@BeforeEach
+	void setUp() {
+		this.embeddingModel = mock(EmbeddingModel.class);
+		this.pinecone = mock(Pinecone.class);
+		this.index = mock(Index.class);
+
+		this.vectorStore = PineconeVectorStore.builder(this.embeddingModel)
+			.apiKey("test-api-key")
+			.indexName(INDEX_NAME)
+			.build();
+
+		ReflectionTestUtils.setField(this.vectorStore, "pinecone", this.pinecone);
+		given(this.pinecone.getIndexConnection(INDEX_NAME)).willReturn(this.index);
+	}
+
+	@Test
+	void reusesIndexConnectionAcrossOperations() {
+		given(this.embeddingModel.embed(anyList(), any(), any())).willReturn(List.of(new float[] { 0.1f, 0.2f }));
+		given(this.embeddingModel.embed(anyString())).willReturn(new float[] { 0.1f, 0.2f });
+
+		QueryResponseWithUnsignedIndices queryResponse = mock(QueryResponseWithUnsignedIndices.class);
+		given(this.index.queryByVector(anyInt(), anyList(), anyString(), isNull(), anyBoolean(), anyBoolean()))
+			.willReturn(queryResponse);
+		given(queryResponse.getMatchesList()).willReturn(List.of());
+
+		this.vectorStore.doAdd(List.of(new Document("content")));
+		this.vectorStore.doDelete(List.of("id-1"));
+		this.vectorStore.doDelete(List.of("id-2"));
+		this.vectorStore.doSimilaritySearch(SearchRequest.builder().query("query").build());
+
+		then(this.pinecone).should(times(1)).getIndexConnection(INDEX_NAME);
+		then(this.index).should(times(1)).upsert(anyList(), eq(""));
+		then(this.index).should(times(2)).delete(anyList(), eq(false), eq(""), isNull());
+		then(this.index).should(times(1)).queryByVector(anyInt(), anyList(), eq(""), isNull(), eq(false), eq(true));
+	}
+
+	@Test
+	void resolvesIndexConnectionLazily() {
+		then(this.pinecone).shouldHaveNoInteractions();
+
+		this.vectorStore.doDelete(List.of("id-1"));
+
+		then(this.pinecone).should(times(1)).getIndexConnection(INDEX_NAME);
+	}
+
+}


### PR DESCRIPTION
`PineconeVectorStore` called `Pinecone.getIndexConnection(indexName)` on every `add`, `delete`, and `similaritySearch` operation. In the Pinecone Java client, `getIndexConnection` performs a blocking control-plane REST call (`describeIndex`) to resolve the index host on every invocation. Under bulk ingestion or query load this adds an extra HTTP round-trip of latency to each data-plane operation and runs into control-plane rate limits (HTTP 429).

The repeated call is pure overhead: the underlying gRPC connection is already cached in the client's static `connectionsMap` (`computeIfAbsent`), so the host resolved by every `describeIndex` call after the first one is discarded.

Changes:

- Resolve the `Index` connection lazily once and reuse it across operations (`volatile` field with double-checked locking). If resolution fails, the field stays unset and the next operation retries.
- The cached connection is intentionally never closed by the store: `Index.close()` closes the shared connection and removes it from the client's static `connectionsMap`, which would affect other consumers of the same index. The store did not close per-operation connections before this change either, so lifecycle behavior is unchanged.
- Remove dead code in `similaritySearch`: a `QueryRequest` builder was constructed but never used (the query is issued via `queryByVector`), along with the now-unused `io.pinecone.proto.QueryRequest` import.
- Add `PineconeVectorStoreTests` (no network) verifying the connection is resolved exactly once across add/delete/search and lazily on first use.
