### PR TITLE
Align FactCheckingEvaluator builder API and add PromptTemplate support

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
@@ -95,6 +95,17 @@ public class FactCheckingEvaluator implements Evaluator {
 	private final String evaluationPrompt;
 
 	/**
+	 * Constructs a new FactCheckingEvaluator with the provided ChatClient.Builder, using
+	 * the default evaluation prompt.
+	 * @param chatClientBuilder the builder for the ChatClient used to perform the
+	 * evaluation
+	 * @since 2.0.0
+	 */
+	public FactCheckingEvaluator(ChatClient.Builder chatClientBuilder) {
+		this(chatClientBuilder, null);
+	}
+
+	/**
 	 * Constructs a new FactCheckingEvaluator with the provided ChatClient.Builder and
 	 * evaluation prompt.
 	 * @param chatClientBuilder The builder for the ChatClient used to perform the

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
@@ -17,10 +17,12 @@
 package org.springframework.ai.chat.evaluation;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.evaluation.EvaluationRequest;
 import org.springframework.ai.evaluation.EvaluationResponse;
 import org.springframework.ai.evaluation.Evaluator;
@@ -71,7 +73,7 @@ import org.springframework.util.Assert;
  */
 public class FactCheckingEvaluator implements Evaluator {
 
-	private static final String DEFAULT_EVALUATION_PROMPT_TEXT = """
+	private static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = new PromptTemplate("""
 				Evaluate whether or not the following claim is supported by the provided document.
 				Respond with "yes" if the claim is supported, or "no" if it is not.
 
@@ -80,19 +82,19 @@ public class FactCheckingEvaluator implements Evaluator {
 
 				Claim:
 				{claim}
-			""";
+			""");
 
-	private static final String BESPOKE_EVALUATION_PROMPT_TEXT = """
+	private static final PromptTemplate BESPOKE_PROMPT_TEMPLATE = new PromptTemplate("""
 				Document:
 				{document}
 
 				Claim:
 				{claim}
-			""";
+			""");
 
 	private final ChatClient.Builder chatClientBuilder;
 
-	private final String evaluationPrompt;
+	private final PromptTemplate promptTemplate;
 
 	/**
 	 * Constructs a new FactCheckingEvaluator with the provided ChatClient.Builder, using
@@ -102,41 +104,48 @@ public class FactCheckingEvaluator implements Evaluator {
 	 * @since 2.0.0
 	 */
 	public FactCheckingEvaluator(ChatClient.Builder chatClientBuilder) {
-		this(chatClientBuilder, null);
+		this(chatClientBuilder, DEFAULT_PROMPT_TEMPLATE);
 	}
 
 	/**
 	 * Constructs a new FactCheckingEvaluator with the provided ChatClient.Builder and
 	 * evaluation prompt.
-	 * @param chatClientBuilder The builder for the ChatClient used to perform the
+	 * @param chatClientBuilder the builder for the ChatClient used to perform the
 	 * evaluation
-	 * @param evaluationPrompt The prompt text to use for evaluation
+	 * @param evaluationPrompt the prompt text to use for evaluation
 	 */
 	protected FactCheckingEvaluator(ChatClient.Builder chatClientBuilder, @Nullable String evaluationPrompt) {
+		this(chatClientBuilder,
+				evaluationPrompt != null ? new PromptTemplate(evaluationPrompt) : DEFAULT_PROMPT_TEMPLATE);
+	}
+
+	private FactCheckingEvaluator(ChatClient.Builder chatClientBuilder, PromptTemplate promptTemplate) {
 		Assert.notNull(chatClientBuilder, "chatClientBuilder cannot be null");
+		Assert.notNull(promptTemplate, "promptTemplate cannot be null");
 		this.chatClientBuilder = chatClientBuilder;
-		this.evaluationPrompt = evaluationPrompt != null ? evaluationPrompt : DEFAULT_EVALUATION_PROMPT_TEXT;
+		this.promptTemplate = promptTemplate;
 	}
 
 	/**
 	 * Creates a FactCheckingEvaluator configured for use with the Bespoke Minicheck
 	 * model.
-	 * @param chatClientBuilder The builder for the ChatClient used to perform the
+	 * @param chatClientBuilder the builder for the ChatClient used to perform the
 	 * evaluation
-	 * @return A FactCheckingEvaluator configured for Bespoke Minicheck
+	 * @return a FactCheckingEvaluator configured for Bespoke Minicheck
 	 */
 	public static FactCheckingEvaluator forBespokeMinicheck(ChatClient.Builder chatClientBuilder) {
-		return FactCheckingEvaluator.builder(chatClientBuilder)
-			.evaluationPrompt(BESPOKE_EVALUATION_PROMPT_TEXT)
+		return FactCheckingEvaluator.builder()
+			.chatClientBuilder(chatClientBuilder)
+			.promptTemplate(BESPOKE_PROMPT_TEMPLATE)
 			.build();
 	}
 
 	/**
 	 * Evaluates whether the response content in the EvaluationRequest is factually
 	 * supported by the context provided in the same request.
-	 * @param evaluationRequest The request containing the response to be evaluated and
+	 * @param evaluationRequest the request containing the response to be evaluated and
 	 * the supporting context
-	 * @return An EvaluationResponse indicating whether the claim is supported by the
+	 * @return an EvaluationResponse indicating whether the claim is supported by the
 	 * document
 	 */
 	@Override
@@ -144,26 +153,44 @@ public class FactCheckingEvaluator implements Evaluator {
 		var response = evaluationRequest.getResponseContent();
 		var context = doGetSupportingData(evaluationRequest);
 
-		String evaluationResponse = this.chatClientBuilder.build()
-			.prompt()
-			.user(userSpec -> userSpec.text(this.evaluationPrompt).param("document", context).param("claim", response))
-			.call()
-			.content();
+		var userMessage = this.promptTemplate.render(Map.of("document", context, "claim", response));
+
+		String evaluationResponse = this.chatClientBuilder.build().prompt().user(userMessage).call().content();
 
 		String normalizedResponse = (evaluationResponse != null) ? evaluationResponse.strip() : "";
 		boolean passing = "yes".equalsIgnoreCase(normalizedResponse);
 		return new EvaluationResponse(passing, "", Collections.emptyMap());
 	}
 
-	public static FactCheckingEvaluator.Builder builder(ChatClient.Builder chatClientBuilder) {
-		return new FactCheckingEvaluator.Builder().chatClientBuilder(chatClientBuilder);
+	/**
+	 * Creates a builder for a FactCheckingEvaluator.
+	 * @return a new builder
+	 * @since 2.0.0
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Creates a builder initialized with a ChatClient.Builder.
+	 * @param chatClientBuilder the builder for the ChatClient used to perform the
+	 * evaluation
+	 * @return a new builder
+	 * @deprecated use {@link #builder()} followed by
+	 * {@link Builder#chatClientBuilder(ChatClient.Builder)} instead
+	 */
+	@Deprecated(since = "2.0.0")
+	public static Builder builder(ChatClient.Builder chatClientBuilder) {
+		return builder().chatClientBuilder(chatClientBuilder);
 	}
 
 	public static final class Builder {
 
 		private ChatClient.@Nullable Builder chatClientBuilder;
 
-		private @Nullable String evaluationPrompt = DEFAULT_EVALUATION_PROMPT_TEXT;
+		private @Nullable PromptTemplate promptTemplate;
+
+		private boolean legacyEvaluationPromptConfigured;
 
 		private Builder() {
 		}
@@ -173,15 +200,37 @@ public class FactCheckingEvaluator implements Evaluator {
 			return this;
 		}
 
-		public FactCheckingEvaluator.Builder evaluationPrompt(String evaluationPrompt) {
-			this.evaluationPrompt = evaluationPrompt;
+		/**
+		 * Configures the template used to evaluate factual accuracy.
+		 * @param promptTemplate the prompt template
+		 * @return this builder
+		 * @since 2.0.0
+		 */
+		public FactCheckingEvaluator.Builder promptTemplate(PromptTemplate promptTemplate) {
+			this.promptTemplate = promptTemplate;
+			this.legacyEvaluationPromptConfigured = false;
+			return this;
+		}
+
+		/**
+		 * Configures the prompt text used to evaluate factual accuracy.
+		 * @param evaluationPrompt the evaluation prompt
+		 * @return this builder
+		 * @deprecated use {@link #promptTemplate(PromptTemplate)} instead
+		 */
+		@Deprecated(since = "2.0.0")
+		public FactCheckingEvaluator.Builder evaluationPrompt(@Nullable String evaluationPrompt) {
+			this.promptTemplate = evaluationPrompt != null ? new PromptTemplate(evaluationPrompt) : null;
+			this.legacyEvaluationPromptConfigured = true;
 			return this;
 		}
 
 		public FactCheckingEvaluator build() {
 			Assert.state(this.chatClientBuilder != null, "ChatClientBuilder cannot be null");
-			Assert.state(this.evaluationPrompt != null, "EvaluationPrompt cannot be null");
-			return new FactCheckingEvaluator(this.chatClientBuilder, this.evaluationPrompt);
+			Assert.state(!this.legacyEvaluationPromptConfigured || this.promptTemplate != null,
+					"EvaluationPrompt cannot be null");
+			PromptTemplate promptTemplate = this.promptTemplate != null ? this.promptTemplate : DEFAULT_PROMPT_TEMPLATE;
+			return new FactCheckingEvaluator(this.chatClientBuilder, promptTemplate);
 		}
 
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluatorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluatorTests.java
@@ -105,4 +105,17 @@ class FactCheckingEvaluatorTests {
 		assertThat(result.isPass()).isFalse();
 	}
 
+	@Test
+	void whenCreatedWithChatClientBuilderThenEvaluatorIsCreated() {
+		FactCheckingEvaluator evaluator = new FactCheckingEvaluator(ChatClient.builder(mock(ChatModel.class)));
+
+		assertThat(evaluator).isNotNull();
+	}
+
+	@Test
+	void whenConstructorChatClientBuilderIsNullThenThrow() {
+		assertThatThrownBy(() -> new FactCheckingEvaluator(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("chatClientBuilder cannot be null");
+	}
+
 }

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluatorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluatorTests.java
@@ -34,6 +34,8 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.document.Document;
 import org.springframework.ai.evaluation.EvaluationRequest;
 import org.springframework.ai.evaluation.EvaluationResponse;
 
@@ -79,6 +81,7 @@ class FactCheckingEvaluatorTests {
 		assertThat(evaluator).isNotNull();
 	}
 
+	@SuppressWarnings("deprecation")
 	@ParameterizedTest
 	@ValueSource(strings = { "yes", " yes", "yes ", " yes ", "YES", " YES\n", "\tYes\t" })
 	void whenEvaluationResponseIsYesWithWhitespaceThenPass(String response) {
@@ -92,6 +95,7 @@ class FactCheckingEvaluatorTests {
 		assertThat(result.isPass()).isTrue();
 	}
 
+	@SuppressWarnings("deprecation")
 	@ParameterizedTest
 	@ValueSource(strings = { "no", " no ", "yes and more", "maybe" })
 	void whenEvaluationResponseIsNotYesThenFail(String response) {
@@ -116,6 +120,93 @@ class FactCheckingEvaluatorTests {
 	void whenConstructorChatClientBuilderIsNullThenThrow() {
 		assertThatThrownBy(() -> new FactCheckingEvaluator(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("chatClientBuilder cannot be null");
+	}
+
+	@Test
+	void whenCreatedWithNewBuilderThenEvaluatorIsCreated() {
+		FactCheckingEvaluator evaluator = FactCheckingEvaluator.builder()
+			.chatClientBuilder(ChatClient.builder(mock(ChatModel.class)))
+			.build();
+
+		assertThat(evaluator).isNotNull();
+	}
+
+	@Test
+	void whenNewBuilderChatClientBuilderIsNullThenThrow() {
+		assertThatThrownBy(() -> FactCheckingEvaluator.builder().build()).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("ChatClientBuilder cannot be null");
+	}
+
+	@Test
+	void whenPromptTemplateIsConfiguredThenUseIt() {
+		given(this.chatModel.call(this.promptCaptor.capture()))
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("yes")))));
+		given(this.chatModel.getOptions()).willReturn(ChatOptions.builder().build());
+
+		PromptTemplate promptTemplate = new PromptTemplate("""
+				Custom fact check
+				Document: {document}
+				Claim: {claim}
+				""");
+		FactCheckingEvaluator evaluator = FactCheckingEvaluator.builder()
+			.chatClientBuilder(ChatClient.builder(this.chatModel))
+			.promptTemplate(promptTemplate)
+			.build();
+
+		evaluator
+			.evaluate(new EvaluationRequest("query", List.of(new Document("supporting context")), "response content"));
+
+		assertThat(this.promptCaptor.getValue().getContents()).contains("Custom fact check", "supporting context",
+				"response content");
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	void whenLegacyEvaluationPromptIsConfiguredThenUseIt() {
+		given(this.chatModel.call(this.promptCaptor.capture()))
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("yes")))));
+		given(this.chatModel.getOptions()).willReturn(ChatOptions.builder().build());
+
+		FactCheckingEvaluator evaluator = FactCheckingEvaluator.builder(ChatClient.builder(this.chatModel))
+			.evaluationPrompt("""
+					Legacy fact check
+					Document: {document}
+					Claim: {claim}
+					""")
+			.build();
+
+		evaluator
+			.evaluate(new EvaluationRequest("query", List.of(new Document("supporting context")), "response content"));
+
+		assertThat(this.promptCaptor.getValue().getContents()).contains("Legacy fact check", "supporting context",
+				"response content");
+	}
+
+	@Test
+	void whenProtectedStringConstructorIsUsedThenUsePrompt() {
+		given(this.chatModel.call(this.promptCaptor.capture()))
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("yes")))));
+		given(this.chatModel.getOptions()).willReturn(ChatOptions.builder().build());
+
+		FactCheckingEvaluator evaluator = new FactCheckingEvaluator(ChatClient.builder(this.chatModel), """
+				Protected constructor fact check
+				Document: {document}
+				Claim: {claim}
+				""");
+
+		evaluator
+			.evaluate(new EvaluationRequest("query", List.of(new Document("supporting context")), "response content"));
+
+		assertThat(this.promptCaptor.getValue().getContents()).contains("Protected constructor fact check",
+				"supporting context", "response content");
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	void whenLegacyEvaluationPromptIsNullThenThrow() {
+		assertThatThrownBy(() -> FactCheckingEvaluator.builder(ChatClient.builder(mock(ChatModel.class)))
+			.evaluationPrompt(null)
+			.build()).isInstanceOf(IllegalStateException.class).hasMessageContaining("EvaluationPrompt cannot be null");
 	}
 
 }


