### PR TITLE
Restore persisted thought signatures in `GoogleGenAiChatModel`

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -141,6 +141,7 @@ import org.springframework.util.StringUtils;
  * @author Dan Dobrin
  * @author Thomas Vitale
  * @author Sebastien Deleuze
+ * @author Taewoong Kim
  * @since 0.8.1
  * @see GoogleGenAiChatOptions
  * @see ToolCallingManager
@@ -149,6 +150,8 @@ import org.springframework.util.StringUtils;
 public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 
 	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();
+
+	private static final String THOUGHT_SIGNATURES_METADATA_KEY = "thoughtSignatures";
 
 	private final Log logger = LogFactory.getLog(getClass());
 
@@ -262,15 +265,9 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			// Check if there are thought signatures to restore.
 			// Per Google's documentation, thought signatures must be attached to the
 			// first functionCall part in each step of the current turn.
-			// See: https://ai.google.dev/gemini-api/docs/thought-signatures
-			List<byte[]> thoughtSignatures = null;
-			if (assistantMessage.getMetadata() != null
-					&& assistantMessage.getMetadata().containsKey("thoughtSignatures")) {
-				Object signaturesObj = assistantMessage.getMetadata().get("thoughtSignatures");
-				if (signaturesObj instanceof List) {
-					thoughtSignatures = new ArrayList<>((List<byte[]>) signaturesObj);
-				}
-			}
+			// See Google's thought signature documentation:
+			// https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures
+			List<byte[]> thoughtSignatures = getThoughtSignatures(assistantMessage);
 
 			// Add text part (without thought signature - signatures go on functionCall
 			// parts)
@@ -292,7 +289,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 							.build());
 
 					// Attach thought signature to function call part if available
-					if (thoughtSignatures != null && !thoughtSignatures.isEmpty()) {
+					if (!thoughtSignatures.isEmpty()) {
 						partBuilder.thoughtSignature(thoughtSignatures.remove(0));
 					}
 
@@ -317,6 +314,46 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		else {
 			throw new IllegalArgumentException("Gemini doesn't support message type: " + message.getClass());
 		}
+	}
+
+	private static List<byte[]> getThoughtSignatures(AssistantMessage assistantMessage) {
+		Object signatures = assistantMessage.getMetadata().get(THOUGHT_SIGNATURES_METADATA_KEY);
+		if (!(signatures instanceof List<?> signatureList)) {
+			return List.of();
+		}
+
+		List<byte[]> thoughtSignatures = new ArrayList<>();
+		for (Object signature : signatureList) {
+			if (signature instanceof byte[] bytes) {
+				thoughtSignatures.add(bytes);
+			}
+			else if (signature instanceof List<?> values) {
+				byte[] bytes = toThoughtSignatureBytes(values);
+				if (bytes == null) {
+					return List.of();
+				}
+				thoughtSignatures.add(bytes);
+			}
+			else {
+				return List.of();
+			}
+		}
+		return thoughtSignatures;
+	}
+
+	private static byte @Nullable [] toThoughtSignatureBytes(List<?> values) {
+		byte[] bytes = new byte[values.size()];
+		for (int i = 0; i < values.size(); i++) {
+			if (!(values.get(i) instanceof Number number)) {
+				return null;
+			}
+			double value = number.doubleValue();
+			if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE || value != Math.rint(value)) {
+				return null;
+			}
+			bytes[i] = (byte) value;
+		}
+		return bytes;
 	}
 
 	private static List<Part> mediaToParts(Collection<Media> media) {
@@ -533,7 +570,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 				.toList();
 
 			if (!thoughtSignatures.isEmpty()) {
-				messageMetadata.put("thoughtSignatures", thoughtSignatures);
+				messageMetadata.put(THOUGHT_SIGNATURES_METADATA_KEY, thoughtSignatures);
 			}
 
 			// Extract server-side tool invocations if present

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -54,6 +55,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Soby Chacko
  * @author Sebastien Deleuze
  * @author Dimitar Proynov
+ * @author Taewoong Kim
  */
 @ExtendWith(MockitoExtension.class)
 public class CreateGeminiRequestTests {
@@ -115,6 +117,45 @@ public class CreateGeminiRequestTests {
 		// The test needs to be updated based on how media is handled in the new SDK
 		Part mediaPart = parts.get(1);
 		assertThat(mediaPart.fileData().isPresent()).isTrue();
+	}
+
+	@Test
+	public void createRequestWithJsonDeserializedThoughtSignatures() {
+		// Gson deserializes JSON arrays read as Object as lists of Double values.
+		var assistantMessage = AssistantMessage.builder()
+			.content("")
+			.properties(Map.of("thoughtSignatures", List.of(List.of(-128.0, -1.0, 0.0, 127.0))))
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "CurrentWeather", "{}")))
+			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+		GeminiRequest request = client.createGeminiRequest(
+				new Prompt(List.of(assistantMessage), GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build()));
+
+		assertThat(request.contents()).hasSize(1);
+		List<Part> parts = request.contents().get(0).parts().orElse(List.of());
+		assertThat(parts).hasSize(1);
+		assertThat(parts.get(0).thoughtSignature()).isPresent();
+		assertThat(parts.get(0).thoughtSignature().get()).containsExactly(-128, -1, 0, 127);
+	}
+
+	@Test
+	public void createRequestWithNativeThoughtSignatures() {
+		var assistantMessage = AssistantMessage.builder()
+			.content("")
+			.properties(Map.of("thoughtSignatures", List.of(new byte[] { -128, -1, 0, 127 })))
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "CurrentWeather", "{}")))
+			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+		GeminiRequest request = client.createGeminiRequest(
+				new Prompt(List.of(assistantMessage), GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build()));
+
+		assertThat(request.contents()).hasSize(1);
+		List<Part> parts = request.contents().get(0).parts().orElse(List.of());
+		assertThat(parts).hasSize(1);
+		assertThat(parts.get(0).thoughtSignature()).isPresent();
+		assertThat(parts.get(0).thoughtSignature().get()).containsExactly(-128, -1, 0, 127);
 	}
 
 	@Test


### PR DESCRIPTION
`GoogleGenAiChatModel` stores Gemini thought signatures in assistant-message metadata as `List<byte[]>` and reattaches them when constructing subsequent function-call requests.

Gemini requires function-calling thought signatures to be returned exactly as received so that reasoning context is preserved across requests.

When this metadata is serialized to JSON and deserialized as `Object`, the Java `byte[]` type is not preserved.

Gson reads JSON arrays as `List` values with `Double` elements, and `RedisChatMemoryRepository` uses this serialization path.

Consequently, a persisted signature has this shape after it is loaded:

```text
List<byte[]>
    -> JSON
    -> List<List<Double>>
```

The existing request conversion verifies only that the metadata value is a `List`, not that its elements are `byte[]`.

When the signature is attached to the next function-call part, the inner numeric list is cast to `byte[]`, causing a `ClassCastException` before the request reaches Gemini.

To reproduce the failure:

1. Create or receive a Google GenAI `AssistantMessage` containing a function call and a `thoughtSignatures` metadata value.
2. Persist and reload the message with `RedisChatMemoryRepository`.
3. Send another Google GenAI request using the conversation history loaded from Redis.
4. Observe a `ClassCastException` while `GoogleGenAiChatModel` constructs the request.
