### PR TITLE
Report time to first streaming chunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ package.json
 shell.log
 
 .profiler
+.codebase-memory/
 nbproject/
 
 **/.claude/settings.local.json

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -349,6 +349,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 			// @formatter:off
 			Flux<ChatResponse> flux = chatResponseFlux
+				.doOnNext(ignored -> observationContext.recordTimeToFirstChunk())
 				.doOnError(observation::error)
 				.doFinally(s -> observation.stop())
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -821,6 +821,7 @@ public class BedrockProxyChatModel implements ChatModel {
 			Assert.state(options != null, "Prompt options must not be null");
 
 			Flux<ChatResponse> chatResponseFlux = chatResponses.concatMap(chatResponse -> Flux.just(chatResponse))
+				.doOnNext(ignored -> observationContext.recordTimeToFirstChunk())
 				.doOnError(observation::error)
 				.doFinally(s -> observation.stop())
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -262,6 +262,7 @@ public class DeepSeekChatModel implements ChatModel {
 
 			// @formatter:off
 			Flux<ChatResponse> flux = chatResponse
+				.doOnNext(ignored -> observationContext.recordTimeToFirstChunk())
 				.doOnError(observation::error)
 				.doFinally(s -> observation.stop())
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -492,7 +492,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 					ChatResponse chatResponse = new ChatResponse(generations,
 							toChatResponseMetadata(cumulativeUsage, response.modelVersion().get()));
 					return Flux.just(chatResponse);
-				});
+				}).doOnNext(ignored -> observationContext.recordTimeToFirstChunk());
 
 				AtomicReference<ChatResponse> aggregatedResponseRef = new AtomicReference<>();
 

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -296,7 +296,8 @@ public class MistralAiChatModel implements ChatModel {
 			// @formatter:off
 			Flux<ChatResponse> chatResponseFlux = chatResponse.flatMap(response ->
 					Flux.just(response))
-			.doOnError(observation::error)
+				.doOnNext(ignored -> observationContext.recordTimeToFirstChunk())
+				.doOnError(observation::error)
 			.doFinally(s -> observation.stop())
 			.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 			// @formatter:on

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -349,6 +349,7 @@ public class OllamaChatModel implements ChatModel {
 			});
 
 			Flux<ChatResponse> chatResponseFlux = chatResponse.flatMap(response -> Flux.just(response))
+				.doOnNext(ignored -> observationContext.recordTimeToFirstChunk())
 				.doOnError(observation::error)
 				.doFinally(s -> observation.stop())
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -352,7 +352,9 @@ public final class OpenAiChatModel implements ChatModel {
 
 			});
 
