### PR TITLE
Fix AnthropicChatOptions.timeout(Duration) being ignored outside model construction

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.anthropic;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.AnthropicClientAsync;
 import com.anthropic.core.JsonValue;
+import com.anthropic.core.RequestOptions;
 import com.anthropic.core.http.HttpResponseFor;
 import com.anthropic.core.http.StreamResponse;
 import com.anthropic.models.messages.Base64ImageSource;
@@ -330,7 +332,9 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			// stream start) can be captured. The SDK exposes this as a blocking
 			// StreamResponse, so events are pulled on a boundedElastic worker.
 			Flux<ChatResponse> chatResponseFlux = Mono
-				.fromFuture(() -> this.anthropicClientAsync.messages().withRawResponse().createStreaming(request))
+				.fromFuture(() -> this.anthropicClientAsync.messages()
+					.withRawResponse()
+					.createStreaming(request, requestOptionsFor(prompt)))
 				.flatMapMany(rawResponse -> {
 					streamingState.setRateLimit(AnthropicRateLimit.from(rawResponse.headers()));
 					StreamResponse<RawMessageStreamEvent> streamResponse = rawResponse.parse();
@@ -552,7 +556,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 				HttpResponseFor<Message> rawResponse = this.anthropicClient.messages()
 					.withRawResponse()
-					.create(request);
+					.create(request, requestOptionsFor(prompt));
 				Message message = rawResponse.parse();
 				RateLimit rateLimit = AnthropicRateLimit.from(rawResponse.headers());
 
@@ -587,6 +591,40 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	}
 
 	/**
+	 * Resolves the effective {@link AnthropicChatOptions} for a prompt — the merged
+	 * default/per-request options set on {@link Prompt#getOptions()}, or an empty
+	 * {@link AnthropicChatOptions} if the prompt carries a different {@link ChatOptions}
+	 * implementation.
+	 * @param prompt the prompt with message history and options
+	 * @return the effective Anthropic chat options
+	 */
+	private static AnthropicChatOptions resolveAnthropicOptions(Prompt prompt) {
+		ChatOptions options = prompt.getOptions();
+		return options instanceof AnthropicChatOptions anthropicOptions ? anthropicOptions
+				: AnthropicChatOptions.builder().build();
+	}
+
+	/**
+	 * Resolves the per-call {@link RequestOptions} (currently just {@code timeout} — the
+	 * SDK's {@code RequestOptions} doesn't expose {@code maxRetries}/{@code proxy}/custom
+	 * headers, so those remain construction-time-only settings) from the effective
+	 * {@link AnthropicChatOptions} on the given prompt. Without this, a {@code timeout}
+	 * set via {@link AnthropicChatOptions#getTimeout()} — whether on {@code ChatClient}
+	 * default options or a per-request override — would silently have no effect: the
+	 * Anthropic Java SDK only honors the {@code timeout} supplied on this
+	 * {@link RequestOptions} argument; a call made without one falls back to whatever
+	 * {@link com.anthropic.core.Timeout} the client was built with once, at construction
+	 * time (see {@link AnthropicSetup}).
+	 * @param prompt the prompt with message history and options
+	 * @return request options carrying the resolved timeout, or
+	 * {@link RequestOptions#none()} if none is set
+	 */
+	private static RequestOptions requestOptionsFor(Prompt prompt) {
+		Duration timeout = resolveAnthropicOptions(prompt).getTimeout();
+		return timeout != null ? RequestOptions.builder().timeout(timeout).build() : RequestOptions.none();
+	}
+
+	/**
 	 * Creates a {@link MessageCreateParams} request from a Spring AI {@link Prompt}. Maps
 	 * message types to Anthropic format: TOOL messages become user messages with
 	 * {@link ToolResultBlockParam}, and ASSISTANT messages with tool calls become
@@ -599,9 +637,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 		MessageCreateParams.Builder builder = MessageCreateParams.builder();
 
-		ChatOptions options = prompt.getOptions();
-		AnthropicChatOptions requestOptions = options instanceof AnthropicChatOptions anthropicOptions
-				? anthropicOptions : AnthropicChatOptions.builder().build();
+		AnthropicChatOptions requestOptions = resolveAnthropicOptions(prompt);
 
 		// Set required fields
 		builder.model(requestOptions.getModel()).maxTokens(requestOptions.getMaxTokens());

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -146,6 +146,7 @@ import org.springframework.util.MimeType;
  * @author Sebastien Deleuze
  * @author Ilayaperumal Gopinathan
  * @author Jewoo Shin
+ * @author Seeun Kim
  * @since 1.0.0
  * @see AnthropicChatOptions
  * @see <a href="https://docs.anthropic.com/en/api/messages">Anthropic Messages API</a>
@@ -590,36 +591,17 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		return response;
 	}
 
-	/**
-	 * Resolves the effective {@link AnthropicChatOptions} for a prompt — the merged
-	 * default/per-request options set on {@link Prompt#getOptions()}, or an empty
-	 * {@link AnthropicChatOptions} if the prompt carries a different {@link ChatOptions}
-	 * implementation.
-	 * @param prompt the prompt with message history and options
-	 * @return the effective Anthropic chat options
-	 */
 	private static AnthropicChatOptions resolveAnthropicOptions(Prompt prompt) {
+		// Use the prompt's merged AnthropicChatOptions, or empty options if it carries a
+		// different ChatOptions implementation.
 		ChatOptions options = prompt.getOptions();
 		return options instanceof AnthropicChatOptions anthropicOptions ? anthropicOptions
 				: AnthropicChatOptions.builder().build();
 	}
 
-	/**
-	 * Resolves the per-call {@link RequestOptions} (currently just {@code timeout} — the
-	 * SDK's {@code RequestOptions} doesn't expose {@code maxRetries}/{@code proxy}/custom
-	 * headers, so those remain construction-time-only settings) from the effective
-	 * {@link AnthropicChatOptions} on the given prompt. Without this, a {@code timeout}
-	 * set via {@link AnthropicChatOptions#getTimeout()} — whether on {@code ChatClient}
-	 * default options or a per-request override — would silently have no effect: the
-	 * Anthropic Java SDK only honors the {@code timeout} supplied on this
-	 * {@link RequestOptions} argument; a call made without one falls back to whatever
-	 * {@link com.anthropic.core.Timeout} the client was built with once, at construction
-	 * time (see {@link AnthropicSetup}).
-	 * @param prompt the prompt with message history and options
-	 * @return request options carrying the resolved timeout, or
-	 * {@link RequestOptions#none()} if none is set
-	 */
 	private static RequestOptions requestOptionsFor(Prompt prompt) {
+		// Carry the resolved timeout as per-call RequestOptions; the SDK only honors a
+		// timeout supplied here, so otherwise AnthropicChatOptions#getTimeout() is ignored.
 		Duration timeout = resolveAnthropicOptions(prompt).getTimeout();
 		return timeout != null ? RequestOptions.builder().timeout(timeout).build() : RequestOptions.none();
 	}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -99,7 +99,11 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 	private final String model;
 
 	/**
-	 * Request timeout for the Anthropic client. Defaults to 60 seconds if not specified.
+	 * Request timeout for the Anthropic client, applied per call — set as a
+	 * {@code ChatClient} default option or a per-request override, this bounds only that
+	 * call, not every call made by the underlying {@link AnthropicChatModel}. Defaults to
+	 * 60 seconds if not specified anywhere (including at {@link AnthropicChatModel}
+	 * construction time).
 	 */
 	private final @Nullable Duration timeout;
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -63,6 +63,7 @@ import org.springframework.util.CollectionUtils;
  * @author Soby Chacko
  * @author Austin Dase
  * @author Sebastien Deleuze
+ * @author Seeun Kim
  * @since 1.0.0
  * @see AnthropicChatModel
  * @see <a href="https://docs.anthropic.com/en/api/messages">Anthropic Messages API</a>

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
@@ -96,6 +96,7 @@ import static org.mockito.Mockito.verify;
  * @author Soby Chacko
  * @author Sebastien Deleuze
  * @author Jewoo Shin
+ * @author Seeun Kim
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.AnthropicClientAsync;
 import com.anthropic.core.JsonValue;
+import com.anthropic.core.RequestOptions;
 import com.anthropic.core.http.Headers;
 import com.anthropic.core.http.HttpResponseFor;
 import com.anthropic.core.http.StreamResponse;
@@ -125,14 +126,15 @@ class AnthropicChatModelTests {
 	void setUp() {
 		given(this.anthropicClient.messages()).willReturn(this.messageService);
 		given(this.messageService.withRawResponse()).willReturn(this.messageServiceWithRawResponse);
-		given(this.messageServiceWithRawResponse.create(any(MessageCreateParams.class))).willAnswer(invocation -> {
-			MessageCreateParams params = invocation.getArgument(0);
-			Message message = this.messageService.create(params);
-			HttpResponseFor<Message> rawResponse = mock(HttpResponseFor.class);
-			given(rawResponse.parse()).willReturn(message);
-			given(rawResponse.headers()).willReturn(Headers.builder().build());
-			return rawResponse;
-		});
+		given(this.messageServiceWithRawResponse.create(any(MessageCreateParams.class), any(RequestOptions.class)))
+			.willAnswer(invocation -> {
+				MessageCreateParams params = invocation.getArgument(0);
+				Message message = this.messageService.create(params);
+				HttpResponseFor<Message> rawResponse = mock(HttpResponseFor.class);
+				given(rawResponse.parse()).willReturn(message);
+				given(rawResponse.headers()).willReturn(Headers.builder().build());
+				return rawResponse;
+			});
 
 		this.chatModel = AnthropicChatModel.builder()
 			.anthropicClient(this.anthropicClient)
@@ -361,7 +363,8 @@ class AnthropicChatModelTests {
 
 		given(this.anthropicClientAsync.messages()).willReturn(this.messageServiceAsync);
 		given(this.messageServiceAsync.withRawResponse()).willReturn(this.messageServiceAsyncWithRawResponse);
-		given(this.messageServiceAsyncWithRawResponse.createStreaming(any(MessageCreateParams.class)))
+		given(this.messageServiceAsyncWithRawResponse.createStreaming(any(MessageCreateParams.class),
+				any(RequestOptions.class)))
 			.willReturn(CompletableFuture.completedFuture(rawResponse));
 		Message finalResponse = createMockMessage("Done.", StopReason.END_TURN);
 		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(finalResponse);
@@ -849,14 +852,15 @@ class AnthropicChatModelTests {
 			.put("anthropic-ratelimit-tokens-reset", resetAt.toString())
 			.build();
 
-		given(this.messageServiceWithRawResponse.create(any(MessageCreateParams.class))).willAnswer(invocation -> {
-			MessageCreateParams params = invocation.getArgument(0);
-			Message message = this.messageService.create(params);
-			HttpResponseFor<Message> rawResponse = mock(HttpResponseFor.class);
-			given(rawResponse.parse()).willReturn(message);
-			given(rawResponse.headers()).willReturn(rateLimitHeaders);
-			return rawResponse;
-		});
+		given(this.messageServiceWithRawResponse.create(any(MessageCreateParams.class), any(RequestOptions.class)))
+			.willAnswer(invocation -> {
+				MessageCreateParams params = invocation.getArgument(0);
+				Message message = this.messageService.create(params);
+				HttpResponseFor<Message> rawResponse = mock(HttpResponseFor.class);
+				given(rawResponse.parse()).willReturn(message);
+				given(rawResponse.headers()).willReturn(rateLimitHeaders);
+				return rawResponse;
+			});
 
 		ChatResponse response = this.chatModel.call(new Prompt("test"));
 
@@ -883,7 +887,8 @@ class AnthropicChatModelTests {
 
 		given(this.anthropicClientAsync.messages()).willReturn(this.messageServiceAsync);
 		given(this.messageServiceAsync.withRawResponse()).willReturn(this.messageServiceAsyncWithRawResponse);
-		given(this.messageServiceAsyncWithRawResponse.createStreaming(any(MessageCreateParams.class)))
+		given(this.messageServiceAsyncWithRawResponse.createStreaming(any(MessageCreateParams.class),
+				any(RequestOptions.class)))
 			.willReturn(CompletableFuture.completedFuture(rawResponse));
 
 		this.chatModel.stream(new Prompt("test")).collectList().block();
@@ -936,7 +941,8 @@ class AnthropicChatModelTests {
 
 		given(this.anthropicClientAsync.messages()).willReturn(this.messageServiceAsync);
 		given(this.messageServiceAsync.withRawResponse()).willReturn(this.messageServiceAsyncWithRawResponse);
-		given(this.messageServiceAsyncWithRawResponse.createStreaming(any(MessageCreateParams.class)))
+		given(this.messageServiceAsyncWithRawResponse.createStreaming(any(MessageCreateParams.class),
+				any(RequestOptions.class)))
 			.willReturn(CompletableFuture.completedFuture(rawResponse));
 
 		List<ChatResponse> responses = this.chatModel.stream(new Prompt("test")).collectList().block();

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTimeoutTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTimeoutTests.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.verify;
  * {@link ChatClient} default option, or as a per-request {@code ChatClient} override —
  * not just at construction time.
  *
- * @author seeun0210
+ * @author Seeun Kim
  */
 class AnthropicChatModelTimeoutTests {
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTimeoutTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTimeoutTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import com.anthropic.client.AnthropicClientAsync;
+import com.anthropic.core.RequestOptions;
+import com.anthropic.core.http.Headers;
+import com.anthropic.core.http.HttpResponseFor;
+import com.anthropic.core.http.StreamResponse;
+import com.anthropic.errors.AnthropicIoException;
+import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.RawMessageStreamEvent;
+import com.anthropic.services.async.MessageServiceAsync;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.MessageAggregator;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verifies that {@link AnthropicChatOptions#getTimeout()} actually bounds the HTTP call
+ * whether it's set at {@link AnthropicChatModel} construction time, as a
+ * {@link ChatClient} default option, or as a per-request {@code ChatClient} override —
+ * not just at construction time.
+ *
+ * @author seeun0210
+ */
+class AnthropicChatModelTimeoutTests {
+
+	private static final String MESSAGES_RESPONSE = """
+			{"id":"msg-test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-haiku-4-5-20251001","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}
+			""";
+
+	@Test
+	void constructionTimeTimeoutBoundsTheCall() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.enqueue(new MockResponse().setHeadersDelay(3, TimeUnit.SECONDS)
+				.setResponseCode(200)
+				.setHeader("Content-Type", "application/json")
+				.setBody(MESSAGES_RESPONSE));
+			server.start();
+
+			AnthropicChatModel chatModel = AnthropicChatModel.builder()
+				.options(AnthropicChatOptions.builder()
+					.baseUrl(server.url("/").toString())
+					.apiKey("test-key")
+					.model("claude-haiku-4-5-20251001")
+					.maxTokens(10)
+					.timeout(Duration.ofMillis(500))
+					.build())
+				.build();
+
+			// Root cause class varies across the SDK's automatic retries
+			// (SocketTimeoutException
+			// on a fresh connection vs. SocketException "Socket closed" when a retry
+			// races a
+			// connection the timeout already tore down) — assert on the stable wrapper
+			// type
+			// instead of pinning an exact root cause class.
+			assertThatThrownBy(() -> chatModel.call(new Prompt("hi")))
+				.as("a 500ms construction-time timeout must interrupt a call whose response is delayed 3s")
+				.isInstanceOf(AnthropicIoException.class);
+		}
+	}
+
+	@Test
+	void perRequestChatClientTimeoutOverridesConstructionTimeTimeout() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			// Construction-time timeout is intentionally too short (500ms) for the 2s
+			// delayed response below. A per-request ChatClient override of 5s should
+			// let the call succeed instead of failing at the construction-time bound.
+			server.enqueue(new MockResponse().setHeadersDelay(2, TimeUnit.SECONDS)
+				.setResponseCode(200)
+				.setHeader("Content-Type", "application/json")
+				.setBody(MESSAGES_RESPONSE));
+			server.start();
+
+			AnthropicChatModel chatModel = AnthropicChatModel.builder()
+				.options(AnthropicChatOptions.builder()
+					.baseUrl(server.url("/").toString())
+					.apiKey("test-key")
+					.model("claude-haiku-4-5-20251001")
+					.maxTokens(10)
+					.timeout(Duration.ofMillis(500))
+					.build())
+				.build();
+			ChatClient chatClient = ChatClient.builder(chatModel).build();
+
+			assertThatCode(() -> {
+				String content = chatClient.prompt()
+					.user("hi")
+					.options(AnthropicChatOptions.builder().timeout(Duration.ofSeconds(5)))
+					.call()
+					.content();
+				assertThat(content).isEqualTo("ok");
+			}).as("a 5s per-request ChatClient timeout must override the 500ms construction-time default")
+				.doesNotThrowAnyException();
+		}
+	}
+
+	@Test
+	void chatClientDefaultOptionsTimeoutOverridesConstructionTimeTimeout() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.enqueue(new MockResponse().setHeadersDelay(2, TimeUnit.SECONDS)
+				.setResponseCode(200)
+				.setHeader("Content-Type", "application/json")
+				.setBody(MESSAGES_RESPONSE));
+			server.start();
+
+			AnthropicChatModel chatModel = AnthropicChatModel.builder()
+				.options(AnthropicChatOptions.builder()
+					.baseUrl(server.url("/").toString())
+					.apiKey("test-key")
+					.model("claude-haiku-4-5-20251001")
+					.maxTokens(10)
+					.timeout(Duration.ofMillis(500))
+					.build())
+				.build();
+			ChatClient chatClient = ChatClient.builder(chatModel)
+				.defaultOptions(AnthropicChatOptions.builder().timeout(Duration.ofSeconds(5)))
+				.build();
+
+			assertThatCode(() -> chatClient.prompt().user("hi").call().content())
+				.as("a 5s ChatClient default-options timeout must override the 500ms construction-time default")
+				.doesNotThrowAnyException();
+		}
+	}
+
+	/**
+	 * Mirrors {@link #perRequestChatClientTimeoutOverridesConstructionTimeTimeout()} for
+	 * the streaming ({@code internalStream()}) code path. A real delayed-response
+	 * MockWebServer setup isn't used here because it would additionally require
+	 * fabricating a valid Anthropic SSE event stream; asserting the
+	 * {@link RequestOptions} actually passed to {@code createStreaming(...)} is a more
+	 * direct and no less faithful check that the fix applies to both call sites.
+	 */
+	@Test
+	@SuppressWarnings("unchecked")
+	void perRequestChatClientTimeoutIsForwardedOnTheStreamingPath() {
+		AnthropicClientAsync anthropicClientAsync = mock(AnthropicClientAsync.class);
+		MessageServiceAsync messageServiceAsync = mock(MessageServiceAsync.class);
+		MessageServiceAsync.WithRawResponse messageServiceAsyncWithRawResponse = mock(
+				MessageServiceAsync.WithRawResponse.class);
+
+		StreamResponse<RawMessageStreamEvent> streamResponse = mock(StreamResponse.class);
+		given(streamResponse.stream()).willReturn(Stream.empty());
+		HttpResponseFor<StreamResponse<RawMessageStreamEvent>> rawResponse = mock(HttpResponseFor.class);
+		given(rawResponse.parse()).willReturn(streamResponse);
+		given(rawResponse.headers()).willReturn(Headers.builder().build());
+
+		given(anthropicClientAsync.messages()).willReturn(messageServiceAsync);
+		given(messageServiceAsync.withRawResponse()).willReturn(messageServiceAsyncWithRawResponse);
+		given(messageServiceAsyncWithRawResponse.createStreaming(any(MessageCreateParams.class),
+				any(RequestOptions.class)))
+			.willReturn(CompletableFuture.completedFuture(rawResponse));
+
+		AnthropicChatModel chatModel = AnthropicChatModel.builder()
+			.anthropicClientAsync(anthropicClientAsync)
+			.options(AnthropicChatOptions.builder()
+				.model("claude-haiku-4-5-20251001")
+				.maxTokens(10)
+				.timeout(Duration.ofMillis(500))
+				.build())
+			.build();
+		ChatClient chatClient = ChatClient.builder(chatModel).build();
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("hi")),
+				AnthropicChatOptions.builder().timeout(Duration.ofSeconds(5)).build());
+		new MessageAggregator().aggregate(chatClient.prompt(prompt).stream().chatResponse(), response -> {
+		}).collectList().block();
+
+		ArgumentCaptor<RequestOptions> captor = ArgumentCaptor.forClass(RequestOptions.class);
+		verify(messageServiceAsyncWithRawResponse).createStreaming(any(MessageCreateParams.class), captor.capture());
+		assertThat(captor.getValue().getTimeout().request()).isEqualTo(Duration.ofSeconds(5));
+	}
+
+}


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* [x] Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* [x] Rebase your changes on the latest `main` branch and squash your commits
* [x] Add/Update unit tests as needed
* [x] Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc

---

## Summary

Fixes #6604.

`AnthropicChatModel.internalCall()`/`internalStream()` never forwarded the effective `AnthropicChatOptions.getTimeout()` (whether set via `ChatClient.Builder.defaultOptions()` or a per-request `ChatClient.prompt().options(...)` override) into a `com.anthropic.core.RequestOptions` for the underlying Anthropic Java SDK call. Both call sites always used the SDK's default `RequestOptions`, so the only timeout that ever had any effect was the one baked into the shared `AnthropicChatModel`/`AnthropicClient` once, at construction time (via `spring.ai.anthropic.timeout`). This contradicts the documented usage, which shows `.timeout(Duration)` as a per-call `AnthropicChatOptions` setting.

**Why this gap existed**: The shared `AnthropicClient`/`AnthropicChatModel` bean is (correctly) built once at startup, so the timeout baked into its HTTP client is fixed at that point. When per-call `AnthropicChatOptions.timeout(Duration)` was documented as an override, the wiring to actually forward it into the SDK's per-call `RequestOptions` (which the SDK already supports without rebuilding the client) was never added — the two call sites just kept using the SDK's single-arg `create()`/`createStreaming()` overloads.

**Why per-call overrides above 60s matter**: Some calls legitimately need longer than the SDK's 60s default:
- `web_search` tool use, where the model can issue multiple search round-trips (query → fetch → read → continue generating) within a single API call.
- Generations with a large `maxTokens`, since output tokens are produced sequentially, so wall-clock time scales with output length.
- Claude Skills (`AnthropicSkillContainer`) invoking code execution to generate/edit complex `xlsx`/`pptx`/`docx`/`pdf` documents.

Without this fix, an app has no way to grant just those calls more time — raising `spring.ai.anthropic.timeout` globally is the only lever, and even then, an unconfigured/short construction-time timeout compounds silently across the SDK's automatic retries (default `maxRetries: 2` → 3 attempts), so a call can fail after ~3× the configured timeout with no indication why.

- Adds a `requestOptionsFor(Prompt)` helper that resolves the merged (default + per-request) `AnthropicChatOptions.getTimeout()` into an explicit `RequestOptions`, passed to both `messageService.create(params, requestOptions)` and `createStreaming(params, requestOptions)`.
- Updates `AnthropicChatModelTests`' Mockito stubs to match the new two-arg SDK call signature (mechanical change, no behavior change to the tests themselves).
- Adds `AnthropicChatModelTimeoutTests` with 3 cases: construction-time timeout bounds a call; a per-request `ChatClient` timeout overrides a too-short construction-time default; a `ChatClient` default-options timeout overrides a too-short construction-time default. All 3 fail without the fix (verified) and pass with it.

## Test plan

- [x] `./mvnw -pl models/spring-ai-anthropic test` — full module suite (123 tests) passes
- [x] New `AnthropicChatModelTimeoutTests` fail without the fix (confirmed via `git stash` on the production change) and pass with it
- [x] Verified no real Anthropic API calls are needed — regression tests use `MockWebServer` with `setHeadersDelay(...)` for deterministic timing
