### PR TITLE
Close OpenAI stream response on cancellation

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
+import com.openai.core.http.AsyncStreamResponse;
 import com.openai.errors.OpenAIInvalidDataException;
 import com.openai.models.FunctionDefinition;
 import com.openai.models.FunctionParameters;
@@ -290,19 +291,20 @@ public final class OpenAiChatModel implements ChatModel {
 			}
 
 			// Convert from AsyncStreamResponse<ChatCompletionChunk> to Flux<CCC>
-			Flux<ChatCompletionChunk> chunks = Flux.<ChatCompletionChunk>create(sink -> this.openAiClientAsync.chat()
-				.completions()
-				.createStreaming(request)
-				.subscribe(sink::next)
-				.onCompleteFuture()
-				.whenComplete((unused, throwable) -> {
+			Flux<ChatCompletionChunk> chunks = Flux.<ChatCompletionChunk>create(sink -> {
+				AsyncStreamResponse<ChatCompletionChunk> response = this.openAiClientAsync.chat()
+					.completions()
+					.createStreaming(request);
+				sink.onDispose(response::close);
+				response.subscribe(sink::next).onCompleteFuture().whenComplete((unused, throwable) -> {
 					if (throwable != null) {
 						sink.error(throwable);
 					}
 					else {
 						sink.complete();
 					}
-				}));
+				});
+			});
 
 			// Next, aggregate CCCs that deal with tool calls together
 			AtomicBoolean isInsideTool = new AtomicBoolean(false);

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
+import com.openai.core.http.AsyncStreamResponse;
 import com.openai.errors.OpenAIInvalidDataException;
 import com.openai.models.FunctionDefinition;
 import com.openai.models.FunctionParameters;
@@ -293,19 +294,20 @@ public final class OpenAiChatModel implements ChatModel {
 			}
 
 			// Convert from AsyncStreamResponse<ChatCompletionChunk> to Flux<CCC>
-			Flux<ChatCompletionChunk> chunks = Flux.<ChatCompletionChunk>create(sink -> this.openAiClientAsync.chat()
-				.completions()
-				.createStreaming(request)
-				.subscribe(sink::next)
-				.onCompleteFuture()
-				.whenComplete((unused, throwable) -> {
+			Flux<ChatCompletionChunk> chunks = Flux.<ChatCompletionChunk>create(sink -> {
+				AsyncStreamResponse<ChatCompletionChunk> response = this.openAiClientAsync.chat()
+					.completions()
+					.createStreaming(request);
+				sink.onDispose(response::close);
+				response.subscribe(sink::next).onCompleteFuture().whenComplete((unused, throwable) -> {
 					if (throwable != null) {
 						sink.error(throwable);
 					}
 					else {
 						sink.complete();
 					}
-				}));
+				});
+			});
 
 			// Next, aggregate CCCs that deal with tool calls together
 			AtomicBoolean isInsideTool = new AtomicBoolean(false);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
@@ -264,6 +265,40 @@ class OpenAiChatModelTests {
 	}
 
 	@Test
