### PR TITLE
Add public FactCheckingEvaluator constructor

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
@@ -95,6 +95,17 @@ public class FactCheckingEvaluator implements Evaluator {
 	private final String evaluationPrompt;
 
 	/**
+	 * Constructs a new FactCheckingEvaluator with the provided ChatClient.Builder, using
+	 * the default evaluation prompt.
+	 * @param chatClientBuilder the builder for the ChatClient used to perform the
+	 * evaluation
+	 * @since 2.0.0
+	 */
+	public FactCheckingEvaluator(ChatClient.Builder chatClientBuilder) {
+		this(chatClientBuilder, null);
+	}
+
+	/**
 	 * Constructs a new FactCheckingEvaluator with the provided ChatClient.Builder and
 	 * evaluation prompt.
 	 * @param chatClientBuilder The builder for the ChatClient used to perform the

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluatorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluatorTests.java
@@ -105,4 +105,17 @@ class FactCheckingEvaluatorTests {
 		assertThat(result.isPass()).isFalse();
 	}
 
+	@Test
+	void whenCreatedWithChatClientBuilderThenEvaluatorIsCreated() {
+		FactCheckingEvaluator evaluator = new FactCheckingEvaluator(ChatClient.builder(mock(ChatModel.class)));
+
+		assertThat(evaluator).isNotNull();
+	}
+
+	@Test
+	void whenConstructorChatClientBuilderIsNullThenThrow() {
+		assertThatThrownBy(() -> new FactCheckingEvaluator(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("chatClientBuilder cannot be null");
+	}
+
 }


### PR DESCRIPTION
## Summary

Adds a public `FactCheckingEvaluator` constructor that accepts a `ChatClient.Builder` and uses the default evaluation prompt.

This aligns `FactCheckingEvaluator` with its documented constructor-based usage and with `RelevancyEvaluator`, while preserving the existing protected constructor for backward compatibility.

## Testing

- Added coverage for construction through the new public constructor.
- Added coverage for rejecting a null `ChatClient.Builder`.
- Ran `FactCheckingEvaluatorTests` successfully.