### PR TITLE
Fix ignored `credentials-uri` in Google GenAI embedding

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfiguration.java
@@ -17,6 +17,8 @@
 package org.springframework.ai.model.google.genai.autoconfigure.embedding;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.genai.Client;
@@ -27,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -42,6 +45,8 @@ import org.springframework.util.StringUtils;
 @ConditionalOnClass({ Client.class, GoogleGenAiEmbeddingConnectionDetails.class })
 @EnableConfigurationProperties(GoogleGenAiEmbeddingConnectionProperties.class)
 public class GoogleGenAiEmbeddingConnectionAutoConfiguration {
+
+	private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 
 	@Bean
 	@ConditionalOnMissingBean
@@ -62,15 +67,21 @@ public class GoogleGenAiEmbeddingConnectionAutoConfiguration {
 			connectionBuilder.projectId(connectionProperties.getProjectId())
 				.location(connectionProperties.getLocation());
 
-			if (connectionProperties.getCredentialsUri() != null) {
-				GoogleCredentials credentials = GoogleCredentials
-					.fromStream(connectionProperties.getCredentialsUri().getInputStream());
-				// Note: Credentials are handled automatically by the SDK when using
-				// Vertex AI mode
+			Resource credentialsUri = connectionProperties.getCredentialsUri();
+			if (credentialsUri != null) {
+				connectionBuilder.credentials(loadScopedCredentials(credentialsUri));
 			}
 		}
 
 		return connectionBuilder.build();
+	}
+
+	// Credentials from GoogleCredentials.fromStream are scopeless; Vertex AI rejects the
+	// token refresh with invalid_scope unless they are scoped to cloud-platform.
+	static GoogleCredentials loadScopedCredentials(Resource credentialsUri) throws IOException {
+		try (InputStream inputStream = credentialsUri.getInputStream()) {
+			return GoogleCredentials.fromStream(inputStream).createScoped(List.of(CLOUD_PLATFORM_SCOPE));
+		}
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfigurationTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.embedding;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link GoogleGenAiEmbeddingConnectionAutoConfiguration}.
+ *
+ * @author Subhash Polisetti
+ */
+class GoogleGenAiEmbeddingConnectionAutoConfigurationTests {
+
+	private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+
+	@Test
+	void credentialsLoadedFromUriAreScopedToCloudPlatform() throws Exception {
+		GoogleCredentials credentials = GoogleGenAiEmbeddingConnectionAutoConfiguration
+			.loadScopedCredentials(serviceAccountResource());
+
+		assertThat(credentials).isInstanceOf(ServiceAccountCredentials.class);
+		assertThat(((ServiceAccountCredentials) credentials).getScopes()).containsExactly(CLOUD_PLATFORM_SCOPE);
+	}
+
+	@Test
+	void credentialsUriStreamIsClosed() throws Exception {
+		AtomicBoolean closed = new AtomicBoolean();
+		Resource credentialsUri = trackingCloseResource(serviceAccountJson(), closed);
+
+		GoogleGenAiEmbeddingConnectionAutoConfiguration.loadScopedCredentials(credentialsUri);
+
+		assertThat(closed).isTrue();
+	}
+
+	private static Resource serviceAccountResource() throws Exception {
+		return new ByteArrayResource(serviceAccountJson());
+	}
+
+	private static Resource trackingCloseResource(byte[] content, AtomicBoolean closed) {
+		return new ByteArrayResource(content) {
+			@Override
+			public InputStream getInputStream() {
+				return new FilterInputStream(new ByteArrayInputStream(content)) {
+					@Override
+					public void close() throws IOException {
+						closed.set(true);
+						super.close();
+					}
+				};
+			}
+		};
+	}
+
+	private static byte[] serviceAccountJson() throws Exception {
+		String json = "{" + "\"type\": \"service_account\"," + "\"project_id\": \"test-project\","
+				+ "\"private_key_id\": \"test-key-id\"," + "\"private_key\": \"" + generatePrivateKeyPem() + "\","
+				+ "\"client_email\": \"test@test-project.iam.gserviceaccount.com\","
+				+ "\"client_id\": \"123456789012345678901\"," + "\"token_uri\": \"https://oauth2.googleapis.com/token\""
+				+ "}";
+		return json.getBytes(StandardCharsets.UTF_8);
+	}
+
+	private static String generatePrivateKeyPem() throws Exception {
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(2048);
+		KeyPair keyPair = generator.generateKeyPair();
+		String base64 = Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded());
+		return "-----BEGIN PRIVATE KEY-----\\n" + base64 + "\\n-----END PRIVATE KEY-----\\n";
+	}
+
+}

--- a/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/embedding/GoogleGenAiEmbeddingConnectionDetails.java
+++ b/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/embedding/GoogleGenAiEmbeddingConnectionDetails.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.google.genai.embedding;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.genai.Client;
 import org.jspecify.annotations.Nullable;
 