### PR DESCRIPTION
## Dependency

This pull request is stacked on #6671 and temporarily includes its constructor commit.

PR #6671 adds the public constructor currently shown in the Spring AI documentation. After it is merged, this branch will be rebased onto `main` so this pull request contains only the builder and prompt-configuration changes. Until then, those changes are isolated in the second commit.

## Summary

Aligns the `FactCheckingEvaluator` builder API with `RelevancyEvaluator` and adds direct `PromptTemplate` configuration.

The preferred configuration becomes:

```java
FactCheckingEvaluator.builder()
	.chatClientBuilder(chatClientBuilder)
	.promptTemplate(promptTemplate)
	.build();
```

## Motivation

`FactCheckingEvaluator` currently differs from `RelevancyEvaluator` in two related ways:

- Its builder requires a `ChatClient.Builder` when the builder is created.
- Custom evaluation prompts are configured as raw strings rather than `PromptTemplate` instances.

Using the same builder shape makes the evaluators more consistent, while `PromptTemplate` provides the appropriate abstraction for prompts containing the `{document}` and `{claim}` variables.

The default and Bespoke MiniCheck prompts are now also represented internally as `PromptTemplate` instances.

## Backward compatibility

Existing API signatures remain available.

The following entry points are deprecated with migration guidance:

- `builder(ChatClient.Builder)`
- `evaluationPrompt(String)`

Existing string prompts are adapted internally to `PromptTemplate`.

The protected constructor accepting a string prompt remains supported and nondeprecated because it is part of the subclassing API, and the builder is not an equivalent replacement for subclasses.

## Testing

- Preserved coverage for the existing builder API.
- Added coverage for the zero-argument builder.
- Added coverage for custom `PromptTemplate` configuration.
- Added coverage for the deprecated string-prompt path.
- Added coverage for the protected string-prompt constructor.
- Preserved null-validation behavior.
- Ran `FactCheckingEvaluatorTests` successfully.