### PR TITLE
Use current GenAI provider attribute

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
@@ -22,8 +22,9 @@ package org.springframework.ai.observation.conventions;
  *
  * @author Thomas Vitale
  * @since 1.0.0
- * @see <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai">OpenTelemetry
- * Semantic Conventions for Generative AI</a>.
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions-genai">OpenTelemetry Semantic
+ * Conventions for Generative AI</a>.
  */
 public enum AiObservationAttributes {
 
@@ -36,9 +37,9 @@ public enum AiObservationAttributes {
 	 */
 	AI_OPERATION_TYPE("gen_ai.operation.name"),
 	/**
-	 * The model provider as identified by the client instrumentation.
+	 * The Generative AI provider as identified by the client instrumentation.
 	 */
-	AI_PROVIDER("gen_ai.system"),
+	AI_PROVIDER("gen_ai.provider.name"),
 
 	// GenAI Request
 

--- a/spring-ai-commons/src/test/java/org/springframework/ai/observation/conventions/AiObservationAttributesTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/observation/conventions/AiObservationAttributesTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.observation.conventions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AiObservationAttributes}.
+ *
+ * @author Fatan
+ */
+class AiObservationAttributesTests {
+
+	@Test
+	void aiProviderShouldUseCurrentOpenTelemetryAttributeName() {
+		assertThat(AiObservationAttributes.AI_PROVIDER.value()).isEqualTo("gen_ai.provider.name");
+	}
+
+}


### PR DESCRIPTION
Replace the deprecated OpenTelemetry GenAI provider attribute `gen_ai.system` with `gen_ai.provider.name`.

The Java enum constant remains unchanged, while its emitted telemetry value is updated centrally. This applies the new key consistently to chat, embedding, image, tool-calling, ChatClient, advisor, span, and metric conventions.

This change also updates the semantic-conventions reference and adds a direct regression test for the emitted attribute name.

Validation:

- `./mvnw -Dmaven.build.cache.enabled=false -pl spring-ai-client-chat -am -DskipTests process-sources -q`
- focused tests for `AiObservationAttributes` and all affected default observation conventions
- `git diff --check`

Fixes #6668