### PR TITLE
Add structured transcription results

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfigurationIT.java
@@ -51,7 +51,7 @@ public class OpenAiAudioTranscriptionAutoConfigurationIT {
 				AudioTranscriptionResponse response = transcriptionModel
 					.call(new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac")));
 				assertThat(response.getResults()).hasSize(1);
-				assertThat(response.getResult().getOutput()).isNotBlank();
+				assertThat(response.getResult().getOutput().text()).isNotBlank();
 			});
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -174,7 +174,7 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 				}
 			}));
 
-		return chunks.map(event -> {
+		return chunks.filter(event -> !event.isTranscriptTextDone()).map(event -> {
 			AudioTranscription transcript = new AudioTranscription(toTranscriptionResult(event));
 			return new AudioTranscriptionResponse(transcript, new AudioTranscriptionResponseMetadata());
 		});

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -28,7 +29,13 @@ import com.openai.client.OpenAIClientAsync;
 import com.openai.core.MultipartField;
 import com.openai.models.audio.transcriptions.TranscriptionCreateParams;
 import com.openai.models.audio.transcriptions.TranscriptionCreateResponse;
+import com.openai.models.audio.transcriptions.TranscriptionDiarized;
+import com.openai.models.audio.transcriptions.TranscriptionDiarizedSegment;
+import com.openai.models.audio.transcriptions.TranscriptionSegment;
 import com.openai.models.audio.transcriptions.TranscriptionStreamEvent;
+import com.openai.models.audio.transcriptions.TranscriptionTextSegmentEvent;
+import com.openai.models.audio.transcriptions.TranscriptionVerbose;
+import com.openai.models.audio.transcriptions.TranscriptionWord;
 import io.micrometer.observation.ObservationRegistry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -39,6 +46,9 @@ import org.springframework.ai.audio.transcription.AudioTranscription;
 import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
 import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
 import org.springframework.ai.audio.transcription.AudioTranscriptionResponseMetadata;
+import org.springframework.ai.audio.transcription.AudioTranscriptionResult;
+import org.springframework.ai.audio.transcription.AudioTranscriptionSegment;
+import org.springframework.ai.audio.transcription.AudioTranscriptionWord;
 import org.springframework.ai.audio.transcription.TranscriptionModel;
 import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
@@ -129,8 +139,7 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 		}
 
 		TranscriptionCreateResponse response = this.openAiClient.audio().transcriptions().create(params);
-		String text = extractText(response);
-		AudioTranscription transcript = new AudioTranscription(text);
+		AudioTranscription transcript = new AudioTranscription(toTranscriptionResult(response));
 		return new AudioTranscriptionResponse(transcript, new AudioTranscriptionResponseMetadata());
 	}
 
@@ -166,8 +175,7 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 			}));
 
 		return chunks.map(event -> {
-			String text = extractStreamEventText(event);
-			AudioTranscription transcript = new AudioTranscription(text);
+			AudioTranscription transcript = new AudioTranscription(toTranscriptionResult(event));
 			return new AudioTranscriptionResponse(transcript, new AudioTranscriptionResponseMetadata());
 		});
 	}
@@ -178,19 +186,10 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 			.value(new ByteArrayInputStream(audioBytes))
 			.filename(filename)
 			.build();
-		String model;
-		if (options.getDeploymentName() != null) {
-			model = options.getDeploymentName();
-		}
-		else {
-			model = options.getModel();
-		}
-		Assert.notNull(model, "Model must not be null");
+		String model = options.getDeploymentName() != null ? options.getDeploymentName() : options.getModel();
 		TranscriptionCreateParams.Builder builder = TranscriptionCreateParams.builder().file(fileField).model(model);
 
-		if (options.getResponseFormat() != null) {
-			builder.responseFormat(options.getResponseFormat());
-		}
+		builder.responseFormat(options.getResponseFormat());
 		if (options.getLanguage() != null) {
 			builder.language(options.getLanguage());
 		}
@@ -206,33 +205,82 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 		return builder.build();
 	}
 
