### PR TITLE
Fix streaming `finishReason` in `OpenAiChatModel`

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -384,8 +384,10 @@ public final class OpenAiChatModel implements ChatModel {
 			}).filter(Objects::nonNull).toList())
 			.orElse(List.of());
 
+		ChatCompletion.Choice.FinishReason.Value finishReasonValue = choice.finishReason().value();
 		var generationMetadataBuilder = ChatGenerationMetadata.builder()
-			.finishReason(choice.finishReason().value().name());
+			.finishReason(finishReasonValue != ChatCompletion.Choice.FinishReason.Value._UNKNOWN
+					? finishReasonValue.name() : null);
 
 		String textContent = message.content().orElse("");
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -1383,4 +1383,20 @@ class OpenAiChatModelTests {
 		assertThat(request.responseFormat().get().jsonSchema().get().jsonSchema().strict()).contains(false);
 	}
 
+	@Test
+	void intermediateStreamingChunksHaveNullFinishReason() {
+		List<ChatCompletionChunk> chunks = List.of(
+				streamingChunk(delta -> delta.role(ChatCompletionChunk.Choice.Delta.Role.ASSISTANT).content("Hello"),
+						null),
+				streamingChunk(delta -> delta.content(", "), null),
+				streamingChunk(delta -> delta.content("world!"), ChatCompletionChunk.Choice.FinishReason.STOP));
+
+		List<ChatResponse> responses = streamResponses(chunks).collectList().block();
+
+		assertThat(responses).hasSize(3);
+		assertThat(responses.get(0).getResult().getMetadata().getFinishReason()).isNull();
+		assertThat(responses.get(1).getResult().getMetadata().getFinishReason()).isNull();
+		assertThat(responses.get(2).getResult().getMetadata().getFinishReason()).isEqualTo("STOP");
+	}
+
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -212,6 +212,25 @@ public class OpenAiChatModelIT {
 	}
 
 	@Test
+	void intermediateStreamingChunksHaveNullFinishReason() {
+		Flux<ChatResponse> flux = this.chatModel.stream(new Prompt("List the days of the week, one per line."));
+		List<ChatResponse> withResult = flux.collectList()
+			.block()
+			.stream()
+			// Only consider chunks that carry a generation — some trailing chunks are
+			// empty usage-only chunks with no result
+			.filter(r -> r.getResult() != null)
+			.collect(Collectors.toList());
+
+		assertThat(withResult).hasSizeGreaterThan(1);
+		// All intermediate chunks must have a null finish reason
+		withResult.subList(0, withResult.size() - 1)
+			.forEach(r -> assertThat(r.getResult().getMetadata().getFinishReason()).isNull());
+		// The final chunk must carry a non-null finish reason (e.g. "STOP")
+		assertThat(withResult.get(withResult.size() - 1).getResult().getMetadata().getFinishReason()).isNotNull();
+	}
+
+	@Test
 	void streamRoleTest() {
 		UserMessage userMessage = new UserMessage(
 				"Tell me about 3 famous pirates from the Golden Age of Piracy and what they did.");


### PR DESCRIPTION
  Intermediate streaming chunks set `ChatGenerationMetadata.finishReason`
  to `"_UNKNOWN"` instead of `null`. This happened because
  `chunkToChatCompletion()` uses `FinishReason.of("")` as a placeholder
  to satisfy the non-streaming builder, which the SDK resolves to the
  internal `_UNKNOWN` value. Fix this by mapping `_UNKNOWN` to `null` in
  `buildGeneration()`.

Resolves #6625