### PR TITLE
Avoid MySQL and MariaDB chat memory deadlocks during concurrent saves

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
@@ -43,6 +43,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.Assert;
 
@@ -81,11 +82,22 @@ public final class JdbcChatMemoryRepository implements ChatMemoryRepository {
 		Assert.notNull(dialect, "dialect cannot be null");
 		this.jdbcTemplate = jdbcTemplate;
 		this.dialect = dialect;
+		boolean usingDefaultTransactionManager = txManager == null;
+		PlatformTransactionManager effectiveTransactionManager;
 		if (txManager == null) {
 			Assert.state(jdbcTemplate.getDataSource() != null, "jdbcTemplate dataSource cannot be null");
-			txManager = new DataSourceTransactionManager(jdbcTemplate.getDataSource());
+			effectiveTransactionManager = new DataSourceTransactionManager(jdbcTemplate.getDataSource());
 		}
-		this.transactionTemplate = new TransactionTemplate(txManager);
+		else {
+			effectiveTransactionManager = txManager;
+		}
+		this.transactionTemplate = new TransactionTemplate(effectiveTransactionManager);
+		if (usingDefaultTransactionManager && dialect instanceof MysqlChatMemoryRepositoryDialect) {
+			// Under MySQL and MariaDB's default REPEATABLE READ isolation, concurrent
+			// deletes for different missing conversation IDs can acquire overlapping gap
+			// locks and deadlock when saveAll() subsequently inserts the messages.
+			this.transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED);
+		}
 	}
 
 	@Override

--- a/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryBuilderTests.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryBuilderTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.chat.memory.repository.jdbc;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -26,10 +27,14 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -252,6 +257,30 @@ public class JdbcChatMemoryRepositoryBuilderTests {
 		JdbcChatMemoryRepository repository = JdbcChatMemoryRepository.builder().jdbcTemplate(jdbcTemplate).build();
 
 		assertThat(repository).extracting("jdbcTemplate").isSameAs(jdbcTemplate);
+	}
+
+	@Test
+	void explicitTransactionManagerKeepsDefaultIsolation() {
+		DataSource dataSource = mock(DataSource.class);
+		JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+		PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+		TransactionStatus transactionStatus = mock(TransactionStatus.class);
+		when(jdbcTemplate.getDataSource()).thenReturn(dataSource);
+		when(transactionManager.getTransaction(any())).thenAnswer(invocation -> {
+			TransactionDefinition definition = invocation.getArgument(0);
+			assertThat(definition.getIsolationLevel()).isEqualTo(TransactionDefinition.ISOLATION_DEFAULT);
+			return transactionStatus;
+		});
+
+		JdbcChatMemoryRepository repository = JdbcChatMemoryRepository.builder()
+			.jdbcTemplate(jdbcTemplate)
+			.dialect(new MysqlChatMemoryRepositoryDialect())
+			.transactionManager(transactionManager)
+			.build();
+
+		repository.saveAll("conversation-id", List.of());
+
+		verify(transactionManager).commit(transactionStatus);
 	}
 
 }

--- a/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryMysqlIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryMysqlIT.java
@@ -16,9 +16,25 @@
 
 package org.springframework.ai.chat.memory.repository.jdbc;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for {@link JdbcChatMemoryRepository} with MySQL.
