### PR TITLE
Scope Vertex AI credentials to cloud-platform

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfiguration.java
@@ -17,6 +17,8 @@
 package org.springframework.ai.model.google.genai.autoconfigure.chat;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.genai.Client;
@@ -41,6 +43,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.core.io.Resource;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -64,6 +67,8 @@ import org.springframework.util.StringUtils;
 public class GoogleGenAiChatAutoConfiguration {
 
 	private static final Log logger = LogFactory.getLog(GoogleGenAiChatAutoConfiguration.class);
+
+	private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 
 	@Bean
 	@ConditionalOnMissingBean
@@ -116,10 +121,17 @@ public class GoogleGenAiChatAutoConfiguration {
 
 		builder.project(props.getProjectId()).location(props.getLocation()).vertexAI(true);
 
-		if (props.getCredentialsUri() != null) {
-			try (var is = props.getCredentialsUri().getInputStream()) {
-				builder.credentials(GoogleCredentials.fromStream(is));
-			}
+		Resource credentialsUri = props.getCredentialsUri();
+		if (credentialsUri != null) {
+			builder.credentials(loadScopedCredentials(credentialsUri));
+		}
+	}
+
+	// Credentials from GoogleCredentials.fromStream are scopeless; Vertex AI rejects the
+	// token refresh with invalid_scope unless they are scoped to cloud-platform.
+	static GoogleCredentials loadScopedCredentials(Resource credentialsUri) throws IOException {
+		try (InputStream inputStream = credentialsUri.getInputStream()) {
+			return GoogleCredentials.fromStream(inputStream).createScoped(List.of(CLOUD_PLATFORM_SCOPE));
 		}
 	}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfigurationTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.chat;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link GoogleGenAiChatAutoConfiguration}.
+ *
+ * @author Subhash Polisetti
+ */
+class GoogleGenAiChatAutoConfigurationTests {
+
+	private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+
+	@Test
+	void credentialsLoadedFromUriAreScopedToCloudPlatform() throws Exception {
+		Resource credentials = serviceAccountResource();
+
+		GoogleCredentials scoped = GoogleGenAiChatAutoConfiguration.loadScopedCredentials(credentials);
+
+		assertThat(scoped).isInstanceOf(ServiceAccountCredentials.class);
+		assertThat(((ServiceAccountCredentials) scoped).getScopes()).containsExactly(CLOUD_PLATFORM_SCOPE);
+	}
+
+	@Test
+	void serviceAccountCredentialsAreScopelessWithoutExplicitScoping() throws Exception {
+		try (InputStream inputStream = serviceAccountResource().getInputStream()) {
+			GoogleCredentials raw = GoogleCredentials.fromStream(inputStream);
+			assertThat(((ServiceAccountCredentials) raw).getScopes()).isEmpty();
+		}
+	}
+
+	private static Resource serviceAccountResource() throws Exception {
+		String json = "{" + "\"type\": \"service_account\"," + "\"project_id\": \"test-project\","
+				+ "\"private_key_id\": \"test-key-id\"," + "\"private_key\": \"" + generatePrivateKeyPem() + "\","
+				+ "\"client_email\": \"test@test-project.iam.gserviceaccount.com\","
+				+ "\"client_id\": \"123456789012345678901\"," + "\"token_uri\": \"https://oauth2.googleapis.com/token\""
+				+ "}";
+		return new ByteArrayResource(json.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static String generatePrivateKeyPem() throws Exception {
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(2048);
+		KeyPair keyPair = generator.generateKeyPair();
+		String base64 = Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded());
+		// PEM embedded in JSON, so line breaks are encoded as the \n escape sequence.
+		return "-----BEGIN PRIVATE KEY-----\\n" + base64 + "\\n-----END PRIVATE KEY-----\\n";
+	}
+
+}


### PR DESCRIPTION
### Problem

In Vertex AI mode, the google-genai starter loads the service-account
credentials from `spring.ai.google.genai.credentials-uri` and currently
applies them to the client without an OAuth scope. `GoogleCredentials.fromStream`
returns scopeless credentials, so Vertex AI rejects the access-token
refresh with `invalid_scope` and no chat request can complete:

    GoogleAuthException: Error getting access token for service account:
    400 Bad Request POST https://oauth2.googleapis.com/token
    {"error":"invalid_scope"}

Only the explicit `credentials-uri` path is affected; the Application
Default Credentials path is scoped by the underlying SDK. There is no
configuration workaround today: there is no scope property, and the
`Client` bean is `@ConditionalOnMissingBean` with no customizer, so the
only escape is replacing the entire bean.

### Fix

Scope the credentials loaded from `credentials-uri` to `cloud-platform`,
matching the scope the SDK applies to Application Default Credentials.

### Testing

Adds `GoogleGenAiChatAutoConfigurationTests`, which is fully
self-contained (no network, no real key, no environment variables — it
generates a throwaway RSA keypair and a synthetic service-account JSON):

- one test pins the root cause: credentials from
  `GoogleCredentials.fromStream` carry no scope;
- one test verifies the fix: the loaded credentials are scoped to
  `cloud-platform`.

I also verified the behavior end to end against a real Google Cloud
service-account key. The unit test can only assert the scope offline,
because `invalid_scope` is returned by a live token exchange — the exact
call the SDK makes (`refreshIfExpired()` on the provided credentials):

```java
// unscoped credentials (current behavior)
GoogleCredentials.fromStream(key).refreshIfExpired();
// 400 Bad Request POST https://oauth2.googleapis.com/token
// {"error":"invalid_scope","error_description":"Invalid OAuth scope or ID token audience provided."}

// scoped to cloud-platform (the fix)
GoogleCredentials.fromStream(key)
    .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"))
    .refreshIfExpired();
// access token obtained
```

Fixes #6595