-	private static String extractText(TranscriptionCreateResponse response) {
+	private static AudioTranscriptionResult toTranscriptionResult(TranscriptionCreateResponse response) {
 		if (response.isTranscription()) {
-			return response.asTranscription().text();
+			return new AudioTranscriptionResult(response.asTranscription().text());
 		}
 		if (response.isVerbose()) {
-			return response.asVerbose().text();
+			return toTranscriptionResult(response.asVerbose());
 		}
 		if (response.isDiarized()) {
-			return response.asDiarized().text();
+			return toTranscriptionResult(response.asDiarized());
 		}
-		return "";
+		return new AudioTranscriptionResult("");
 	}
 
-	private static String extractStreamEventText(TranscriptionStreamEvent event) {
+	private static AudioTranscriptionResult toTranscriptionResult(TranscriptionVerbose transcription) {
+		List<AudioTranscriptionSegment> segments = transcription.segments()
+			.orElseGet(List::of)
+			.stream()
+			.map(OpenAiAudioTranscriptionModel::toTranscriptionSegment)
+			.toList();
+		List<AudioTranscriptionWord> words = transcription.words()
+			.orElseGet(List::of)
+			.stream()
+			.map(OpenAiAudioTranscriptionModel::toTranscriptionWord)
+			.toList();
+		return new AudioTranscriptionResult(transcription.text(), transcription.language(),
+				toDuration(transcription.duration()), segments, words);
+	}
+
+	private static AudioTranscriptionResult toTranscriptionResult(TranscriptionDiarized transcription) {
+		List<AudioTranscriptionSegment> segments = transcription.segments()
+			.stream()
+			.map(OpenAiAudioTranscriptionModel::toTranscriptionSegment)
+			.toList();
+		return new AudioTranscriptionResult(transcription.text(), null, toDuration(transcription.duration()), segments,
+				List.of());
+	}
+
+	private static AudioTranscriptionSegment toTranscriptionSegment(TranscriptionSegment segment) {
+		return new AudioTranscriptionSegment(Long.toString(segment.id()), null, toDuration(segment.start()),
+				toDuration(segment.end()), segment.text());
+	}
+
+	private static AudioTranscriptionSegment toTranscriptionSegment(TranscriptionDiarizedSegment segment) {
+		return new AudioTranscriptionSegment(segment.id(), segment.speaker(), toDuration(segment.start()),
+				toDuration(segment.end()), segment.text());
+	}
+
+	private static AudioTranscriptionWord toTranscriptionWord(TranscriptionWord word) {
+		return new AudioTranscriptionWord(word.word(), toDuration(word.start()), toDuration(word.end()));
+	}
+
+	private static Duration toDuration(double seconds) {
+		return Duration.ofNanos(Math.round(seconds * 1_000_000_000));
+	}
+
+	private static AudioTranscriptionResult toTranscriptionResult(TranscriptionStreamEvent event) {
 		if (event.isTranscriptTextDelta()) {
-			return event.asTranscriptTextDelta().delta();
+			return new AudioTranscriptionResult(event.asTranscriptTextDelta().delta());
 		}
 		if (event.isTranscriptTextSegment()) {
-			return event.asTranscriptTextSegment().text();
+			TranscriptionTextSegmentEvent segment = event.asTranscriptTextSegment();
+			return new AudioTranscriptionResult(segment.text(), null, null, List.of(toTranscriptionSegment(segment)),
+					List.of());
 		}
-		return "";
+		return new AudioTranscriptionResult("");
+	}
+
+	private static AudioTranscriptionSegment toTranscriptionSegment(TranscriptionTextSegmentEvent segment) {
+		return new AudioTranscriptionSegment(segment.id(), segment.speaker(), toDuration(segment.start()),
+				toDuration(segment.end()), segment.text());
 	}
 
 	private static byte[] toBytes(Resource resource) {
 		Assert.notNull(resource, "Resource must not be null");
-		try {
-			return resource.getInputStream().readAllBytes();
+		try (InputStream inputStream = resource.getInputStream()) {
+			return inputStream.readAllBytes();
 		}
 		catch (IOException e) {
 			throw new IllegalArgumentException("Failed to read resource: " + resource, e);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/transcription/TranscriptionModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/transcription/TranscriptionModelTests.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 import org.springframework.ai.audio.transcription.AudioTranscription;
 import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
 import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
+import org.springframework.ai.audio.transcription.AudioTranscriptionResult;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.core.io.Resource;
 
@@ -53,7 +54,7 @@ class TranscriptionModelTests {
 
 		// Create a mock Transcript
 		AudioTranscription transcript = Mockito.mock(AudioTranscription.class);
-		given(transcript.getOutput()).willReturn(mockTranscription);
+		given(transcript.getOutput()).willReturn(new AudioTranscriptionResult(mockTranscription));
 
 		// Create a mock TranscriptionResponse with the mock Transcript
 		AudioTranscriptionResponse response = Mockito.mock(AudioTranscriptionResponse.class);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiAudioTranscriptionModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiAudioTranscriptionModelIT.java
@@ -62,7 +62,8 @@ class AzureOpenAiAudioTranscriptionModelIT {
 				transcriptionOptions);
 		AudioTranscriptionResponse response = this.transcriptionModel.call(transcriptionRequest);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().toLowerCase(Locale.ROOT).contains("fellow")).isTrue();
+		assertThat(response.getResults().get(0).getOutput().text().toLowerCase(Locale.ROOT).contains("fellow"))
+			.isTrue();
 	}
 
 	@Test
@@ -79,7 +80,8 @@ class AzureOpenAiAudioTranscriptionModelIT {
 				transcriptionOptions);
 		AudioTranscriptionResponse response = this.transcriptionModel.call(transcriptionRequest);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().toLowerCase(Locale.ROOT).contains("fellow")).isTrue();
+		assertThat(response.getResults().get(0).getOutput().text().toLowerCase(Locale.ROOT).contains("fellow"))
+			.isTrue();
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelIT.java
@@ -29,6 +29,7 @@ import reactor.core.publisher.Flux;
 import org.springframework.ai.audio.transcription.AudioTranscription;
 import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
 import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
+import org.springframework.ai.audio.transcription.AudioTranscriptionResult;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionOptions;
 import org.springframework.ai.openai.OpenAiTestConfiguration;
@@ -60,7 +61,7 @@ public class OpenAiAudioTranscriptionModelIT {
 		AudioTranscriptionResponse response = this.transcriptionModel.call(prompt);
 
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResult().getOutput()).isNotBlank();
+		assertThat(response.getResult().getOutput().text()).isNotBlank();
 	}
 
 	@Test
@@ -82,7 +83,7 @@ public class OpenAiAudioTranscriptionModelIT {
 		AudioTranscriptionResponse response = this.transcriptionModel.call(prompt);
 
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResult().getOutput()).isNotBlank();
+		assertThat(response.getResult().getOutput().text()).isNotBlank();
 	}
 
 	@Test
@@ -123,7 +124,7 @@ public class OpenAiAudioTranscriptionModelIT {
 		AudioTranscriptionResponse response = this.transcriptionModel.call(prompt);
 
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResult().getOutput()).isNotBlank();
+		assertThat(response.getResult().getOutput().text()).isNotBlank();
 	}
 
 	@Test
