### PR TITLE
Restore stateless `@Mcp*` registration

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
@@ -28,10 +28,10 @@ import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
-import org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration.ServerMcpAnnotatedBeans;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -41,11 +41,11 @@ import org.springframework.context.annotation.Configuration;
  * @author Christian Tzolov
  */
 @AutoConfiguration(after = McpServerAnnotationScannerAutoConfiguration.class)
+@ConditionalOnClass(McpTool.class)
 @ConditionalOnProperty(prefix = McpServerAnnotationScannerProperties.CONFIG_PREFIX, name = "enabled",
 		havingValue = "true", matchIfMissing = true)
 @Conditional({ McpServerStdioDisabledCondition.class,
-		McpServerStatelessAutoConfiguration.EnabledStatelessServerCondition.class,
-		StatelessToolCallbackConverterAutoConfiguration.ToolCallbackConverterCondition.class })
+		McpServerStatelessAutoConfiguration.EnabledStatelessServerCondition.class })
 public class StatelessServerSpecificationFactoryAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
-import org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration.ServerMcpAnnotatedBeans;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -44,8 +43,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(prefix = McpServerAnnotationScannerProperties.CONFIG_PREFIX, name = "enabled",
 		havingValue = "true", matchIfMissing = true)
 @Conditional({ McpServerStdioDisabledCondition.class,
-		McpServerStatelessAutoConfiguration.EnabledStatelessServerCondition.class,
-		StatelessToolCallbackConverterAutoConfiguration.ToolCallbackConverterCondition.class })
+		McpServerStatelessAutoConfiguration.EnabledStatelessServerCondition.class })
 public class StatelessServerSpecificationFactoryAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -59,6 +59,7 @@ import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -156,6 +157,16 @@ public class McpStatelessServerAutoConfigurationIT {
 			assertThat(context).doesNotHaveBean(McpStatelessAsyncServer.class);
 			assertThat(context).doesNotHaveBean(McpStatelessServerTransport.class);
 		});
+	}
+
+	@Test
+	void annotationSpecificationConfigurationBacksOffWhenMcpAnnotationsMissing() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(McpTool.class))
+			.withConfiguration(AutoConfigurations.of(McpServerAnnotationScannerAutoConfiguration.class,
+					StatelessServerSpecificationFactoryAutoConfiguration.class))
+			.withPropertyValues("spring.ai.mcp.server.tool-callback-converter=false")
+			.run(context -> assertThat(context)
+				.doesNotHaveBean(StatelessServerSpecificationFactoryAutoConfiguration.class));
 	}
 
 	@Test
@@ -319,12 +330,16 @@ public class McpStatelessServerAutoConfigurationIT {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	void syncStatelessServerSpecificationConfiguration() {
-		this.contextRunner
+	void syncAnnotatedSpecificationsWhenToolCallbackConverterDisabled() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.tool-callback-converter=false")
 			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
 					StatelessServerSpecificationFactoryAutoConfiguration.class)
 			.withBean(SyncTestMcpSpecsComponent.class)
 			.run(context -> {
+				assertThat(context).doesNotHaveBean(StatelessToolCallbackConverterAutoConfiguration.class);
+				assertThat(context).doesNotHaveBean("syncTools");
+				assertThat(context).doesNotHaveBean("asyncTools");
+
 				McpStatelessSyncServer syncServer = context.getBean(McpStatelessSyncServer.class);
 				McpStatelessAsyncServer asyncServer = (McpStatelessAsyncServer) ReflectionTestUtils.getField(syncServer,
 						"asyncServer");
@@ -358,13 +373,17 @@ public class McpStatelessServerAutoConfigurationIT {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	void asyncStatelessServerSpecificationConfiguration() {
+	void asyncAnnotatedSpecificationsWhenToolCallbackConverterDisabled() {
 		this.contextRunner
 			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
 					StatelessServerSpecificationFactoryAutoConfiguration.class)
 			.withBean(AsyncTestMcpSpecsComponent.class)
-			.withPropertyValues("spring.ai.mcp.server.type=async")
+			.withPropertyValues("spring.ai.mcp.server.type=async", "spring.ai.mcp.server.tool-callback-converter=false")
 			.run(context -> {
+				assertThat(context).doesNotHaveBean(StatelessToolCallbackConverterAutoConfiguration.class);
+				assertThat(context).doesNotHaveBean("syncTools");
+				assertThat(context).doesNotHaveBean("asyncTools");
+
 				McpStatelessAsyncServer asyncServer = context.getBean(McpStatelessAsyncServer.class);
 
 				CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -317,10 +317,16 @@ public class McpStatelessServerAutoConfigurationIT {
 			.run(context -> assertThat(context).hasSingleBean(ToolCallbackProvider.class));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	void syncStatelessServerSpecificationConfiguration() {
-		this.contextRunner
+		assertSyncStatelessServerSpecificationConfiguration(this.contextRunner);
+		assertSyncStatelessServerSpecificationConfiguration(
+				this.contextRunner.withPropertyValues("spring.ai.mcp.server.tool-callback-converter=false"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private void assertSyncStatelessServerSpecificationConfiguration(ApplicationContextRunner contextRunner) {
+		contextRunner
 			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
 					StatelessServerSpecificationFactoryAutoConfiguration.class)
 			.withBean(SyncTestMcpSpecsComponent.class)
@@ -356,10 +362,16 @@ public class McpStatelessServerAutoConfigurationIT {
 			});
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	void asyncStatelessServerSpecificationConfiguration() {
-		this.contextRunner
+		assertAsyncStatelessServerSpecificationConfiguration(this.contextRunner);
+		assertAsyncStatelessServerSpecificationConfiguration(
+				this.contextRunner.withPropertyValues("spring.ai.mcp.server.tool-callback-converter=false"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private void assertAsyncStatelessServerSpecificationConfiguration(ApplicationContextRunner contextRunner) {
+		contextRunner
 			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
 					StatelessServerSpecificationFactoryAutoConfiguration.class)
 			.withBean(AsyncTestMcpSpecsComponent.class)


### PR DESCRIPTION
## Problem

Setting spring.ai.mcp.server.tool-callback-converter=false on a stateless MCP server also disabled annotation-based tools, resources, resource templates, prompts, and completions. The stateless annotation specification factory was incorrectly guarded by the converter condition.

## Change

Remove that unrelated condition and run the existing stateless annotation registration assertions in both SYNC and ASYNC modes, with the converter enabled and disabled.

## Verification

- The focused test fails on unchanged main with no registered annotation specifications and passes with this change.
- All 87 integration tests in spring-ai-autoconfigure-mcp-server-common pass.

Fixes #6664