@@ -126,6 +127,12 @@ public final class GoogleGenAiEmbeddingConnectionDetails {
 		private @Nullable String apiKey;
 
 		/**
+		 * The credentials used to authenticate Vertex AI calls. If null, Application
+		 * Default Credentials are used. Ignored in Gemini Developer API mode.
+		 */
+		private @Nullable GoogleCredentials credentials;
+
+		/**
 		 * Custom GenAI client instance. If provided, other settings will be ignored.
 		 */
 		private @Nullable Client genAiClient;
@@ -142,6 +149,18 @@ public final class GoogleGenAiEmbeddingConnectionDetails {
 
 		public Builder apiKey(@Nullable String apiKey) {
 			this.apiKey = apiKey;
+			return this;
+		}
+
+		/**
+		 * Sets the credentials used to authenticate Vertex AI calls.
+		 * @param credentials the credentials, or {@code null} to fall back to Application
+		 * Default Credentials
+		 * @return this builder
+		 * @since 2.0.1
+		 */
+		public Builder credentials(@Nullable GoogleCredentials credentials) {
+			this.credentials = credentials;
 			return this;
 		}
 
@@ -173,6 +192,10 @@ public final class GoogleGenAiEmbeddingConnectionDetails {
 				}
 
 				clientBuilder.project(this.projectId).location(this.location).vertexAI(true);
+
+				if (this.credentials != null) {
+					clientBuilder.credentials(this.credentials);
+				}
 			}
 
 			Client builtClient = clientBuilder.build();

--- a/models/spring-ai-google-genai-embedding/src/test/java/org/springframework/ai/google/genai/embedding/GoogleGenAiEmbeddingConnectionDetailsTests.java
+++ b/models/spring-ai-google-genai-embedding/src/test/java/org/springframework/ai/google/genai/embedding/GoogleGenAiEmbeddingConnectionDetailsTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.embedding;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.List;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.genai.Client;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link GoogleGenAiEmbeddingConnectionDetails}.
+ *
+ * @author Subhash Polisetti
+ */
+class GoogleGenAiEmbeddingConnectionDetailsTests {
+
+	private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+
+	@Test
+	void vertexClientIsBuiltFromSuppliedCredentials() throws Exception {
+		GoogleGenAiEmbeddingConnectionDetails connectionDetails = GoogleGenAiEmbeddingConnectionDetails.builder()
+			.projectId("test-project")
+			.location("us-central1")
+			.credentials(scopedCredentials())
+			.build();
+
+		Client client = connectionDetails.getGenAiClient();
+		assertThat(client.vertexAI()).isTrue();
+		assertThat(client.project()).isEqualTo("test-project");
+		assertThat(client.location()).isEqualTo("us-central1");
+	}
+
+	@Test
+	void apiKeyModeIgnoresCredentials() throws Exception {
+		GoogleGenAiEmbeddingConnectionDetails connectionDetails = GoogleGenAiEmbeddingConnectionDetails.builder()
+			.apiKey("test-api-key")
+			.credentials(scopedCredentials())
+			.build();
+
+		assertThat(connectionDetails.getGenAiClient().vertexAI()).isFalse();
+	}
+
+	private static GoogleCredentials scopedCredentials() throws Exception {
+		String json = "{" + "\"type\": \"service_account\"," + "\"project_id\": \"test-project\","
+				+ "\"private_key_id\": \"test-key-id\"," + "\"private_key\": \"" + generatePrivateKeyPem() + "\","
+				+ "\"client_email\": \"test@test-project.iam.gserviceaccount.com\","
+				+ "\"client_id\": \"123456789012345678901\"," + "\"token_uri\": \"https://oauth2.googleapis.com/token\""
+				+ "}";
+		return GoogleCredentials.fromStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))
+			.createScoped(List.of(CLOUD_PLATFORM_SCOPE));
+	}
+
+	private static String generatePrivateKeyPem() throws Exception {
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(2048);
+		KeyPair keyPair = generator.generateKeyPair();
+		String base64 = Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded());
+		return "-----BEGIN PRIVATE KEY-----\\n" + base64 + "\\n-----END PRIVATE KEY-----\\n";
+	}
+
+}


### PR DESCRIPTION
`GoogleGenAiEmbeddingConnectionAutoConfiguration` reads
`spring.ai.google.genai.embedding.credentials-uri` into a local variable that is never
used and leaves the input stream open, so the embedding connection silently falls back
to Application Default Credentials. With no ADC present the call fails as if the
property had never been set; with an ADC belonging to a different account it succeeds
under the wrong identity.

(Note the embedding connection binds `spring.ai.google.genai.embedding.*`, not the chat
prefix used in the issue's reproduction steps.)

This applies the loaded credentials, scoped to `cloud-platform` consistently with the
chat side, and closes the stream. `GoogleGenAiEmbeddingConnectionDetails.Builder` gains
a `credentials` setter to carry them, applied in Vertex AI mode only.

The tests are self-contained: they generate a throwaway key pair and a synthetic
service-account JSON, so no credentials or network access are needed.

Fixes #6644