@@ -34,4 +50,63 @@ import org.springframework.test.context.jdbc.Sql;
 @Sql(scripts = "classpath:org/springframework/ai/chat/memory/repository/jdbc/schema-mysql.sql")
 class JdbcChatMemoryRepositoryMysqlIT extends AbstractJdbcChatMemoryRepositoryIT {
 
+	@Test
+	void savesDifferentConversationsConcurrently() throws Exception {
+		this.jdbcTemplate.update("DELETE FROM SPRING_AI_CHAT_MEMORY");
+		var dataSource = Objects.requireNonNull(this.jdbcTemplate.getDataSource());
+		var conversationIds = List.of("conversation-1", "conversation-2", "conversation-3", "conversation-4");
+		var repository = JdbcChatMemoryRepository.builder()
+			.jdbcTemplate(new DeleteBarrierJdbcTemplate(dataSource, conversationIds.size()))
+			.build();
+		var executor = Executors.newFixedThreadPool(conversationIds.size());
+
+		try {
+			var saves = conversationIds.stream()
+				.map(conversationId -> executor
+					.submit(() -> repository.saveAll(conversationId, List.of(new UserMessage(conversationId)))))
+				.toList();
+			for (var save : saves) {
+				save.get(10, TimeUnit.SECONDS);
+			}
+		}
+		finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(conversationIds)
+			.allSatisfy(conversationId -> assertThat(repository.findByConversationId(conversationId)).hasSize(1));
+	}
+
+	private static final class DeleteBarrierJdbcTemplate extends JdbcTemplate {
+
+		private final CyclicBarrier barrier;
+
+		private DeleteBarrierJdbcTemplate(DataSource dataSource, int concurrentSaves) {
+			super(dataSource);
+			this.barrier = new CyclicBarrier(concurrentSaves);
+		}
+
+		@Override
+		public int update(String sql, Object... args) {
+			int updatedRows = super.update(sql, args);
+			if (sql.startsWith("DELETE FROM SPRING_AI_CHAT_MEMORY")) {
+				awaitDeleteBarrier();
+			}
+			return updatedRows;
+		}
+
+		private void awaitDeleteBarrier() {
+			try {
+				this.barrier.await(10, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException("Interrupted while waiting for concurrent deletes", ex);
+			}
+			catch (BrokenBarrierException | TimeoutException ex) {
+				throw new IllegalStateException("Concurrent deletes did not reach the barrier", ex);
+			}
+		}
+
+	}
 }


### PR DESCRIPTION
Fixes #6655

Thank you for taking the time to contribute to Spring AI!

## Problem

`JdbcChatMemoryRepository.saveAll()` deletes the existing conversation rows and then inserts the replacement messages in one transaction. With MySQL or MariaDB's default `REPEATABLE_READ` isolation, concurrent saves for different, previously unseen conversation IDs can acquire overlapping gap locks during the deletes and deadlock when the inserts begin.

The new MySQL integration test deterministically reproduces this by pausing four concurrent saves after their deletes. It fails on `main` with `Deadlock found when trying to get lock`.

## Changes

- Use `READ_COMMITTED` for the repository-created `DataSourceTransactionManager` when the resolved dialect is MySQL or MariaDB. This prevents the missing-row deletes from taking the conflicting gap locks.
- Keep `ISOLATION_DEFAULT` when an application supplies its own `PlatformTransactionManager`, preserving outer-transaction participation and compatibility with transaction managers that do not support JDBC isolation levels.
- Add a MySQL integration test for concurrent saves to different conversations.
- Add a unit test that protects the explicit transaction-manager isolation contract.

## Design rationale

When only a `DataSource` is supplied, the repository creates its own transaction manager and therefore owns the transaction boundary. Selecting a safe isolation level for its delete-then-insert algorithm avoids requiring every MySQL and MariaDB user to reconfigure an application-wide connection pool. The override applies only to repository-created transactions; it does not change the `DataSource` default or unrelated application transactions. `READ_COMMITTED` preserves the atomicity of the delete and inserts, while `saveAll()` does not require a repeatable-read snapshot.

## Trade-off

When an application supplies its own `PlatformTransactionManager`, the repository does not override that manager's isolation level. If it starts or joins a MySQL or MariaDB `REPEATABLE_READ` transaction, concurrent saves can still encounter the same gap-lock deadlock. Applications using an explicit transaction manager remain responsible for selecting `READ_COMMITTED` or handling deadlock retries; forcing an isolation level here would break outer-transaction semantics and can be unsupported by non-JDBC transaction managers.

## Verification

- `./mvnw clean package`
- `./mvnw -pl memory-repositories/spring-ai-model-chat-memory-repository-jdbc -Pintegration-tests -Dit.test=JdbcChatMemoryRepositoryMysqlIT verify`
- `./mvnw -pl memory-repositories/spring-ai-model-chat-memory-repository-jdbc -Dtest=JdbcChatMemoryRepositoryBuilderTests test`
- `./mvnw -pl memory-repositories/spring-ai-model-chat-memory-repository-jdbc process-sources`
- The same four-save barrier scenario was also executed against MariaDB 10.3.39, PostgreSQL 17, H2, and SQL Server 2022; all database-specific test suites passed.

## Contributor checklist

- [x] Every commit contains a `Signed-off-by` line (`git commit -s`) per the DCO.
- [x] The branch is based on the latest `main`.
- [x] Unit and integration tests cover the change.
- [x] The full build passes.