-			Flux<ChatResponse> observedResponses = chatResponses.doOnError(observation::error)
+			Flux<ChatResponse> observedResponses = chatResponses
+				.doOnNext(ignored -> observationContext.recordTimeToFirstChunk())
+				.doOnError(observation::error)
 				.doFinally(s -> observation.stop())
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
@@ -115,6 +115,11 @@ public enum AiObservationAttributes {
 	 * The name of the model that generated the response.
 	 */
 	RESPONSE_MODEL("gen_ai.response.model"),
+	/**
+	 * The time elapsed from when the request was made until the first response chunk
+	 * was received, in seconds.
+	 */
+	RESPONSE_TIME_TO_FIRST_CHUNK("gen_ai.response.time_to_first_chunk"),
 
 	// GenAI Usage
 

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationMetricNames.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationMetricNames.java
@@ -34,6 +34,10 @@ public enum AiObservationMetricNames {
 	 */
 	OPERATION_DURATION("gen_ai.client.operation.duration"),
 	/**
+	 * The time elapsed until the first response chunk was received.
+	 */
+	TIME_TO_FIRST_CHUNK("gen_ai.client.operation.time_to_first_chunk"),
+	/**
 	 * The number of AI operations.
 	 */
 	TOKEN_USAGE("gen_ai.client.token.usage");

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelMeterObservationHandler.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelMeterObservationHandler.java
@@ -16,11 +16,18 @@
 
 package org.springframework.ai.chat.observation;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import io.micrometer.common.KeyValue;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 
 import org.springframework.ai.model.observation.ModelUsageMetricsGenerator;
+import org.springframework.ai.observation.conventions.AiObservationMetricNames;
 
 /**
  * Handler for generating metrics from chat model observations.
@@ -38,6 +45,13 @@ public class ChatModelMeterObservationHandler implements ObservationHandler<Chat
 
 	@Override
 	public void onStop(ChatModelObservationContext context) {
+		if (context.getTimeToFirstChunk() != null) {
+			Timer.builder(AiObservationMetricNames.TIME_TO_FIRST_CHUNK.value())
+				.description("Time to first response chunk")
+				.tags(createTags(context))
+				.register(this.meterRegistry)
+				.record(context.getTimeToFirstChunk());
+		}
 		if (context.getResponse() != null && context.getResponse().getMetadata() != null
 				&& context.getResponse().getMetadata().getUsage() != null) {
 			ModelUsageMetricsGenerator.generate(context.getResponse().getMetadata().getUsage(), context,
@@ -48,6 +62,14 @@ public class ChatModelMeterObservationHandler implements ObservationHandler<Chat
 	@Override
 	public boolean supportsContext(Observation.Context context) {
 		return context instanceof ChatModelObservationContext;
+	}
+
+	private static List<Tag> createTags(ChatModelObservationContext context) {
+		List<Tag> tags = new ArrayList<>();
+		for (KeyValue keyValue : context.getLowCardinalityKeyValues()) {
+			tags.add(Tag.of(keyValue.getKey(), keyValue.getValue()));
+		}
+		return tags;
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.chat.observation;
 
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.chat.model.ChatResponse;
@@ -35,6 +38,12 @@ public class ChatModelObservationContext extends ModelObservationContext<Prompt,
 
 	private final boolean streaming;
 
+	private final long requestStartNanos = System.nanoTime();
+
+	private final AtomicBoolean firstChunkReceived = new AtomicBoolean();
+
+	private volatile @Nullable Duration timeToFirstChunk;
+
 	ChatModelObservationContext(Prompt prompt, String provider, boolean streaming) {
 		super(prompt,
 				AiOperationMetadata.builder().operationType(AiOperationType.CHAT.value()).provider(provider).build());
@@ -43,6 +52,24 @@ public class ChatModelObservationContext extends ModelObservationContext<Prompt,
 
 	public boolean isStreaming() {
 		return this.streaming;
+	}
+
+	/**
+	 * Record the elapsed time from the creation of this context until the first response
+	 * chunk. Subsequent invocations have no effect.
+	 */
+	public void recordTimeToFirstChunk() {
+		if (this.streaming && this.firstChunkReceived.compareAndSet(false, true)) {
+			this.timeToFirstChunk = Duration.ofNanos(System.nanoTime() - this.requestStartNanos);
+		}
+	}
+
+	/**
+	 * Return the time elapsed until the first response chunk, if one was received.
+	 * @return the time to the first chunk, or {@code null}
+	 */
+	public @Nullable Duration getTimeToFirstChunk() {
+		return this.timeToFirstChunk;
 	}
 
 	public static Builder builder() {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationDocumentation.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationDocumentation.java
@@ -214,6 +214,17 @@ public enum ChatModelObservationDocumentation implements ObservationDocumentatio
 			}
 		},
 
+		/**
+		 * The time elapsed from when the request was made until the first response chunk
+		 * was received, in seconds.
+		 */
+		RESPONSE_TIME_TO_FIRST_CHUNK {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.RESPONSE_TIME_TO_FIRST_CHUNK.value();
+			}
+		},
+
 		// Usage
 
 		/**

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
@@ -108,6 +108,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 		// Response
 		keyValues = responseFinishReasons(keyValues, context);
 		keyValues = responseId(keyValues, context);
+		keyValues = responseTimeToFirstChunk(keyValues, context);
 		keyValues = usageCacheWriteInputTokens(keyValues, context);
 		keyValues = usageCacheReadInputTokens(keyValues, context);
 		keyValues = usageInputTokens(keyValues, context);
@@ -242,6 +243,16 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 		if (context.getResponse() != null && StringUtils.hasText(context.getResponse().getMetadata().getId())) {
 			return keyValues.and(ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_ID.asString(),
 					context.getResponse().getMetadata().getId());
+		}
+		return keyValues;
+	}
+
+	protected KeyValues responseTimeToFirstChunk(KeyValues keyValues, ChatModelObservationContext context) {
+		if (context.getTimeToFirstChunk() != null) {
+			double seconds = context.getTimeToFirstChunk().toNanos() / 1_000_000_000.0;
+			return keyValues.and(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString(),
+					String.valueOf(seconds));
 		}
 		return keyValues;
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelMeterObservationHandlerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelMeterObservationHandlerTests.java
@@ -159,6 +159,29 @@ class ChatModelMeterObservationHandlerTests {
 			.noneMatch(meter -> meter.getId().getName().equals(AiObservationMetricNames.TOKEN_USAGE.value()));
 	}
 
+	@Test
+	void shouldRecordTimeToFirstChunkForStreamingObservation() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+		var observation = Observation
+			.createNotStarted(new DefaultChatModelObservationConvention(), () -> observationContext,
+					this.observationRegistry)
+			.start();
+
+		observationContext.recordTimeToFirstChunk();
+		observation.stop();
+
+		assertThat(this.meterRegistry.get(AiObservationMetricNames.TIME_TO_FIRST_CHUNK.value())
+			.tag(LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(), AiOperationType.CHAT.value())
+			.tag(LowCardinalityKeyNames.AI_PROVIDER.asString(), "superprovider")
+			.tag(LowCardinalityKeyNames.REQUEST_MODEL.asString(), "mistral")
+			.timer()
+			.count()).isEqualTo(1);
+	}
+
 	private ChatModelObservationContext generateObservationContext() {
 		return ChatModelObservationContext.builder()
 			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelObservationContextTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelObservationContextTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.chat.observation;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.prompt.ChatOptions;
@@ -70,6 +72,31 @@ class ChatModelObservationContextTests {
 			.build();
 
 		assertThat(observationContext.isStreaming()).isFalse();
+	}
+
+	@Test
+	void whenFirstChunkReceivedThenRecordElapsedTime() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+
+		observationContext.recordTimeToFirstChunk();
+
+		assertThat(observationContext.getTimeToFirstChunk()).isNotNull().isGreaterThanOrEqualTo(Duration.ZERO);
+	}
+
+	@Test
+	void whenNotStreamingThenDoNotRecordElapsedTime() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.build();
+
+		observationContext.recordTimeToFirstChunk();
+
+		assertThat(observationContext.getTimeToFirstChunk()).isNull();
 	}
 
 	private Prompt generatePrompt(ChatOptions chatOptions) {

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
@@ -192,6 +192,21 @@ class DefaultChatModelObservationConventionTests {
 	}
 
 	@Test
+	void shouldHaveResponseTimeToFirstChunkWhenRecorded() {
+		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+		observationContext.recordTimeToFirstChunk();
+
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext)).anySatisfy(keyValue -> {
+			assertThat(keyValue.getKey()).isEqualTo(HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString());
+			assertThat(Double.parseDouble(keyValue.getValue())).isGreaterThanOrEqualTo(0.0);
+		});
+	}
+
+	@Test
 	void shouldHaveKeyValuesWhenCacheTokensDefined() {
 		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))


### PR DESCRIPTION
Record the latency from starting a streaming chat request until the first `ChatResponse` is emitted.

This change:

- exposes `gen_ai.response.time_to_first_chunk` on chat model observations
- records `gen_ai.client.operation.time_to_first_chunk` as a tagged timer
- instruments all current streaming chat model implementations
- adds focused tests for the context, observation convention, and meter handler

Validation:

- `./mvnw -Dmaven.build.cache.enabled=false -pl spring-ai-model -am -Dtest=ChatModelObservationContextTests,DefaultChatModelObservationConventionTests,ChatModelMeterObservationHandlerTests -Dsurefire.failIfNoSpecifiedTests=false test -q`
- compiled all affected provider modules with the Maven build cache disabled
- formatting and checkstyle validation passed

Fixes #6670