### PR TITLE
Add scalar metadata fields to Milvus

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
@@ -173,6 +173,27 @@ Integer values are returned as `Long` and decimal values as `Double`.
 Code that casts integer metadata fields directly to `Double` should be
 updated to use `Long` or the `Number` supertype instead.
 
+=== Scalar metadata fields
+
+By default, Milvus stores document metadata in a JSON field and filter expressions reference that JSON field.
+You can opt in to storing selected metadata keys as Milvus scalar fields when you want those keys to be filtered as top-level Milvus fields.
+The original JSON metadata field is still stored and used to reconstruct returned `Document` metadata.
+When Spring AI creates a collection, configured metadata keys are added as scalar fields.
+Generated filters reference configured keys as scalar fields, while unconfigured keys continue to use the JSON metadata field.
+Scalar fields created by Spring AI are nullable, so documents may omit a configured metadata key.
+
+NOTE: Existing collections must already contain matching scalar fields, and existing documents must have values in those fields to match scalar filters.
+
+[source,java]
+----
+MilvusVectorStore vectorStore = MilvusVectorStore.builder(milvusClient, embeddingModel)
+    .metadataFields(
+        MilvusVectorStore.MetadataField.int64("year"),
+        MilvusVectorStore.MetadataField.text("category"))
+    .initializeSchema(true)
+    .build();
+----
+
 == Using MilvusSearchRequest
 
 MilvusSearchRequest extends SearchRequest, allowing you to use Milvus-specific search parameters such as native expressions and search parameter JSON.

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverter.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.vectorstore.milvus;
 
+import java.util.Collection;
+import java.util.Set;
+
 import org.springframework.ai.vectorstore.filter.Filter.Expression;
 import org.springframework.ai.vectorstore.filter.Filter.Group;
 import org.springframework.ai.vectorstore.filter.Filter.Key;
@@ -35,13 +38,21 @@ public class MilvusFilterExpressionConverter extends AbstractFilterExpressionCon
 
 	private final String metadataFieldName;
 
+	private final Set<String> scalarMetadataFieldNames;
+
 	public MilvusFilterExpressionConverter() {
 		this(MilvusVectorStore.METADATA_FIELD_NAME);
 	}
 
 	public MilvusFilterExpressionConverter(String metadataFieldName) {
+		this(metadataFieldName, Set.of());
+	}
+
+	MilvusFilterExpressionConverter(String metadataFieldName, Collection<String> scalarMetadataFieldNames) {
 		Assert.hasText(metadataFieldName, "Metadata field name must not be empty");
+		Assert.notNull(scalarMetadataFieldNames, "Scalar metadata field names must not be null");
 		this.metadataFieldName = metadataFieldName;
+		this.scalarMetadataFieldNames = Set.copyOf(scalarMetadataFieldNames);
 	}
 
 	@Override
