### PR TITLE
Expose OpenAI chat rate limits

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
+import com.openai.core.http.HttpResponseFor;
 import com.openai.errors.OpenAIInvalidDataException;
 import com.openai.models.FunctionDefinition;
 import com.openai.models.FunctionParameters;
@@ -85,7 +86,9 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.EmptyRateLimit;
 import org.springframework.ai.chat.metadata.EmptyUsage;
+import org.springframework.ai.chat.metadata.RateLimit;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -101,6 +104,7 @@ import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
+import org.springframework.ai.openai.metadata.OpenAiRateLimit;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
@@ -216,37 +220,45 @@ public final class OpenAiChatModel implements ChatModel {
 					this.observationRegistry)
 			.observe(() -> {
 
-				ChatCompletion chatCompletion = this.openAiClient.chat().completions().create(request);
+				try (HttpResponseFor<ChatCompletion> rawResponse = this.openAiClient.chat()
+					.completions()
+					.withRawResponse()
+					.create(request)) {
 
-				List<ChatCompletion.Choice> choices = chatCompletion.choices();
-				if (choices.isEmpty()) {
-					if (logger.isWarnEnabled()) {
-						logger.warn("No choices returned for prompt: " + prompt);
+					ChatCompletion chatCompletion = rawResponse.parse();
+					RateLimit rateLimit = OpenAiRateLimit.from(rawResponse.headers());
+
+					List<ChatCompletion.Choice> choices = chatCompletion.choices();
+					if (choices.isEmpty()) {
+						if (logger.isWarnEnabled()) {
+							logger.warn("No choices returned for prompt: " + prompt);
+						}
+						return new ChatResponse(List.of());
 					}
-					return new ChatResponse(List.of());
+
+					List<Generation> generations = choices.stream().map(choice -> {
+						Map<String, Object> metadata = Map.of("id", chatCompletion.id(), "role",
+								choice.message()._role().asString().isPresent()
+										? choice.message()._role().asStringOrThrow() : "",
+								"index", choice.index(), "finishReason", choice.finishReason().value().toString(),
+								"refusal", choice.message().refusal().orElse(""), "annotations",
+								choice.message().annotations().orElse((List) List.of(Map.of())), REASONING_CONTENT,
+								getReasoningContent(choice));
+						return buildGeneration(choice, metadata, request);
+					}).toList();
+
+					// Current usage
+					CompletionUsage usage = chatCompletion.usage().orElse(null);
+					Usage currentChatResponseUsage = usage != null ? getDefaultUsage(usage) : new EmptyUsage();
+					Usage accumulatedUsage = UsageCalculator.getCumulativeUsage(currentChatResponseUsage,
+							previousChatResponse);
+					ChatResponse chatResponse = new ChatResponse(generations,
+							from(chatCompletion, accumulatedUsage, rateLimit));
+
+					observationContext.setResponse(chatResponse);
+
+					return chatResponse;
 				}
-
-				List<Generation> generations = choices.stream().map(choice -> {
-					Map<String, Object> metadata = Map.of("id", chatCompletion.id(), "role",
-							choice.message()._role().asString().isPresent() ? choice.message()._role().asStringOrThrow()
-									: "",
-							"index", choice.index(), "finishReason", choice.finishReason().value().toString(),
-							"refusal", choice.message().refusal().orElse(""), "annotations",
-							choice.message().annotations().orElse((List) List.of(Map.of())), REASONING_CONTENT,
-							getReasoningContent(choice));
-					return buildGeneration(choice, metadata, request);
-				}).toList();
-
-				// Current usage
-				CompletionUsage usage = chatCompletion.usage().orElse(null);
-				Usage currentChatResponseUsage = usage != null ? getDefaultUsage(usage) : new EmptyUsage();
-				Usage accumulatedUsage = UsageCalculator.getCumulativeUsage(currentChatResponseUsage,
-						previousChatResponse);
-				ChatResponse chatResponse = new ChatResponse(generations, from(chatCompletion, accumulatedUsage));
-
-				observationContext.setResponse(chatResponse);
-
-				return chatResponse;
 
 			});
 
@@ -443,6 +455,10 @@ public final class OpenAiChatModel implements ChatModel {
 	}
 
 	private ChatResponseMetadata from(ChatCompletion result, Usage usage) {
+		return from(result, usage, new EmptyRateLimit());
+	}
+
+	private ChatResponseMetadata from(ChatCompletion result, Usage usage, RateLimit rateLimit) {
 		Assert.notNull(result, "OpenAI ChatCompletion must not be null");
 		result.model();
 		result.id();
@@ -450,6 +466,7 @@ public final class OpenAiChatModel implements ChatModel {
 			.id(result.id())
 			.usage(usage)
 			.model(result.model())
+			.rateLimit(rateLimit)
 			.keyValue("created", getCreated(result));
 
 		result._additionalProperties().forEach((key, jsonValue) -> {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiAudioSpeechResponseMetadata.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiAudioSpeechResponseMetadata.java
@@ -16,15 +16,12 @@
 
 package org.springframework.ai.openai.metadata;
 
-import java.time.Duration;
-
 import com.openai.core.http.Headers;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.audio.tts.TextToSpeechResponseMetadata;
 import org.springframework.ai.chat.metadata.EmptyRateLimit;
 import org.springframework.ai.chat.metadata.RateLimit;
-import org.springframework.util.Assert;
 
 /**
  * Audio speech metadata implementation for OpenAI using the OpenAI Java SDK.
@@ -38,18 +35,6 @@ public class OpenAiAudioSpeechResponseMetadata extends TextToSpeechResponseMetad
 
 	protected static final String AI_METADATA_STRING = "{ @type: %1$s, rateLimit: %2$s }";
 
-	private static final String REQUESTS_LIMIT_HEADER = "x-ratelimit-limit-requests";
-
-	private static final String REQUESTS_REMAINING_HEADER = "x-ratelimit-remaining-requests";
-
-	private static final String REQUESTS_RESET_HEADER = "x-ratelimit-reset-requests";
-
-	private static final String TOKENS_LIMIT_HEADER = "x-ratelimit-limit-tokens";
-
-	private static final String TOKENS_REMAINING_HEADER = "x-ratelimit-remaining-tokens";
-
-	private static final String TOKENS_RESET_HEADER = "x-ratelimit-reset-tokens";
-
 	private final @Nullable RateLimit rateLimit;
 
 	public OpenAiAudioSpeechResponseMetadata() {
@@ -61,46 +46,7 @@ public class OpenAiAudioSpeechResponseMetadata extends TextToSpeechResponseMetad
 	}
 
 	public static OpenAiAudioSpeechResponseMetadata from(Headers headers) {
-		Assert.notNull(headers, "Headers must not be null");
-
-		Long requestsLimit = getHeaderAsLong(headers, REQUESTS_LIMIT_HEADER);
-		Long requestsRemaining = getHeaderAsLong(headers, REQUESTS_REMAINING_HEADER);
-		Duration requestsReset = getHeaderAsDuration(headers, REQUESTS_RESET_HEADER);
-
-		Long tokensLimit = getHeaderAsLong(headers, TOKENS_LIMIT_HEADER);
-		Long tokensRemaining = getHeaderAsLong(headers, TOKENS_REMAINING_HEADER);
-		Duration tokensReset = getHeaderAsDuration(headers, TOKENS_RESET_HEADER);
-
-		RateLimit rateLimit = (requestsLimit != null || tokensLimit != null) ? new OpenAiRateLimit(requestsLimit,
-				requestsRemaining, requestsReset, tokensLimit, tokensRemaining, tokensReset) : new EmptyRateLimit();
-
-		return new OpenAiAudioSpeechResponseMetadata(rateLimit);
-	}
-
-	private static @Nullable Long getHeaderAsLong(Headers headers, String headerName) {
-		var values = headers.values(headerName);
-		if (!values.isEmpty()) {
-			try {
-				return Long.parseLong(values.get(0).trim());
-			}
-			catch (NumberFormatException e) {
-				return null;
-			}
-		}
-		return null;
-	}
-
-	private static @Nullable Duration getHeaderAsDuration(Headers headers, String headerName) {
-		var values = headers.values(headerName);
-		if (!values.isEmpty()) {
-			try {
-				return Duration.ofSeconds(Long.parseLong(values.get(0).trim()));
-			}
-			catch (Exception e) {
-				return null;
-			}
-		}
-		return null;
+		return new OpenAiAudioSpeechResponseMetadata(OpenAiRateLimit.from(headers));
 	}
 
 	public @Nullable RateLimit getRateLimit() {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiRateLimit.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiRateLimit.java
@@ -18,9 +18,12 @@ package org.springframework.ai.openai.metadata;
 
 import java.time.Duration;
 
+import com.openai.core.http.Headers;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.ai.chat.metadata.EmptyRateLimit;
 import org.springframework.ai.chat.metadata.RateLimit;
+import org.springframework.util.Assert;
 
 /**
  * {@link RateLimit} implementation for {@literal OpenAI SDK}.
@@ -33,6 +36,18 @@ import org.springframework.ai.chat.metadata.RateLimit;
  */
 @SuppressWarnings("NullAway")
 public class OpenAiRateLimit implements RateLimit {
+
+	private static final String REQUESTS_LIMIT_HEADER = "x-ratelimit-limit-requests";
+
+	private static final String REQUESTS_REMAINING_HEADER = "x-ratelimit-remaining-requests";
+
+	private static final String REQUESTS_RESET_HEADER = "x-ratelimit-reset-requests";
+
+	private static final String TOKENS_LIMIT_HEADER = "x-ratelimit-limit-tokens";
+
+	private static final String TOKENS_REMAINING_HEADER = "x-ratelimit-remaining-tokens";
+
+	private static final String TOKENS_RESET_HEADER = "x-ratelimit-reset-tokens";
 
 	private final @Nullable Long requestsLimit;
 
@@ -56,6 +71,26 @@ public class OpenAiRateLimit implements RateLimit {
 		this.tokensLimit = tokensLimit;
 		this.tokensRemaining = tokensRemaining;
 		this.tokensReset = tokensReset;
+	}
+
+	/**
+	 * Parses OpenAI rate-limit response headers.
+	 * @param headers the HTTP response headers
+	 * @return an {@link OpenAiRateLimit} populated from the headers, or an
+	 * {@link EmptyRateLimit} if no rate-limit headers are present
+	 */
+	public static RateLimit from(Headers headers) {
+		Assert.notNull(headers, "Headers must not be null");
+
+		Long requestsLimit = getHeaderAsLong(headers, REQUESTS_LIMIT_HEADER);
+		Long requestsRemaining = getHeaderAsLong(headers, REQUESTS_REMAINING_HEADER);
+		Duration requestsReset = getHeaderAsDuration(headers, REQUESTS_RESET_HEADER);
+		Long tokensLimit = getHeaderAsLong(headers, TOKENS_LIMIT_HEADER);
+		Long tokensRemaining = getHeaderAsLong(headers, TOKENS_REMAINING_HEADER);
+		Duration tokensReset = getHeaderAsDuration(headers, TOKENS_RESET_HEADER);
+
+		return (requestsLimit != null || tokensLimit != null) ? new OpenAiRateLimit(requestsLimit, requestsRemaining,
+				requestsReset, tokensLimit, tokensRemaining, tokensReset) : new EmptyRateLimit();
 	}
 
 	@Override
@@ -86,6 +121,32 @@ public class OpenAiRateLimit implements RateLimit {
 	@Override
 	public Duration getTokensReset() {
 		return this.tokensReset;
+	}
+
+	private static @Nullable Long getHeaderAsLong(Headers headers, String headerName) {
+		var values = headers.values(headerName);
+		if (!values.isEmpty()) {
+			try {
+				return Long.parseLong(values.get(0).trim());
+			}
+			catch (NumberFormatException e) {
+				return null;
+			}
+		}
+		return null;
+	}
+
+	private static @Nullable Duration getHeaderAsDuration(Headers headers, String headerName) {
+		var values = headers.values(headerName);
+		if (!values.isEmpty()) {
+			try {
+				return Duration.ofSeconds(Long.parseLong(values.get(0).trim()));
+			}
+			catch (Exception e) {
+				return null;
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiRateLimit.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiRateLimit.java
@@ -17,6 +17,8 @@
 package org.springframework.ai.openai.metadata;
 
 import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.openai.core.http.Headers;
 import org.jspecify.annotations.Nullable;
@@ -48,6 +50,8 @@ public class OpenAiRateLimit implements RateLimit {
 	private static final String TOKENS_REMAINING_HEADER = "x-ratelimit-remaining-tokens";
 
 	private static final String TOKENS_RESET_HEADER = "x-ratelimit-reset-tokens";
+
+	private static final Pattern DURATION_COMPONENT_PATTERN = Pattern.compile("(\\d+)(ms|d|h|m|s)");
 
 	private final @Nullable Long requestsLimit;
 
@@ -139,14 +143,44 @@ public class OpenAiRateLimit implements RateLimit {
 	private static @Nullable Duration getHeaderAsDuration(Headers headers, String headerName) {
 		var values = headers.values(headerName);
 		if (!values.isEmpty()) {
+			return parseDuration(values.get(0).trim());
+		}
+		return null;
+	}
+
+	private static @Nullable Duration parseDuration(String value) {
+		if (value.isEmpty()) {
+			return null;
+		}
+		try {
+			return Duration.ofSeconds(Long.parseLong(value));
+		}
+		catch (NumberFormatException ex) {
+			Matcher matcher = DURATION_COMPONENT_PATTERN.matcher(value);
+			Duration duration = Duration.ZERO;
+			int end = 0;
 			try {
-				return Duration.ofSeconds(Long.parseLong(values.get(0).trim()));
+				while (matcher.find()) {
+					if (matcher.start() != end) {
+						return null;
+					}
+					long amount = Long.parseLong(matcher.group(1));
+					duration = switch (matcher.group(2)) {
+						case "ms" -> duration.plusMillis(amount);
+						case "d" -> duration.plusDays(amount);
+						case "h" -> duration.plusHours(amount);
+						case "m" -> duration.plusMinutes(amount);
+						case "s" -> duration.plusSeconds(amount);
+						default -> throw new IllegalArgumentException("Unsupported duration unit");
+					};
+					end = matcher.end();
+				}
+				return end == value.length() ? duration : null;
 			}
-			catch (Exception e) {
+			catch (ArithmeticException | NumberFormatException ignored) {
 				return null;
 			}
 		}
-		return null;
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.openai;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -32,6 +33,8 @@ import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
 import com.openai.core.http.AsyncStreamResponse;
+import com.openai.core.http.Headers;
+import com.openai.core.http.HttpResponseFor;
 import com.openai.models.FunctionDefinition;
 import com.openai.models.FunctionParameters;
 import com.openai.models.ReasoningEffort;
@@ -70,6 +73,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel.ResponseFormat;
+import org.springframework.ai.openai.metadata.OpenAiRateLimit;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.util.JsonHelper;
 
@@ -110,7 +114,7 @@ class OpenAiChatModelTests {
 		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
 		when(this.openAiClient.chat()).thenReturn(chatService);
 		when(chatService.completions()).thenReturn(chatCompletionService);
-		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+		ChatCompletion chatCompletion = ChatCompletion.builder()
 			.id("gen-1888888888-XYZabc123NewId")
 			.created(1777799928)
 			.model("moonshotai/kimi-k2.5-0127")
@@ -128,7 +132,8 @@ class OpenAiChatModelTests {
 					.build())
 				.build())
 			.additionalProperties(additionalProperties)
-			.build());
+			.build();
+		mockChatCompletion(chatCompletionService, chatCompletion);
 
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
@@ -150,12 +155,65 @@ class OpenAiChatModelTests {
 	}
 
 	@Test
+	void mapsRateLimitHeadersForNonStreamingResponses() {
+		ChatService chatService = mock(ChatService.class);
+		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
+		ChatCompletion chatCompletion = ChatCompletion.builder()
+			.id("chatcmpl-rate-limit")
+			.created(1777799928)
+			.model("test-model")
+			.usage(CompletionUsage.builder().promptTokens(1).completionTokens(1).totalTokens(2).build())
+			.addChoice(ChatCompletion.Choice.builder()
+				.finishReason(ChatCompletion.Choice.FinishReason.STOP)
+				.index(0)
+				.logprobs(Optional.empty())
+				.message(ChatCompletionMessage.builder()
+					.content("hello")
+					.refusal(Optional.empty())
+					.role(JsonValue.from("assistant"))
+					.annotations(List.of())
+					.toolCalls(List.of())
+					.build())
+				.build())
+			.build();
+
+		when(this.openAiClient.chat()).thenReturn(chatService);
+		when(chatService.completions()).thenReturn(chatCompletionService);
+		mockChatCompletion(chatCompletionService, chatCompletion,
+				Headers.builder()
+					.put("x-ratelimit-limit-requests", "10000")
+					.put("x-ratelimit-remaining-requests", "9999")
+					.put("x-ratelimit-reset-requests", "60")
+					.put("x-ratelimit-limit-tokens", "1000000")
+					.put("x-ratelimit-remaining-tokens", "999000")
+					.put("x-ratelimit-reset-tokens", "120")
+					.build());
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.call(new Prompt("hi", options));
+
+		assertThat(response.getMetadata().getRateLimit()).isInstanceOf(OpenAiRateLimit.class);
+		assertThat(response.getMetadata().getRateLimit().getRequestsLimit()).isEqualTo(10000L);
+		assertThat(response.getMetadata().getRateLimit().getRequestsRemaining()).isEqualTo(9999L);
+		assertThat(response.getMetadata().getRateLimit().getRequestsReset()).isEqualTo(Duration.ofSeconds(60));
+		assertThat(response.getMetadata().getRateLimit().getTokensLimit()).isEqualTo(1000000L);
+		assertThat(response.getMetadata().getRateLimit().getTokensRemaining()).isEqualTo(999000L);
+		assertThat(response.getMetadata().getRateLimit().getTokensReset()).isEqualTo(Duration.ofSeconds(120));
+	}
+
+	@Test
 	void preserveUnmappedToolCallAdditionalProperties() {
 		ChatService chatService = mock(ChatService.class);
 		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
 		when(this.openAiClient.chat()).thenReturn(chatService);
 		when(chatService.completions()).thenReturn(chatCompletionService);
-		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+		ChatCompletion chatCompletion = ChatCompletion.builder()
 			.id("chatcmpl-test")
 			.created(1777799928)
 			.model("gemini-3.5-flash")
@@ -181,7 +239,8 @@ class OpenAiChatModelTests {
 							.build())))
 					.build())
 				.build())
-			.build());
+			.build();
+		mockChatCompletion(chatCompletionService, chatCompletion);
 
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gemini-3.5-flash").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
@@ -591,7 +650,7 @@ class OpenAiChatModelTests {
 
 		when(this.openAiClient.chat()).thenReturn(chatService);
 		when(chatService.completions()).thenReturn(chatCompletionService);
-		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+		ChatCompletion chatCompletion = ChatCompletion.builder()
 			.id("gen-1888888888-XYZabc123NewId")
 			.created(1777799928)
 			.model("deepseek-reasoner")
@@ -609,7 +668,8 @@ class OpenAiChatModelTests {
 					.putAdditionalProperty("reasoning_content", JsonValue.from("Test reasoning content"))
 					.build())
 				.build())
-			.build());
+			.build();
+		mockChatCompletion(chatCompletionService, chatCompletion);
 
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("deepseek-reasoner").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
@@ -631,7 +691,7 @@ class OpenAiChatModelTests {
 
 		when(this.openAiClient.chat()).thenReturn(chatService);
 		when(chatService.completions()).thenReturn(chatCompletionService);
-		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+		ChatCompletion chatCompletion = ChatCompletion.builder()
 			.id("gen-1888888888-XYZabc123NewId")
 			.created(1777799928)
 			.model("test-reasoner")
@@ -649,7 +709,8 @@ class OpenAiChatModelTests {
 					.putAdditionalProperty("reasoning", JsonValue.from("Test reasoning content"))
 					.build())
 				.build())
-			.build());
+			.build();
+		mockChatCompletion(chatCompletionService, chatCompletion);
 
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-reasoner").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
@@ -671,7 +732,7 @@ class OpenAiChatModelTests {
 
 		when(this.openAiClient.chat()).thenReturn(chatService);
 		when(chatService.completions()).thenReturn(chatCompletionService);
-		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+		ChatCompletion chatCompletion = ChatCompletion.builder()
 			.id("gen-1888888888-XYZabc123NewId")
 			.created(1777799928)
 			.model("test-model")
@@ -688,7 +749,8 @@ class OpenAiChatModelTests {
 					.toolCalls(List.of())
 					.build())
 				.build())
-			.build());
+			.build();
+		mockChatCompletion(chatCompletionService, chatCompletion);
 
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
@@ -708,7 +770,7 @@ class OpenAiChatModelTests {
 		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
 		when(this.openAiClient.chat()).thenReturn(chatService);
 		when(chatService.completions()).thenReturn(chatCompletionService);
-		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+		ChatCompletion chatCompletion = ChatCompletion.builder()
 			.id("test-id")
 			.created(1234567890L)
 			.model("test-model")
@@ -725,7 +787,8 @@ class OpenAiChatModelTests {
 					.toolCalls(List.of())
 					.build())
 				.build())
-			.build());
+			.build();
+		mockChatCompletion(chatCompletionService, chatCompletion);
 
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
@@ -898,6 +961,20 @@ class OpenAiChatModelTests {
 		return chatModel.stream(new Prompt("Preserve reasoning metadata while streaming", options));
 	}
 
+	private void mockChatCompletion(ChatCompletionService chatCompletionService, ChatCompletion chatCompletion) {
+		mockChatCompletion(chatCompletionService, chatCompletion, Headers.builder().build());
+	}
+
+	private void mockChatCompletion(ChatCompletionService chatCompletionService, ChatCompletion chatCompletion,
+			Headers headers) {
+		ChatCompletionService.WithRawResponse rawResponseService = mock(ChatCompletionService.WithRawResponse.class);
+		HttpResponseFor<ChatCompletion> httpResponse = mock();
+		when(chatCompletionService.withRawResponse()).thenReturn(rawResponseService);
+		when(rawResponseService.create(any(ChatCompletionCreateParams.class))).thenReturn(httpResponse);
+		when(httpResponse.parse()).thenReturn(chatCompletion);
+		when(httpResponse.headers()).thenReturn(headers);
+	}
+
 	private static ChatCompletionChunk streamingChunk(
 			Consumer<ChatCompletionChunk.Choice.Delta.Builder> deltaCustomizer,
 			ChatCompletionChunk.Choice.FinishReason finishReason) {
@@ -1062,7 +1139,7 @@ class OpenAiChatModelTests {
 		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
 		when(this.openAiClient.chat()).thenReturn(chatService);
 		when(chatService.completions()).thenReturn(chatCompletionService);
-		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+		ChatCompletion chatCompletion = ChatCompletion.builder()
 			.id("test-id")
 			.created(1777799928)
 			.model("test-model")
@@ -1079,7 +1156,8 @@ class OpenAiChatModelTests {
 					.toolCalls(List.of())
 					.build())
 				.build())
-			.build());
+			.build();
+		mockChatCompletion(chatCompletionService, chatCompletion);
 
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -183,10 +183,10 @@ class OpenAiChatModelTests {
 				Headers.builder()
 					.put("x-ratelimit-limit-requests", "10000")
 					.put("x-ratelimit-remaining-requests", "9999")
-					.put("x-ratelimit-reset-requests", "60")
+					.put("x-ratelimit-reset-requests", "1s")
 					.put("x-ratelimit-limit-tokens", "1000000")
 					.put("x-ratelimit-remaining-tokens", "999000")
-					.put("x-ratelimit-reset-tokens", "120")
+					.put("x-ratelimit-reset-tokens", "6m0s")
 					.build());
 
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
@@ -201,10 +201,10 @@ class OpenAiChatModelTests {
 		assertThat(response.getMetadata().getRateLimit()).isInstanceOf(OpenAiRateLimit.class);
 		assertThat(response.getMetadata().getRateLimit().getRequestsLimit()).isEqualTo(10000L);
 		assertThat(response.getMetadata().getRateLimit().getRequestsRemaining()).isEqualTo(9999L);
-		assertThat(response.getMetadata().getRateLimit().getRequestsReset()).isEqualTo(Duration.ofSeconds(60));
+		assertThat(response.getMetadata().getRateLimit().getRequestsReset()).isEqualTo(Duration.ofSeconds(1));
 		assertThat(response.getMetadata().getRateLimit().getTokensLimit()).isEqualTo(1000000L);
 		assertThat(response.getMetadata().getRateLimit().getTokensRemaining()).isEqualTo(999000L);
-		assertThat(response.getMetadata().getRateLimit().getTokensReset()).isEqualTo(Duration.ofSeconds(120));
+		assertThat(response.getMetadata().getRateLimit().getTokensReset()).isEqualTo(Duration.ofMinutes(6));
 	}
 
 	@Test

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -116,6 +116,19 @@ public class OpenAiChatModelIT {
 		assertThat((Object) response.getResult().getOutput().getMetadata().get("reasoningContent")).isNotNull();
 	}
 
+	@Test
+	void nonStreamingCallIncludesRateLimitMetadata() {
+		ChatResponse response = this.chatModel.call(new Prompt("Reply with OK."));
+
+		var rateLimit = response.getMetadata().getRateLimit();
+		assertThat(rateLimit.getRequestsLimit()).isPositive();
+		assertThat(rateLimit.getRequestsRemaining()).isNotNull();
+		assertThat(rateLimit.getRequestsReset()).isNotNull();
+		assertThat(rateLimit.getTokensLimit()).isPositive();
+		assertThat(rateLimit.getTokensRemaining()).isNotNull();
+		assertThat(rateLimit.getTokensReset()).isNotNull();
+	}
+
 	void roleTest() {
 		UserMessage userMessage = new UserMessage(
 				"Tell me about 3 famous pirates from the Golden Age of Piracy and what they did.");


### PR DESCRIPTION
Fixes #6607.

Chat completions discard the OpenAI SDK response headers, so `ChatResponseMetadata` exposes `EmptyRateLimit` for non-streaming calls. This reads the raw response headers and maps the rate-limit values while keeping streaming behavior unchanged.

Tests:
- `./mvnw.cmd --no-transfer-progress -q -pl models/spring-ai-openai -am -Dtest=OpenAiChatModelTests,OpenAiAudioSpeechModelWithResponseMetadataTests -Dsurefire.failIfNoSpecifiedTests=false test`