### PR TITLE
Allow nested values in Bedrock `requestParameters`

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
@@ -52,7 +52,7 @@ public class BedrockConverseProxyChatProperties {
 
 	private @Nullable Double presencePenalty;
 
-	private Map<String, String> requestParameters = new HashMap<>();
+	private Map<String, Object> requestParameters = new HashMap<>();
 
 	private @Nullable List<String> stopSequences;
 
@@ -106,11 +106,18 @@ public class BedrockConverseProxyChatProperties {
 		this.presencePenalty = presencePenalty;
 	}
 
-	public Map<String, String> getRequestParameters() {
+	/**
+	 * Additional Bedrock Converse {@code additionalModelRequestFields}. Values may be
+	 * nested maps or lists (in addition to plain scalars) to express structured fields
+	 * such as Anthropic's {@code output_config}, e.g.: <pre>{@code
+	 * spring.ai.bedrock.converse.chat.request-parameters.output_config.effort=low
+	 * }</pre>
+	 */
+	public Map<String, Object> getRequestParameters() {
 		return this.requestParameters;
 	}
 
-	public void setRequestParameters(Map<String, String> requestParameters) {
+	public void setRequestParameters(Map<String, Object> requestParameters) {
 		this.requestParameters = requestParameters;
 	}
 
@@ -223,11 +230,11 @@ public class BedrockConverseProxyChatProperties {
 
 		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.request-parameters")
 		@Deprecated(since = "2.0.0", forRemoval = true)
-		public Map<String, String> getRequestParameters() {
+		public Map<String, Object> getRequestParameters() {
 			return BedrockConverseProxyChatProperties.this.getRequestParameters();
 		}
 
-		public void setRequestParameters(Map<String, String> requestParameters) {
+		public void setRequestParameters(Map<String, Object> requestParameters) {
 			BedrockConverseProxyChatProperties.this.setRequestParameters(requestParameters);
 		}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.bedrock.converse.autoconfigure;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.bedrock.converse.BedrockProxyChatModel;
@@ -92,6 +94,27 @@ public class BedrockConverseProxyChatPropertiesTests {
 			.run(context -> {
 				assertThat(context.getBeansOfType(BedrockConverseProxyChatProperties.class)).isEmpty();
 				assertThat(context.getBeansOfType(BedrockProxyChatModel.class)).isEmpty();
+			});
+	}
+
+	@Test
+	public void requestParametersSupportsMixedFlatAndNestedValuesTest() {
+
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.ai.bedrock.converse.chat.request-parameters.output_config.effort=low",
+					"spring.ai.bedrock.converse.chat.request-parameters.anthropic_version=bedrock-2023-05-31")
+			.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class,
+					ToolCallingAutoConfiguration.class))
+			.run(context -> {
+				var chatProperties = context.getBean(BedrockConverseProxyChatProperties.class);
+
+				assertThat(chatProperties.getRequestParameters()).containsEntry("anthropic_version",
+						"bedrock-2023-05-31");
+				assertThat(chatProperties.getRequestParameters().get("output_config")).isInstanceOfSatisfying(Map.class,
+						outputConfig -> assertThat(outputConfig).containsEntry("effort", "low"));
+
+				var options = chatProperties.toOptions();
+				assertThat(options.getRequestParameters()).containsKey("output_config");
 			});
 	}
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
@@ -46,7 +46,7 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 
 	private final @Nullable Double presencePenalty;
 
-	private final @Nullable Map<String, String> requestParameters;
+	private final @Nullable Map<String, Object> requestParameters;
 
 	private final @Nullable List<String> stopSequences;
 
@@ -65,7 +65,7 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 	private final @Nullable String outputSchema;
 
 	protected BedrockChatOptions(@Nullable String model, @Nullable Double frequencyPenalty, @Nullable Integer maxTokens,
-			@Nullable Double presencePenalty, @Nullable Map<String, String> requestParameters,
+			@Nullable Double presencePenalty, @Nullable Map<String, Object> requestParameters,
 			@Nullable List<String> stopSequences, @Nullable Double temperature, @Nullable Integer topK,
 			@Nullable Double topP, @Nullable List<ToolCallback> toolCallbacks,
 			@Nullable Map<String, Object> toolContext, @Nullable BedrockCacheOptions cacheOptions,
@@ -104,7 +104,14 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		return this.maxTokens;
 	}
 
-	public @Nullable Map<String, String> getRequestParameters() {
+	/**
+	 * Additional Bedrock Converse {@code additionalModelRequestFields}, passed through
+	 * verbatim to the underlying model. Values may be nested {@link Map}s or
+	 * {@link List}s (in addition to plain scalars) to express structured fields such as
+	 * Anthropic's {@code output_config}, e.g. {@code Map.of("output_config",
+	 * Map.of("effort", "low"))}.
+	 */
+	public @Nullable Map<String, Object> getRequestParameters() {
 		return this.requestParameters;
 	}
 
@@ -216,13 +223,16 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 			return copy;
 		}
 
-		protected @Nullable Map<String, String> requestParameters;
+		protected @Nullable Map<String, Object> requestParameters;
 
 		protected @Nullable BedrockCacheOptions cacheOptions;
 
 		private @Nullable String outputSchema;
 
-		public B requestParameters(@Nullable Map<String, String> requestParameters) {
+		/**
+		 * @see BedrockChatOptions#getRequestParameters()
+		 */
+		public B requestParameters(@Nullable Map<String, Object> requestParameters) {
 			this.requestParameters = requestParameters;
 			return self();
 		}
@@ -240,7 +250,7 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 						this.requestParameters = new HashMap<>(that.requestParameters);
 					}
 					else {
-						Map<String, String> merged = new HashMap<>(this.requestParameters);
+						Map<String, Object> merged = new HashMap<>(this.requestParameters);
 						merged.putAll(that.requestParameters);
 						this.requestParameters = merged;
 					}

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
@@ -108,7 +108,7 @@ class BedrockChatOptionsTests extends AbstractChatOptionsTests<BedrockChatOption
 
 	@Test
 	void cloneCreatesIndependentRequestParameters() {
-		Map<String, String> requestParameters = new HashMap<>();
+		Map<String, Object> requestParameters = new HashMap<>();
 		requestParameters.put("key", "value");
 
 		Builder source = BedrockChatOptions.builder().requestParameters(requestParameters);
@@ -121,6 +121,35 @@ class BedrockChatOptionsTests extends AbstractChatOptionsTests<BedrockChatOption
 	@Test
 	void cloneHandlesNullRequestParameters() {
 		assertThat(BedrockChatOptions.builder().clone().build().getRequestParameters()).isNull();
+	}
+
+	@Test
+	void requestParametersSupportsFlatStringValues() {
+		Map<String, Object> flatRequestParameters = Map.of("anthropic_version", "bedrock-2023-05-31");
+
+		BedrockChatOptions options = BedrockChatOptions.builder().requestParameters(flatRequestParameters).build();
+
+		assertThat(options.getRequestParameters()).containsEntry("anthropic_version", "bedrock-2023-05-31");
+	}
+
+	@Test
+	void requestParametersSupportsNestedMapValues() {
+		Map<String, Object> nestedRequestParameters = Map.of("output_config", Map.of("effort", "low"));
+
+		BedrockChatOptions options = BedrockChatOptions.builder().requestParameters(nestedRequestParameters).build();
+
+		assertThat(options.getRequestParameters().get("output_config")).isEqualTo(Map.of("effort", "low"));
+	}
+
+	@Test
+	void requestParametersSupportsMixedFlatAndNestedValuesInOneCall() {
+		Map<String, Object> mixedRequestParameters = Map.of("anthropic_version", "bedrock-2023-05-31", "output_config",
+				Map.of("effort", "low"));
+
+		BedrockChatOptions options = BedrockChatOptions.builder().requestParameters(mixedRequestParameters).build();
+
+		assertThat(options.getRequestParameters()).containsEntry("anthropic_version", "bedrock-2023-05-31");
+		assertThat(options.getRequestParameters().get("output_config")).isEqualTo(Map.of("effort", "low"));
 	}
 
 }

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -18,6 +18,7 @@ package org.springframework.ai.bedrock.converse;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
@@ -211,6 +213,30 @@ class BedrockProxyChatModelTest {
 			.cause()
 			.isInstanceOf(SecurityException.class)
 			.hasMessageContaining("evil.com");
+	}
+
+	@Test
+	void requestParametersWithMixedFlatAndNestedValuesBuildAdditionalModelRequestFields() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.requestParameters(
+					Map.of("anthropic_version", "bedrock-2023-05-31", "output_config", Map.of("effort", "low")))
+			.build();
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("Question?")), options);
+
+		ConverseRequest request = model.createRequest(prompt);
+
+		Document additionalModelRequestFields = request.additionalModelRequestFields();
+		assertThat(additionalModelRequestFields.isMap()).isTrue();
+
+		Document anthropicVersion = additionalModelRequestFields.asMap().get("anthropic_version");
+		assertThat(anthropicVersion.asString()).isEqualTo("bedrock-2023-05-31");
+
+		Document outputConfig = additionalModelRequestFields.asMap().get("output_config");
+		assertThat(outputConfig.isMap()).isTrue();
+		assertThat(outputConfig.asMap().get("effort").asString()).isEqualTo("low");
 	}
 
 	@Test

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse.api;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.document.Document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConverseApiUtils}.
+ *
+ * @author Seyed Hosseini
+ */
+class ConverseApiUtilsTests {
+
+	@Test
+	void convertsScalarValues() {
+		assertThat(ConverseApiUtils.convertObjectToDocument("low")).isEqualTo(Document.fromString("low"));
+		assertThat(ConverseApiUtils.convertObjectToDocument(true)).isEqualTo(Document.fromBoolean(true));
+		assertThat(ConverseApiUtils.convertObjectToDocument(null)).isEqualTo(Document.fromNull());
+	}
+
+	@Test
+	void convertsNumericValues() {
+		assertThat(ConverseApiUtils.convertObjectToDocument(42)).isEqualTo(Document.fromNumber(42));
+		assertThat(ConverseApiUtils.convertObjectToDocument(42L)).isEqualTo(Document.fromNumber(42L));
+		assertThat(ConverseApiUtils.convertObjectToDocument(4.2f)).isEqualTo(Document.fromNumber(4.2f));
+		assertThat(ConverseApiUtils.convertObjectToDocument(4.2)).isEqualTo(Document.fromNumber(4.2));
+		assertThat(ConverseApiUtils.convertObjectToDocument(BigDecimal.valueOf(4.2)))
+			.isEqualTo(Document.fromNumber(BigDecimal.valueOf(4.2)));
+		assertThat(ConverseApiUtils.convertObjectToDocument(BigInteger.valueOf(42)))
+			.isEqualTo(Document.fromNumber(BigInteger.valueOf(42)));
+	}
+
+	@Test
+	void convertsNestedMapValue() {
+		Document document = ConverseApiUtils.convertObjectToDocument(Map.of("output_config", Map.of("effort", "low")));
+
+		assertThat(document.isMap()).isTrue();
+		Document outputConfig = document.asMap().get("output_config");
+		assertThat(outputConfig.isMap()).isTrue();
+		assertThat(outputConfig.asMap().get("effort")).isEqualTo(Document.fromString("low"));
+	}
+
+	@Test
+	void convertsEmptyNestedMapValue() {
+		Document document = ConverseApiUtils.convertObjectToDocument(Map.of("output_config", Map.of()));
+
+		Document outputConfig = document.asMap().get("output_config");
+		assertThat(outputConfig.isMap()).isTrue();
+		assertThat(outputConfig.asMap()).isEmpty();
+	}
+
+	@Test
+	void convertsNullValueInsideNestedMap() {
+		Map<String, Object> withNullValue = new HashMap<>();
+		withNullValue.put("effort", null);
+
+		Document document = ConverseApiUtils.convertObjectToDocument(Map.of("output_config", withNullValue));
+
+		assertThat(document.asMap().get("output_config").asMap().get("effort")).isEqualTo(Document.fromNull());
+	}
+
+	@Test
+	void convertsListOfMultipleNestedMapsValue() {
+		Document document = ConverseApiUtils
+			.convertObjectToDocument(List.of(Map.of("effort", "low"), Map.of("effort", "high")));
+
+		assertThat(document.isList()).isTrue();
+		assertThat(document.asList()).hasSize(2);
+		assertThat(document.asList().get(0).asMap().get("effort")).isEqualTo(Document.fromString("low"));
+		assertThat(document.asList().get(1).asMap().get("effort")).isEqualTo(Document.fromString("high"));
+	}
+
+	@Test
+	void convertsThreeLevelsDeepMapListMapStructure() {
+		Document document = ConverseApiUtils
+			.convertObjectToDocument(Map.of("level1", Map.of("level2", List.of(Map.of("level3", "value")))));
+
+		Document level2List = document.asMap().get("level1").asMap().get("level2");
+		assertThat(level2List.isList()).isTrue();
+		assertThat(level2List.asList().get(0).asMap().get("level3")).isEqualTo(Document.fromString("value"));
+	}
+
+}


