### PR TITLE
Add GenAI conversation ID observation

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/ChatClientObservationDocumentation.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/ChatClientObservationDocumentation.java
@@ -21,6 +21,8 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.docs.ObservationDocumentation;
 
+import org.springframework.ai.observation.conventions.AiObservationAttributes;
+
 /**
  * Documented conventions for chat client observations.
  *
@@ -92,7 +94,7 @@ public enum ChatClientObservationDocumentation implements ObservationDocumentati
 		CHAT_CLIENT_CONVERSATION_ID {
 			@Override
 			public String asString() {
-				return "spring.ai.chat.client.conversation.id";
+				return AiObservationAttributes.CONVERSATION_ID.value();
 			}
 		},
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConventionTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConventionTests.java
@@ -165,6 +165,7 @@ class DefaultChatClientObservationConventionTests {
 				KeyValue.of(HighCardinalityKeyNames.CHAT_CLIENT_CONVERSATION_ID.asString(), "007"),
 				KeyValue.of(HighCardinalityKeyNames.CHAT_CLIENT_TOOL_NAMES.asString(), """
 						["toolCallback1", "toolCallback2"]"""));
+		assertThat(HighCardinalityKeyNames.CHAT_CLIENT_CONVERSATION_ID.asString()).isEqualTo("gen_ai.conversation.id");
 	}
 
 }

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
@@ -39,6 +39,10 @@ public enum AiObservationAttributes {
 	 * The model provider as identified by the client instrumentation.
 	 */
 	AI_PROVIDER("gen_ai.system"),
+	/**
+	 * The unique identifier for the conversation.
+	 */
+	CONVERSATION_ID("gen_ai.conversation.id"),
 
 	// GenAI Request
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
@@ -35,14 +35,26 @@ public class ChatModelObservationContext extends ModelObservationContext<Prompt,
 
 	private final boolean streaming;
 
