### PR TITLE
Add MCP tool callback converter property metadata

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
@@ -57,6 +57,12 @@ public class McpServerProperties {
 	private boolean enabled = true;
 
 	/**
+	 * Enable/disable the conversion of Spring AI ToolCallbacks into MCP Tool
+	 * specifications. Defaults to true.
+	 */
+	private boolean toolCallbackConverter = true;
+
+	/**
 	 * Enable/disable the standard input/output (stdio) transport.
 	 * <p>
 	 * When enabled, the server will listen for incoming messages on the standard input
@@ -175,6 +181,14 @@ public class McpServerProperties {
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	public boolean isToolCallbackConverter() {
+		return this.toolCallbackConverter;
+	}
+
+	public void setToolCallbackConverter(boolean toolCallbackConverter) {
+		this.toolCallbackConverter = toolCallbackConverter;
 	}
 
 	public String getName() {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
@@ -90,6 +90,7 @@ public class McpServerAutoConfigurationIT {
 			assertThat(properties.getVersion()).isEqualTo("1.0.0");
 			assertThat(properties.getType()).isEqualTo(McpServerProperties.ApiType.SYNC);
 			assertThat(properties.getRequestTimeout().getSeconds()).isEqualTo(20);
+			assertThat(properties.isToolCallbackConverter()).isTrue();
 
 			// Check capabilities
 			assertThat(properties.getCapabilities().isTool()).isTrue();
@@ -103,6 +104,14 @@ public class McpServerAutoConfigurationIT {
 			assertThat(changeNotificationProperties.isResourceChangeNotification()).isTrue();
 			assertThat(changeNotificationProperties.isPromptChangeNotification()).isTrue();
 
+		});
+	}
+
+	@Test
+	void toolCallbackConverterConfiguration() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.tool-callback-converter=false").run(context -> {
+			McpServerProperties properties = context.getBean(McpServerProperties.class);
+			assertThat(properties.isToolCallbackConverter()).isFalse();
 		});
 	}
 


### PR DESCRIPTION
Fixes #6663

## Problem

`spring.ai.mcp.server.tool-callback-converter` is referenced by both tool callback converter auto-configurations:

- `ToolCallbackConverterAutoConfiguration`
- `StatelessToolCallbackConverterAutoConfiguration`

Both conditions use `matchIfMissing = true`, so the runtime behavior already defaults to enabling tool callback conversion.

However, `McpServerProperties` did not expose a matching JavaBean property. As a result, the Spring Boot configuration processor could not include `spring.ai.mcp.server.tool-callback-converter` in the generated `spring-configuration-metadata.json`.

Configuration metadata consumers such as IntelliJ IDEA and VS Code therefore treated the property as unknown and could not provide completion, type information, or its default value.

## Changes

Add the missing property to `McpServerProperties`:

```java
private boolean toolCallbackConverter = true;

public boolean isToolCallbackConverter() {
	return this.toolCallbackConverter;
}

public void setToolCallbackConverter(boolean toolCallbackConverter) {
	this.toolCallbackConverter = toolCallbackConverter;
}
```

The default value of `true` remains consistent with the existing `matchIfMissing = true` conditions.

This change does not modify:

- `McpServerProperties.CONFIG_PREFIX`
- Existing `@ConditionalOnProperty` declarations
- Tool callback registration or conversion behavior
- Other MCP server configuration properties

The existing property conditions remain responsible for enabling or disabling the auto-configurations before configuration property beans are created.

## Tests

Updated `McpServerAutoConfigurationIT` to verify:

- `toolCallbackConverter` defaults to `true`
- `spring.ai.mcp.server.tool-callback-converter=false` binds to `false`

Existing tests continue to verify that synchronous, asynchronous, and stateless tool callback converter auto-configurations:

- Are enabled when the property is absent
- Are enabled when the property is `true`
- Are disabled when the property is `false`

The targeted test suite completed successfully:

```text
Tests run: 55, Failures: 0, Errors: 0, Skipped: 0
```

## Generated Metadata

After compilation, the generated `spring-configuration-metadata.json` contains:

```json
{
  "name": "spring.ai.mcp.server.tool-callback-converter",
  "type": "java.lang.Boolean",
  "description": "Enable/disable the conversion of Spring AI ToolCallbacks into MCP Tool specifications. Defaults to true.",
  "sourceType": "org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties",
  "defaultValue": true
}
```

The generated metadata file itself is not committed.

## Verification

The following targeted tests were run:

```shell
./mvnw -pl auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common \
  -Dtest=McpServerAutoConfigurationIT,ToolCallbackConverterAutoConfigurationIT,StatelessToolCallbackConverterAutoConfigurationIT \
  test
```

The module and its required dependencies were also compiled to generate and inspect the configuration metadata:

```shell
./mvnw -pl auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common \
  -am -DskipTests compile
```

Checkstyle completed with no violations.