### PR TITLE
Preserve cache usage metadata in MessageAggregator

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -70,6 +71,9 @@ public class MessageAggregator {
 		AtomicReference<Integer> metadataUsagePromptTokensRef = new AtomicReference<>(0);
 		AtomicReference<Integer> metadataUsageGenerationTokensRef = new AtomicReference<>(0);
 		AtomicReference<Integer> metadataUsageTotalTokensRef = new AtomicReference<>(0);
+		AtomicReference<@Nullable Long> metadataUsageCacheReadInputTokensRef = new AtomicReference<>();
+		AtomicReference<@Nullable Long> metadataUsageCacheWriteInputTokensRef = new AtomicReference<>();
+		AtomicReference<@Nullable Object> metadataNativeUsageRef = new AtomicReference<>();
 
 		AtomicReference<PromptMetadata> metadataPromptMetadataRef = new AtomicReference<>(PromptMetadata.empty());
 		AtomicReference<RateLimit> metadataRateLimitRef = new AtomicReference<>(new EmptyRateLimit());
@@ -88,6 +92,9 @@ public class MessageAggregator {
 			metadataUsagePromptTokensRef.set(0);
 			metadataUsageGenerationTokensRef.set(0);
 			metadataUsageTotalTokensRef.set(0);
+			metadataUsageCacheReadInputTokensRef.set(null);
+			metadataUsageCacheWriteInputTokensRef.set(null);
+			metadataNativeUsageRef.set(null);
 			metadataPromptMetadataRef.set(PromptMetadata.empty());
 			metadataRateLimitRef.set(new EmptyRateLimit());
 
@@ -129,6 +136,15 @@ public class MessageAggregator {
 							: metadataUsageGenerationTokensRef.get());
 					metadataUsageTotalTokensRef
 						.set(usage.getTotalTokens() > 0 ? usage.getTotalTokens() : metadataUsageTotalTokensRef.get());
+					if (usage.getCacheReadInputTokens() != null) {
+						metadataUsageCacheReadInputTokensRef.set(usage.getCacheReadInputTokens());
+					}
+					if (usage.getCacheWriteInputTokens() != null) {
+						metadataUsageCacheWriteInputTokensRef.set(usage.getCacheWriteInputTokens());
+					}
+					if (usage.getNativeUsage() != null) {
+						metadataNativeUsageRef.set(usage.getNativeUsage());
+					}
 				}
 				if (chatResponse.getMetadata().getPromptMetadata() != null
 						&& chatResponse.getMetadata().getPromptMetadata().iterator().hasNext()) {
@@ -154,8 +170,10 @@ public class MessageAggregator {
 			}
 		}).doOnComplete(() -> {
 
-			var usage = new DefaultUsage(metadataUsagePromptTokensRef.get(), metadataUsageGenerationTokensRef.get(),
-					metadataUsageTotalTokensRef.get());
+			var usage = new org.springframework.ai.chat.metadata.DefaultUsage(metadataUsagePromptTokensRef.get(),
+					metadataUsageGenerationTokensRef.get(), metadataUsageTotalTokensRef.get(),
+					metadataNativeUsageRef.get(), metadataUsageCacheReadInputTokensRef.get(),
+					metadataUsageCacheWriteInputTokensRef.get());
 
 			var chatResponseMetadata = ChatResponseMetadata.builder()
 				.id(metadataIdRef.get())
@@ -201,6 +219,9 @@ public class MessageAggregator {
 			metadataUsagePromptTokensRef.set(0);
 			metadataUsageGenerationTokensRef.set(0);
 			metadataUsageTotalTokensRef.set(0);
+			metadataUsageCacheReadInputTokensRef.set(null);
+			metadataUsageCacheWriteInputTokensRef.set(null);
+			metadataNativeUsageRef.set(null);
 			metadataPromptMetadataRef.set(PromptMetadata.empty());
 			metadataRateLimitRef.set(new EmptyRateLimit());
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
@@ -25,8 +25,10 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.metadata.EmptyRateLimit;
 import org.springframework.ai.chat.metadata.RateLimit;
+import org.springframework.ai.chat.metadata.Usage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,8 +62,60 @@ class MessageAggregatorTests {
 		assertThat(aggregated.get().getMetadata().getRateLimit()).isInstanceOf(EmptyRateLimit.class);
 	}
 
+	@Test
+	void usageMetadataSurvivesAggregation() {
+		Object nativeUsage = new Object();
+		Usage usage = new DefaultUsage(10, 5, 15, nativeUsage, 42L, 7L);
+		Flux<ChatResponse> responses = Flux.just(chunk("Hello", usage));
+
+		AtomicReference<ChatResponse> aggregated = new AtomicReference<>();
+		new MessageAggregator().aggregate(responses, aggregated::set).blockLast();
+
+		Usage aggregatedUsage = aggregated.get().getMetadata().getUsage();
+		assertThat(aggregatedUsage.getPromptTokens()).isEqualTo(10);
+		assertThat(aggregatedUsage.getCompletionTokens()).isEqualTo(5);
+		assertThat(aggregatedUsage.getTotalTokens()).isEqualTo(15);
+		assertThat(aggregatedUsage.getCacheReadInputTokens()).isEqualTo(42L);
+		assertThat(aggregatedUsage.getCacheWriteInputTokens()).isEqualTo(7L);
+		assertThat(aggregatedUsage.getNativeUsage()).isSameAs(nativeUsage);
+	}
+
+	@Test
+	void lastReportedUsageMetadataWins() {
+		Object firstNativeUsage = new Object();
+		Object lastNativeUsage = new Object();
+		Flux<ChatResponse> responses = Flux.just(chunk("Hello", new DefaultUsage(10, 5, 15, firstNativeUsage, 20L, 3L)),
+				chunk(" ", new DefaultUsage(0, 0, 0)),
+				chunk("world", new DefaultUsage(12, 8, 20, lastNativeUsage, 42L, 7L)));
+
+		AtomicReference<ChatResponse> aggregated = new AtomicReference<>();
+		new MessageAggregator().aggregate(responses, aggregated::set).blockLast();
+
+		Usage aggregatedUsage = aggregated.get().getMetadata().getUsage();
+		assertThat(aggregatedUsage.getCacheReadInputTokens()).isEqualTo(42L);
+		assertThat(aggregatedUsage.getCacheWriteInputTokens()).isEqualTo(7L);
+		assertThat(aggregatedUsage.getNativeUsage()).isSameAs(lastNativeUsage);
+	}
+
+	@Test
+	void cacheUsageRemainsNullWhenNoChunkReportsIt() {
+		Flux<ChatResponse> responses = Flux.just(chunk("Hello", new DefaultUsage(10, 5, 15)));
+
+		AtomicReference<ChatResponse> aggregated = new AtomicReference<>();
+		new MessageAggregator().aggregate(responses, aggregated::set).blockLast();
+
+		Usage aggregatedUsage = aggregated.get().getMetadata().getUsage();
+		assertThat(aggregatedUsage.getCacheReadInputTokens()).isNull();
+		assertThat(aggregatedUsage.getCacheWriteInputTokens()).isNull();
+	}
+
 	private static ChatResponse chunk(String text, RateLimit rateLimit) {
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().rateLimit(rateLimit).build();
+		return new ChatResponse(List.of(new Generation(new AssistantMessage(text))), metadata);
+	}
+
+	private static ChatResponse chunk(String text, Usage usage) {
+		ChatResponseMetadata metadata = ChatResponseMetadata.builder().usage(usage).build();
 		return new ChatResponse(List.of(new Generation(new AssistantMessage(text))), metadata);
 	}
 


### PR DESCRIPTION
## Summary

- preserve cache read and cache write input token counts when aggregating streaming chat responses
- preserve the provider-native usage object in the aggregated response
- retain the last non-null cache/native usage value reported by streaming chunks
- add regression tests for preservation, multiple chunks, and absent cache metrics

## Testing

- `./mvnw.cmd -pl spring-ai-model -Dtest=MessageAggregatorTests test`

Closes [#6667](https://github.com/spring-projects/spring-ai/issues/6667)