@@ -81,6 +92,10 @@ public class MilvusFilterExpressionConverter extends AbstractFilterExpressionCon
 	@Override
 	protected void doKey(Key key, StringBuilder context) {
 		var identifier = key.key();
+		if (this.scalarMetadataFieldNames.contains(identifier)) {
+			context.append(identifier);
+			return;
+		}
 		context.append(this.metadataFieldName).append("[");
 		emitJsonValue(identifier, context);
 		context.append("]");

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
@@ -18,6 +18,7 @@ package org.springframework.ai.vectorstore.milvus;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -58,6 +59,7 @@ import io.milvus.response.QueryResultsWrapper.RowRecord;
 import io.milvus.response.SearchResultsWrapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentMetadata;
@@ -68,7 +70,6 @@ import org.springframework.ai.observation.conventions.VectorStoreProvider;
 import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetric;
 import org.springframework.ai.vectorstore.AbstractVectorStoreBuilder;
 import org.springframework.ai.vectorstore.SearchRequest;
-import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionConverter;
 import org.springframework.ai.vectorstore.observation.AbstractObservationVectorStore;
@@ -207,8 +208,10 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 
 	private final String embeddingFieldName;
 
+	private final List<MetadataField> metadataFields;
+
 	/**
-	 * @param builder {@link VectorStore.Builder} for chroma vector store
+	 * @param builder the builder for the Milvus vector store
 	 */
 	protected MilvusVectorStore(Builder builder) {
 		super(builder);
@@ -228,7 +231,10 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		this.contentFieldName = builder.contentFieldName;
 		this.metadataFieldName = builder.metadataFieldName;
 		this.embeddingFieldName = builder.embeddingFieldName;
-		this.filterExpressionConverter = new MilvusFilterExpressionConverter(this.metadataFieldName);
+		this.metadataFields = List.copyOf(builder.metadataFields);
+		validateMetadataFields();
+		this.filterExpressionConverter = new MilvusFilterExpressionConverter(this.metadataFieldName,
+				this.metadataFields.stream().map(MetadataField::name).toList());
 	}
 
 	/**
@@ -248,6 +254,9 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		List<String> docIdArray = new ArrayList<>();
 		List<String> contentArray = new ArrayList<>();
 		List<JsonObject> metadataArray = new ArrayList<>();
+		List<List<@Nullable Object>> metadataFieldArrays = this.metadataFields.stream()
+			.map(field -> new ArrayList<@Nullable Object>())
+			.collect(Collectors.toList());
 		List<List<Float>> embeddingArray = new ArrayList<>();
 
 		// TODO: Need to customize how we pass the embedding options
@@ -263,6 +272,11 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 			Gson gson = new Gson();
 			String jsonString = gson.toJson(document.getMetadata());
 			metadataArray.add(gson.fromJson(jsonString, JsonObject.class));
+			for (int j = 0; j < this.metadataFields.size(); j++) {
+				MetadataField metadataField = this.metadataFields.get(j);
+				metadataFieldArrays.get(j)
+					.add(toScalarMetadataFieldValue(metadataField, document.getMetadata().get(metadataField.name())));
+			}
 			embeddingArray.add(EmbeddingUtils.toList(embeddings.get(i)));
 		}
 
@@ -273,6 +287,9 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		}
 		fields.add(new InsertParam.Field(this.contentFieldName, contentArray));
 		fields.add(new InsertParam.Field(this.metadataFieldName, metadataArray));
+		for (int i = 0; i < this.metadataFields.size(); i++) {
+			fields.add(new InsertParam.Field(this.metadataFields.get(i).name(), metadataFieldArrays.get(i)));
+		}
 		fields.add(new InsertParam.Field(this.embeddingFieldName, embeddingArray));
 
 		InsertParam insertParam = InsertParam.newBuilder()
@@ -464,7 +481,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 
 		if (!isDatabaseCollectionExists()) {
 			createCollection(this.databaseName, this.collectionName, this.idFieldName, this.isAutoId,
-					this.contentFieldName, this.metadataFieldName, this.embeddingFieldName);
+					this.contentFieldName, this.metadataFieldName, this.embeddingFieldName, this.metadataFields);
 			createIndex(this.databaseName, this.collectionName, this.embeddingFieldName, this.indexType,
 					this.metricType, this.indexParameters);
 		}
@@ -491,7 +508,8 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 	}
 
 	void createCollection(String databaseName, String collectionName, String idFieldName, boolean isAutoId,
-			String contentFieldName, String metadataFieldName, String embeddingFieldName) {
+			String contentFieldName, String metadataFieldName, String embeddingFieldName,
+			List<MetadataField> metadataFields) {
 		FieldType docIdFieldType = FieldType.newBuilder()
 			.withName(idFieldName)
 			.withDataType(DataType.VarChar)
@@ -514,18 +532,22 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 			.withDimension(this.embeddingDimensions())
 			.build();
 
+		CollectionSchemaParam.Builder schemaBuilder = CollectionSchemaParam.newBuilder()
+			.addFieldType(docIdFieldType)
+			.addFieldType(contentFieldType)
+			.addFieldType(metadataFieldType);
+
+		for (MetadataField metadataField : metadataFields) {
+			schemaBuilder.addFieldType(toMilvusFieldType(metadataField));
+		}
+
 		CreateCollectionParam createCollectionReq = CreateCollectionParam.newBuilder()
 			.withDatabaseName(databaseName)
 			.withCollectionName(collectionName)
 			.withDescription("Spring AI Vector Store")
 			.withConsistencyLevel(ConsistencyLevelEnum.STRONG)
 			.withShardsNum(2)
-			.withSchema(CollectionSchemaParam.newBuilder()
-				.addFieldType(docIdFieldType)
-				.addFieldType(contentFieldType)
-				.addFieldType(metadataFieldType)
-				.addFieldType(embeddingFieldType)
-				.build())
+			.withSchema(schemaBuilder.addFieldType(embeddingFieldType).build())
 			.build();
 
 		R<RpcStatus> collectionStatus = this.milvusClient.createCollection(createCollectionReq);
@@ -533,6 +555,102 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 			throw new RuntimeException("Failed to create collection", collectionStatus.getException());
 		}
 
+	}
+
+	private void validateMetadataFields() {
+		long uniqueFieldNames = this.metadataFields.stream().map(MetadataField::name).distinct().count();
+		Assert.isTrue(uniqueFieldNames == this.metadataFields.size(),
+				"Metadata fields must not contain duplicate names");
+		for (MetadataField metadataField : this.metadataFields) {
+			String name = metadataField.name();
+			Assert.isTrue(!name.equals(this.idFieldName), "Metadata field name must not match the ID field name");
+			Assert.isTrue(!name.equals(this.contentFieldName),
+					"Metadata field name must not match the content field name");
+			Assert.isTrue(!name.equals(this.metadataFieldName),
+					"Metadata field name must not match the metadata field name");
+			Assert.isTrue(!name.equals(this.embeddingFieldName),
+					"Metadata field name must not match the embedding field name");
+		}
+	}
+
+	private static FieldType toMilvusFieldType(MetadataField metadataField) {
+		FieldType.Builder fieldTypeBuilder = FieldType.newBuilder()
+			.withName(metadataField.name())
+			.withDataType(metadataField.fieldType())
+			.withNullable(true);
+
+		if (metadataField.fieldType() == DataType.VarChar) {
+			fieldTypeBuilder.withMaxLength(65535);
+		}
+
+		return fieldTypeBuilder.build();
+	}
+
+	private static @Nullable Object toScalarMetadataFieldValue(MetadataField metadataField, @Nullable Object value) {
+		if (value == null) {
+			return null;
+		}
+
+		return switch (metadataField.fieldType()) {
+			case Bool -> {
+				Assert.isInstanceOf(Boolean.class, value,
+						"Metadata field '%s' must be a Boolean".formatted(metadataField.name()));
+				yield value;
+			}
+			case Int8 -> toIntegerMetadataFieldValue(metadataField, value, Byte.MIN_VALUE, Byte.MAX_VALUE);
+			case Int16 -> toIntegerMetadataFieldValue(metadataField, value, Short.MIN_VALUE, Short.MAX_VALUE);
+			case Int32 -> toIntegerMetadataFieldValue(metadataField, value, Integer.MIN_VALUE, Integer.MAX_VALUE);
+			case Int64 -> toLongMetadataFieldValue(metadataField, value);
+			case Float -> {
+				Assert.isInstanceOf(Number.class, value,
+						"Metadata field '%s' must be a Number".formatted(metadataField.name()));
+				yield ((Number) value).floatValue();
+			}
+			case Double -> {
+				Assert.isInstanceOf(Number.class, value,
+						"Metadata field '%s' must be a Number".formatted(metadataField.name()));
+				yield ((Number) value).doubleValue();
+			}
+			case VarChar -> {
+				Assert.isInstanceOf(String.class, value,
+						"Metadata field '%s' must be a String".formatted(metadataField.name()));
+				yield value;
+			}
+			default ->
+				throw new IllegalArgumentException("Unsupported metadata field type: " + metadataField.fieldType());
+		};
+	}
+
+	private static Integer toIntegerMetadataFieldValue(MetadataField metadataField, Object value, int min, int max) {
+		Assert.isInstanceOf(Number.class, value,
+				"Metadata field '%s' must be a Number".formatted(metadataField.name()));
+		Number number = (Number) value;
+		Assert.isTrue(isIntegralNumber(number),
+				"Metadata field '%s' must be an integer value".formatted(metadataField.name()));
+		long longValue = number.longValue();
+		Assert.isTrue(longValue >= min && longValue <= max, "Metadata field '%s' value is out of range for %s"
+			.formatted(metadataField.name(), metadataField.fieldType()));
+		return (int) longValue;
+	}
+
+	private static Long toLongMetadataFieldValue(MetadataField metadataField, Object value) {
+		Assert.isInstanceOf(Number.class, value,
+				"Metadata field '%s' must be a Number".formatted(metadataField.name()));
+		Number number = (Number) value;
+		Assert.isTrue(isIntegralNumber(number),
+				"Metadata field '%s' must be an integer value".formatted(metadataField.name()));
+		return number.longValue();
+	}
+
+	private static boolean isIntegralNumber(Number number) {
+		return number instanceof Byte || number instanceof Short || number instanceof Integer || number instanceof Long;
+	}
+
+	private static boolean isSupportedScalarMetadataFieldType(DataType fieldType) {
+		return switch (fieldType) {
+			case Bool, Int8, Int16, Int32, Int64, Float, Double, VarChar -> true;
+			default -> false;
+		};
 	}
 
 	void createIndex(String databaseName, String collectionName, String embeddingFieldName, IndexType indexType,
@@ -625,6 +743,84 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		return Optional.of(client);
 	}
 
+	/**
+	 * Defines a document metadata key that is also stored as a Milvus scalar field. The
+	 * full metadata map is still stored in the JSON metadata field. Supported field types
+	 * are {@link DataType#Bool}, {@link DataType#Int8}, {@link DataType#Int16},
+	 * {@link DataType#Int32}, {@link DataType#Int64}, {@link DataType#Float},
+	 * {@link DataType#Double}, and {@link DataType#VarChar}. Fields created by Spring AI
+	 * are nullable, so documents may omit the configured metadata key.
+	 *
+	 * @param name the document metadata key and Milvus field name
+	 * @param fieldType the Milvus scalar field type
+	 * @since 2.0.1
+	 */
+	public record MetadataField(String name, DataType fieldType) {
+
+		public MetadataField {
+			Assert.hasText(name, "Metadata field name must not be empty");
+			Assert.notNull(fieldType, "Metadata field type must not be null");
+			Assert.isTrue(isSupportedScalarMetadataFieldType(fieldType),
+					"Metadata field type '%s' is not supported".formatted(fieldType));
+		}
+
+		/**
+		 * Creates a VarChar metadata field.
+		 * @param name the metadata field name
+		 * @return a VarChar metadata field
+		 * @throws IllegalArgumentException if name is null or empty
+		 * @since 2.0.1
+		 */
+		public static MetadataField text(String name) {
+			return new MetadataField(name, DataType.VarChar);
+		}
+
+		/**
+		 * Creates a Boolean metadata field.
+		 * @param name the metadata field name
+		 * @return a Boolean metadata field
+		 * @throws IllegalArgumentException if name is null or empty
+		 * @since 2.0.1
+		 */
+		public static MetadataField bool(String name) {
+			return new MetadataField(name, DataType.Bool);
+		}
+
+		/**
+		 * Creates an Int32 metadata field.
+		 * @param name the metadata field name
+		 * @return an Int32 metadata field
+		 * @throws IllegalArgumentException if name is null or empty
+		 * @since 2.0.1
+		 */
+		public static MetadataField int32(String name) {
+			return new MetadataField(name, DataType.Int32);
+		}
+
+		/**
+		 * Creates an Int64 metadata field.
+		 * @param name the metadata field name
+		 * @return an Int64 metadata field
+		 * @throws IllegalArgumentException if name is null or empty
+		 * @since 2.0.1
+		 */
+		public static MetadataField int64(String name) {
+			return new MetadataField(name, DataType.Int64);
+		}
+
+		/**
+		 * Creates a Double metadata field.
+		 * @param name the metadata field name
+		 * @return a Double metadata field
+		 * @throws IllegalArgumentException if name is null or empty
+		 * @since 2.0.1
+		 */
+		public static MetadataField decimal(String name) {
+			return new MetadataField(name, DataType.Double);
+		}
+
+	}
+
 	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final MilvusServiceClient milvusClient;
@@ -650,6 +846,8 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		private String metadataFieldName = METADATA_FIELD_NAME;
 
 		private String embeddingFieldName = EMBEDDING_FIELD_NAME;
+
+		private List<MetadataField> metadataFields = List.of();
 
 		private boolean initializeSchema = false;
 
@@ -775,6 +973,34 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 */
 		public Builder metadataFieldName(String metadataFieldName) {
 			this.metadataFieldName = metadataFieldName;
+			return this;
+		}
+
+		/**
+		 * Configures metadata keys to also be stored as Milvus scalar fields.
+		 * @param metadataFields metadata fields to store as Milvus scalar fields
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if metadataFields is null or contains null
+		 * values
+		 * @since 2.0.1
+		 */
+		public Builder metadataFields(MetadataField... metadataFields) {
+			Assert.notNull(metadataFields, "Metadata fields must not be null");
+			return metadataFields(Arrays.asList(metadataFields));
+		}
+
+		/**
+		 * Configures metadata keys to also be stored as Milvus scalar fields.
+		 * @param metadataFields metadata fields to store as Milvus scalar fields
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if metadataFields is null or contains null
+		 * values
+		 * @since 2.0.1
+		 */
+		public Builder metadataFields(List<MetadataField> metadataFields) {
+			Assert.notNull(metadataFields, "Metadata fields must not be null");
+			Assert.noNullElements(metadataFields, "Metadata fields must not contain null values");
+			this.metadataFields = List.copyOf(metadataFields);
 			return this;
 		}
 

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.vectorstore.milvus;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +61,26 @@ public class MilvusFilterExpressionConverterTests {
 		String vectorExpr = customConverter.convertExpression(new Expression(EQ, new Key("country"), new Value("BG")));
 
 		assertThat(vectorExpr).isEqualTo("meta[\"country\"] == \"BG\"");
+	}
+
+	@Test
+	public void testEQWithScalarMetadataField() {
+		FilterExpressionConverter scalarConverter = new MilvusFilterExpressionConverter("metadata", Set.of("country"));
+
+		String vectorExpr = scalarConverter.convertExpression(new Expression(EQ, new Key("country"), new Value("BG")));
+
+		assertThat(vectorExpr).isEqualTo("country == \"BG\"");
+	}
+
+	@Test
+	public void testMixedJsonAndScalarMetadataFields() {
+		FilterExpressionConverter scalarConverter = new MilvusFilterExpressionConverter("metadata", Set.of("year"));
+
+		String vectorExpr = scalarConverter
+			.convertExpression(new Expression(AND, new Expression(EQ, new Key("genre"), new Value("drama")),
+					new Expression(GTE, new Key("year"), new Value(2020))));
+
+		assertThat(vectorExpr).isEqualTo("metadata[\"genre\"] == \"drama\" && year >= 2020");
 	}
 
 	@Test

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreCustomMetadataFieldFilterIT.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreCustomMetadataFieldFilterIT.java
@@ -19,11 +19,19 @@ package org.springframework.ai.vectorstore.milvus;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import io.milvus.client.MilvusServiceClient;
+import io.milvus.grpc.DataType;
+import io.milvus.grpc.DescribeCollectionResponse;
 import io.milvus.param.ConnectParam;
 import io.milvus.param.IndexType;
 import io.milvus.param.MetricType;
+import io.milvus.param.R;
+import io.milvus.param.collection.DescribeCollectionParam;
+import io.milvus.param.collection.FieldType;
+import io.milvus.response.DescCollResponseWrapper;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -36,6 +44,7 @@ import org.springframework.ai.embedding.EmbeddingRequest;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -43,7 +52,8 @@ import org.springframework.context.annotation.Bean;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration tests for filtered similarity search using a custom metadata field name.
+ * Integration tests for filtered similarity search using custom and scalar metadata
+ * fields.
  *
  * @author Taewoong Kim
  * @author Soby Chacko
@@ -82,6 +92,143 @@ class MilvusVectorStoreCustomMetadataFieldFilterIT {
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(matchingDocument.getId());
 		});