@@ -141,6 +142,7 @@ public class OpenAiAudioTranscriptionModelIT {
 			.map(AudioTranscriptionResponse::getResult)
 			.filter(Objects::nonNull)
 			.map(AudioTranscription::getOutput)
+			.map(AudioTranscriptionResult::text)
 			.collect(Collectors.joining());
 		assertThat(text).isNotBlank();
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
@@ -34,6 +34,7 @@ import com.openai.models.audio.transcriptions.TranscriptionDiarizedSegment;
 import com.openai.models.audio.transcriptions.TranscriptionSegment;
 import com.openai.models.audio.transcriptions.TranscriptionStreamEvent;
 import com.openai.models.audio.transcriptions.TranscriptionTextDeltaEvent;
+import com.openai.models.audio.transcriptions.TranscriptionTextDoneEvent;
 import com.openai.models.audio.transcriptions.TranscriptionTextSegmentEvent;
 import com.openai.models.audio.transcriptions.TranscriptionVerbose;
 import com.openai.models.audio.transcriptions.TranscriptionWord;
@@ -435,6 +436,29 @@ class OpenAiAudioTranscriptionModelTests {
 		assertThat(chunks).isNotNull();
 		String text = String.join("", chunks);
 		assertThat(text).isEqualTo("Hello, streamed transcription result");
+	}
+
+	@Test
+	void streamDoesNotEmitTranscriptTextDoneEvent() {
+		AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse = asyncStreamResponse(
+				TranscriptionStreamEvent
+					.ofTranscriptTextDelta(TranscriptionTextDeltaEvent.builder().delta("Hello, ").build()),
+				TranscriptionStreamEvent.ofTranscriptTextDelta(
+						TranscriptionTextDeltaEvent.builder().delta("streamed transcription result").build()),
+				TranscriptionStreamEvent.ofTranscriptTextDone(
+						TranscriptionTextDoneEvent.builder().text("Hello, streamed transcription result").build()));
+
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(mock(OpenAIClient.class))
+			.openAiClientAsync(createMockAsyncClient(mockAsyncResponse))
+			.build();
+
+		List<String> chunks = model.stream(audioPrompt())
+			.map(response -> response.getResult().getOutput().text())
+			.collectList()
+			.block();
+
+		assertThat(chunks).containsExactly("Hello, ", "streamed transcription result");
 	}
 
 	@Test

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.openai.transcription;
 
+import java.io.InputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -27,8 +29,14 @@ import com.openai.core.http.AsyncStreamResponse;
 import com.openai.models.audio.AudioResponseFormat;
 import com.openai.models.audio.transcriptions.Transcription;
 import com.openai.models.audio.transcriptions.TranscriptionCreateResponse;
+import com.openai.models.audio.transcriptions.TranscriptionDiarized;
+import com.openai.models.audio.transcriptions.TranscriptionDiarizedSegment;
+import com.openai.models.audio.transcriptions.TranscriptionSegment;
 import com.openai.models.audio.transcriptions.TranscriptionStreamEvent;
 import com.openai.models.audio.transcriptions.TranscriptionTextDeltaEvent;
+import com.openai.models.audio.transcriptions.TranscriptionTextSegmentEvent;
+import com.openai.models.audio.transcriptions.TranscriptionVerbose;
+import com.openai.models.audio.transcriptions.TranscriptionWord;
 import com.openai.services.async.AudioServiceAsync;
 import com.openai.services.async.audio.TranscriptionServiceAsync;
 import com.openai.services.blocking.AudioService;
@@ -40,10 +48,12 @@ import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionOptions;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -73,7 +83,22 @@ class OpenAiAudioTranscriptionModelTests {
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
 		AudioTranscriptionResponse response = model.call(prompt);
 
-		assertThat(response.getResult().getOutput()).isEqualTo("Hello, transcribed text");
+		assertThat(response.getResult().getOutput().text()).isEqualTo("Hello, transcribed text");
+		assertThat(response.getResult().getOutput().segments()).isEmpty();
+		assertThat(response.getResult().getOutput().words()).isEmpty();
+	}
+
+	@Test
+	void callClosesAudioResourceInputStream() throws Exception {
+		Resource audioResource = mock(Resource.class);
+		InputStream inputStream = mock(InputStream.class);
+		when(audioResource.getInputStream()).thenReturn(inputStream);
+		when(inputStream.readAllBytes()).thenReturn(new byte[0]);
+
+		createModel(TranscriptionCreateResponse.ofTranscription(Transcription.builder().text("Hello").build()))
+			.call(new AudioTranscriptionPrompt(audioResource));
+
+		verify(inputStream).close();
 	}
 
 	@Test
@@ -91,7 +116,7 @@ class OpenAiAudioTranscriptionModelTests {
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
 		AudioTranscriptionResponse response = model.call(prompt);
 
-		assertThat(response.getResult().getOutput()).isEqualTo("Hello, this is a test transcription.");
+		assertThat(response.getResult().getOutput().text()).isEqualTo("Hello, this is a test transcription.");
 		assertThat(response.getResults()).hasSize(1);
 	}
 
@@ -115,7 +140,94 @@ class OpenAiAudioTranscriptionModelTests {
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"), options);
 		AudioTranscriptionResponse response = model.call(prompt);
 
-		assertThat(response.getResult().getOutput()).isEqualTo("Hello, this is a test transcription with options.");
+		assertThat(response.getResult().getOutput().text())
+			.isEqualTo("Hello, this is a test transcription with options.");
+	}
+
+	@Test
+	void callWithVerboseResponsePreservesStructuredTranscription() {
+		TranscriptionVerbose verbose = TranscriptionVerbose.builder()
+			.text("Hello, structured transcription")
+			.language("en")
+			.duration(2.5)
+			.addSegment(TranscriptionSegment.builder()
+				.id(1)
+				.avgLogprob(0.0f)
+				.compressionRatio(0.0f)
+				.start(0.0)
+				.end(2.5)
+				.noSpeechProb(0.0f)
+				.seek(0)
+				.temperature(0.0f)
+				.text("Hello, structured transcription")
+				.tokens(List.of())
+				.build())
+			.addWord(TranscriptionWord.builder().word("Hello").start(0.0).end(0.5).build())
+			.build();
+
+		AudioTranscriptionResponse response = createModel(TranscriptionCreateResponse.ofVerbose(verbose))
+			.call(audioPrompt());
+
+		assertThat(response.getResult().getOutput().text()).isEqualTo("Hello, structured transcription");
+		assertThat(response.getResult().getOutput().language()).isEqualTo("en");
+		assertThat(response.getResult().getOutput().duration()).isEqualTo(Duration.ofMillis(2500));
+		assertThat(response.getResult().getOutput().segments()).singleElement().satisfies(segment -> {
+			assertThat(segment.id()).isEqualTo("1");
+			assertThat(segment.speaker()).isNull();
+			assertThat(segment.start()).isZero();
+			assertThat(segment.end()).isEqualTo(Duration.ofMillis(2500));
+			assertThat(segment.text()).isEqualTo("Hello, structured transcription");
+		});
+		assertThat(response.getResult().getOutput().words()).singleElement().satisfies(word -> {
+			assertThat(word.text()).isEqualTo("Hello");
+			assertThat(word.start()).isZero();
+			assertThat(word.end()).isEqualTo(Duration.ofMillis(500));
+		});
+	}
+
+	@Test
+	void callWithDiarizedResponsePreservesStructuredTranscription() {
+		TranscriptionDiarized diarized = TranscriptionDiarized.builder()
+			.text("Hello, diarized transcription")
+			.duration(2.5)
+			.segments(List.of(TranscriptionDiarizedSegment.builder()
+				.id("segment_0")
+				.speaker("speaker_0")
+				.start(0.0)
+				.end(2.5)
+				.text("Hello, diarized transcription")
+				.build()))
+			.build();
+
+		AudioTranscriptionResponse response = createModel(TranscriptionCreateResponse.ofDiarized(diarized))
+			.call(audioPrompt());
+
+		assertThat(response.getResult().getOutput().text()).isEqualTo("Hello, diarized transcription");
+		assertThat(response.getResult().getOutput().language()).isNull();
+		assertThat(response.getResult().getOutput().duration()).isEqualTo(Duration.ofMillis(2500));
+		assertThat(response.getResult().getOutput().segments()).singleElement().satisfies(segment -> {
+			assertThat(segment.id()).isEqualTo("segment_0");
+			assertThat(segment.speaker()).isEqualTo("speaker_0");
+			assertThat(segment.start()).isZero();
+			assertThat(segment.end()).isEqualTo(Duration.ofMillis(2500));
+			assertThat(segment.text()).isEqualTo("Hello, diarized transcription");
+		});
+		assertThat(response.getResult().getOutput().words()).isEmpty();
+	}
+
+	@Test
+	void callWithVerboseResponseWithoutTimestampDataReturnsEmptyCollections() {
+		TranscriptionVerbose verbose = TranscriptionVerbose.builder()
+			.text("Hello, transcription without timestamp data")
+			.language("en")
+			.duration(2.5)
+			.build();
+
+		AudioTranscriptionResponse response = createModel(TranscriptionCreateResponse.ofVerbose(verbose))
+			.call(audioPrompt());
+
+		assertThat(response.getResult().getOutput().segments()).isEmpty();
+		assertThat(response.getResult().getOutput().words()).isEmpty();
 	}
 
 	@Test
@@ -316,13 +428,42 @@ class OpenAiAudioTranscriptionModelTests {
 			.build();
 
 		List<String> chunks = model.stream(prompt)
-			.map(response -> response.getResult().getOutput())
+			.map(response -> response.getResult().getOutput().text())
 			.collectList()
 			.block();
 
 		assertThat(chunks).isNotNull();
 		String text = String.join("", chunks);
 		assertThat(text).isEqualTo("Hello, streamed transcription result");
+	}
+
+	@Test
+	void streamWithSegmentEventPreservesStructuredTranscription() {
+		AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse = asyncStreamResponse(
+				TranscriptionStreamEvent.ofTranscriptTextSegment(TranscriptionTextSegmentEvent.builder()
+					.id("segment_0")
+					.speaker("speaker_0")
+					.start(0.0)
+					.end(2.5)
+					.text("Hello, streamed transcription result")
+					.build()));
+
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(mock(OpenAIClient.class))
+			.openAiClientAsync(createMockAsyncClient(mockAsyncResponse))
+			.build();
+
+		AudioTranscriptionResponse response = model.stream(audioPrompt()).blockFirst();
+
+		assertThat(response).isNotNull();
+		assertThat(response.getResult().getOutput().text()).isEqualTo("Hello, streamed transcription result");
+		assertThat(response.getResult().getOutput().segments()).singleElement().satisfies(segment -> {
+			assertThat(segment.id()).isEqualTo("segment_0");
+			assertThat(segment.speaker()).isEqualTo("speaker_0");
+			assertThat(segment.start()).isZero();
+			assertThat(segment.end()).isEqualTo(Duration.ofMillis(2500));
+			assertThat(segment.text()).isEqualTo("Hello, streamed transcription result");
+		});
 	}
 
 	@Test
@@ -346,7 +487,7 @@ class OpenAiAudioTranscriptionModelTests {
 			.build();
 
 		List<String> chunks = model.stream(prompt)
-			.map(response -> response.getResult().getOutput())
+			.map(response -> response.getResult().getOutput().text())
 			.collectList()
 			.block();
 
@@ -410,6 +551,17 @@ class OpenAiAudioTranscriptionModelTests {
 		when(audioService.transcriptions()).thenReturn(transcriptionService);
 		when(transcriptionService.create(any())).thenReturn(mockResponse);
 		return client;
+	}
+
+	private OpenAiAudioTranscriptionModel createModel(TranscriptionCreateResponse response) {
+		return OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(createMockClient(response))
+			.openAiClientAsync(mock(OpenAIClientAsync.class))
+			.build();
+	}
+
+	private AudioTranscriptionPrompt audioPrompt() {
+		return new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
 	}
 
 	private OpenAIClientAsync createMockAsyncClient(AsyncStreamResponse<TranscriptionStreamEvent> mockAsyncResponse) {

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions.adoc
@@ -29,7 +29,7 @@ public interface TranscriptionModel extends Model<AudioTranscriptionPrompt, Audi
      */
     default String transcribe(Resource resource) {
         AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource);
-        return this.call(prompt).getResult().getOutput();
+        return this.call(prompt).getResult().getOutput().text();
     }
 
     /**
@@ -37,7 +37,7 @@ public interface TranscriptionModel extends Model<AudioTranscriptionPrompt, Audi
      */
     default String transcribe(Resource resource, AudioTranscriptionOptions options) {
         AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource, options);
-        return this.call(prompt).getResult().getOutput();
+        return this.call(prompt).getResult().getOutput().text();
     }
 }
 ----
