### PR TITLE
Replace System.out with debug-level logging in `ParagraphManager`

### DIFF
--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
@@ -17,10 +17,11 @@
 package org.springframework.ai.reader.pdf.config;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageTree;
@@ -40,6 +41,8 @@ import org.springframework.util.CollectionUtils;
  * @author Christian Tzolov
  */
 public class ParagraphManager {
+
+	private static final Log logger = LogFactory.getLog(ParagraphManager.class);
 
 	/**
 	 * Root of the paragraphs tree.
@@ -64,7 +67,9 @@ public class ParagraphManager {
 					new Paragraph(null, "root", -1, 1, this.document.getNumberOfPages(), 0),
 					this.document.getDocumentCatalog().getDocumentOutline(), 0);
 
-			printParagraph(this.rootParagraph, System.out);
+			if (logger.isDebugEnabled()) {
+				logParagraph(this.rootParagraph);
+			}
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
@@ -87,10 +92,10 @@ public class ParagraphManager {
 		}
 	}
 
-	private void printParagraph(Paragraph paragraph, PrintStream printStream) {
-		printStream.println(paragraph);
+	private void logParagraph(Paragraph paragraph) {
+		logger.debug(paragraph);
 		for (Paragraph childParagraph : paragraph.children()) {
-			printParagraph(childParagraph, printStream);
+			logParagraph(childParagraph);
 		}
 	}
 

--- a/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.reader.pdf;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.util.List;
 
 import org.apache.pdfbox.Loader;
@@ -112,6 +113,20 @@ public class ParagraphPdfDocumentReaderTests {
 		assertThat(documents).hasSize(2);
 		assertThat(documents.get(0).getMetadata().get("title")).isEqualTo("Chapter 1");
 		assertThat(documents.get(1).getMetadata().get("title")).isEqualTo("Chapter 3");
+	}
+
+	@Test
+	void shouldNotWriteToStdoutDuringInitialization() {
+		PrintStream originalOut = System.out;
+		ByteArrayOutputStream capturedOutput = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(capturedOutput));
+		try {
+			new ParagraphPdfDocumentReader("classpath:/sample3.pdf", PdfDocumentReaderConfig.defaultConfig());
+		}
+		finally {
+			System.setOut(originalOut);
+		}
+		assertThat(capturedOutput.toString()).isEmpty();
 	}
 
 }


### PR DESCRIPTION
The `ParagraphManager` constructor unconditionally calls `printParagraph(this.rootParagraph, System.out)`, dumping the entire PDF outline to stdout on every `ParagraphPdfDocumentReader` instantiation.

This cannot be controlled through logging configuration and produces noisy output when processing multiple PDFs.

**Changes:**
- Replace `System.out` usage with Commons Logging at DEBUG level
- Add `isDebugEnabled()` guard to avoid tree traversal when not needed
- Rename `printParagraph` → `logParagraph` to reflect new behavior
- Add regression test verifying no stdout output during initialization

The logging pattern matches sibling classes `PagePdfDocumentReader` and `ForkPDFLayoutTextStripper`.

Fixes #6599