### PR TITLE
Add password support to Redis chat memory autoconfigure

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.chat.memory.repository.redis.autoconfigure;
 
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.RedisClient;
 
 import org.springframework.ai.chat.memory.ChatMemory;
@@ -71,6 +73,20 @@ public class RedisChatMemoryRepositoryAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public RedisClient jedisClient(RedisChatMemoryRepositoryProperties properties) {
+		if (StringUtils.hasText(properties.getUsername()) || StringUtils.hasText(properties.getPassword())) {
+			DefaultJedisClientConfig.Builder configBuilder = DefaultJedisClientConfig.builder();
+			if (StringUtils.hasText(properties.getUsername())) {
+				configBuilder.user(properties.getUsername());
+			}
+			if (StringUtils.hasText(properties.getPassword())) {
+				configBuilder.password(properties.getPassword());
+			}
+			JedisClientConfig clientConfig = configBuilder.build();
+			return RedisClient.builder()
+				.hostAndPort(properties.getHost(), properties.getPort())
+				.clientConfig(clientConfig)
+				.build();
+		}
 		return RedisClient.builder().hostAndPort(properties.getHost(), properties.getPort()).build();
 	}
 

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryProperties.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryProperties.java
@@ -47,6 +47,16 @@ public class RedisChatMemoryRepositoryProperties {
 	private int port = 6379;
 
 	/**
+	 * Redis ACL username.
+	 */
+	private @Nullable String username;
+
+	/**
+	 * Redis server password.
+	 */
+	private @Nullable String password;
+
+	/**
 	 * Name of the Redis search index.
 	 */
 	private String indexName = RedisChatMemoryConfig.DEFAULT_INDEX_NAME;
@@ -101,6 +111,22 @@ public class RedisChatMemoryRepositoryProperties {
 
 	public void setPort(int port) {
 		this.port = port;
+	}
+
+	public @Nullable String getUsername() {
+		return this.username;
+	}
+
+	public void setUsername(@Nullable String username) {
+		this.username = username;
+	}
+
+	public @Nullable String getPassword() {
+		return this.password;
+	}
+
+	public void setPassword(@Nullable String password) {
+		this.password = password;
 	}
 
 	public String getIndexName() {

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryProperties.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryProperties.java
@@ -66,6 +66,26 @@ public class RedisChatMemoryProperties {
 		this.delegate.setPort(port);
 	}
 
+	@DeprecatedConfigurationProperty(replacement = "spring.ai.chat.memory.repository.redis.username")
+	@Deprecated(since = "2.0.1", forRemoval = true)
+	public @Nullable String getUsername() {
+		return this.delegate.getUsername();
+	}
+
+	public void setUsername(@Nullable String username) {
+		this.delegate.setUsername(username);
+	}
+
+	@DeprecatedConfigurationProperty(replacement = "spring.ai.chat.memory.repository.redis.password")
+	@Deprecated(since = "2.0.1", forRemoval = true)
+	public @Nullable String getPassword() {
+		return this.delegate.getPassword();
+	}
+
+	public void setPassword(@Nullable String password) {
+		this.delegate.setPassword(password);
+	}
+
 	@DeprecatedConfigurationProperty(replacement = "spring.ai.chat.memory.repository.redis.index-name")
 	@Deprecated(since = "2.0.1", forRemoval = true)
 	public String getIndexName() {

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/test/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfigurationTests.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/test/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfigurationTests.java
@@ -16,12 +16,19 @@
 
 package org.springframework.ai.model.chat.memory.redis.autoconfigure;
 
+import org.apache.commons.pool2.PooledObjectFactory;
 import org.junit.jupiter.api.Test;
+import redis.clients.jedis.ConnectionFactory;
+import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.providers.PooledConnectionProvider;
+import redis.clients.jedis.util.Pool;
 
 import org.springframework.ai.model.chat.memory.repository.redis.autoconfigure.RedisChatMemoryRepositoryAutoConfiguration;
 import org.springframework.ai.model.chat.memory.repository.redis.autoconfigure.RedisChatMemoryRepositoryProperties;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,6 +73,100 @@ class RedisChatMemoryAutoConfigurationTests {
 				assertThat(chatProperties.getPort()).isEqualTo(6380);
 				assertThat(chatProperties.getInitializeSchema()).isEqualTo(false);
 			});
+	}
+
+	@Test
+	void jedisClientUsesUsernameAndPasswordFromLegacyPrefix() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.memory.redis.host=10.0.0.1", "spring.ai.chat.memory.redis.port=6380",
+					"spring.ai.chat.memory.redis.username=app-user", "spring.ai.chat.memory.redis.password=secret",
+					"spring.ai.chat.memory.redis.initialize-schema=false")
+			.run(context -> {
+				RedisChatMemoryRepositoryProperties properties = context
+					.getBean(RedisChatMemoryRepositoryProperties.class);
+				assertThat(properties.getUsername()).isEqualTo("app-user");
+				assertThat(properties.getPassword()).isEqualTo("secret");
+
+				JedisClientConfig clientConfig = extractJedisClientConfig(context.getBean(RedisClient.class));
+				assertThat(clientConfig.getUser()).isEqualTo("app-user");
+				assertThat(clientConfig.getPassword()).isEqualTo("secret");
+			});
+	}
+
+	@Test
+	void jedisClientUsesUsernameAndPasswordFromNewPrefix() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.memory.repository.redis.host=10.0.0.1",
+					"spring.ai.chat.memory.repository.redis.port=6380",
+					"spring.ai.chat.memory.repository.redis.username=app-user",
+					"spring.ai.chat.memory.repository.redis.password=secret",
+					"spring.ai.chat.memory.repository.redis.initialize-schema=false")
+			.run(context -> {
+				RedisChatMemoryRepositoryProperties properties = context
+					.getBean(RedisChatMemoryRepositoryProperties.class);
+				assertThat(properties.getUsername()).isEqualTo("app-user");
+				assertThat(properties.getPassword()).isEqualTo("secret");
+
+				JedisClientConfig clientConfig = extractJedisClientConfig(context.getBean(RedisClient.class));
+				assertThat(clientConfig.getUser()).isEqualTo("app-user");
+				assertThat(clientConfig.getPassword()).isEqualTo("secret");
+			});
+	}
+
+	@Test
+	void jedisClientUsesPasswordFromLegacyPrefix() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.memory.redis.host=10.0.0.1", "spring.ai.chat.memory.redis.port=6380",
+					"spring.ai.chat.memory.redis.password=secret",
+					"spring.ai.chat.memory.redis.initialize-schema=false")
+			.run(context -> {
+				assertThat(context.getBean(RedisChatMemoryRepositoryProperties.class).getPassword())
+					.isEqualTo("secret");
+				assertThat(extractJedisClientConfig(context.getBean(RedisClient.class)).getPassword())
+					.isEqualTo("secret");
+			});
+	}
+
+	@Test
+	void jedisClientUsesPasswordFromNewPrefix() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.memory.repository.redis.host=10.0.0.1",
+					"spring.ai.chat.memory.repository.redis.port=6380",
+					"spring.ai.chat.memory.repository.redis.password=secret",
+					"spring.ai.chat.memory.repository.redis.initialize-schema=false")
+			.run(context -> {
+				assertThat(context.getBean(RedisChatMemoryRepositoryProperties.class).getPassword())
+					.isEqualTo("secret");
+				assertThat(extractJedisClientConfig(context.getBean(RedisClient.class)).getPassword())
+					.isEqualTo("secret");
+			});
+	}
+
+	@Test
+	void jedisClientWithoutCredentialsDoesNotConfigureUserOrPassword() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.memory.repository.redis.host=10.0.0.1",
+					"spring.ai.chat.memory.repository.redis.port=6380",
+					"spring.ai.chat.memory.repository.redis.initialize-schema=false")
+			.run(context -> {
+				RedisChatMemoryRepositoryProperties properties = context
+					.getBean(RedisChatMemoryRepositoryProperties.class);
+				assertThat(properties.getUsername()).isNull();
+				assertThat(properties.getPassword()).isNull();
+
+				JedisClientConfig clientConfig = extractJedisClientConfig(context.getBean(RedisClient.class));
+				assertThat(clientConfig.getUser()).isNull();
+				assertThat(clientConfig.getPassword()).isNull();
+			});
+	}
+
+	private static JedisClientConfig extractJedisClientConfig(RedisClient redisClient) {
+		Object provider = ReflectionTestUtils.getField(redisClient, "provider");
+		assertThat(provider).isInstanceOf(PooledConnectionProvider.class);
+		Pool<?> pool = ((PooledConnectionProvider) provider).getPool();
+		PooledObjectFactory<?> factory = pool.getFactory();
+		assertThat(factory).isInstanceOf(ConnectionFactory.class);
+		return (JedisClientConfig) ReflectionTestUtils.getField(factory, "clientConfig");
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -522,6 +522,8 @@ ChatMemory chatMemory = MessageWindowChatMemory.builder()
 |Property | Description | Default Value
 | `spring.ai.chat.memory.repository.redis.host` | Redis server host | `localhost`
 | `spring.ai.chat.memory.repository.redis.port` | Redis server port | `6379`
+| `spring.ai.chat.memory.repository.redis.username` | Redis ACL username | _none_
+| `spring.ai.chat.memory.repository.redis.password` | Redis server password | _none_
 | `spring.ai.chat.memory.repository.redis.index-name` | Name of the Redis search index | `chat-memory-idx`
 | `spring.ai.chat.memory.repository.redis.key-prefix` | Key prefix for chat memory entries | `chat-memory:`
 | `spring.ai.chat.memory.repository.redis.time-to-live` | Time to live for chat memory entries (e.g., `24h`, `30d`) | _no expiration_


### PR DESCRIPTION
Fixes #6621

## Summary

Redis chat memory autoconfiguration supports `host` and `port`, but not `password`. Users with password-protected Redis instances had to provide their own `RedisClient` bean instead of using `spring.ai.chat.memory.repository.redis.*` properties.

This PR adds optional username and password properties and wires them into the Jedis RedisClient when configured.The legacy `spring.ai.chat.memory.redis.*` prefix continues to work via delegation.

## Changes
* Add `username` to RedisChatMemoryRepositoryProperties
* Delegate `username` in deprecated RedisChatMemoryProperties
* Add `password` to `RedisChatMemoryRepositoryProperties`
* Apply password when creating `RedisClient` in `RedisChatMemoryRepositoryAutoConfiguration`
* Delegate `password` in deprecated `RedisChatMemoryProperties` for the legacy prefix
* Document `spring.ai.chat.memory.repository.redis.password` in `chat-memory.adoc`
* Add unit tests for password binding with old and new property prefixes

## Configuration

```yaml
spring:
  ai:
    chat:
      memory:
        repository:
          redis:
            host: redis.example.com
            port: 6379
            username: redis-user
            password: ${REDIS_PASSWORD}
```
##  Legacy prefix (still supported):
```yaml
spring:
  ai:
    chat:
      memory:
        redis:
          username: redis-user
          password: ${REDIS_PASSWORD}
```

##  Test plan
- [x]  ./mvnw -pl auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis,auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis -am test '-Dtest=RedisChatMemoryAutoConfigurationTests' -Dsurefire.failIfNoSpecifiedTests=false
- [x]  Password binds correctly via spring.ai.chat.memory.repository.redis.password
- [x]  Password binds correctly via legacy spring.ai.chat.memory.redis.password
- [x]  No password configured → existing behavior unchanged