### PR TITLE
Use Jackson enum values in generated schemas

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
@@ -83,7 +83,8 @@ public final class McpJsonSchemaGenerator {
 	 * spring-ai-model's JsonSchemaGenerator.
 	 */
 	static {
-		Module jacksonModule = new JacksonSchemaModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED);
+		Module jacksonModule = new JacksonSchemaModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
+				JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY);
 		Module openApiModule = new Swagger2Module();
 		Module springAiSchemaModule = PROPERTY_REQUIRED_BY_DEFAULT ? new McpSpringAiSchemaModule()
 				: new McpSpringAiSchemaModule(McpSpringAiSchemaModule.Option.PROPERTY_REQUIRED_FALSE_BY_DEFAULT);

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
@@ -19,6 +19,8 @@ package org.springframework.ai.mcp.annotation.method.tool.utils;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 
@@ -126,6 +128,31 @@ class McpJsonSchemaGeneratorTests {
 			.isEqualTo("#/$defs/Filter_2");
 	}
 
+	// gh-1985: enum constants annotated with @JsonProperty must surface their custom
+	// values in the generated schema, matching Jackson's deserialization behavior.
+	@Test
+	void generateSchemaForMethodWithCustomEnumValues() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("useCustomEnum", CustomEnum.class);
+
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = jsonHelper.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/properties/status/enum")).map(JsonNode::asString)
+			.containsExactly("value.a", "value.b");
+	}
+
+	// gh-1985: enums serialized through a @JsonValue method must surface those values
+	// in the generated schema as well.
+	@Test
+	void generateSchemaForMethodWithJsonValueEnum() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("useJsonValueEnum", TemperatureUnit.class);
+
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = jsonHelper.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/properties/unit/enum")).map(JsonNode::asString).containsExactly("C", "F");
+	}
+
 	@Test
 	void generateForMethodInputThrowsWhenMethodIsNull() {
 		assertThatThrownBy(() -> McpJsonSchemaGenerator.generateForMethodInput(null))
@@ -163,6 +190,37 @@ class McpJsonSchemaGeneratorTests {
 		}
 
 		public void peerReferenceMethod(PeerA.SearchRequest a, PeerB.SearchRequest b) {
+		}
+
+		public void useCustomEnum(CustomEnum status) {
+		}
+
+		public void useJsonValueEnum(TemperatureUnit unit) {
+		}
+
+	}
+
+	enum CustomEnum {
+
+		@JsonProperty("value.a")
+		A, @JsonProperty("value.b")
+		B
+
+	}
+
+	public enum TemperatureUnit {
+
+		CELSIUS("C"), FAHRENHEIT("F");
+
+		private final String symbol;
+
+		TemperatureUnit(String symbol) {
+			this.symbol = symbol;
+		}
+
+		@JsonValue
+		public String symbol() {
+			return this.symbol;
 		}
 
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -4,6 +4,16 @@
 [[upgrading-to-2-0-1]]
 == Upgrading to 2.0.1
 
+=== JSON Schemas Honor Custom Enum Values from `@JsonValue` and `@JsonProperty`
+
+JSON schemas generated for tool calling and structured output now use Jackson's serialized form for enums that declare a `@JsonValue` method or annotate all constants with `@JsonProperty`.
+Previously the schema advertised the Java constant names while deserialization expected the custom values, causing an `InvalidFormatException` when the model followed the schema.
+
+==== Impact
+
+Generated schemas change only for enums using those annotations: the `enum` values now match what Jackson accepts during deserialization.
+Enums without these annotations keep emitting their constant names.
+
 === Redis Chat Memory Repository Auto-Configuration Module Renaming
 
 The Redis chat memory auto-configurations module renamed to `spring-ai-autoconfigure-model-chat-memory-repository-redis`.

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -71,6 +71,10 @@ import org.springframework.util.StringUtils;
  * If none of these annotations are present, the default behavior is to consider the
  * property as required and not to include a description.
  * <p>
+ * Enum values are aligned with Jackson's serialized form when the enum declares a
+ * {@code @JsonValue} method or all of its constants are annotated with
+ * {@code @JsonProperty}.
+ * <p>
  *
  * @author Thomas Vitale
  * @author Sebastien Deleuze
@@ -95,7 +99,8 @@ public final class JsonSchemaGenerator {
 	 */
 	static {
 		Module jacksonModule = new JacksonSchemaModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
-				JacksonOption.RESPECT_JSONPROPERTY_ORDER);
+				JacksonOption.RESPECT_JSONPROPERTY_ORDER, JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE,
+				JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY);
 		Module openApiModule = new Swagger2Module();
 		Module springAiSchemaModule = PROPERTY_REQUIRED_BY_DEFAULT ? new SpringAiSchemaModule()
 				: new SpringAiSchemaModule(SpringAiSchemaModule.Option.PROPERTY_REQUIRED_FALSE_BY_DEFAULT);

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaUtils.java
@@ -57,7 +57,8 @@ public final class JsonSchemaUtils {
 	private static final SchemaGenerator schemaGenerator;
 
 	static {
-		JacksonSchemaModule jacksonModule = new JacksonSchemaModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED);
+		JacksonSchemaModule jacksonModule = new JacksonSchemaModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
+				JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY);
 		Swagger2Module swaggerModule = new Swagger2Module();
 
 		SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12,

--- a/spring-ai-model/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -133,6 +134,39 @@ class BeanOutputConverterTest {
 	record TestClassWithNullable(String requiredField, @Nullable String optionalField) {
 	}
 
+	record TestClassWithCustomEnumValues(CustomEnum values) {
+
+		enum CustomEnum {
+
+			@JsonProperty("value.a")
+			A, @JsonProperty("value.b")
+			B
+
+		}
+
+	}
+
+	record TestClassWithJsonValueEnum(TemperatureUnit unit) {
+
+		public enum TemperatureUnit {
+
+			CELSIUS("C"), FAHRENHEIT("F");
+
+			private final String symbol;
+
+			TemperatureUnit(String symbol) {
+				this.symbol = symbol;
+			}
+
+			@JsonValue
+			public String symbol() {
+				return this.symbol;
+			}
+
+		}
+
+	}
+
 	@Nested
 	class ConverterTest {
 
@@ -148,6 +182,24 @@ class BeanOutputConverterTest {
 			var converter = new BeanOutputConverter<>(TestClassWithDateProperty.class);
 			var testClass = converter.convert("{ \"someString\": \"2020-01-01\" }");
 			assertThat(testClass.getSomeString()).isEqualTo(LocalDate.of(2020, 1, 1));
+		}
+
+		@Test
+		void convertEnumWithCustomJsonPropertyValues() {
+			var converter = new BeanOutputConverter<>(TestClassWithCustomEnumValues.class);
+			// the generated schema must advertise the same enum values that the
+			// deserializer accepts
+			assertThat(converter.getJsonSchema()).contains("value.a", "value.b");
+			var result = converter.convert("{ \"values\": \"value.a\" }");
+			assertThat(result.values()).isEqualTo(TestClassWithCustomEnumValues.CustomEnum.A);
+		}
+
+		@Test
+		void convertEnumWithJsonValueMappings() {
+			var converter = new BeanOutputConverter<>(TestClassWithJsonValueEnum.class);
+			assertThat(converter.getJsonSchema()).contains("\"C\"", "\"F\"");
+			var result = converter.convert("{ \"unit\": \"C\" }");
+			assertThat(result.unit()).isEqualTo(TestClassWithJsonValueEnum.TemperatureUnit.CELSIUS);
 		}
 
 		@Test

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -749,6 +750,50 @@ class JsonSchemaGeneratorTests {
 	}
 
 	@Test
+	void generateSchemaForEnumWithJsonPropertyValues() {
+		String schema = JsonSchemaGenerator.generateForType(CustomEnumWrapper.class);
+		String expectedJsonSchema = """
+				{
+				  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+				  "type" : "object",
+				  "properties" : {
+				    "values" : {
+				      "type" : "string",
+				      "enum" : [ "value.a", "value.b" ]
+				    }
+				  },
+				  "required" : [ "values" ],
+				  "additionalProperties" : false
+				}
+				""";
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForEnumWithJsonValue() {
+		String schema = JsonSchemaGenerator.generateForType(TemperatureUnit.class);
+		String expectedJsonSchema = """
+				{
+				  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+				  "type" : "string",
+				  "enum" : [ "C", "F" ]
+				}
+				""";
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForMethodInputWithCustomEnumValues() throws Exception {
+		Method method = CustomEnumMethods.class.getDeclaredMethod("setTemperature", CustomEnumWrapper.CustomEnum.class,
+				TemperatureUnit.class);
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JacksonUtils.getDefaultJsonMapper().readTree(schema);
+		assertThat(schemaNode.at("/properties/value/enum")).map(JsonNode::asString)
+			.containsExactly("value.a", "value.b");
+		assertThat(schemaNode.at("/properties/unit/enum")).map(JsonNode::asString).containsExactly("C", "F");
+	}
+
+	@Test
 	void generateSchemaForTypeWithJSpecifyNullableField() {
 		String schema = JsonSchemaGenerator.generateForType(JSpecifyNullablePerson.class);
 		String expectedJsonSchema = """
@@ -1118,6 +1163,42 @@ class JsonSchemaGeneratorTests {
 	}
 
 	record WithMapField(String name, Map<String, Integer> scores) {
+
+	}
+
+	record CustomEnumWrapper(CustomEnum values) {
+
+		enum CustomEnum {
+
+			@JsonProperty("value.a")
+			A, @JsonProperty("value.b")
+			B
+
+		}
+
+	}
+
+	public enum TemperatureUnit {
+
+		CELSIUS("C"), FAHRENHEIT("F");
+
+		private final String symbol;
+
+		TemperatureUnit(String symbol) {
+			this.symbol = symbol;
+		}
+
+		@JsonValue
+		public String symbol() {
+			return this.symbol;
+		}
+
+	}
+
+	static class CustomEnumMethods {
+
+		public void setTemperature(CustomEnumWrapper.CustomEnum value, TemperatureUnit unit) {
+		}
 
 	}
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/schema/JsonSchemaUtilsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/schema/JsonSchemaUtilsTests.java
@@ -28,7 +28,9 @@ import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
 import org.springframework.ai.util.JsonHelper;
@@ -204,9 +206,60 @@ class JsonSchemaUtilsTests {
 		}
 	}
 
+	// gh-1985: enum constants annotated with @JsonProperty must surface their custom
+	// values in the generated schema, matching Jackson's deserialization behavior.
+	@Test
+	void getJsonSchemaHonorsJsonPropertyEnumValues() {
+		ObjectNode schema = JsonSchemaUtils.getJsonSchema(CustomEnumHolder.class);
+
+		assertThat(schema.at("/properties/status/enum")).map(JsonNode::asString).containsExactly("value.a", "value.b");
+	}
+
+	// gh-1985: enums serialized through a @JsonValue method must surface those values
+	// in the generated schema as well.
+	@Test
+	void getJsonSchemaHonorsJsonValueEnumValues() {
+		ObjectNode schema = JsonSchemaUtils.getJsonSchema(UnitHolder.class);
+
+		assertThat(schema.at("/properties/unit/enum")).map(JsonNode::asString).containsExactly("C", "F");
+	}
+
 	@JsonPropertyOrder({ "accountId", "accountName", "currency", "totals" })
 	record OrderedStatement(@JsonProperty(required = true) String accountId,
 			@JsonProperty(required = true) String accountName, String currency, Map<String, Double> totals) {
+
+	}
+
+	record CustomEnumHolder(CustomEnum status) {
+
+		enum CustomEnum {
+
+			@JsonProperty("value.a")
+			A, @JsonProperty("value.b")
+			B
+
+		}
+
+	}
+
+	record UnitHolder(TemperatureUnit unit) {
+
+	}
+
+	public enum TemperatureUnit {
+
+		CELSIUS("C"), FAHRENHEIT("F");
+
+		private final String symbol;
+
+		TemperatureUnit(String symbol) {
+			this.symbol = symbol;
+		}
+
+		@JsonValue
+		public String symbol() {
+			return this.symbol;
+		}
 
 	}
 

--- a/spring-ai-model/src/test/kotlin/org/springframework/ai/util/json/schema/JsonSchemaGeneratorKotlinTests.kt
+++ b/spring-ai-model/src/test/kotlin/org/springframework/ai/util/json/schema/JsonSchemaGeneratorKotlinTests.kt
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.util.json.schema
 
+import com.fasterxml.jackson.annotation.JsonValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.ai.tool.annotation.Tool
@@ -77,6 +78,17 @@ class JsonSchemaGeneratorKotlinTests {
 		assertThat(requiredNames(schemaNode["required"])).containsExactly("url")
 	}
 
+	// gh-1985: victools resolves @JsonValue from methods, so Kotlin properties must use
+	// the get-site target for their values to surface in the generated schema.
+	@Test
+	fun `enum values follow get-site JsonValue annotation`() {
+		val schema = JsonSchemaGenerator.generateForType(UnitHolder::class.java)
+		val schemaNode = jsonMapper.readTree(schema)
+		val values = schemaNode.at("/properties/unit/enum").iterator().asSequence().map { it.asString() }.toList()
+
+		assertThat(values).containsExactly("C", "F")
+	}
+
 	private fun requiredNames(required: JsonNode?): List<String> {
 		if (required == null || required.isNull) {
 			return emptyList()
@@ -89,6 +101,14 @@ class JsonSchemaGeneratorKotlinTests {
 	private data class FilterWithDefaultValue(val name: String?, val ids: List<String> = emptyList())
 
 	private data class SearchRequest(val query: String, val filter: String?)
+
+	private data class UnitHolder(val unit: TemperatureUnit)
+
+	enum class TemperatureUnit(@get:JsonValue val symbol: String) {
+
+		CELSIUS("C"), FAHRENHEIT("F")
+
+	}
 
 	private class SearchTools {
 


### PR DESCRIPTION
Fixes #1985

Jackson uses the values declared by `@JsonValue` or `@JsonProperty` when serializing and deserializing enums, but generated JSON schemas currently advertise the Java constant names. A model following such a schema can therefore produce a value that `BeanOutputConverter` cannot deserialize.

This change enables victools' `FLATTENED_ENUMS_FROM_JSONVALUE` and `FLATTENED_ENUMS_FROM_JSONPROPERTY` options in `JsonSchemaGenerator`, `JsonSchemaUtils`, and `McpJsonSchemaGenerator`. This keeps structured output, tool input, and MCP schemas consistent with Jackson's enum representation.

The `@JsonProperty` mapping applies when all constants are annotated. Plain enums keep their existing constant names. For the affected enums, the previous schema advertised values the default deserializer rejects, so enabling the options by default corrects broken behavior rather than changing a working setup. No public API or converter-selection behavior is changed.

The option pair was originally suggested in the [#1985 discussion](https://github.com/spring-projects/spring-ai/issues/1985#issuecomment-3259478660); the general schema-generator customization hook raised in the same thread is left as a separate follow-up.

An upgrade note and regression tests are included.

## Tests

- `JsonSchemaGeneratorTests`
- `JsonSchemaGeneratorKotlinTests` — victools resolves `@JsonValue` from methods, so Kotlin properties use the `@get:` site target
- `JsonSchemaUtilsTests`
- `BeanOutputConverterTest`
- `McpJsonSchemaGeneratorTests`

```shell
./mvnw -pl spring-ai-model,spring-ai-client-chat,mcp/mcp-annotations test
```