+	}
+
+	@Test
+	void shouldFilterWithScalarMetadataField() {
+		this.contextRunner.run(context -> {
+			MilvusServiceClient milvusClient = context.getBean(MilvusServiceClient.class);
+			EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+			String collectionName = "test_scalar_metadata_filter_" + UUID.randomUUID().toString().replace("-", "_");
+			MilvusVectorStore vectorStore = MilvusVectorStore.builder(milvusClient, embeddingModel)
+				.collectionName(collectionName)
+				.databaseName(MilvusVectorStore.DEFAULT_DATABASE_NAME)
+				.indexType(IndexType.IVF_FLAT)
+				.metricType(MetricType.COSINE)
+				.embeddingDimension(3)
+				.metadataFields(MilvusVectorStore.MetadataField.int64("age"))
+				.batchingStrategy(new TokenCountBatchingStrategy())
+				.build();
+
+			vectorStore.createCollection();
+
+			try {
+				Document matchingDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("age", 35, "country", "NL"));
+				Document filteredByAgeDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("age", 20, "country", "NL"));
+				Document filteredByCountryDocument = new Document(
+						"The World is Big and Salvation Lurks Around the Corner", Map.of("age", 40, "country", "BG"));
+				Document missingAgeDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "NL"));
+				vectorStore.add(List.of(matchingDocument, filteredByAgeDocument, filteredByCountryDocument,
+						missingAgeDocument));
+
+				List<Document> results = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("The World")
+					.topK(5)
+					.similarityThresholdAll()
+					.filterExpression("age > 30 && country == 'NL'")
+					.build());
+
+				assertThat(results).hasSize(1);
+				assertThat(results.get(0).getId()).isEqualTo(matchingDocument.getId());
+			}
+			finally {
+				vectorStore.dropCollection();
+			}
+		});
+	}
+
+	@Test
+	void shouldCreateInsertAndFilterAllSupportedScalarMetadataFieldTypes() {
+		this.contextRunner.run(context -> {
+			MilvusServiceClient milvusClient = context.getBean(MilvusServiceClient.class);
+			EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+			String collectionName = "test_scalar_metadata_types_" + UUID.randomUUID().toString().replace("-", "_");
+			List<ScalarMetadataFieldCase> fieldCases = List.of(
+					new ScalarMetadataFieldCase("bool_value", DataType.Bool, true, false),
+					new ScalarMetadataFieldCase("int8_value", DataType.Int8, 8, 7),
+					new ScalarMetadataFieldCase("int16_value", DataType.Int16, 1600, 1500),
+					new ScalarMetadataFieldCase("int32_value", DataType.Int32, 320000, 310000),
+					new ScalarMetadataFieldCase("int64_value", DataType.Int64, 6_400_000_000L, 6_300_000_000L),
+					new ScalarMetadataFieldCase("float_value", DataType.Float, 1.25f, 1.0f),
+					new ScalarMetadataFieldCase("double_value", DataType.Double, 2.5, 2.0),
+					new ScalarMetadataFieldCase("text_value", DataType.VarChar, "match", "other"));
+			List<MilvusVectorStore.MetadataField> metadataFields = fieldCases.stream()
+				.map(ScalarMetadataFieldCase::metadataField)
+				.toList();
+			MilvusVectorStore vectorStore = MilvusVectorStore.builder(milvusClient, embeddingModel)
+				.collectionName(collectionName)
+				.databaseName(MilvusVectorStore.DEFAULT_DATABASE_NAME)
+				.indexType(IndexType.IVF_FLAT)
+				.metricType(MetricType.COSINE)
+				.embeddingDimension(3)
+				.metadataFields(metadataFields)
+				.batchingStrategy(new TokenCountBatchingStrategy())
+				.build();
+
+			vectorStore.createCollection();
+
+			try {
+				R<DescribeCollectionResponse> response = milvusClient
+					.describeCollection(DescribeCollectionParam.newBuilder()
+						.withDatabaseName(MilvusVectorStore.DEFAULT_DATABASE_NAME)
+						.withCollectionName(collectionName)
+						.build());
+				assertThat(response.getException()).isNull();
+				DescCollResponseWrapper collection = new DescCollResponseWrapper(response.getData());
+				for (MilvusVectorStore.MetadataField metadataField : metadataFields) {
+					FieldType field = collection.getFieldByName(metadataField.name());
+					assertThat(field).isNotNull();
+					assertThat(field.getDataType()).isEqualTo(metadataField.fieldType());
+					assertThat(field.isNullable()).isTrue();
+				}
+
+				Map<String, Object> matchingMetadata = fieldCases.stream()
+					.collect(Collectors.toMap(field -> field.metadataField().name(),
+							ScalarMetadataFieldCase::matchingValue));
+				Map<String, Object> nonMatchingMetadata = fieldCases.stream()
+					.collect(Collectors.toMap(field -> field.metadataField().name(),
+							ScalarMetadataFieldCase::nonMatchingValue));
+				Document matchingDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						matchingMetadata);
+				Document filteredDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						nonMatchingMetadata);
+				vectorStore.add(List.of(matchingDocument, filteredDocument));
+
+				for (ScalarMetadataFieldCase field : fieldCases) {
+					Filter.Expression filter = new Filter.Expression(Filter.ExpressionType.EQ,
+							new Filter.Key(field.metadataField().name()), new Filter.Value(field.matchingValue()));
+					assertFilterReturnsOnly(vectorStore, filter, matchingDocument);
+				}
+			}
+			finally {
+				vectorStore.dropCollection();
+			}
+		});
+	}
+
+	private static void assertFilterReturnsOnly(MilvusVectorStore vectorStore, Filter.Expression filterExpression,
+			Document expectedDocument) {
+		List<Document> results = vectorStore.similaritySearch(SearchRequest.builder()
+			.query("The World")
+			.topK(5)
+			.similarityThresholdAll()
+			.filterExpression(filterExpression)
+			.build());
+
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo(expectedDocument.getId());
+	}
+
+	private record ScalarMetadataFieldCase(MilvusVectorStore.MetadataField metadataField, Object matchingValue,
+			Object nonMatchingValue) {
+
+		private ScalarMetadataFieldCase(String name, DataType dataType, Object matchingValue, Object nonMatchingValue) {
+			this(new MilvusVectorStore.MetadataField(name, dataType), matchingValue, nonMatchingValue);
+		}
+
 	}
 
 	@SpringBootConfiguration

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreTest.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreTest.java
@@ -16,16 +16,22 @@
 
 package org.springframework.ai.vectorstore.milvus;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import com.google.gson.JsonObject;
 import io.milvus.client.MilvusServiceClient;
