### PR TITLE
Expose OpenAI Image Usage Metadata

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiImageResponseMetadata.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiImageResponseMetadata.java
@@ -33,12 +33,25 @@ public class OpenAiImageResponseMetadata extends ImageResponseMetadata {
 
 	private final Long created;
 
+	private final @Nullable OpenAiImageUsage usage;
+
 	/**
 	 * Creates a new OpenAiImageResponseMetadata.
 	 * @param created the creation timestamp
 	 */
 	protected OpenAiImageResponseMetadata(Long created) {
+		this(created, null);
+	}
+
+	/**
+	 * Creates a new OpenAiImageResponseMetadata.
+	 * @param created the creation timestamp
+	 * @param usage the image token usage, or {@code null} if not available
+	 * @since 2.0.1
+	 */
+	protected OpenAiImageResponseMetadata(Long created, @Nullable OpenAiImageUsage usage) {
 		this.created = created;
+		this.usage = usage;
 	}
 
 	/**
@@ -48,7 +61,20 @@ public class OpenAiImageResponseMetadata extends ImageResponseMetadata {
 	 */
 	public static OpenAiImageResponseMetadata from(ImagesResponse imagesResponse) {
 		Assert.notNull(imagesResponse, "imagesResponse must not be null");
-		return new OpenAiImageResponseMetadata(imagesResponse.created());
+		@Nullable OpenAiImageUsage usage = imagesResponse.usage().map(OpenAiImageResponseMetadata::from).orElse(null);
+		return new OpenAiImageResponseMetadata(imagesResponse.created(), usage);
+	}
+
+	private static OpenAiImageUsage from(ImagesResponse.Usage usage) {
+		ImagesResponse.Usage.InputTokensDetails inputDetails = usage.inputTokensDetails();
+		@Nullable Long outputTextTokens = usage.outputTokensDetails()
+			.map(ImagesResponse.Usage.OutputTokensDetails::textTokens)
+			.orElse(null);
+		@Nullable Long outputImageTokens = usage.outputTokensDetails()
+			.map(ImagesResponse.Usage.OutputTokensDetails::imageTokens)
+			.orElse(null);
+		return new OpenAiImageUsage(usage.inputTokens(), usage.outputTokens(), usage.totalTokens(),
+				inputDetails.textTokens(), inputDetails.imageTokens(), outputTextTokens, outputImageTokens);
 	}
 
 	@Override
@@ -56,9 +82,21 @@ public class OpenAiImageResponseMetadata extends ImageResponseMetadata {
 		return this.created;
 	}
 
+	/**
+	 * Returns the token usage reported by the OpenAI Images API.
+	 * @return the image token usage, or {@code null} if not available
+	 * @since 2.0.1
+	 */
+	public @Nullable OpenAiImageUsage getUsage() {
+		return this.usage;
+	}
+
 	@Override
 	public String toString() {
-		return "OpenAiImageResponseMetadata{" + "created=" + this.created + '}';
+		if (this.usage == null) {
+			return "OpenAiImageResponseMetadata{" + "created=" + this.created + '}';
+		}
+		return "OpenAiImageResponseMetadata{" + "created=" + this.created + ", usage=" + this.usage + '}';
 	}
 
 	@Override
@@ -69,12 +107,12 @@ public class OpenAiImageResponseMetadata extends ImageResponseMetadata {
 		if (!(o instanceof OpenAiImageResponseMetadata that)) {
 			return false;
 		}
-		return Objects.equals(this.created, that.created);
+		return Objects.equals(this.created, that.created) && Objects.equals(this.usage, that.usage);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.created);
+		return this.usage == null ? Objects.hash(this.created) : Objects.hash(this.created, this.usage);
 	}
 
 }

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiImageUsage.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiImageUsage.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.metadata;
+
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Token usage reported by the OpenAI Images API.
+ *
+ * @since 2.0.1
+ */
+public final class OpenAiImageUsage {
+
+	private final long inputTokens;
+
+	private final long outputTokens;
+
+	private final long totalTokens;
+
+	private final long inputTextTokens;
+
+	private final long inputImageTokens;
+
+	private final @Nullable Long outputTextTokens;
+
+	private final @Nullable Long outputImageTokens;
+
+	OpenAiImageUsage(long inputTokens, long outputTokens, long totalTokens, long inputTextTokens, long inputImageTokens,
+			@Nullable Long outputTextTokens, @Nullable Long outputImageTokens) {
+		this.inputTokens = inputTokens;
+		this.outputTokens = outputTokens;
+		this.totalTokens = totalTokens;
+		this.inputTextTokens = inputTextTokens;
+		this.inputImageTokens = inputImageTokens;
+		this.outputTextTokens = outputTextTokens;
+		this.outputImageTokens = outputImageTokens;
+	}
+
+	/**
+	 * Returns the number of tokens in the image generation input.
+	 * @return the input token count
+	 * @since 2.0.1
+	 */
+	public long getInputTokens() {
+		return this.inputTokens;
+	}
+
+	/**
+	 * Returns the number of tokens in the image generation output.
+	 * @return the output token count
+	 * @since 2.0.1
+	 */
+	public long getOutputTokens() {
+		return this.outputTokens;
+	}
+
+	/**
+	 * Returns the total number of tokens used for image generation.
+	 * @return the total token count
+	 * @since 2.0.1
+	 */
+	public long getTotalTokens() {
+		return this.totalTokens;
+	}
+
+	/**
+	 * Returns the number of text tokens in the image generation input.
+	 * @return the input text token count
+	 * @since 2.0.1
+	 */
+	public long getInputTextTokens() {
+		return this.inputTextTokens;
+	}
+
+	/**
+	 * Returns the number of image tokens in the image generation input.
+	 * @return the input image token count
+	 * @since 2.0.1
+	 */
+	public long getInputImageTokens() {
+		return this.inputImageTokens;
+	}
+
+	/**
+	 * Returns the number of text tokens in the image generation output.
+	 * @return the output text token count, or {@code null} if not available
+	 * @since 2.0.1
+	 */
+	public @Nullable Long getOutputTextTokens() {
+		return this.outputTextTokens;
+	}
+
+	/**
+	 * Returns the number of image tokens in the image generation output.
+	 * @return the output image token count, or {@code null} if not available
+	 * @since 2.0.1
+	 */
+	public @Nullable Long getOutputImageTokens() {
+		return this.outputImageTokens;
+	}
+
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof OpenAiImageUsage that)) {
+			return false;
+		}
+		return this.inputTokens == that.inputTokens && this.outputTokens == that.outputTokens
+				&& this.totalTokens == that.totalTokens && this.inputTextTokens == that.inputTextTokens
+				&& this.inputImageTokens == that.inputImageTokens
+				&& Objects.equals(this.outputTextTokens, that.outputTextTokens)
+				&& Objects.equals(this.outputImageTokens, that.outputImageTokens);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.inputTokens, this.outputTokens, this.totalTokens, this.inputTextTokens,
+				this.inputImageTokens, this.outputTextTokens, this.outputImageTokens);
+	}
+
+	@Override
+	public String toString() {
+		return "OpenAiImageUsage{" + "inputTokens=" + this.inputTokens + ", outputTokens=" + this.outputTokens
+				+ ", totalTokens=" + this.totalTokens + ", inputTextTokens=" + this.inputTextTokens
+				+ ", inputImageTokens=" + this.inputImageTokens + ", outputTextTokens=" + this.outputTextTokens
+				+ ", outputImageTokens=" + this.outputImageTokens + '}';
+	}
+
+}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/metadata/OpenAiImageResponseMetadataTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/metadata/OpenAiImageResponseMetadataTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.metadata;
+
+import java.util.Objects;
+
+import com.openai.models.images.ImagesResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAiImageResponseMetadataTests {
+
+	@Test
+	void mapsAllUsageFields() {
+		ImagesResponse.Usage usage = ImagesResponse.Usage.builder()
+			.inputTokens(150L)
+			.outputTokens(200L)
+			.totalTokens(350L)
+			.inputTokensDetails(inputTokensDetails(100L, 50L))
+			.outputTokensDetails(outputTokensDetails(180L, 20L))
+			.build();
+		ImagesResponse imagesResponse = ImagesResponse.builder().created(123L).usage(usage).build();
+
+		OpenAiImageResponseMetadata metadata = OpenAiImageResponseMetadata.from(imagesResponse);
+		OpenAiImageUsage imageUsage = Objects.requireNonNull(metadata.getUsage());
+
+		assertThat(metadata.getCreated()).isEqualTo(123L);
+		assertThat(imageUsage.getInputTokens()).isEqualTo(150L);
+		assertThat(imageUsage.getOutputTokens()).isEqualTo(200L);
+		assertThat(imageUsage.getTotalTokens()).isEqualTo(350L);
+		assertThat(imageUsage.getInputTextTokens()).isEqualTo(100L);
+		assertThat(imageUsage.getInputImageTokens()).isEqualTo(50L);
+		assertThat(imageUsage.getOutputTextTokens()).isEqualTo(180L);
+		assertThat(imageUsage.getOutputImageTokens()).isEqualTo(20L);
+	}
+
+	@Test
+	void handlesMissingUsage() {
+		ImagesResponse imagesResponse = ImagesResponse.builder().created(123L).build();
+
+		OpenAiImageResponseMetadata metadata = OpenAiImageResponseMetadata.from(imagesResponse);
+
+		assertThat(metadata.getCreated()).isEqualTo(123L);
+		assertThat(metadata.getUsage()).isNull();
+	}
+
+	@Test
+	void handlesMissingOutputTokenDetails() {
+		ImagesResponse.Usage usage = ImagesResponse.Usage.builder()
+			.inputTokens(75L)
+			.outputTokens(25L)
+			.totalTokens(100L)
+			.inputTokensDetails(inputTokensDetails(60L, 15L))
+			.build();
+		ImagesResponse imagesResponse = ImagesResponse.builder().created(456L).usage(usage).build();
+
+		OpenAiImageUsage imageUsage = Objects
+			.requireNonNull(OpenAiImageResponseMetadata.from(imagesResponse).getUsage());
+
+		assertThat(imageUsage.getInputTokens()).isEqualTo(75L);
+		assertThat(imageUsage.getOutputTokens()).isEqualTo(25L);
+		assertThat(imageUsage.getTotalTokens()).isEqualTo(100L);
+		assertThat(imageUsage.getInputTextTokens()).isEqualTo(60L);
+		assertThat(imageUsage.getInputImageTokens()).isEqualTo(15L);
+		assertThat(imageUsage.getOutputTextTokens()).isNull();
+		assertThat(imageUsage.getOutputImageTokens()).isNull();
+	}
+
+	@Test
+	void preservesLegacyConstructorBehavior() {
+		OpenAiImageResponseMetadata metadata = new OpenAiImageResponseMetadata(789L);
+		OpenAiImageResponseMetadata sameMetadata = new OpenAiImageResponseMetadata(789L);
+
+		assertThat(metadata.getCreated()).isEqualTo(789L);
+		assertThat(metadata.getUsage()).isNull();
+		assertThat(metadata).isEqualTo(sameMetadata).hasSameHashCodeAs(sameMetadata);
+		assertThat(metadata.toString()).isEqualTo("OpenAiImageResponseMetadata{created=789}");
+	}
+
+	@Test
+	void includesUsageInValueSemantics() {
+		ImagesResponse imagesResponse = ImagesResponse.builder()
+			.created(123L)
+			.usage(ImagesResponse.Usage.builder()
+				.inputTokens(75L)
+				.outputTokens(25L)
+				.totalTokens(100L)
+				.inputTokensDetails(inputTokensDetails(60L, 15L))
+				.build())
+			.build();
+
+		OpenAiImageResponseMetadata metadata = OpenAiImageResponseMetadata.from(imagesResponse);
+		OpenAiImageResponseMetadata sameMetadata = OpenAiImageResponseMetadata.from(imagesResponse);
+		OpenAiImageResponseMetadata differentCreatedMetadata = OpenAiImageResponseMetadata
+			.from(imagesResponse.toBuilder().created(124L).build());
+		OpenAiImageResponseMetadata legacyMetadata = new OpenAiImageResponseMetadata(123L);
+
+		assertThat(metadata).isEqualTo(metadata)
+			.isEqualTo(sameMetadata)
+			.hasSameHashCodeAs(sameMetadata)
+			.isNotEqualTo(differentCreatedMetadata)
+			.isNotEqualTo(legacyMetadata)
+			.isNotEqualTo("metadata");
+		assertThat(metadata.toString()).contains("created=123", "usage=OpenAiImageUsage{", "inputTokens=75");
+	}
+
+	@Test
+	void imageUsageIncludesEveryFieldInValueSemantics() {
+		OpenAiImageUsage usage = imageUsage(1L, 2L, 3L, 4L, 5L, 6L, 7L);
+		OpenAiImageUsage sameUsage = imageUsage(1L, 2L, 3L, 4L, 5L, 6L, 7L);
+
+		assertThat(usage).isEqualTo(usage)
+			.isEqualTo(sameUsage)
+			.hasSameHashCodeAs(sameUsage)
+			.isNotEqualTo(imageUsage(8L, 2L, 3L, 4L, 5L, 6L, 7L))
+			.isNotEqualTo(imageUsage(1L, 8L, 3L, 4L, 5L, 6L, 7L))
+			.isNotEqualTo(imageUsage(1L, 2L, 8L, 4L, 5L, 6L, 7L))
+			.isNotEqualTo(imageUsage(1L, 2L, 3L, 8L, 5L, 6L, 7L))
+			.isNotEqualTo(imageUsage(1L, 2L, 3L, 4L, 8L, 6L, 7L))
+			.isNotEqualTo(imageUsage(1L, 2L, 3L, 4L, 5L, 8L, 7L))
+			.isNotEqualTo(imageUsage(1L, 2L, 3L, 4L, 5L, 6L, 8L))
+			.isNotEqualTo("usage");
+	}
+
+	private static ImagesResponse.Usage.InputTokensDetails inputTokensDetails(long textTokens, long imageTokens) {
+		return ImagesResponse.Usage.InputTokensDetails.builder()
+			.textTokens(textTokens)
+			.imageTokens(imageTokens)
+			.build();
+	}
+
+	private static ImagesResponse.Usage.OutputTokensDetails outputTokensDetails(long textTokens, long imageTokens) {
+		return ImagesResponse.Usage.OutputTokensDetails.builder()
+			.textTokens(textTokens)
+			.imageTokens(imageTokens)
+			.build();
+	}
+
+	private static OpenAiImageUsage imageUsage(long inputTokens, long outputTokens, long totalTokens,
+			long inputTextTokens, long inputImageTokens, Long outputTextTokens, Long outputImageTokens) {
+		return new OpenAiImageUsage(inputTokens, outputTokens, totalTokens, inputTextTokens, inputImageTokens,
+				outputTextTokens, outputImageTokens);
+	}
+
+}


### PR DESCRIPTION
## Summary

- Preserve token usage returned by the OpenAI Images API in
  `OpenAiImageResponseMetadata`.
- Add the Spring AI-owned `OpenAiImageUsage` value type without exposing OpenAI
  SDK types in the public API.
- Cover complete usage data, absent usage, absent output token details, legacy
  metadata behavior, and value semantics with unit tests.

Closes #6661

## Scope

This change only maps usage from image generation responses. It does not change
image editing, retries, batching, observability, or common image usage
abstractions.

## Compatibility

The existing `OpenAiImageResponseMetadata(Long)` constructor remains unchanged
and delegates to the new constructor. When usage is absent, the existing
`equals()`, `hashCode()`, and `toString()` behavior is preserved. Responses
containing usage now include that usage in their value semantics.

Required token counts use `long`, while optional output text and image token
counts use nullable `Long` values.
