### PR TITLE
Add Together AI image generation support

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-autoconfigure-model-together-ai</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Together AI Auto Configuration</name>
+	<description>Spring AI Together AI Auto Configuration</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<!-- Spring AI dependencies -->
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-together-ai</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Spring AI auto configurations -->
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiConnectionProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.togetherai.autoconfigure;
+
+import org.springframework.ai.togetherai.api.TogetherAiApi;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Together AI connection properties.
+ *
+ * @since 2.0.1
+ * @author Maksym Uimanov
+ */
+@ConfigurationProperties(TogetherAiConnectionProperties.CONFIG_PREFIX)
+public class TogetherAiConnectionProperties extends TogetherAiParentProperties {
+	public static final String CONFIG_PREFIX = "spring.ai.togetherai";
+	public static final String DEFAULT_BASE_URL = TogetherAiApi.DEFAULT_BASE_URL;
+
+	public TogetherAiConnectionProperties() {
+		super.setBaseUrl(DEFAULT_BASE_URL);
+	}
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiImageAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiImageAutoConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.togetherai.autoconfigure;
+
+import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.togetherai.TogetherAiImageModel;
+import org.springframework.ai.togetherai.api.TogetherAiApi;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Together AI image auto-configuration.
+ *
+ * @since 2.0.1
+ * @author Maksym Uimanov
+ */
+@AutoConfiguration
+@ConditionalOnClass(TogetherAiApi.class)
+@ConditionalOnProperty(
+		name = SpringAIModelProperties.IMAGE_MODEL,
+		havingValue = SpringAIModels.TOGETHER_AI,
+		matchIfMissing = true
+)
+@EnableConfigurationProperties({
+		TogetherAiConnectionProperties.class,
+		TogetherAiImageProperties.class
+})
+public class TogetherAiImageAutoConfiguration {
+	@Bean
+	@ConditionalOnMissingBean
+	public TogetherAiApi togetherAiApi(
+			TogetherAiConnectionProperties commonProperties,
+			TogetherAiImageProperties imageProperties,
+			ObjectProvider<RestClient.Builder> restClientBuilderProvider
+	) {
+		String apiKey = StringUtils.hasText(imageProperties.getApiKey())
+				? imageProperties.getApiKey()
+				: commonProperties.getApiKey();
+
+		String baseUrl = StringUtils.hasText(imageProperties.getBaseUrl())
+				? imageProperties.getBaseUrl()
+				: commonProperties.getBaseUrl();
+
+		Assert.hasText(apiKey, "TogetherAI API key must be set");
+		Assert.hasText(baseUrl, "TogetherAI base URL must be set");
+
+		return new TogetherAiApi(apiKey, baseUrl, restClientBuilderProvider.getIfAvailable(RestClient::builder));
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public TogetherAiImageModel togetherAiImageModel(
+			TogetherAiApi togetherAiApi,
+			TogetherAiImageProperties togetherAiImageProperties
+	) {
+		return new TogetherAiImageModel(togetherAiApi, togetherAiImageProperties.toOptions());
+	}
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiImageProperties.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.togetherai.autoconfigure;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.ai.togetherai.api.TogetherAiImageOptions;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Together AI image properties.
+ *
+ * @since 2.0.1
+ * @author Maksym Uimanov
+ */
+@ConfigurationProperties(TogetherAiImageProperties.CONFIG_PREFIX)
+public class TogetherAiImageProperties extends TogetherAiParentProperties {
+	public static final String CONFIG_PREFIX = "spring.ai.togetherai.image";
+	@Nullable
+	private String model;
+	@Nullable
+	private Integer steps;
+	@Nullable
+	private String imageUrl;
+	@Nullable
+	private Long seed;
+	@Nullable
+	private Integer n;
+	@Nullable
+	private Integer height;
+	@Nullable
+	private Integer width;
+	@Nullable
+	private String negativePrompt;
+	@Nullable
+	private String responseFormat;
+	@Nullable
+	private Float guidanceScale;
+	@Nullable
+	private String outputFormat;
+	@Nullable
+	private List<TogetherAiImageOptions.ImageLora> imageLoras;
+	@Nullable
+	private List<String> referenceImages;
+	@Nullable
+	private Boolean disableSafetyChecker;
+
+	@Nullable
+	public String getModel() {
+		return model;
+	}
+
+	public void setModel(@Nullable String model) {
+		this.model = model;
+	}
+
+	@Nullable
+	public Integer getSteps() {
+		return steps;
+	}
+
+	public void setSteps(@Nullable Integer steps) {
+		this.steps = steps;
+	}
+
+	@Nullable
+	public String getImageUrl() {
+		return imageUrl;
+	}
+
+	public void setImageUrl(@Nullable String imageUrl) {
+		this.imageUrl = imageUrl;
+	}
+
+	@Nullable
+	public Long getSeed() {
+		return seed;
+	}
+
+	public void setSeed(@Nullable Long seed) {
+		this.seed = seed;
+	}
+
+	@Nullable
+	public Integer getN() {
+		return n;
+	}
+
+	public void setN(@Nullable Integer n) {
+		this.n = n;
+	}
+
+	@Nullable
+	public Integer getHeight() {
+		return height;
+	}
+
+	public void setHeight(@Nullable Integer height) {
+		this.height = height;
+	}
+
+	@Nullable
+	public Integer getWidth() {
+		return width;
+	}
+
+	public void setWidth(@Nullable Integer width) {
+		this.width = width;
+	}
+
+	@Nullable
+	public String getNegativePrompt() {
+		return negativePrompt;
+	}
+
+	public void setNegativePrompt(@Nullable String negativePrompt) {
+		this.negativePrompt = negativePrompt;
+	}
+
+	@Nullable
+	public String getResponseFormat() {
+		return responseFormat;
+	}
+
+	public void setResponseFormat(@Nullable String responseFormat) {
+		this.responseFormat = responseFormat;
+	}
+
+	@Nullable
+	public Float getGuidanceScale() {
+		return guidanceScale;
+	}
+
+	public void setGuidanceScale(@Nullable Float guidanceScale) {
+		this.guidanceScale = guidanceScale;
+	}
+
+	@Nullable
+	public String getOutputFormat() {
+		return outputFormat;
+	}
+
+	public void setOutputFormat(@Nullable String outputFormat) {
+		this.outputFormat = outputFormat;
+	}
+
+	@Nullable
+	public List<TogetherAiImageOptions.ImageLora> getImageLoras() {
+		return imageLoras;
+	}
+
+	public void setImageLoras(@Nullable List<TogetherAiImageOptions.ImageLora> imageLoras) {
+		this.imageLoras = imageLoras;
+	}
+
+	@Nullable
+	public List<String> getReferenceImages() {
+		return referenceImages;
+	}
+
+	public void setReferenceImages(@Nullable List<String> referenceImages) {
+		this.referenceImages = referenceImages;
+	}
+
+	@Nullable
+	public Boolean getDisableSafetyChecker() {
+		return disableSafetyChecker;
+	}
+
+	public void setDisableSafetyChecker(@Nullable Boolean disableSafetyChecker) {
+		this.disableSafetyChecker = disableSafetyChecker;
+	}
+
+	public TogetherAiImageOptions toOptions() {
+		return TogetherAiImageOptions.builder()
+				.model(this.model)
+				.steps(this.steps)
+				.imageUrl(this.imageUrl)
+				.seed(this.seed)
+				.n(this.n)
+				.height(this.height)
+				.width(this.width)
+				.negativePrompt(this.negativePrompt)
+				.responseFormat(TogetherAiImageOptions.ResponseFormat.from(this.responseFormat))
+				.guidanceScale(this.guidanceScale)
+				.outputFormat(TogetherAiImageOptions.OutputFormat.from(this.outputFormat))
+				.imageLoras(this.imageLoras)
+				.referenceImages(this.referenceImages)
+				.disableSafetyChecker(this.disableSafetyChecker)
+				.build();
+	}
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiParentProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiParentProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.togetherai.autoconfigure;
+
+import org.jspecify.annotations.Nullable;
+
+class TogetherAiParentProperties {
+	@Nullable
+	private String apiKey;
+	@Nullable
+	private String baseUrl;
+
+	@Nullable
+	public String getApiKey() {
+		return this.apiKey;
+	}
+
+	public void setApiKey(@Nullable String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	@Nullable
+	public String getBaseUrl() {
+		return this.baseUrl;
+	}
+
+	public void setBaseUrl(@Nullable String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/package-info.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/java/org/springframework/ai/model/togetherai/autoconfigure/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.model.togetherai.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.ai.model.togetherai.autoconfigure.TogetherAiImageAutoConfiguration

--- a/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/test/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/test/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiAutoConfigurationIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.togetherai.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.togetherai.TogetherAiImageModel;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TogetherAiAutoConfigurationIT {
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.ai.togetherai.api-key=API_KEY", "spring.ai.togetherai.base-url=ENDPOINT");
+
+	@Test
+	void imageBeans_shouldNotBeRegistered_whenGlobalImageModelIsDisabled() {
+		this.contextRunner.withPropertyValues("spring.ai.model.image=none")
+			.withConfiguration(AutoConfigurations.of(TogetherAiImageAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context.getBeansOfType(TogetherAiImageProperties.class)).isEmpty();
+				assertThat(context.getBeansOfType(TogetherAiImageModel.class)).isEmpty();
+			});
+	}
+
+	@Test
+	void imageBeans_shouldBeRegistered_whenGlobalImageModelIsNotSet() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(TogetherAiImageAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context.getBeansOfType(TogetherAiImageProperties.class)).isNotEmpty();
+				assertThat(context.getBeansOfType(TogetherAiImageModel.class)).isNotEmpty();
+			});
+	}
+
+	@Test
+	void imageBeans_shouldBeRegistered_whenGlobalImageModelIsTogetherAi() {
+		this.contextRunner.withPropertyValues("spring.ai.model.image=togetherai")
+			.withConfiguration(AutoConfigurations.of(TogetherAiImageAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context.getBeansOfType(TogetherAiImageProperties.class)).isNotEmpty();
+				assertThat(context.getBeansOfType(TogetherAiImageModel.class)).isNotEmpty();
+			});
+	}
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/test/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiImagePropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-together-ai/src/test/java/org/springframework/ai/model/togetherai/autoconfigure/TogetherAiImagePropertiesTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.togetherai.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.togetherai.api.TogetherAiImageOptions;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TogetherAiImagePropertiesTests {
+
+	@Test
+	void togetherAiImageProperties_shouldBindValues_whenPropertiesAreSet() {
+		new ApplicationContextRunner().withPropertyValues(
+		// @formatter:off
+				"spring.ai.togetherai.api-key=API_KEY",
+				"spring.ai.togetherai.base-url=ENDPOINT",
+				"spring.ai.togetherai.image.model=MODEL_XYZ",
+				"spring.ai.togetherai.image.steps=30",
+				"spring.ai.togetherai.image.image-url=https://example.com/input.png",
+				"spring.ai.togetherai.image.seed=1234",
+				"spring.ai.togetherai.image.n=4",
+				"spring.ai.togetherai.image.height=256",
+				"spring.ai.togetherai.image.width=512",
+				"spring.ai.togetherai.image.negative-prompt=NEGATIVE",
+				"spring.ai.togetherai.image.response-format=base64",
+				"spring.ai.togetherai.image.guidance-scale=7.5",
+				"spring.ai.togetherai.image.output-format=png",
+				"spring.ai.togetherai.image.image-loras[0].path=lora-a",
+				"spring.ai.togetherai.image.image-loras[0].scale=0.5",
+				"spring.ai.togetherai.image.reference-images[0]=https://example.com/reference.png",
+				"spring.ai.togetherai.image.disable-safety-checker=true"
+				)
+			// @formatter:on
+			.withConfiguration(AutoConfigurations.of(TogetherAiImageAutoConfiguration.class))
+			.run(context -> {
+				var connectionProperties = context.getBean(TogetherAiConnectionProperties.class);
+				var imageProperties = context.getBean(TogetherAiImageProperties.class);
+
+				assertThat(connectionProperties.getApiKey()).isEqualTo("API_KEY");
+				assertThat(connectionProperties.getBaseUrl()).isEqualTo("ENDPOINT");
+
+				assertThat(imageProperties.getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(imageProperties.getSteps()).isEqualTo(30);
+				assertThat(imageProperties.getImageUrl()).isEqualTo("https://example.com/input.png");
+				assertThat(imageProperties.getSeed()).isEqualTo(1234L);
+				assertThat(imageProperties.getN()).isEqualTo(4);
+				assertThat(imageProperties.getHeight()).isEqualTo(256);
+				assertThat(imageProperties.getWidth()).isEqualTo(512);
+				assertThat(imageProperties.getNegativePrompt()).isEqualTo("NEGATIVE");
+				assertThat(imageProperties.getResponseFormat()).isEqualTo("base64");
+				assertThat(imageProperties.getGuidanceScale()).isEqualTo(7.5f);
+				assertThat(imageProperties.getOutputFormat()).isEqualTo("png");
+				assertThat(imageProperties.getImageLoras())
+					.containsExactly(new TogetherAiImageOptions.ImageLora("lora-a", 0.5f));
+				assertThat(imageProperties.getReferenceImages())
+					.containsExactly("https://example.com/reference.png");
+				assertThat(imageProperties.getDisableSafetyChecker()).isTrue();
+
+				TogetherAiImageOptions imageOptions = imageProperties.toOptions();
+				assertThat(imageOptions.getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(imageOptions.getSteps()).isEqualTo(30);
+				assertThat(imageOptions.getImageUrl()).isEqualTo("https://example.com/input.png");
+				assertThat(imageOptions.getSeed()).isEqualTo(1234L);
+				assertThat(imageOptions.getN()).isEqualTo(4);
+				assertThat(imageOptions.getHeight()).isEqualTo(256);
+				assertThat(imageOptions.getWidth()).isEqualTo(512);
+				assertThat(imageOptions.getNegativePrompt()).isEqualTo("NEGATIVE");
+				assertThat(imageOptions.getResponseFormat()).isEqualTo("base64");
+				assertThat(imageOptions.getGuidanceScale()).isEqualTo(7.5f);
+				assertThat(imageOptions.getOutputFormat()).isEqualTo("png");
+				assertThat(imageOptions.getImageLoras())
+					.containsExactly(new TogetherAiImageOptions.ImageLora("lora-a", 0.5f));
+				assertThat(imageOptions.getReferenceImages()).containsExactly("https://example.com/reference.png");
+				assertThat(imageOptions.getDisableSafetyChecker()).isTrue();
+			});
+	}
+
+	@Test
+	void togetherAiImageProperties_shouldUseDefaultBaseUrl_whenBaseUrlIsNotSet() {
+		new ApplicationContextRunner().withPropertyValues("spring.ai.togetherai.api-key=API_KEY")
+			.withConfiguration(AutoConfigurations.of(TogetherAiImageAutoConfiguration.class))
+			.run(context -> {
+				var connectionProperties = context.getBean(TogetherAiConnectionProperties.class);
+
+				assertThat(connectionProperties.getApiKey()).isEqualTo("API_KEY");
+				assertThat(connectionProperties.getBaseUrl()).isEqualTo(TogetherAiConnectionProperties.DEFAULT_BASE_URL);
+			});
+	}
+}

--- a/models/spring-ai-together-ai/README.md
+++ b/models/spring-ai-together-ai/README.md
@@ -1,0 +1,1 @@
+[Together AI Image Generation](https://docs.spring.io/spring-ai/reference/api/image/togetherai-image.html)

--- a/models/spring-ai-together-ai/pom.xml
+++ b/models/spring-ai-together-ai/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-together-ai</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Model - Together AI</name>
+	<description>Together AI models support</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<!-- production dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- Spring Framework -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/TogetherAiImageGenerationMetadata.java
+++ b/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/TogetherAiImageGenerationMetadata.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.togetherai;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.image.ImageGenerationMetadata;
+import org.springframework.ai.togetherai.api.TogetherAiApi;
+
+/**
+ * Together AI image generation metadata.
+ *
+ * @since 2.0.1
+ * @author Maksym Uimanov
+ */
+public record TogetherAiImageGenerationMetadata(Integer index,
+		@Nullable ImageType type) implements ImageGenerationMetadata {
+	public enum ImageType {
+
+		BASE64_JSON("b64_json"), URL("url");
+
+		private final String value;
+
+		@Nullable public static ImageType from(TogetherAiApi.GenerateImageResponse.@Nullable ImageType type) {
+			if (type == null) {
+				return null;
+			}
+			return switch (type) {
+				case BASE64_JSON -> BASE64_JSON;
+				case URL -> URL;
+			};
+		}
+
+		ImageType(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return this.value;
+		}
+
+	}
+}

--- a/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/TogetherAiImageModel.java
+++ b/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/TogetherAiImageModel.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.togetherai;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.image.Image;
+import org.springframework.ai.image.ImageGeneration;
+import org.springframework.ai.image.ImageMessage;
+import org.springframework.ai.image.ImageModel;
+import org.springframework.ai.image.ImageOptions;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.image.ImageResponseMetadata;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.togetherai.api.TogetherAiApi;
+import org.springframework.ai.togetherai.api.TogetherAiImageOptions;
+import org.springframework.util.Assert;
+
+/**
+ * Together AI image model implementation.
+ *
+ * @since 2.0.1
+ * @author Maksym Uimanov
+ */
+public class TogetherAiImageModel implements ImageModel {
+
+	private final TogetherAiImageOptions options;
+
+	private final TogetherAiApi togetherAiApi;
+
+	public TogetherAiImageModel(TogetherAiApi togetherAiApi) {
+		this(togetherAiApi, TogetherAiImageOptions.builder().build());
+	}
+
+	public TogetherAiImageModel(TogetherAiApi togetherAiApi, TogetherAiImageOptions options) {
+		Assert.notNull(togetherAiApi, "StabilityAiApi must not be null");
+		Assert.notNull(options, "StabilityAiImageOptions must not be null");
+		this.togetherAiApi = togetherAiApi;
+		this.options = options;
+	}
+
+	@Override
+	public ImageResponse call(ImagePrompt imagePrompt) {
+		TogetherAiImageOptions requestImageOptions = mergeOptions(imagePrompt.getOptions(), this.options);
+		TogetherAiApi.GenerateImageRequest generateImageRequest = getGenerateImageRequest(imagePrompt,
+				requestImageOptions);
+		TogetherAiApi.GenerateImageResponse generateImageResponse = this.togetherAiApi
+			.generateImage(generateImageRequest);
+		return convertResponse(generateImageResponse);
+	}
+
+	private TogetherAiImageOptions mergeOptions(@Nullable ImageOptions runtimeOptions, TogetherAiImageOptions options) {
+		if (runtimeOptions == null) {
+			return options;
+		}
+		TogetherAiImageOptions.Builder builder = TogetherAiImageOptions.builder()
+			.model(ModelOptionsUtils.mergeOption(runtimeOptions, options, ImageOptions::getModel))
+			.steps(options.getSteps())
+			.imageUrl(options.getImageUrl())
+			.seed(options.getSeed())
+			.n(ModelOptionsUtils.mergeOption(runtimeOptions, options, ImageOptions::getN))
+			.height(ModelOptionsUtils.mergeOption(runtimeOptions, options, ImageOptions::getHeight))
+			.width(ModelOptionsUtils.mergeOption(runtimeOptions, options, ImageOptions::getWidth))
+			.negativePrompt(options.getNegativePrompt())
+			.responseFormat(ModelOptionsUtils.mergeOption(runtimeOptions, options,
+					imageOptions -> TogetherAiImageOptions.ResponseFormat.from(imageOptions.getResponseFormat())))
+			.guidanceScale(options.getGuidanceScale())
+			.outputFormat(TogetherAiImageOptions.OutputFormat.from(options.getOutputFormat()))
+			.imageLoras(options.getImageLoras())
+			.referenceImages(options.getReferenceImages())
+			.disableSafetyChecker(options.getDisableSafetyChecker());
+		if (runtimeOptions instanceof TogetherAiImageOptions togetherAiImageOptions) {
+			builder
+				.steps(ModelOptionsUtils.mergeOption(togetherAiImageOptions, options, TogetherAiImageOptions::getSteps))
+				.imageUrl(ModelOptionsUtils.mergeOption(togetherAiImageOptions, options,
+						TogetherAiImageOptions::getImageUrl))
+				.seed(ModelOptionsUtils.mergeOption(togetherAiImageOptions, options, TogetherAiImageOptions::getSeed))
+				.negativePrompt(ModelOptionsUtils.mergeOption(togetherAiImageOptions, options,
+						TogetherAiImageOptions::getNegativePrompt))
+				.guidanceScale(ModelOptionsUtils.mergeOption(togetherAiImageOptions, options,
+						TogetherAiImageOptions::getGuidanceScale))
+				.outputFormat(ModelOptionsUtils.mergeOption(togetherAiImageOptions, options,
+						imageOptions -> TogetherAiImageOptions.OutputFormat.from(imageOptions.getOutputFormat())))
+				.imageLoras(ModelOptionsUtils.mergeOption(togetherAiImageOptions, options,
+						TogetherAiImageOptions::getImageLoras))
+				.referenceImages(ModelOptionsUtils.mergeOption(togetherAiImageOptions, options,
+						TogetherAiImageOptions::getReferenceImages))
+				.disableSafetyChecker(ModelOptionsUtils.mergeOption(togetherAiImageOptions, options,
+						TogetherAiImageOptions::getDisableSafetyChecker));
+		}
+		return builder.build();
+	}
+
+	private TogetherAiApi.GenerateImageRequest getGenerateImageRequest(ImagePrompt imagePrompt,
+			TogetherAiImageOptions imageOptions) {
+		return TogetherAiApi.GenerateImageRequest.builder()
+			.prompt(imagePrompt.getInstructions()
+				.stream()
+				.map(ImageMessage::toString)
+				.collect(Collectors.joining("\n")))
+			.model(imageOptions.getModel())
+			.steps(imageOptions.getSteps())
+			.imageUrl(imageOptions.getImageUrl())
+			.seed(imageOptions.getSeed())
+			.n(imageOptions.getN())
+			.height(imageOptions.getHeight())
+			.width(imageOptions.getWidth())
+			.negativePrompt(imageOptions.getNegativePrompt())
+			.responseFormat(imageOptions.getResponseFormat())
+			.guidanceScale(imageOptions.getGuidanceScale())
+			.outputFormat(imageOptions.getOutputFormat())
+			.imageLoras(Objects.nonNull(imageOptions.getImageLoras()) ? imageOptions.getImageLoras()
+				.stream()
+				.map(TogetherAiApi.GenerateImageRequest.ImageLora::from)
+				.toList() : null)
+			.referenceImages(imageOptions.getReferenceImages())
+			.disableSafetyChecker(imageOptions.getDisableSafetyChecker())
+			.build();
+	}
+
+	private ImageResponse convertResponse(TogetherAiApi.GenerateImageResponse generateImageResponse) {
+		List<ImageGeneration> imageGenerationList = generateImageResponse.data()
+			.stream()
+			.map(entry -> new ImageGeneration(new Image(entry.url(), entry.b64Json()),
+					new TogetherAiImageGenerationMetadata(entry.index(),
+							TogetherAiImageGenerationMetadata.ImageType.from(entry.type()))))
+			.toList();
+		return new ImageResponse(imageGenerationList, new ImageResponseMetadata());
+	}
+
+	public TogetherAiImageOptions getOptions() {
+		return this.options;
+	}
+
+}

--- a/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/api/TogetherAiApi.java
+++ b/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/api/TogetherAiApi.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.togetherai.api;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Together AI API client.
+ *
+ * @since 2.0.1
+ * @author Maksym Uimanov
+ */
+public class TogetherAiApi {
+
+	public static final String DEFAULT_BASE_URL = "https://api.together.ai";
+
+	public static final String IMAGE_GENERATION_ENDPOINT = "/v1/images/generations";
+
+	private final RestClient restClient;
+
+	public TogetherAiApi(String apiKey) {
+		this(apiKey, DEFAULT_BASE_URL, RestClient.builder());
+	}
+
+	public TogetherAiApi(String apiKey, String baseUrl) {
+		this(apiKey, baseUrl, RestClient.builder());
+	}
+
+	public TogetherAiApi(String apiKey, String baseUrl, RestClient.Builder restClientBuilder) {
+		Assert.notNull(apiKey, "'apiKey' must not be null");
+		Assert.notNull(baseUrl, "'baseUrl' must not be null");
+		Assert.notNull(restClientBuilder, "'restClientBuilder' must not be null");
+
+		Consumer<HttpHeaders> jsonContentHeaders = headers -> {
+			headers.setBearerAuth(apiKey);
+			headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+			headers.setContentType(MediaType.APPLICATION_JSON);
+		};
+
+		this.restClient = restClientBuilder.clone()
+			.baseUrl(baseUrl)
+			.defaultHeaders(jsonContentHeaders)
+			.defaultStatusHandler(RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER)
+			.build();
+	}
+
+	public GenerateImageResponse generateImage(GenerateImageRequest request) {
+		Assert.notNull(request, "The request body can not be null.");
+		return Objects.requireNonNull(this.restClient.post()
+			.uri(IMAGE_GENERATION_ENDPOINT)
+			.body(request)
+			.retrieve()
+			.body(GenerateImageResponse.class), "received a response without a body");
+	}
+
+	// See: https://docs.together.ai/reference/post-images-generations
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record GenerateImageRequest(@JsonProperty(value = "prompt", required = true) String prompt,
+			@JsonProperty(value = "model", required = true) String model,
+			@Nullable @JsonProperty("steps") Integer steps, @Nullable @JsonProperty("image_url") String imageUrl,
+			@Nullable @JsonProperty("seed") Long seed, @Nullable @JsonProperty("n") Integer n,
+			@Nullable @JsonProperty("height") Integer height, @Nullable @JsonProperty("width") Integer width,
+			@Nullable @JsonProperty("negative_prompt") String negativePrompt,
+			@Nullable @JsonProperty("response_format") String responseFormat,
+			@Nullable @JsonProperty("guidance_scale") Float guidanceScale,
+			@Nullable @JsonProperty("output_format") String outputFormat,
+			@Nullable @JsonProperty("image_loras") List<ImageLora> imageLoras,
+			@Nullable @JsonProperty("reference_images") List<String> referenceImages,
+			@Nullable @JsonProperty("disable_safety_checker") Boolean disableSafetyChecker) {
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		public record ImageLora(@JsonProperty(value = "path", required = true) String path,
+				@JsonProperty(value = "scale", required = true) Float scale) {
+			public static ImageLora from(TogetherAiImageOptions.ImageLora imageLora) {
+				return new ImageLora(imageLora.path(), imageLora.scale());
+			}
+		}
+
+		public static final class Builder {
+
+			@Nullable private String prompt;
+
+			@Nullable private String model;
+
+			@Nullable private Integer steps;
+
+			@Nullable private String imageUrl;
+
+			@Nullable private Long seed;
+
+			@Nullable private Integer n;
+
+			@Nullable private Integer height;
+
+			@Nullable private Integer width;
+
+			@Nullable private String negativePrompt;
+
+			@Nullable private String responseFormat;
+
+			@Nullable private Float guidanceScale;
+
+			@Nullable private String outputFormat;
+
+			@Nullable private List<ImageLora> imageLoras;
+
+			@Nullable private List<String> referenceImages;
+
+			@Nullable private Boolean disableSafetyChecker;
+
+			private Builder() {
+			}
+
+			public Builder prompt(@Nullable String prompt) {
+				this.prompt = prompt;
+				return this;
+			}
+
+			public Builder model(@Nullable String model) {
+				this.model = model;
+				return this;
+			}
+
+			public Builder steps(@Nullable Integer steps) {
+				this.steps = steps;
+				return this;
+			}
+
+			public Builder imageUrl(@Nullable String imageUrl) {
+				this.imageUrl = imageUrl;
+				return this;
+			}
+
+			public Builder seed(@Nullable Long seed) {
+				this.seed = seed;
+				return this;
+			}
+
+			public Builder n(@Nullable Integer n) {
+				this.n = n;
+				return this;
+			}
+
+			public Builder height(@Nullable Integer height) {
+				this.height = height;
+				return this;
+			}
+
+			public Builder width(@Nullable Integer width) {
+				this.width = width;
+				return this;
+			}
+
+			public Builder negativePrompt(@Nullable String negativePrompt) {
+				this.negativePrompt = negativePrompt;
+				return this;
+			}
+
+			public Builder responseFormat(@Nullable String responseFormat) {
+				this.responseFormat = responseFormat;
+				return this;
+			}
+
+			public Builder guidanceScale(@Nullable Float guidanceScale) {
+				this.guidanceScale = guidanceScale;
+				return this;
+			}
+
+			public Builder outputFormat(@Nullable String outputFormat) {
+				this.outputFormat = outputFormat;
+				return this;
+			}
+
+			public Builder imageLoras(@Nullable List<ImageLora> imageLoras) {
+				this.imageLoras = imageLoras;
+				return this;
+			}
+
+			public Builder referenceImages(@Nullable List<String> referenceImages) {
+				this.referenceImages = referenceImages;
+				return this;
+			}
+
+			public Builder disableSafetyChecker(@Nullable Boolean disableSafetyChecker) {
+				this.disableSafetyChecker = disableSafetyChecker;
+				return this;
+			}
+
+			public GenerateImageRequest build() {
+				Assert.state(Objects.nonNull(this.prompt), "prompt must not be null.");
+				Assert.state(Objects.nonNull(this.model), "model must not be null.");
+				return new GenerateImageRequest(this.prompt, this.model, this.steps, this.imageUrl, this.seed, this.n,
+						this.height, this.width, this.negativePrompt, this.responseFormat, this.guidanceScale,
+						this.outputFormat, this.imageLoras, this.referenceImages, this.disableSafetyChecker);
+			}
+
+		}
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record GenerateImageResponse(@JsonProperty(value = "id", required = true) String id,
+			@JsonProperty(value = "model", required = true) String model,
+			@JsonProperty(value = "object", required = true) String object,
+			@JsonProperty(value = "data", required = true) List<Image> data) {
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
+		public record Image(@JsonProperty(value = "index", required = true) Integer index,
+				@Nullable @JsonProperty("b64_json") String b64Json, @Nullable @JsonProperty("url") String url,
+				@Nullable @JsonProperty("type") ImageType type) {
+		}
+
+		public enum ImageType {
+
+			BASE64_JSON("b64_json"), URL("url");
+
+			private final String value;
+
+			@JsonCreator
+			public static ImageType from(String value) {
+				for (ImageType type : values()) {
+					if (type.value.equals(value)) {
+						return type;
+					}
+				}
+				throw new IllegalArgumentException("Unknown image type: " + value);
+			}
+
+			ImageType(String value) {
+				this.value = value;
+			}
+
+			public String getValue() {
+				return this.value;
+			}
+
+		}
+	}
+
+}

--- a/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/api/TogetherAiImageOptions.java
+++ b/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/api/TogetherAiImageOptions.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.togetherai.api;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.image.ImageOptions;
+
+/**
+ * Together AI image generation options.
+ *
+ * @since 2.0.1
+ * @author Maksym Uimanov
+ */
+public class TogetherAiImageOptions implements ImageOptions {
+
+	@Nullable private final String model;
+
+	@Nullable private final Integer steps;
+
+	@Nullable private final String imageUrl;
+
+	@Nullable private final Long seed;
+
+	@Nullable private final Integer n;
+
+	@Nullable private final Integer height;
+
+	@Nullable private final Integer width;
+
+	@Nullable private final String negativePrompt;
+
+	@Nullable private final String responseFormat;
+
+	@Nullable private final Float guidanceScale;
+
+	@Nullable private final String outputFormat;
+
+	@Nullable private final List<ImageLora> imageLoras;
+
+	@Nullable private final List<String> referenceImages;
+
+	@Nullable private final Boolean disableSafetyChecker;
+
+	public TogetherAiImageOptions(@Nullable String model, @Nullable Integer steps, @Nullable String imageUrl,
+			@Nullable Long seed, @Nullable Integer n, @Nullable Integer height, @Nullable Integer width,
+			@Nullable String negativePrompt, @Nullable String responseFormat, @Nullable Float guidanceScale,
+			@Nullable String outputFormat, @Nullable List<ImageLora> imageLoras, @Nullable List<String> referenceImages,
+			@Nullable Boolean disableSafetyChecker) {
+		this.model = model;
+		this.steps = steps;
+		this.imageUrl = imageUrl;
+		this.seed = seed;
+		this.n = n;
+		this.height = height;
+		this.width = width;
+		this.negativePrompt = negativePrompt;
+		this.responseFormat = responseFormat;
+		this.guidanceScale = guidanceScale;
+		this.outputFormat = outputFormat;
+		this.imageLoras = imageLoras;
+		this.referenceImages = referenceImages;
+		this.disableSafetyChecker = disableSafetyChecker;
+	}
+
+	@Override
+	@Nullable public String getModel() {
+		return this.model;
+	}
+
+	@Nullable public Integer getSteps() {
+		return this.steps;
+	}
+
+	@Nullable public String getImageUrl() {
+		return this.imageUrl;
+	}
+
+	@Nullable public Long getSeed() {
+		return this.seed;
+	}
+
+	@Override
+	@Nullable public Integer getN() {
+		return this.n;
+	}
+
+	@Override
+	@Nullable public Integer getHeight() {
+		return this.height;
+	}
+
+	@Override
+	@Nullable public Integer getWidth() {
+		return this.width;
+	}
+
+	@Nullable public String getNegativePrompt() {
+		return this.negativePrompt;
+	}
+
+	@Override
+	@Nullable public String getResponseFormat() {
+		return this.responseFormat;
+	}
+
+	@Override
+	@Nullable public String getStyle() {
+		return null; // Together AI does not support style
+	}
+
+	@Nullable public Float getGuidanceScale() {
+		return this.guidanceScale;
+	}
+
+	@Nullable public String getOutputFormat() {
+		return this.outputFormat;
+	}
+
+	@Nullable public List<ImageLora> getImageLoras() {
+		return this.imageLoras;
+	}
+
+	@Nullable public List<String> getReferenceImages() {
+		return this.referenceImages;
+	}
+
+	@Nullable public Boolean getDisableSafetyChecker() {
+		return this.disableSafetyChecker;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public record ImageLora(String path, Float scale) {
+	}
+
+	public enum OutputFormat {
+
+		JPEG("jpeg"), PNG("png");
+
+		private final String value;
+
+		@Nullable public static OutputFormat from(@Nullable String value) {
+			if (value == null) {
+				return null;
+			}
+			for (OutputFormat type : values()) {
+				if (type.value.equals(value)) {
+					return type;
+				}
+			}
+			throw new IllegalArgumentException("Unknown output format: " + value);
+		}
+
+		OutputFormat(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return this.value;
+		}
+
+	}
+
+	public enum ResponseFormat {
+
+		BASE64("base64"), URL("url");
+
+		private final String value;
+
+		@Nullable public static ResponseFormat from(@Nullable String value) {
+			if (value == null) {
+				return null;
+			}
+			for (ResponseFormat type : values()) {
+				if (type.value.equals(value)) {
+					return type;
+				}
+			}
+			throw new IllegalArgumentException("Unknown response format: " + value);
+		}
+
+		ResponseFormat(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return this.value;
+		}
+
+	}
+
+	public static final class Builder {
+
+		@Nullable private String model;
+
+		@Nullable private Integer steps;
+
+		@Nullable private String imageUrl;
+
+		@Nullable private Long seed;
+
+		@Nullable private Integer n;
+
+		@Nullable private Integer height;
+
+		@Nullable private Integer width;
+
+		@Nullable private String negativePrompt;
+
+		@Nullable private String responseFormat;
+
+		@Nullable private Float guidanceScale;
+
+		@Nullable private String outputFormat;
+
+		@Nullable private List<ImageLora> imageLoras;
+
+		@Nullable private List<String> referenceImages;
+
+		@Nullable private Boolean disableSafetyChecker;
+
+		public Builder model(@Nullable String model) {
+			this.model = model;
+			return this;
+		}
+
+		public Builder steps(@Nullable Integer steps) {
+			this.steps = steps;
+			return this;
+		}
+
+		public Builder imageUrl(@Nullable String imageUrl) {
+			this.imageUrl = imageUrl;
+			return this;
+		}
+
+		public Builder seed(@Nullable Long seed) {
+			this.seed = seed;
+			return this;
+		}
+
+		public Builder n(@Nullable Integer n) {
+			this.n = n;
+			return this;
+		}
+
+		public Builder height(@Nullable Integer height) {
+			this.height = height;
+			return this;
+		}
+
+		public Builder width(@Nullable Integer width) {
+			this.width = width;
+			return this;
+		}
+
+		public Builder negativePrompt(@Nullable String negativePrompt) {
+			this.negativePrompt = negativePrompt;
+			return this;
+		}
+
+		public Builder responseFormat(@Nullable ResponseFormat responseFormat) {
+			this.responseFormat = responseFormat != null ? responseFormat.getValue() : null;
+			return this;
+		}
+
+		public Builder guidanceScale(@Nullable Float guidanceScale) {
+			this.guidanceScale = guidanceScale;
+			return this;
+		}
+
+		public Builder outputFormat(@Nullable OutputFormat outputFormat) {
+			this.outputFormat = outputFormat != null ? outputFormat.getValue() : null;
+			return this;
+		}
+
+		public Builder imageLoras(@Nullable List<ImageLora> imageLoras) {
+			this.imageLoras = imageLoras;
+			return this;
+		}
+
+		public Builder referenceImages(@Nullable List<String> referenceImages) {
+			this.referenceImages = referenceImages;
+			return this;
+		}
+
+		public Builder disableSafetyChecker(@Nullable Boolean disableSafetyChecker) {
+			this.disableSafetyChecker = disableSafetyChecker;
+			return this;
+		}
+
+		public TogetherAiImageOptions build() {
+			return new TogetherAiImageOptions(this.model, this.steps, this.imageUrl, this.seed, this.n, this.height,
+					this.width, this.negativePrompt, this.responseFormat, this.guidanceScale, this.outputFormat,
+					this.imageLoras, this.referenceImages, this.disableSafetyChecker);
+		}
+
+	}
+
+}

--- a/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/api/package-info.java
+++ b/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/api/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Together AI API support.
+ */
+@NullMarked
+package org.springframework.ai.togetherai.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/package-info.java
+++ b/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Together AI model support.
+ */
+@NullMarked
+package org.springframework.ai.togetherai;
+
+import org.jspecify.annotations.NullMarked;

--- a/models/spring-ai-together-ai/src/test/java/org/springframework/ai/togetherai/TogetherAiApiIT.java
+++ b/models/spring-ai-together-ai/src/test/java/org/springframework/ai/togetherai/TogetherAiApiIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.togetherai;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.togetherai.api.TogetherAiApi;
+import org.springframework.ai.togetherai.api.TogetherAiImageOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfEnvironmentVariable(named = "TOGETHERAI_API_KEY", matches = ".+")
+class TogetherAiApiIT {
+
+	private TogetherAiApi togetherAiApi;
+
+	@BeforeEach
+	void setUp() {
+		this.togetherAiApi = new TogetherAiApi(System.getenv("TOGETHERAI_API_KEY"));
+	}
+
+	@Test
+	void generateImage_shouldReturnBase64Png_whenResponseFormatIsBase64AndOutputFormatIsPng() {
+		TogetherAiApi.GenerateImageRequest request = TogetherAiApi.GenerateImageRequest.builder()
+			.prompt("A green apple on a plate with leaf")
+			.model("black-forest-labs/FLUX.1-schnell")
+			.height(1024)
+			.width(1024)
+			.responseFormat(TogetherAiImageOptions.ResponseFormat.BASE64.getValue())
+			.outputFormat(TogetherAiImageOptions.OutputFormat.PNG.getValue())
+			.build();
+		TogetherAiApi.GenerateImageResponse response = this.togetherAiApi.generateImage(request);
+
+		assertThat(response).isNotNull();
+		List<TogetherAiApi.GenerateImageResponse.Image> data = response.data();
+		assertThat(data).hasSize(1);
+		var firstImage = data.get(0);
+		assertThat(firstImage.b64Json()).isNotEmpty();
+		assertThat(firstImage.url()).isNull();
+	}
+
+	@Test
+	void generateImage_shouldReturnBase64Jpeg_whenResponseFormatIsBase64AndOutputFormatIsJpeg() {
+		TogetherAiApi.GenerateImageRequest request = TogetherAiApi.GenerateImageRequest.builder()
+			.prompt("A green apple on a plate with leaf")
+			.model("black-forest-labs/FLUX.1-schnell")
+			.height(1024)
+			.width(1024)
+			.responseFormat(TogetherAiImageOptions.ResponseFormat.BASE64.getValue())
+			.outputFormat(TogetherAiImageOptions.OutputFormat.JPEG.getValue())
+			.build();
+		TogetherAiApi.GenerateImageResponse response = this.togetherAiApi.generateImage(request);
+
+		assertThat(response).isNotNull();
+		List<TogetherAiApi.GenerateImageResponse.Image> data = response.data();
+		assertThat(data).hasSize(1);
+		var firstImage = data.get(0);
+		assertThat(firstImage.b64Json()).isNotEmpty();
+		assertThat(firstImage.url()).isNull();
+	}
+
+	@Test
+	void generateImage_shouldReturnUrlPng_whenResponseFormatIsUrlAndOutputFormatIsPng() {
+		TogetherAiApi.GenerateImageRequest request = TogetherAiApi.GenerateImageRequest.builder()
+			.prompt("A green apple on a plate with leaf")
+			.model("black-forest-labs/FLUX.1-schnell")
+			.height(1024)
+			.width(1024)
+			.responseFormat(TogetherAiImageOptions.ResponseFormat.URL.getValue())
+			.outputFormat(TogetherAiImageOptions.OutputFormat.PNG.getValue())
+			.build();
+		TogetherAiApi.GenerateImageResponse response = this.togetherAiApi.generateImage(request);
+
+		assertThat(response).isNotNull();
+		List<TogetherAiApi.GenerateImageResponse.Image> data = response.data();
+		assertThat(data).hasSize(1);
+		var firstImage = data.get(0);
+		assertThat(firstImage.b64Json()).isNull();
+		assertThat(firstImage.url()).isNotEmpty();
+	}
+
+	@Test
+	void generateImage_shouldReturnUrlJpeg_whenResponseFormatIsUrlAndOutputFormatIsJpeg() {
+		TogetherAiApi.GenerateImageRequest request = TogetherAiApi.GenerateImageRequest.builder()
+			.prompt("A green apple on a plate with leaf")
+			.model("black-forest-labs/FLUX.1-schnell")
+			.height(1024)
+			.width(1024)
+			.responseFormat(TogetherAiImageOptions.ResponseFormat.URL.getValue())
+			.outputFormat(TogetherAiImageOptions.OutputFormat.JPEG.getValue())
+			.build();
+		TogetherAiApi.GenerateImageResponse response = this.togetherAiApi.generateImage(request);
+
+		assertThat(response).isNotNull();
+		List<TogetherAiApi.GenerateImageResponse.Image> data = response.data();
+		assertThat(data).hasSize(1);
+		var firstImage = data.get(0);
+		assertThat(firstImage.b64Json()).isNull();
+		assertThat(firstImage.url()).isNotEmpty();
+	}
+
+}

--- a/models/spring-ai-together-ai/src/test/java/org/springframework/ai/togetherai/TogetherAiImageModelIT.java
+++ b/models/spring-ai-together-ai/src/test/java/org/springframework/ai/togetherai/TogetherAiImageModelIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.togetherai;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.image.Image;
+import org.springframework.ai.image.ImageGeneration;
+import org.springframework.ai.image.ImageModel;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.togetherai.api.TogetherAiImageOptions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = TogetherAiImageTestConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "TOGETHERAI_API_KEY", matches = ".+")
+class TogetherAiImageModelIT {
+
+	@Autowired
+	protected ImageModel togetherAiImageModel;
+
+	@Test
+	void generateImage_shouldReturnUrlPng() {
+		TogetherAiImageOptions imageOptions = TogetherAiImageOptions.builder()
+			.model("black-forest-labs/FLUX.1-schnell")
+			.outputFormat(TogetherAiImageOptions.OutputFormat.PNG)
+			.responseFormat(TogetherAiImageOptions.ResponseFormat.URL)
+			.build();
+		String instruction = "A green apple on a plate with leaf";
+		ImagePrompt imagePrompt = new ImagePrompt(instruction, imageOptions);
+		ImageResponse imageResponse = this.togetherAiImageModel.call(imagePrompt);
+		ImageGeneration imageGeneration = imageResponse.getResult();
+		Image image = imageGeneration.getOutput();
+		assertThat(image.getUrl()).isNotEmpty();
+		System.out.println(image.getUrl());
+	}
+
+}

--- a/models/spring-ai-together-ai/src/test/java/org/springframework/ai/togetherai/TogetherAiImageOptionsTests.java
+++ b/models/spring-ai-together-ai/src/test/java/org/springframework/ai/togetherai/TogetherAiImageOptionsTests.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.togetherai;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.image.ImageOptions;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.togetherai.api.TogetherAiApi;
+import org.springframework.ai.togetherai.api.TogetherAiImageOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TogetherAiImageOptionsTests {
+
+	@Mock
+	private TogetherAiApi togetherAiApi;
+
+	@BeforeEach
+	void setUp() {
+		TogetherAiApi.GenerateImageResponse generateImageResponse = new TogetherAiApi.GenerateImageResponse("id",
+				"model", "image", List.of());
+		when(this.togetherAiApi.generateImage(ArgumentMatchers.any())).thenReturn(generateImageResponse);
+	}
+
+	@Test
+	void shouldPreferRuntimeOptionsOverDefaultOptions() {
+		TogetherAiImageOptions defaultOptions = TogetherAiImageOptions.builder()
+			.model("default-model")
+			.steps(20)
+			.imageUrl("https://example.com/default.png")
+			.seed(1234L)
+			.n(1)
+			.height(512)
+			.width(512)
+			.negativePrompt("default negative prompt")
+			.responseFormat(TogetherAiImageOptions.ResponseFormat.BASE64)
+			.guidanceScale(7.0f)
+			.outputFormat(TogetherAiImageOptions.OutputFormat.PNG)
+			.imageLoras(List.of(new TogetherAiImageOptions.ImageLora("default-lora", 0.5f)))
+			.referenceImages(List.of("https://example.com/default-reference.png"))
+			.disableSafetyChecker(false)
+			.build();
+
+		TogetherAiImageOptions runtimeOptions = TogetherAiImageOptions.builder()
+			.model("runtime-model")
+			.steps(50)
+			.imageUrl("https://example.com/runtime.png")
+			.seed(5678L)
+			.n(2)
+			.height(768)
+			.width(1024)
+			.negativePrompt("runtime negative prompt")
+			.responseFormat(TogetherAiImageOptions.ResponseFormat.URL)
+			.guidanceScale(14.0f)
+			.outputFormat(TogetherAiImageOptions.OutputFormat.JPEG)
+			.imageLoras(List.of(new TogetherAiImageOptions.ImageLora("runtime-lora", 1.0f)))
+			.referenceImages(List.of("https://example.com/runtime-reference.png"))
+			.disableSafetyChecker(true)
+			.build();
+
+		TogetherAiImageModel imageModel = new TogetherAiImageModel(this.togetherAiApi, defaultOptions);
+
+		imageModel.call(new ImagePrompt("prompt", runtimeOptions));
+
+		ArgumentCaptor<TogetherAiApi.GenerateImageRequest> requestCaptor = ArgumentCaptor
+			.forClass(TogetherAiApi.GenerateImageRequest.class);
+		verify(this.togetherAiApi, times(1)).generateImage(requestCaptor.capture());
+
+		TogetherAiApi.GenerateImageRequest request = requestCaptor.getValue();
+		assertThat(request.model()).isEqualTo("runtime-model");
+		assertThat(request.steps()).isEqualTo(50);
+		assertThat(request.imageUrl()).isEqualTo("https://example.com/runtime.png");
+		assertThat(request.seed()).isEqualTo(5678L);
+		assertThat(request.n()).isEqualTo(2);
+		assertThat(request.height()).isEqualTo(768);
+		assertThat(request.width()).isEqualTo(1024);
+		assertThat(request.negativePrompt()).isEqualTo("runtime negative prompt");
+		assertThat(request.responseFormat()).isEqualTo(TogetherAiImageOptions.ResponseFormat.URL.getValue());
+		assertThat(request.guidanceScale()).isEqualTo(14.0f);
+		assertThat(request.outputFormat()).isEqualTo(TogetherAiImageOptions.OutputFormat.JPEG.getValue());
+		assertThat(request.imageLoras())
+			.containsExactly(new TogetherAiApi.GenerateImageRequest.ImageLora("runtime-lora", 1.0f));
+		assertThat(request.referenceImages()).containsExactly("https://example.com/runtime-reference.png");
+		assertThat(request.disableSafetyChecker()).isTrue();
+	}
+
+	@Test
+	void shouldUseDefaultOptions_whenRuntimeOptionsAreNull() {
+		TogetherAiImageOptions defaultOptions = TogetherAiImageOptions.builder()
+			.model("default-model")
+			.steps(20)
+			.seed(1234L)
+			.n(1)
+			.height(512)
+			.width(512)
+			.responseFormat(TogetherAiImageOptions.ResponseFormat.BASE64)
+			.guidanceScale(7.0f)
+			.outputFormat(TogetherAiImageOptions.OutputFormat.PNG)
+			.build();
+
+		TogetherAiImageModel imageModel = new TogetherAiImageModel(this.togetherAiApi, defaultOptions);
+
+		imageModel.call(new ImagePrompt("prompt", null));
+
+		ArgumentCaptor<TogetherAiApi.GenerateImageRequest> requestCaptor = ArgumentCaptor
+			.forClass(TogetherAiApi.GenerateImageRequest.class);
+		verify(this.togetherAiApi, times(1)).generateImage(requestCaptor.capture());
+
+		TogetherAiApi.GenerateImageRequest request = requestCaptor.getValue();
+		assertThat(request.model()).isEqualTo("default-model");
+		assertThat(request.steps()).isEqualTo(20);
+		assertThat(request.seed()).isEqualTo(1234L);
+		assertThat(request.n()).isEqualTo(1);
+		assertThat(request.height()).isEqualTo(512);
+		assertThat(request.width()).isEqualTo(512);
+		assertThat(request.responseFormat()).isEqualTo(TogetherAiImageOptions.ResponseFormat.BASE64.getValue());
+		assertThat(request.guidanceScale()).isEqualTo(7.0f);
+		assertThat(request.outputFormat()).isEqualTo(TogetherAiImageOptions.OutputFormat.PNG.getValue());
+	}
+
+	@Test
+	void shouldHandleGenericImageOptionsCorrectly() {
+		TogetherAiImageOptions defaultOptions = TogetherAiImageOptions.builder()
+			.model("default-model")
+			.steps(20)
+			.n(1)
+			.height(512)
+			.width(512)
+			.responseFormat(TogetherAiImageOptions.ResponseFormat.BASE64)
+			.guidanceScale(7.0f)
+			.outputFormat(TogetherAiImageOptions.OutputFormat.PNG)
+			.build();
+
+		ImageOptions genericOptions = new ImageOptions() {
+			@Override
+			public Integer getN() {
+				return 2;
+			}
+
+			@Override
+			public String getModel() {
+				return "generic-model";
+			}
+
+			@Override
+			public Integer getWidth() {
+				return 1024;
+			}
+
+			@Override
+			public Integer getHeight() {
+				return 768;
+			}
+
+			@Override
+			public String getResponseFormat() {
+				return "url";
+			}
+
+			@Override
+			public String getStyle() {
+				return null;
+			}
+		};
+
+		TogetherAiImageModel imageModel = new TogetherAiImageModel(this.togetherAiApi, defaultOptions);
+
+		imageModel.call(new ImagePrompt("prompt", genericOptions));
+
+		ArgumentCaptor<TogetherAiApi.GenerateImageRequest> requestCaptor = ArgumentCaptor
+			.forClass(TogetherAiApi.GenerateImageRequest.class);
+		verify(this.togetherAiApi, times(1)).generateImage(requestCaptor.capture());
+
+		TogetherAiApi.GenerateImageRequest request = requestCaptor.getValue();
+		assertThat(request.model()).isEqualTo("generic-model");
+		assertThat(request.n()).isEqualTo(2);
+		assertThat(request.width()).isEqualTo(1024);
+		assertThat(request.height()).isEqualTo(768);
+		assertThat(request.responseFormat()).isEqualTo("url");
+		assertThat(request.steps()).isEqualTo(20);
+		assertThat(request.guidanceScale()).isEqualTo(7.0f);
+		assertThat(request.outputFormat()).isEqualTo(TogetherAiImageOptions.OutputFormat.PNG.getValue());
+	}
+
+}

--- a/models/spring-ai-together-ai/src/test/java/org/springframework/ai/togetherai/TogetherAiImageTestConfiguration.java
+++ b/models/spring-ai-together-ai/src/test/java/org/springframework/ai/togetherai/TogetherAiImageTestConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.togetherai;
+
+import org.springframework.ai.togetherai.api.TogetherAiApi;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.StringUtils;
+
+@SpringBootConfiguration
+public class TogetherAiImageTestConfiguration {
+
+	@Bean
+	public TogetherAiApi togetherAiApi() {
+		return new TogetherAiApi(getApiKey());
+	}
+
+	@Bean
+	public TogetherAiImageModel togetherAiImageModel(TogetherAiApi togetherAiApi) {
+		return new TogetherAiImageModel(togetherAiApi);
+	}
+
+	private String getApiKey() {
+		String apiKey = System.getenv("TOGETHERAI_API_KEY");
+		if (!StringUtils.hasText(apiKey)) {
+			throw new IllegalArgumentException(
+					"You must provide an API key. Put it in an environment variable under the name TOGETHERAI_API_KEY");
+		}
+		return apiKey;
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,9 @@
 		<module>vector-stores/spring-ai-s3-vector-store</module>
 		<module>vector-stores/spring-ai-typesense-store</module>
 		<module>vector-stores/spring-ai-weaviate-store</module>
+        <module>models/spring-ai-together-ai</module>
+		<module>auto-configurations/models/spring-ai-autoconfigure-model-together-ai</module>
+		<module>starters/spring-ai-starter-model-together-ai</module>
 	</modules>
 
 	<organization>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -52,6 +52,7 @@
 **** xref:api/image/azure-openai-image.adoc[Azure OpenAI]
 **** xref:api/image/openai-image.adoc[OpenAI]
 **** xref:api/image/stabilityai-image.adoc[Stability]
+**** xref:api/image/togetherai-image.adoc[Together AI]
 
 *** xref:api/audio.adoc[Audio Models]
 **** xref:api/audio/transcriptions.adoc[]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/togetherai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/togetherai-image.adoc
@@ -1,0 +1,160 @@
+= Together AI Image Generation
+
+Spring AI supports Together AI's https://docs.together.ai/reference/post-images-generations[image generation API].
+
+== Prerequisites
+
+You will need to create an API key with Together AI to access their image models.
+
+The Spring AI project defines a configuration property named `spring.ai.togetherai.api-key` that you should set to the value of the API key obtained from Together AI.
+
+You can set this configuration property in your `application.properties` file:
+
+[source,properties]
+----
+spring.ai.togetherai.api-key=<your-togetherai-api-key>
+----
+
+For enhanced security when handling sensitive information like API keys, you can use Spring Expression Language (SpEL) to reference a custom environment variable:
+
+[source,yaml]
+----
+# In application.yml
+spring:
+  ai:
+    togetherai:
+      api-key: ${TOGETHERAI_API_KEY}
+----
+
+[source,bash]
+----
+# In your environment or .env file
+export TOGETHERAI_API_KEY=<your-togetherai-api-key>
+----
+
+You can also set this configuration programmatically in your application code:
+
+[source,java]
+----
+// Retrieve API key from a secure source or environment variable
+String apiKey = System.getenv("TOGETHERAI_API_KEY");
+----
+
+== Auto-configuration
+
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
+Spring AI provides Spring Boot auto-configuration for the Together AI Image Generation Client.
+To enable it add the following dependency to your project's Maven `pom.xml` file:
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-model-together-ai</artifactId>
+</dependency>
+----
+
+or to your Gradle `build.gradle` build file.
+
+[source,groovy]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-starter-model-together-ai'
+}
+----
+
+TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
+
+=== Image Generation Properties
+
+==== Connection Properties
+
+The prefix `spring.ai.togetherai` is used as the property prefix that lets you connect to Together AI.
+
+[cols="3,5,1"]
+|====
+| Property | Description | Default
+
+| spring.ai.togetherai.base-url   | The URL to connect to |  `https://api.together.ai`
+| spring.ai.togetherai.api-key    | The API Key           |  -
+|====
+
+==== Configuration Properties
+
+[NOTE]
+====
+Enabling and disabling of the image auto-configurations are now configured via top level properties with the prefix `spring.ai.model.image`.
+
+To enable, `spring.ai.model.image=togetherai`.
+
+To disable, `spring.ai.model.image=none` (or any value which doesn't match `togetherai`).
+
+This change is done to allow configuration of multiple models.
+====
+
+The prefix `spring.ai.togetherai.image` is the property prefix that lets you configure the `ImageModel` implementation for Together AI.
+
+[cols="3,5,1"]
+|====
+| Property | Description | Default
+
+| spring.ai.model.image | Enable Together AI image model. | togetherai
+| spring.ai.togetherai.image.base-url | Optional override of `spring.ai.togetherai.base-url`. | -
+| spring.ai.togetherai.image.api-key | Optional override of `spring.ai.togetherai.api-key`. | -
+| spring.ai.togetherai.image.model | The model to use for image generation. This property is required. | -
+| spring.ai.togetherai.image.steps | The number of sampling steps to use. | -
+| spring.ai.togetherai.image.image-url | An optional image URL to send with the request. | -
+| spring.ai.togetherai.image.seed | Random noise seed to use. | -
+| spring.ai.togetherai.image.n | The number of images to be generated. | -
+| spring.ai.togetherai.image.height | The height of the generated image, in pixels. | -
+| spring.ai.togetherai.image.width | The width of the generated image, in pixels. | -
+| spring.ai.togetherai.image.negative-prompt | A prompt fragment that should be avoided. | -
+| spring.ai.togetherai.image.response-format | The format in which the generated images are returned. Valid values are `base64` and `url`. | -
+| spring.ai.togetherai.image.guidance-scale | The guidance scale to use when generating the image. | -
+| spring.ai.togetherai.image.output-format | The output image format. Valid values are `jpeg` and `png`. | -
+| spring.ai.togetherai.image.image-loras | A list of image LoRA settings, each with a `path` and `scale`. | -
+| spring.ai.togetherai.image.reference-images | A list of reference image URLs. | -
+| spring.ai.togetherai.image.disable-safety-checker | Whether to disable the safety checker. | -
+|====
+
+NOTE: You can override the common `spring.ai.togetherai.base-url` and `spring.ai.togetherai.api-key` properties.
+The `spring.ai.togetherai.image.base-url` and `spring.ai.togetherai.image.api-key` properties, if set, take precedence over the common properties.
+This is useful if you want to use different Together AI accounts or endpoints for different models.
+The effective default base URL is `https://api.together.ai`.
+
+== Runtime Options [[image-options]]
+
+The https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/api/TogetherAiImageOptions.java[TogetherAiImageOptions.java] provides model configurations, such as the model to use, the number of steps, the output format, and the image references.
+
+On start-up, the default options can be configured with the `TogetherAiImageModel(TogetherAiApi togetherAiApi, TogetherAiImageOptions options)` constructor.
+Alternatively, use the `spring.ai.togetherai.image.*` properties described previously.
+
+At runtime, you can override the default options by adding new, request specific, options to the `ImagePrompt` call.
+For example, to override Together AI specific options such as the guidance scale and the number of images to create, use the following code example:
+
+[source,java]
+----
+ImageResponse response = togetherAiImageModel.call(
+        new ImagePrompt("A light cream colored mini golden doodle",
+        TogetherAiImageOptions.builder()
+                .model("black-forest-labs/FLUX.1-schnell")
+                .steps(20)
+                .n(4)
+                .height(1024)
+                .width(1024)
+                .guidanceScale(7.5f)
+                .outputFormat(TogetherAiImageOptions.OutputFormat.PNG)
+                .responseFormat(TogetherAiImageOptions.ResponseFormat.URL)
+                .build())
+
+);
+----
+
+TIP: In addition to the model specific https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-together-ai/src/main/java/org/springframework/ai/togetherai/api/TogetherAiImageOptions.java[TogetherAiImageOptions] you can use a portable https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/image/ImageOptions.java[ImageOptions] instance, created with the https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/image/ImageOptionsBuilder.java[ImageOptionsBuilder#builder()].
+
+NOTE: Together AI does not expose a style preset option.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/imageclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/imageclient.adoc
@@ -161,3 +161,4 @@ public class ImageGeneration implements ModelResult<Image> {
 
 * xref:api/image/openai-image.adoc[OpenAI Image Generation]
 * xref:api/image/stabilityai-image.adoc[StabilityAI Image Generation]
+* xref:api/image/togetherai-image.adoc[Together AI Image Generation]

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
@@ -19,6 +19,9 @@ package org.springframework.ai.model;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.lang.Contract;
+import org.springframework.util.Assert;
+
+import java.util.function.Function;
 
 /**
  * Utility class for manipulating {@link ModelOptions} objects.
@@ -30,6 +33,19 @@ import org.springframework.lang.Contract;
  * @since 0.8.0
  */
 public abstract class ModelOptionsUtils {
+
+	/**
+	 * Return the runtime option extracted from the provided options if present,
+	 * otherwise return the default option.
+	 */
+	public static <O extends ModelOptions, T> @Nullable T mergeOption(
+			O runtimeOptions,
+			O defaultOptions,
+			Function<O, @Nullable T> function
+	) {
+		Assert.notNull(function, "Function must not be null");
+		return mergeOption(function.apply(runtimeOptions), function.apply(defaultOptions));
+	}
 
 	/**
 	 * Return the runtime value if not null, or else the default value.

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModels.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModels.java
@@ -56,4 +56,6 @@ public final class SpringAIModels {
 
 	public static final String ELEVEN_LABS = "elevenlabs";
 
+	public static final String TOGETHER_AI = "togetherai";
+
 }

--- a/starters/spring-ai-starter-model-together-ai/pom.xml
+++ b/starters/spring-ai-starter-model-together-ai/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-starter-model-together-ai</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Starter - Together AI</name>
+	<description>Spring AI Together Spring Boot Starter</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webclient</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-together-ai</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-together-ai</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+	</dependencies>
+
+</project>


### PR DESCRIPTION
## Summary

This pull request adds support for Together AI image generation models in Spring AI.

## Details

- Added Together AI image model implementation
- Integrated Together AI image generation API with Spring AI's ImageModel abstraction
- Added configuration properties for Together AI image model usage
- Added tests covering request creation and response handling
- Added documentation for configuring and using the Together AI image model

## Motivation

This integration allows Spring AI applications to generate images using Together AI models while keeping the standard Spring AI API.

## Testing

- Added integration tests for image generation request
- Verified model configuration and API interaction