+import io.milvus.grpc.DataType;
 import io.milvus.grpc.MutationResult;
 import io.milvus.grpc.SearchResultData;
 import io.milvus.grpc.SearchResults;
 import io.milvus.param.R;
+import io.milvus.param.RpcStatus;
+import io.milvus.param.collection.CreateCollectionParam;
+import io.milvus.param.collection.FieldType;
 import io.milvus.param.dml.DeleteParam;
+import io.milvus.param.dml.InsertParam;
 import io.milvus.param.dml.SearchParam;
 import io.milvus.response.QueryResultsWrapper.RowRecord;
 import io.milvus.response.SearchResultsWrapper;
@@ -45,6 +51,7 @@ import org.springframework.ai.model.EmbeddingUtils;
 import org.springframework.ai.vectorstore.SearchRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -171,6 +178,140 @@ class MilvusVectorStoreTest {
 	}
 
 	@Test
+	void shouldPerformSimilaritySearchWithScalarMetadataFieldFilterExpression() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+			.metadataFields(MilvusVectorStore.MetadataField.int64("age"))
+			.build();
+
+		try (MockedStatic<EmbeddingUtils> mockedEmbeddingUtils = mockStatic(EmbeddingUtils.class);
+				MockedConstruction<SearchResultsWrapper> mockedSearchResultsWrapper = mockConstruction(
+						SearchResultsWrapper.class,
+						(mock, context) -> when(mock.getRowRecords(0)).thenReturn(List.of()))) {
+
+			SearchRequest request = SearchRequest.builder()
+				.query("sample query")
+				.topK(5)
+				.similarityThreshold(0.7)
+				.filterExpression("age > 30 && country == 'NL'")
+				.build();
+
+			SearchParam capturedParam = performSimilaritySearch(mockedEmbeddingUtils, request);
+
+			assertThat(capturedParam.getExpr()).isEqualTo("age > 30 && metadata[\"country\"] == \"NL\"");
+		}
+	}
+
+	@Test
+	void shouldInsertConfiguredScalarMetadataFields() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+			.metadataFields(MilvusVectorStore.MetadataField.int64("year"),
+					MilvusVectorStore.MetadataField.text("category"), MilvusVectorStore.MetadataField.bool("published"))
+			.build();
+
+		when(this.embeddingModel.embed(any(), any(), any()))
+			.thenReturn(List.of(new float[] { 0.1f, 0.2f, 0.3f }, new float[] { 0.4f, 0.5f, 0.6f }));
+		when(this.milvusClient.insert(any(InsertParam.class)))
+			.thenReturn(R.success(MutationResult.getDefaultInstance()));
+
+		try (MockedStatic<EmbeddingUtils> mockedEmbeddingUtils = mockStatic(EmbeddingUtils.class)) {
+			mockedEmbeddingUtils.when(() -> EmbeddingUtils.toList(any())).thenReturn(List.of(0.1f, 0.2f, 0.3f));
+
+			this.vectorStore.doAdd(List.of(
+					new Document("doc-1", "content one", Map.of("year", 2020, "category", "news", "published", true)),
+					new Document("doc-2", "content two", Map.of("category", "blog", "published", false))));
+		}
+
+		ArgumentCaptor<InsertParam> captor = ArgumentCaptor.forClass(InsertParam.class);
+		verify(this.milvusClient).insert(captor.capture());
+
+		List<InsertParam.Field> fields = captor.getValue().getFields();
+		assertThat(field(fields, "year").getValues()).isEqualTo(Arrays.asList(2020L, null));
+		assertThat(field(fields, "category").getValues()).isEqualTo(List.of("news", "blog"));
+		assertThat(field(fields, "published").getValues()).isEqualTo(List.of(true, false));
+
+		JsonObject metadata = (JsonObject) field(fields, MilvusVectorStore.METADATA_FIELD_NAME).getValues().get(0);
+		assertThat(metadata.get("year").getAsInt()).isEqualTo(2020);
+		assertThat(metadata.get("category").getAsString()).isEqualTo("news");
+		assertThat(metadata.get("published").getAsBoolean()).isTrue();
+	}
+
+	@Test
+	void shouldRejectFractionalValueForIntegerScalarMetadataField() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+			.metadataFields(MilvusVectorStore.MetadataField.int64("year"))
+			.build();
+
+		when(this.embeddingModel.embed(any(), any(), any())).thenReturn(List.of(new float[] { 0.1f, 0.2f, 0.3f }));
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> this.vectorStore.doAdd(List.of(new Document("doc-1", "content", Map.of("year", 2020.5)))))
+			.withMessageContaining("integer value");
+	}
+
+	@Test
+	void shouldRejectOutOfRangeValueForIntegerScalarMetadataField() {
+		this.vectorStore = MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+			.metadataFields(new MilvusVectorStore.MetadataField("priority", DataType.Int8))
+			.build();
+
+		when(this.embeddingModel.embed(any(), any(), any())).thenReturn(List.of(new float[] { 0.1f, 0.2f, 0.3f }));
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(
+					() -> this.vectorStore.doAdd(List.of(new Document("doc-1", "content", Map.of("priority", 128)))))
+			.withMessageContaining("out of range");
+	}
+
+	@Test
+	void shouldCreateScalarMetadataFieldsInCollectionSchema() {
+		when(this.milvusClient.createCollection(any(CreateCollectionParam.class)))
+			.thenReturn(R.success(new RpcStatus(RpcStatus.SUCCESS_MSG)));
+
+		this.vectorStore.createCollection("default", "test_collection", "doc_id", false, "content", "metadata",
+				"embedding", List.of(MilvusVectorStore.MetadataField.int64("year"),
+						MilvusVectorStore.MetadataField.text("category")));
+
+		ArgumentCaptor<CreateCollectionParam> captor = ArgumentCaptor.forClass(CreateCollectionParam.class);
+		verify(this.milvusClient).createCollection(captor.capture());
+
+		List<FieldType> fields = captor.getValue().getFieldTypes();
+		FieldType yearField = fieldType(fields, "year");
+		assertThat(yearField.getDataType()).isEqualTo(DataType.Int64);
+		assertThat(yearField.isNullable()).isTrue();
+
+		FieldType categoryField = fieldType(fields, "category");
+		assertThat(categoryField.getDataType()).isEqualTo(DataType.VarChar);
+		assertThat(categoryField.getMaxLength()).isEqualTo(65535);
+		assertThat(categoryField.isNullable()).isTrue();
+	}
+
+	@Test
+	void shouldRejectDuplicateScalarMetadataFieldNames() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+				.metadataFields(MilvusVectorStore.MetadataField.int64("year"),
+						MilvusVectorStore.MetadataField.int32("year"))
+				.build())
+			.withMessageContaining("duplicate names");
+	}
+
+	@Test
+	void shouldRejectScalarMetadataFieldNameConflict() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> MilvusVectorStore.builder(this.milvusClient, this.embeddingModel)
+				.metadataFields(MilvusVectorStore.MetadataField.text(MilvusVectorStore.METADATA_FIELD_NAME))
+				.build())
+			.withMessageContaining("metadata field name");
+	}
+
+	@Test
+	void shouldRejectUnsupportedScalarMetadataFieldType() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> new MilvusVectorStore.MetadataField("attributes", DataType.JSON))
+			.withMessageContaining("JSON");
+	}
+
+	@Test
 	void shouldPreserveMetadataIntegerNumberTypesInSearchResults() {
 		long externalId = 10_000_000_000_000_001L;
 		JsonObject metadata = new JsonObject();
@@ -247,6 +388,14 @@ class MilvusVectorStoreTest {
 		assertThat(results).isNotNull();
 		verify(this.milvusClient).search(searchParamCaptor.capture());
 		return searchParamCaptor.getValue();
+	}
+
+	private InsertParam.Field field(List<InsertParam.Field> fields, String name) {
+		return fields.stream().filter(field -> field.getName().equals(name)).findFirst().orElseThrow();
+	}
+
+	private FieldType fieldType(List<FieldType> fields, String name) {
+		return fields.stream().filter(field -> field.getName().equals(name)).findFirst().orElseThrow();
 	}
 
 }


### PR DESCRIPTION
Closes #6593

`MilvusVectorStore` currently stores all document metadata in a JSON field.
Filter expressions therefore reference metadata through JSON paths.

This PR adds an opt-in `metadataFields(...)` builder option for storing selected metadata keys as Milvus scalar fields.
When Spring AI creates a collection, configured metadata keys are added as nullable scalar fields.
The supported metadata field types are `Bool`, `Int8`, `Int16`, `Int32`, `Int64`, `Float`, `Double`, and `VarChar`.

The remaining Milvus scalar field types (`Array`, `JSON`, `Geometry`, and `Timestamptz`) require type-specific handling and are intentionally left for follow-up work.

On insert, configured metadata values are also stored in those fields, while all metadata remains in the JSON field.
Spring AI filter expressions reference configured keys by their scalar field names.

Metadata keys that are not configured as scalar fields continue to use the JSON metadata field.
If no scalar metadata fields are configured, existing behavior is unchanged.

Verified collection creation, insertion, and filtering for the eight currently supported field types, as well as missing configured values and mixed scalar/JSON filtering, against `milvusdb/milvus:v2.6.18`.