### PR TITLE
Make JSON schema strict configurable in OpenAiChatModel

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -768,7 +768,8 @@ public final class OpenAiChatModel implements ChatModel {
 					ResponseFormatJsonSchema.JsonSchema.Builder jsonSchemaBuilder = ResponseFormatJsonSchema.JsonSchema
 						.builder();
 					jsonSchemaBuilder.name("json_schema");
-					jsonSchemaBuilder.strict(true);
+					Boolean strict = responseFormat.getStrict();
+					jsonSchemaBuilder.strict(strict != null ? strict : true);
 
 					ResponseFormatJsonSchema.JsonSchema.Schema schema = objectMapper.readValue(jsonSchemaString,
 							ResponseFormatJsonSchema.JsonSchema.Schema.class);
@@ -1237,12 +1238,15 @@ public final class OpenAiChatModel implements ChatModel {
 	 * @author Hyunjoon Choi
 	 * @author Jonghoon Park
 	 * @author Sebastien Deleuze
+	 * @author Bishen Yu
 	 */
 	public static class ResponseFormat {
 
 		private Type type = Type.TEXT;
 
 		private @Nullable String jsonSchema;
+
+		private @Nullable Boolean strict;
 
 		public Type getType() {
 			return this.type;
@@ -1258,6 +1262,41 @@ public final class OpenAiChatModel implements ChatModel {
 
 		public void setJsonSchema(@Nullable String jsonSchema) {
 			this.jsonSchema = jsonSchema;
+		}
+
+		/**
+		 * Whether to enable strict schema adherence for JSON schema response format.
+		 * Defaults to {@code true} when unset.
+		 * <p>
+		 * This applies only to the JSON schema response format and is distinct from
+		 * {@link OpenAiChatOptions.Builder#strict(Boolean)}, which controls strict mode
+		 * for tool/function calling.
+		 * @return the strict flag, or {@code null} if not configured
+		 */
+		public @Nullable Boolean getStrict() {
+			return this.strict;
+		}
+
+		public void setStrict(@Nullable Boolean strict) {
+			this.strict = strict;
+		}
+
+		@Override
+		public boolean equals(@Nullable Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			ResponseFormat that = (ResponseFormat) o;
+			return this.type == that.type && Objects.equals(this.jsonSchema, that.jsonSchema)
+					&& Objects.equals(this.strict, that.strict);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.type, this.jsonSchema, this.strict);
 		}
 
 		public static Builder builder() {
@@ -1279,6 +1318,19 @@ public final class OpenAiChatModel implements ChatModel {
 			public Builder jsonSchema(String jsonSchema) {
 				this.responseFormat.setType(Type.JSON_SCHEMA);
 				this.responseFormat.setJsonSchema(jsonSchema);
+				return this;
+			}
+
+			/**
+			 * Whether to enable strict schema adherence for JSON schema response format.
+			 * <p>
+			 * Not to be confused with {@link OpenAiChatOptions.Builder#strict(Boolean)},
+			 * which applies to tool/function calling rather than response format.
+			 * @param strict the strict flag
+			 * @return this builder
+			 */
+			public Builder strict(@Nullable Boolean strict) {
+				this.responseFormat.setStrict(strict);
 				return this;
 			}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -471,6 +471,10 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 
 	/**
 	 * Gets whether OpenAI Tool/Function calling strict mode is enabled.
+	 * <p>
+	 * This is distinct from
+	 * {@link OpenAiChatModel.ResponseFormat.Builder#strict(Boolean)}, which controls
+	 * strict schema adherence for JSON schema response format.
 	 * @return true if strict mode is explicitly enabled
 	 */
 	public @Nullable Boolean getStrict() {
@@ -1002,6 +1006,15 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 			return self();
 		}
 
+		/**
+		 * Whether to enable OpenAI Tool/Function calling strict mode.
+		 * <p>
+		 * Not to be confused with
+		 * {@link OpenAiChatModel.ResponseFormat.Builder#strict(Boolean)}, which applies
+		 * to JSON schema response format rather than tool/function calling.
+		 * @param strict the strict flag
+		 * @return this builder
+		 */
 		public B strict(@Nullable Boolean strict) {
 			this.strict = strict;
 			return self();

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -69,6 +69,7 @@ import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.openai.OpenAiChatModel.ResponseFormat;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.util.JsonHelper;
 
@@ -1326,6 +1327,60 @@ class OpenAiChatModelTests {
 		// Verify isolation across execution payloads
 		assertThat(functionDefA.strict()).contains(false);
 		assertThat(functionDefB.strict()).contains(true);
+	}
+
+	@Test
+	void jsonSchemaResponseFormatStrictDefaultsToTrue() {
+		String jsonSchema = """
+				{
+					"type": "object",
+					"properties": {
+						"name": { "type": "string" }
+					}
+				}
+				""";
+		OpenAiChatOptions options = OpenAiChatOptions.builder()
+			.model("test-model")
+			.responseFormat(ResponseFormat.builder().jsonSchema(jsonSchema).build())
+			.build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), false);
+
+		assertThat(request.responseFormat()).isPresent();
+		assertThat(request.responseFormat().get().isJsonSchema()).isTrue();
+		assertThat(request.responseFormat().get().jsonSchema().get().jsonSchema().strict()).contains(true);
+	}
+
+	@Test
+	void jsonSchemaResponseFormatStrictCanBeDisabled() {
+		String jsonSchema = """
+				{
+					"type": "object",
+					"properties": {
+						"name": { "type": "string" }
+					}
+				}
+				""";
+		OpenAiChatOptions options = OpenAiChatOptions.builder()
+			.model("test-model")
+			.responseFormat(ResponseFormat.builder().jsonSchema(jsonSchema).strict(false).build())
+			.build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), false);
+
+		assertThat(request.responseFormat()).isPresent();
+		assertThat(request.responseFormat().get().isJsonSchema()).isTrue();
+		assertThat(request.responseFormat().get().jsonSchema().get().jsonSchema().strict()).contains(false);
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
@@ -611,7 +611,30 @@ public class OpenAiChatOptionsTests extends AbstractChatOptionsTests<OpenAiChatO
 		assertThat(options.getResponseFormat()).isNotNull();
 		assertThat(options.getResponseFormat().getType()).isEqualTo(ResponseFormat.Type.JSON_SCHEMA);
 		assertThat(options.getResponseFormat().getJsonSchema()).isEqualTo(schema);
+		assertThat(options.getResponseFormat().getStrict()).isNull();
 		assertThat(options.getOutputSchema()).isEqualTo(schema);
+	}
+
+	@Test
+	void testSetOutputSchemaWithStrictDisabled() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().build();
+		String schema = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						}
+					}
+				}
+				""";
+
+		options = options.mutate()
+			.responseFormat(ResponseFormat.builder().jsonSchema(schema).strict(false).build())
+			.build();
+
+		assertThat(options.getResponseFormat()).isNotNull();
+		assertThat(options.getResponseFormat().getStrict()).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #6564

## Summary

In Spring AI 2.0, `OpenAiChatModel` hardcoded `strict(true)` when building JSON schema response format requests. In 1.x this was configurable; users who need non-strict JSON schema output had no way to disable it.

This PR adds an optional `strict` property to `OpenAiChatModel.ResponseFormat` and applies it when constructing the OpenAI SDK request. When unset, behavior remains backward compatible (`strict` defaults to `true`).

## Changes

- Add `strict` to `OpenAiChatModel.ResponseFormat` (getter, setter, builder)
- Use `ResponseFormat.strict` in `OpenAiChatModel#createRequest` instead of hardcoding `true`
- Add unit tests in `OpenAiChatModelTests` and `OpenAiChatOptionsTests`

## Configuration

Programmatic:
```java
OpenAiChatModel.ResponseFormat.builder()
    .jsonSchema(schema)
    .strict(false)
    .build();
```

Properties:

```yaml
spring:
  ai:
    openai:
      chat:
        options:
          response-format:
            type: json_schema
            json-schema: |
              {"type":"object","properties":{"name":{"type":"string"}}}
            strict: false
```

## Test plan

- [x] ./mvnw -pl models/spring-ai-openai test '-Dtest=OpenAiChatModelTests#jsonSchemaResponseFormatStrict*,OpenAiChatOptionsTests#testSetOutputSchema*'
- [x] Default strict=true when unset
- [x] strict=false propagated to the outgoing request