### PR DESCRIPTION
## Problem

`BedrockChatOptions.requestParameters` (and its Spring Boot property mirror in `BedrockConverseProxyChatProperties`) is declared as `Map<String, String>`. This field feeds Bedrock Converse's `additionalModelRequestFields` — the generic escape hatch for provider-specific fields the common schema doesn't cover.

Some providers need a *nested* object there, not a flat string — e.g. Anthropic's `output_config: { effort: "low" }`, supported since Claude Opus 4.5 and on every Claude model since (see [effort docs](https://platform.claude.com/docs/en/build-with-claude/effort)). Claude Sonnet 5 is where this becomes unavoidable rather than optional: it's the first Sonnet-tier model that also rejects non-default `temperature`/`top_p`/`top_k` ([source](https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5)), removing the fallback Sonnet-tier users previously had.

`ConverseApiUtils.convertObjectToDocument` already converts nested `Map`/`List` values recursively — only `requestParameters`'s declared type made that path unreachable, since every value arriving through it was guaranteed to be a `String`.

## Fix

Widen `requestParameters` to `Map<String, Object>` in `BedrockChatOptions` and `BedrockConverseProxyChatProperties` (incl. its deprecated `Options` mirror). No changes needed elsewhere — the conversion call site already accepts `Object`.

```java
BedrockChatOptions.builder()
    .requestParameters(Map.of("output_config", Map.of("effort", "low")))
    .build();
```
```yaml
spring.ai.bedrock.converse.chat.request-parameters.output_config.effort=low
```

**Compatibility:** source-breaking for callers with an explicitly-typed `Map<String, String>` variable passed into/read from this API (generics are invariant); inline usages and existing flat-string values are unaffected.

**Note:** map keys bind literally, no dash/camelCase transform — use the exact provider field name (`output_config`, not `output-config`).

**Related:** #6222 touches the same `combineWith()` method for a different bug; may need a small rebase against whichever merges second.

## Test

- `ConverseApiUtilsTests` (new) — scalars, numerics, nested/empty/null maps, lists, 3-level nesting.
- `BedrockChatOptionsTests` — flat, nested, and mixed `requestParameters` values.
- `BedrockProxyChatModelTest` — end-to-end: mixed flat+nested values build the correct `additionalModelRequestFields` `Document`.
- `BedrockConverseProxyChatPropertiesTests` — YAML binding produces a nested `Map<String, Object>`.
All green — full reactor build, 0 checkstyle violations.
