### PR TITLE
Fix ParagraphManager unconditionally printing PDF outline to stdout

### DIFF
--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
@@ -21,6 +21,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageTree;
@@ -31,6 +32,8 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The ParagraphManager class is responsible for managing the paragraphs and hierarchy of
@@ -44,6 +47,9 @@ public class ParagraphManager {
 	/**
 	 * Root of the paragraphs tree.
 	 */
+	private static final Log logger = LogFactory.getLog(ParagraphManager.class);
+
+
 	private final Paragraph rootParagraph;
 
 	private final PDDocument document;
@@ -64,7 +70,9 @@ public class ParagraphManager {
 					new Paragraph(null, "root", -1, 1, this.document.getNumberOfPages(), 0),
 					this.document.getDocumentCatalog().getDocumentOutline(), 0);
 
-			printParagraph(this.rootParagraph, System.out);
+			if (logger.isDebugEnabled()) {
+				printParagraph(this.rootParagraph, System.out);
+			}
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
Fixes #6599 

## Problem
`ParagraphManager` constructor calls `printParagraph(this.rootParagraph, System.out)` 
unconditionally at line 67, printing the entire PDF Table of Contents to stdout 
every time a `ParagraphPdfDocumentReader` is created. There is no way to suppress 
this output through logging configuration.

## Fix
Wrapped the `printParagraph` call with a `logger.isDebugEnabled()` guard using 
Commons Logging — consistent with the pattern already used in 
`PagePdfDocumentReader` and `ForkPDFLayoutTextStripper`.

## Changes
- Added `Log` and `LogFactory` imports to `ParagraphManager.java`
- Added `private static final Log logger = LogFactory.getLog(ParagraphManager.class)`
- Wrapped `printParagraph` call with `if (logger.isDebugEnabled())`