@@ -57,13 +57,27 @@ AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(
 
 === AudioTranscriptionResponse
 
-The `AudioTranscriptionResponse` class contains the transcribed text and metadata:
+The `AudioTranscriptionResponse` class contains an `AudioTranscriptionResult` and response metadata:
 
 [source,java]
 ----
 AudioTranscriptionResponse response = model.call(prompt);
-String transcribedText = response.getResult().getOutput();
+AudioTranscriptionResult transcription = response.getResult().getOutput();
+String transcribedText = transcription.text();
 AudioTranscriptionResponseMetadata metadata = response.getMetadata();
+----
+
+`AudioTranscriptionResult` always provides the transcribed `text`.
+When supplied by the provider, it also provides the detected `language`, the audio `duration`, timestamped `segments`, and timestamped `words`.
+The optional scalar values are `null` when unavailable; the lists are empty when the provider does not supply the corresponding data.
+
+[source,java]
+----
+AudioTranscriptionResult transcription = response.getResult().getOutput();
+
+for (AudioTranscriptionSegment segment : transcription.segments()) {
+    System.out.printf("%s - %s: %s%n", segment.start(), segment.end(), segment.text());
+}
 ----
 
 == Writing Provider-Agnostic Code
@@ -92,7 +106,7 @@ public class TranscriptionService {
     public String transcribeWithOptions(Resource audioFile, AudioTranscriptionOptions options) {
         AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(audioFile, options);
         AudioTranscriptionResponse response = transcriptionModel.call(prompt);
-        return response.getResult().getOutput();
+        return response.getResult().getOutput().text();
     }
 }
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
@@ -88,8 +88,8 @@ The prefix `spring.ai.openai.audio.transcription` is used as the property prefix
 | spring.ai.openai.audio.transcription.api-key    | The API Key           |  -
 | spring.ai.openai.audio.transcription.organization-id | Optionally you can specify which organization  used for an API request. |  -
 | spring.ai.openai.audio.transcription.project-id      | Optionally, you can specify which project is used for an API request. |  -
-| spring.ai.openai.audio.transcription.model  | ID of the model to use for transcription. Available models: `gpt-4o-transcribe` (speech-to-text powered by GPT-4o), `gpt-4o-mini-transcribe` (speech-to-text powered by GPT-4o mini), or `whisper-1` (general-purpose speech recognition model, default). |  whisper-1
-| spring.ai.openai.audio.transcription.response-format | The format of the transcript output, in one of these options: json, text, srt, verbose_json, or vtt. |  json
+| spring.ai.openai.audio.transcription.model  | ID of the model to use for transcription. Available models: `gpt-4o-transcribe` (speech-to-text powered by GPT-4o), `gpt-4o-mini-transcribe` (speech-to-text powered by GPT-4o mini), `gpt-4o-transcribe-diarize` (speaker diarization), or `whisper-1` (general-purpose speech recognition model, default). |  whisper-1
+| spring.ai.openai.audio.transcription.response-format | The format of the transcript output, in one of these options: json, text, srt, verbose_json, vtt, or diarized_json. | text
 | spring.ai.openai.audio.transcription.prompt | An optional text to guide the model's style or continue a previous audio segment. The prompt should match the audio language. |
 | spring.ai.openai.audio.transcription.language | The language of the input audio. Supplying the input language in ISO-639-1 format will improve accuracy and latency. |
 | spring.ai.openai.audio.transcription.temperature | The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use log probability to automatically increase the temperature until certain thresholds are hit. | 0
@@ -122,6 +122,31 @@ OpenAiAudioTranscriptionOptions transcriptionOptions = OpenAiAudioTranscriptionO
 AudioTranscriptionPrompt transcriptionRequest = new AudioTranscriptionPrompt(audioFile, this.transcriptionOptions);
 AudioTranscriptionResponse response = openAiTranscriptionModel.call(this.transcriptionRequest);
 ----
+
+== Structured Transcription Results
+
+`AudioTranscriptionResponse.getResult().getOutput()` returns an `AudioTranscriptionResult`.
+For `verbose_json`, Spring AI exposes the detected language, duration, timestamped segments, and timestamped words when OpenAI returns them.
+For `diarized_json`, segments also include the speaker identifier.
+
+[source,java]
+----
+OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
+    .responseFormat(AudioResponseFormat.DIARIZED_JSON)
+    .build();
+
+AudioTranscriptionResponse response = openAiTranscriptionModel
+    .call(new AudioTranscriptionPrompt(audioFile, options));
+
+AudioTranscriptionResult transcription = response.getResult().getOutput();
+for (AudioTranscriptionSegment segment : transcription.segments()) {
+    System.out.printf("%s [%s - %s]: %s%n",
+        segment.speaker(), segment.start(), segment.end(), segment.text());
+}
+----
+
+The availability of structured fields depends on the selected response format and the OpenAI model.
+`text` is always available; optional scalar values are `null` and unavailable collections are empty.
 
 == Manual Configuration
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscription.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscription.java
@@ -29,19 +29,19 @@ import org.springframework.ai.model.ModelResult;
  * @author Piotr Olaszewski
  * @since 0.8.1
  */
-public class AudioTranscription implements ModelResult<String> {
+public class AudioTranscription implements ModelResult<AudioTranscriptionResult> {
 
-	private final String text;
+	private final AudioTranscriptionResult output;
 
 	private AudioTranscriptionMetadata transcriptionMetadata = AudioTranscriptionMetadata.NULL;
 
-	public AudioTranscription(String text) {
-		this.text = text;
+	public AudioTranscription(AudioTranscriptionResult output) {
+		this.output = output;
 	}
 
 	@Override
-	public String getOutput() {
-		return this.text;
+	public AudioTranscriptionResult getOutput() {
+		return this.output;
 	}
 
 	@Override
@@ -62,18 +62,18 @@ public class AudioTranscription implements ModelResult<String> {
 		if (!(o instanceof AudioTranscription that)) {
 			return false;
 		}
-		return Objects.equals(this.text, that.text)
+		return Objects.equals(this.output, that.output)
 				&& Objects.equals(this.transcriptionMetadata, that.transcriptionMetadata);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.text, this.transcriptionMetadata);
+		return Objects.hash(this.output, this.transcriptionMetadata);
 	}
 
 	@Override
 	public String toString() {
-		return "Transcript{" + "text=" + this.text + ", transcriptionMetadata=" + this.transcriptionMetadata + '}';
+		return "Transcript{" + "output=" + this.output + ", transcriptionMetadata=" + this.transcriptionMetadata + '}';
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionResult.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionResult.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.audio.transcription;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * A structured audio transcription result.
+ *
+ * @param text the transcribed text
+ * @param language the detected language, if available
+ * @param duration the duration of the transcribed audio, if available
+ * @param segments the timestamped transcription segments
+ * @param words the timestamped transcription words
+ * @since 2.0.1
+ */
+public record AudioTranscriptionResult(String text, @Nullable String language, @Nullable Duration duration,
+		List<AudioTranscriptionSegment> segments, List<AudioTranscriptionWord> words) {
+
+	public AudioTranscriptionResult {
+		Assert.notNull(text, "Text must not be null");
+		segments = List.copyOf(segments);
+		words = List.copyOf(words);
+	}
+
+	/**
+	 * Create a transcription result containing only text.
+	 * @param text the transcribed text
+	 */
+	public AudioTranscriptionResult(String text) {
+		this(text, null, null, List.of(), List.of());
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionSegment.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionSegment.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.audio.transcription;
+
+import java.time.Duration;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * A timestamped segment of an audio transcription.
+ *
+ * @param id the provider-assigned segment identifier, if available
+ * @param speaker the identified speaker, if available
+ * @param start the start offset of the segment
+ * @param end the end offset of the segment
+ * @param text the transcribed text of the segment
+ * @since 2.0.1
+ */
+public record AudioTranscriptionSegment(@Nullable String id, @Nullable String speaker, Duration start, Duration end,
+		String text) {
+
+	public AudioTranscriptionSegment {
+		Assert.notNull(start, "Start must not be null");
+		Assert.notNull(end, "End must not be null");
+		Assert.notNull(text, "Text must not be null");
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionWord.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionWord.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.audio.transcription;
+
+import java.time.Duration;
+
+import org.springframework.util.Assert;
+
+/**
+ * A timestamped word in an audio transcription.
+ *
+ * @param text the transcribed word
+ * @param start the start offset of the word
+ * @param end the end offset of the word
+ * @since 2.0.1
+ */
+public record AudioTranscriptionWord(String text, Duration start, Duration end) {
+
+	public AudioTranscriptionWord {
+		Assert.notNull(text, "Text must not be null");
+		Assert.notNull(start, "Start must not be null");
+		Assert.notNull(end, "End must not be null");
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/StreamingTranscriptionModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/StreamingTranscriptionModel.java
@@ -16,8 +16,6 @@
 
 package org.springframework.ai.audio.transcription;
 
-import java.util.Optional;
-
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 
@@ -65,8 +63,7 @@ public interface StreamingTranscriptionModel
 	 */
 	default Flux<String> streamTranscribe(Resource resource, @Nullable AudioTranscriptionOptions options) {
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource, options);
-		return stream(prompt)
-			.map(response -> Optional.ofNullable(response.getResult()).map(AudioTranscription::getOutput).orElse(""));
+		return stream(prompt).map(response -> response.getResult().getOutput().text());
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/TranscriptionModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/TranscriptionModel.java
@@ -56,8 +56,7 @@ public interface TranscriptionModel
 	 */
 	default String transcribe(Resource resource, @Nullable AudioTranscriptionOptions options) {
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource, options);
-		AudioTranscription result = this.call(prompt).getResult();
-		return result != null ? result.getOutput() : "";
+		return this.call(prompt).getResult().getOutput().text();
 	}
 
 }


### PR DESCRIPTION
## Summary

- Add `AudioTranscriptionResult`, `AudioTranscriptionSegment`, and `AudioTranscriptionWord` to expose structured transcription data.
- Preserve language, duration, segments, words, and speaker annotations from OpenAI verbose and diarized responses.
- Preserve diarized segment data for streaming responses.
- Update the transcription reference documentation.
- Close audio resource input streams and simplify redundant option checks.

## Breaking Change

`AudioTranscription.getOutput()` now returns `AudioTranscriptionResult` instead of `String`.

Use `.text()` when only the transcription text is needed:

```java
String text = response.getResult().getOutput().text();
```

## Testing

- `./mvnw process-sources`
- `./mvnw javadoc:javadoc`
- `./mvnw clean package`
- `./mvnw -pl spring-ai-docs antora`

Closes #6640