### PR TITLE
Reduce `RedisVectorStore` search payloads by omitting unused embeddings

### DIFF
--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
@@ -239,6 +239,7 @@ import org.springframework.util.StringUtils;
  * @author Jihoon Kim
  * @author chabinhwang
  * @author Yanming Zhou
+ * @author Taewoong Kim
  * @see EmbeddingModel
  * @since 1.0.0
  */
@@ -475,11 +476,6 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		String queryString = String.format(QUERY_FORMAT, filter, request.getTopK(), this.embeddingFieldName,
 				EMBEDDING_PARAM_NAME, DISTANCE_FIELD_NAME);
 
-		List<String> returnFields = new ArrayList<>();
-		this.metadataFields.stream().map(MetadataField::name).forEach(returnFields::add);
-		returnFields.add(this.embeddingFieldName);
-		returnFields.add(this.contentFieldName);
-		returnFields.add(DISTANCE_FIELD_NAME);
 		float[] embedding = this.embeddingModel.embed(request.getQuery());
 
 		// Normalize embeddings for COSINE distance metric
@@ -488,7 +484,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		}
 
 		Query query = new Query(queryString).addParam(EMBEDDING_PARAM_NAME, RediSearchUtil.toByteArray(embedding))
-			.returnFields(returnFields.toArray(new String[0]))
+			.returnFields(getReturnFields().toArray(new String[0]))
 			.limit(0, request.getTopK())
 			.dialect(2);
 
@@ -757,7 +753,6 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 	private List<String> getReturnFields() {
 		List<String> returnFields = new ArrayList<>();
 		this.metadataFields.stream().map(MetadataField::name).forEach(returnFields::add);
-		returnFields.add(this.embeddingFieldName);
 		returnFields.add(this.contentFieldName);
 		returnFields.add(DISTANCE_FIELD_NAME);
 		return returnFields;
@@ -1128,12 +1123,6 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 			queryString = "(" + queryString + " " + filterExpression + ")";
 		}
 
-		List<String> returnFields = new ArrayList<>();
-		this.metadataFields.stream().map(MetadataField::name).forEach(returnFields::add);
-		returnFields.add(this.embeddingFieldName);
-		returnFields.add(this.contentFieldName);
-		returnFields.add(DISTANCE_FIELD_NAME);
-
 		// Log query information for debugging
 		if (logger.isDebugEnabled()) {
 			logger.debug("Range query string: " + queryString);
@@ -1142,7 +1131,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 
 		Query query1 = new Query(queryString).addParam("radius", effectiveRadius)
 			.addParam(EMBEDDING_PARAM_NAME, RediSearchUtil.toByteArray(embedding))
-			.returnFields(returnFields.toArray(new String[0]))
+			.returnFields(getReturnFields().toArray(new String[0]))
 			.dialect(2);
 
 		SearchResult result = this.jedisClient.ftSearch(this.indexName, query1);

--- a/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreIT.java
+++ b/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreIT.java
@@ -57,6 +57,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Thomas Vitale
  * @author Soby Chacko
  * @author Yanming Zhou
+ * @author Taewoong Kim
  */
 @Testcontainers
 class RedisVectorStoreIT extends BaseVectorStoreTests {
@@ -112,6 +113,7 @@ class RedisVectorStoreIT extends BaseVectorStoreTests {
 		this.contextRunner.run(context -> {
 
 			VectorStore vectorStore = context.getBean(VectorStore.class);
+			RedisVectorStore redisVectorStore = context.getBean(RedisVectorStore.class);
 
 			vectorStore.add(this.documents);
 
@@ -126,6 +128,10 @@ class RedisVectorStoreIT extends BaseVectorStoreTests {
 			assertThat(resultDoc.getMetadata()).hasSize(3);
 			assertThat(resultDoc.getMetadata()).containsKeys("meta1", RedisVectorStore.DISTANCE_FIELD_NAME,
 					DocumentMetadata.DISTANCE.value());
+			assertThat(redisVectorStore.searchByText("Spring", RedisVectorStore.DEFAULT_CONTENT_FIELD_NAME, 5))
+				.extracting(Document::getId)
+				.contains("1");
+			assertThat(redisVectorStore.searchByRange("Spring", 0.0)).extracting(Document::getId).contains("1");
 
 			// Remove all documents from the store
 			vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());

--- a/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreTests.java
+++ b/vector-stores/spring-ai-redis-store/src/test/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.redis;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.search.Query;
+import redis.clients.jedis.search.SearchProtocol.SearchCommand;
+import redis.clients.jedis.search.SearchResult;
+
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.SearchRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Taewoong Kim
+ */
+class RedisVectorStoreTests {
+
+	@Test
+	void searchesDoNotReturnEmbeddingField() {
+		RedisClient jedisClient = mock(RedisClient.class);
+		EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+		SearchResult searchResult = mock(SearchResult.class);
+		when(embeddingModel.embed(anyString())).thenReturn(new float[] { 1.0f, 0.0f, 0.0f });
+		when(searchResult.getDocuments()).thenReturn(List.of());
+		when(jedisClient.ftSearch(anyString(), any(Query.class))).thenReturn(searchResult);
+		RedisVectorStore vectorStore = RedisVectorStore.builder(jedisClient, embeddingModel)
+			.embeddingFieldName("custom_embedding")
+			.build();
+
+		vectorStore.similaritySearch(SearchRequest.builder().query("query").topK(1).build());
+		vectorStore.searchByText("query", RedisVectorStore.DEFAULT_CONTENT_FIELD_NAME, 1);
+		vectorStore.searchByRange("query", 0.75);
+
+		ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+		verify(jedisClient, times(3)).ftSearch(eq(RedisVectorStore.DEFAULT_INDEX_NAME), queryCaptor.capture());
+		assertThat(queryCaptor.getAllValues()).allSatisfy(query -> assertThat(returnFields(query))
+			.contains(RedisVectorStore.DEFAULT_CONTENT_FIELD_NAME, RedisVectorStore.DISTANCE_FIELD_NAME)
+			.doesNotContain("custom_embedding"));
+	}
+
+	private static List<String> returnFields(Query query) {
+		CommandArguments commandArguments = new CommandArguments(SearchCommand.SEARCH);
+		query.addParams(commandArguments);
+		List<String> arguments = StreamSupport.stream(commandArguments.spliterator(), false)
+			.map(argument -> new String(argument.getRaw(), StandardCharsets.UTF_8))
+			.toList();
+		int returnIndex = arguments.indexOf("RETURN");
+		int returnFieldCount = Integer.parseInt(arguments.get(returnIndex + 1));
+		return arguments.subList(returnIndex + 2, returnIndex + 2 + returnFieldCount);
+	}
+
+}


### PR DESCRIPTION
`RedisVectorStore` currently asks Redis to include each matched document's stored embedding in the response for similarity, text, and range searches. 

Vector searches still need the stored embeddings inside Redis to find matching documents, but Spring AI does not use the returned copy when converting any result to a `Document`.

As a result, Redis sends the full vector for every match even though Spring AI never uses it. 

In a local Redis Stack payload check, a single 3,072-dimensional embedding added about 37 KB to the returned data. 
This overhead grows with the number of results requested through `topK`.

This change removes only the unused embedding from search responses. 
Stored embeddings are still used for indexing and vector search, and the returned `Document` results are unchanged. 

Tests verify the generated `RETURN` fields and cover similarity, text, and range search paths, including a custom embedding field name.