+	void closesAsyncStreamResponseOnCancellation() {
+		ChatServiceAsync chatServiceAsync = mock(ChatServiceAsync.class);
+		ChatCompletionServiceAsync chatCompletionServiceAsync = mock(ChatCompletionServiceAsync.class);
+		when(this.openAiClientAsync.chat()).thenReturn(chatServiceAsync);
+		when(chatServiceAsync.completions()).thenReturn(chatCompletionServiceAsync);
+		AtomicBoolean closed = new AtomicBoolean();
+		AsyncStreamResponse<ChatCompletionChunk> streamResponse = asyncStreamResponse(closed, false,
+				ChatCompletionChunk.builder()
+					.id("chatcmpl-stream-test")
+					.created(1777799928)
+					.model("test-model")
+					.addChoice(ChatCompletionChunk.Choice.builder()
+						.index(0)
+						.finishReason(ChatCompletionChunk.Choice.FinishReason.STOP)
+						.delta(ChatCompletionChunk.Choice.Delta.builder().content("hello").build())
+						.build())
+					.build());
+		when(chatCompletionServiceAsync.createStreaming(any(ChatCompletionCreateParams.class)))
+			.thenReturn(streamResponse);
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.stream(new Prompt("hi", options)).take(1).blockLast();
+
+		assertThat(response).isNotNull();
+		assertThat(closed).isTrue();
+	}
+
+	@Test
 	void restoreUnmappedToolCallAdditionalProperties() {
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gemini-3.5-flash").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
@@ -348,6 +383,11 @@ class OpenAiChatModelTests {
 	}
 
 	private AsyncStreamResponse<ChatCompletionChunk> asyncStreamResponse(ChatCompletionChunk... chunks) {
+		return asyncStreamResponse(new AtomicBoolean(), true, chunks);
+	}
+
+	private AsyncStreamResponse<ChatCompletionChunk> asyncStreamResponse(AtomicBoolean closed, boolean complete,
+			ChatCompletionChunk... chunks) {
 		return new AsyncStreamResponse<>() {
 			private final CompletableFuture<Void> completion = new CompletableFuture<>();
 
@@ -358,8 +398,10 @@ class OpenAiChatModelTests {
 					for (ChatCompletionChunk chunk : chunks) {
 						handler.onNext(chunk);
 					}
-					handler.onComplete(Optional.empty());
-					this.completion.complete(null);
+					if (complete) {
+						handler.onComplete(Optional.empty());
+						this.completion.complete(null);
+					}
 				}
 				catch (Throwable throwable) {
 					handler.onComplete(Optional.of(throwable));
@@ -382,6 +424,7 @@ class OpenAiChatModelTests {
 
 			@Override
 			public void close() {
+				closed.set(true);
 			}
 		};
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -286,6 +287,7 @@ class OpenAiChatModelTests {
 		ChatCompletionServiceAsync chatCompletionServiceAsync = mock(ChatCompletionServiceAsync.class);
 		when(this.openAiClientAsync.chat()).thenReturn(chatServiceAsync);
 		when(chatServiceAsync.completions()).thenReturn(chatCompletionServiceAsync);
+
 		when(chatCompletionServiceAsync.createStreaming(any(ChatCompletionCreateParams.class)))
 			.thenReturn(asyncStreamResponse(ChatCompletionChunk.builder()
 				.id("chatcmpl-stream-test")
@@ -360,6 +362,40 @@ class OpenAiChatModelTests {
 			assertThat(toolCall.name()).isEqualTo("get_current_weather");
 			assertThat(toolCall.arguments()).isEqualTo("{\"location\":\"Seoul\"}");
 		});
+	}
+
+	@Test
+	void closesAsyncStreamResponseOnCancellation() {
+		ChatServiceAsync chatServiceAsync = mock(ChatServiceAsync.class);
+		ChatCompletionServiceAsync chatCompletionServiceAsync = mock(ChatCompletionServiceAsync.class);
+		when(this.openAiClientAsync.chat()).thenReturn(chatServiceAsync);
+		when(chatServiceAsync.completions()).thenReturn(chatCompletionServiceAsync);
+		AtomicBoolean closed = new AtomicBoolean();
+		AsyncStreamResponse<ChatCompletionChunk> streamResponse = asyncStreamResponse(closed, false,
+				ChatCompletionChunk.builder()
+					.id("chatcmpl-stream-test")
+					.created(1777799928)
+					.model("test-model")
+					.addChoice(ChatCompletionChunk.Choice.builder()
+						.index(0)
+						.finishReason(ChatCompletionChunk.Choice.FinishReason.STOP)
+						.delta(ChatCompletionChunk.Choice.Delta.builder().content("hello").build())
+						.build())
+					.build());
+		when(chatCompletionServiceAsync.createStreaming(any(ChatCompletionCreateParams.class)))
+			.thenReturn(streamResponse);
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.stream(new Prompt("hi", options)).take(1).blockLast();
+
+		assertThat(response).isNotNull();
+		assertThat(closed).isTrue();
 	}
 
 	@Test
@@ -447,6 +483,11 @@ class OpenAiChatModelTests {
 	}
 
 	private AsyncStreamResponse<ChatCompletionChunk> asyncStreamResponse(ChatCompletionChunk... chunks) {
+		return asyncStreamResponse(new AtomicBoolean(), true, chunks);
+	}
+
+	private AsyncStreamResponse<ChatCompletionChunk> asyncStreamResponse(AtomicBoolean closed, boolean complete,
+			ChatCompletionChunk... chunks) {
 		return new AsyncStreamResponse<>() {
 			private final CompletableFuture<Void> completion = new CompletableFuture<>();
 
@@ -457,8 +498,10 @@ class OpenAiChatModelTests {
 					for (ChatCompletionChunk chunk : chunks) {
 						handler.onNext(chunk);
 					}
-					handler.onComplete(Optional.empty());
-					this.completion.complete(null);
+					if (complete) {
+						handler.onComplete(Optional.empty());
+						this.completion.complete(null);
+					}
 				}
 				catch (Throwable throwable) {
 					handler.onComplete(Optional.of(throwable));
@@ -481,6 +524,7 @@ class OpenAiChatModelTests {
 
 			@Override
 			public void close() {
+				closed.set(true);
 			}
 		};
 	}


### PR DESCRIPTION
Closes #6654

## Summary

- retain the OpenAI SDK asynchronous stream response while bridging it to Reactor
- close the SDK response whenever the Reactor sink is disposed
- add a regression test for downstream cancellation of a stream that has not completed

## Testing

- `OpenAiChatModelTests`: 23 tests passed
- focused cancellation regression test passed
- Spring Java Format and Checkstyle passed for the affected module