-	ChatModelObservationContext(Prompt prompt, String provider, boolean streaming) {
+	private final @Nullable String conversationId;
+
+	ChatModelObservationContext(Prompt prompt, String provider, boolean streaming, @Nullable String conversationId) {
 		super(prompt,
 				AiOperationMetadata.builder().operationType(AiOperationType.CHAT.value()).provider(provider).build());
 		this.streaming = streaming;
+		this.conversationId = conversationId;
 	}
 
 	public boolean isStreaming() {
 		return this.streaming;
+	}
+
+	/**
+	 * Return the unique identifier for the conversation, if available.
+	 * @return the conversation identifier, or {@code null}
+	 * @since 2.0.1
+	 */
+	public @Nullable String getConversationId() {
+		return this.conversationId;
 	}
 
 	public static Builder builder() {
@@ -56,6 +68,8 @@ public class ChatModelObservationContext extends ModelObservationContext<Prompt,
 		private @Nullable String provider;
 
 		private boolean streaming;
+
+		private @Nullable String conversationId;
 
 		private Builder() {
 		}
@@ -75,10 +89,21 @@ public class ChatModelObservationContext extends ModelObservationContext<Prompt,
 			return this;
 		}
 
+		/**
+		 * Configure the unique identifier for the conversation.
+		 * @param conversationId the conversation identifier
+		 * @return this builder
+		 * @since 2.0.1
+		 */
+		public Builder conversationId(@Nullable String conversationId) {
+			this.conversationId = conversationId;
+			return this;
+		}
+
 		public ChatModelObservationContext build() {
 			Assert.state(this.prompt != null, "Prompt must not be null");
 			Assert.state(this.provider != null, "Provider must not be null");
-			return new ChatModelObservationContext(this.prompt, this.provider, this.streaming);
+			return new ChatModelObservationContext(this.prompt, this.provider, this.streaming, this.conversationId);
 		}
 
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationDocumentation.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationDocumentation.java
@@ -102,6 +102,16 @@ public enum ChatModelObservationDocumentation implements ObservationDocumentatio
 	public enum HighCardinalityKeyNames implements KeyName {
 
 		/**
+		 * The unique identifier for the conversation.
+		 */
+		CONVERSATION_ID {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.CONVERSATION_ID.value();
+			}
+		},
+
+		/**
 		 * The frequency penalty setting for the model request.
 		 */
 		REQUEST_FREQUENCY_PENALTY {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
@@ -95,6 +95,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 	@Override
 	public KeyValues getHighCardinalityKeyValues(ChatModelObservationContext context) {
 		var keyValues = KeyValues.empty();
+		keyValues = conversationId(keyValues, context);
 		// Request
 		keyValues = requestFrequencyPenalty(keyValues, context);
 		keyValues = requestMaxTokens(keyValues, context);
@@ -113,6 +114,14 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 		keyValues = usageInputTokens(keyValues, context);
 		keyValues = usageOutputTokens(keyValues, context);
 		keyValues = usageTotalTokens(keyValues, context);
+		return keyValues;
+	}
+
+	protected KeyValues conversationId(KeyValues keyValues, ChatModelObservationContext context) {
+		if (StringUtils.hasText(context.getConversationId())) {
+			return keyValues.and(ChatModelObservationDocumentation.HighCardinalityKeyNames.CONVERSATION_ID.asString(),
+					context.getConversationId());
+		}
 		return keyValues;
 	}
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelObservationContextTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelObservationContextTests.java
@@ -72,6 +72,27 @@ class ChatModelObservationContextTests {
 		assertThat(observationContext.isStreaming()).isFalse();
 	}
 
+	@Test
+	void whenConversationIdSetThenReturn() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.conversationId("conversation-42")
+			.build();
+
+		assertThat(observationContext.getConversationId()).isEqualTo("conversation-42");
+	}
+
+	@Test
+	void whenConversationIdNotSetThenReturnNull() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.build();
+
+		assertThat(observationContext.getConversationId()).isNull();
+	}
+
 	private Prompt generatePrompt(ChatOptions chatOptions) {
 		return new Prompt("hello", chatOptions);
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
@@ -145,7 +145,8 @@ class DefaultChatModelObservationConventionTests {
 		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext)
 			.stream()
 			.map(KeyValue::getKey)
-			.toList()).doesNotContain(HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString(),
+			.toList()).doesNotContain(HighCardinalityKeyNames.CONVERSATION_ID.asString(),
+					HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString(),
 					HighCardinalityKeyNames.REQUEST_MAX_TOKENS.asString(),
 					HighCardinalityKeyNames.REQUEST_PRESENCE_PENALTY.asString(),
 					HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString(),
@@ -189,6 +190,18 @@ class DefaultChatModelObservationConventionTests {
 			.build();
 		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext))
 			.contains(KeyValue.of(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true"));
+	}
+
+	@Test
+	void shouldHaveConversationIdWhenDefined() {
+		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))
+			.provider("superprovider")
+			.conversationId("conversation-42")
+			.build();
+
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext))
+			.contains(KeyValue.of(HighCardinalityKeyNames.CONVERSATION_ID.asString(), "conversation-42"));
 	}
 
 	@Test


### PR DESCRIPTION
Expose the OpenTelemetry `gen_ai.conversation.id` attribute for chat observations.

This change:

- adds the standard conversation ID key to `AiObservationAttributes`
- updates the existing ChatClient conversation attribute so advisor-provided conversation IDs are emitted automatically under the standard key
- adds optional conversation ID support to `ChatModelObservationContext`
- emits the ID from the default chat model observation convention
- covers configured, missing, and automatically propagated conversation IDs with focused tests

Validation:

- `./mvnw -Dmaven.build.cache.enabled=false -pl spring-ai-client-chat -am -DskipTests process-sources -q`
- `./mvnw -Dmaven.build.cache.enabled=false -pl spring-ai-client-chat -am -Dtest=ChatModelObservationContextTests,DefaultChatModelObservationConventionTests,DefaultChatClientObservationConventionTests -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `git diff --check`

Fixes #6669