### PR TITLE
Reject lossy `int` and `long` conversions in `@McpPrompt`

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AbstractMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AbstractMcpPromptMethodCallback.java
@@ -17,6 +17,8 @@
 package org.springframework.ai.mcp.annotation.method.prompt;
 
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -293,7 +295,7 @@ public abstract class AbstractMcpPromptMethodCallback {
 		}
 		else if (targetType == Integer.class || targetType == int.class) {
 			if (value instanceof Number) {
-				return ((Number) value).intValue();
+				return this.toIntegerExact((Number) value);
 			}
 			else {
 				return Integer.parseInt(value.toString());
@@ -301,7 +303,7 @@ public abstract class AbstractMcpPromptMethodCallback {
 		}
 		else if (targetType == Long.class || targetType == long.class) {
 			if (value instanceof Number) {
-				return ((Number) value).longValue();
+				return this.toLongExact((Number) value);
 			}
 			else {
 				return Long.parseLong(value.toString());
@@ -326,6 +328,42 @@ public abstract class AbstractMcpPromptMethodCallback {
 
 		// For other types, return as is and hope for the best
 		return value;
+	}
+
+	private int toIntegerExact(Number value) {
+		try {
+			return this.toBigDecimal(value).intValueExact();
+		}
+		catch (ArithmeticException | NumberFormatException ex) {
+			throw new IllegalArgumentException("Cannot safely convert numeric value '" + value + "' to int", ex);
+		}
+	}
+
+	private long toLongExact(Number value) {
+		try {
+			return this.toBigDecimal(value).longValueExact();
+		}
+		catch (ArithmeticException | NumberFormatException ex) {
+			throw new IllegalArgumentException("Cannot safely convert numeric value '" + value + "' to long", ex);
+		}
+	}
+
+	private BigDecimal toBigDecimal(Number value) {
+		if (value instanceof BigDecimal bigDecimal) {
+			return bigDecimal;
+		}
+		if (value instanceof BigInteger bigInteger) {
+			return new BigDecimal(bigInteger);
+		}
+		if (value instanceof Byte || value instanceof Short || value instanceof Integer || value instanceof Long) {
+			return BigDecimal.valueOf(value.longValue());
+		}
+		if (value instanceof Float || value instanceof Double) {
+			// Use the exact binary floating-point value. The shorter toString()
+			// representation may denote a different integer near large boundaries.
+			return new BigDecimal(value.doubleValue());
+		}
+		return new BigDecimal(value.toString());
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallbackTests.java
@@ -26,6 +26,7 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.Prompt;
@@ -400,6 +401,26 @@ public class AsyncMcpPromptMethodCallbackTests {
 	}
 
 	@Test
+	public void testCallbackRejectsLossyIntegerConversion() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+		Method method = TestPromptProvider.class.getMethod("getMonoPromptWithIntegerArgument", int.class);
+		Prompt prompt = createTestPrompt("integer-argument", "A prompt with an integer argument");
+		BiFunction<McpAsyncServerExchange, GetPromptRequest, Mono<GetPromptResult>> callback = AsyncMcpPromptMethodCallback
+			.builder()
+			.method(method)
+			.bean(provider)
+			.prompt(prompt)
+			.build();
+		GetPromptRequest request = GetPromptRequest.builder("integer-argument").arguments(Map.of("value", 1.5)).build();
+
+		StepVerifier.create(callback.apply(mock(McpAsyncServerExchange.class), request)).expectErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(McpError.class);
+			assertThat(((McpError) error).getJsonRpcError().code()).isEqualTo(ErrorCodes.INVALID_PARAMS);
+		}).verify();
+		assertThat(provider.integerArgument).isNull();
+	}
+
+	@Test
 	public void testInvalidSyncExchangeParameter() throws Exception {
 		TestPromptProvider provider = new TestPromptProvider();
 		Method method = TestPromptProvider.class.getMethod("invalidSyncExchangeParameter", McpSyncServerExchange.class,
@@ -551,6 +572,8 @@ public class AsyncMcpPromptMethodCallbackTests {
 
 	private static class TestPromptProvider {
 
+		private Integer integerArgument;
+
 		@McpPrompt(name = "greeting", description = "A simple greeting prompt")
 		public GetPromptResult getPromptWithRequest(GetPromptRequest request) {
 			return GetPromptResult
@@ -586,6 +609,13 @@ public class AsyncMcpPromptMethodCallbackTests {
 						TextContent.builder("Hello " + name + ", you are " + age + " years old").build())))
 				.description("Individual arguments prompt")
 				.build();
+		}
+
+		@McpPrompt(name = "integer-argument", description = "A prompt with an integer argument")
+		public Mono<GetPromptResult> getMonoPromptWithIntegerArgument(
+				@McpArg(name = "value", description = "An integer value", required = true) int value) {
+			this.integerArgument = value;
+			return Mono.just(GetPromptResult.builder(List.of()).description("Integer argument prompt").build());
 		}
 
 		@McpPrompt(name = "mixed-args", description = "A prompt with mixed argument types")

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallbackTests.java
@@ -17,13 +17,17 @@
 package org.springframework.ai.mcp.annotation.method.prompt;
 
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.Prompt;
@@ -201,6 +205,157 @@ public class SyncMcpPromptMethodCallbackTests {
 		PromptMessage message = result.messages().get(0);
 		assertThat(message.role()).isEqualTo(Role.ASSISTANT);
 		assertThat(((TextContent) message.content()).text()).isEqualTo("Hello John, you are 30 years old");
+	}
+
+	@Test
+	public void testCallbackRejectsUnsafeIntegerConversions() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+
+		assertInvalidNumericArgument(provider, "getPromptWithIntegerArgument", int.class, 1.5);
+		assertThat(provider.integerArgument).isNull();
+
+		assertInvalidNumericArgument(provider, "getPromptWithIntegerArgument", int.class, (long) Integer.MAX_VALUE + 1);
+		assertThat(provider.integerArgument).isNull();
+
+		assertInvalidNumericArgument(provider, "getPromptWithIntegerArgument", int.class, Double.NaN);
+		assertThat(provider.integerArgument).isNull();
+
+		assertInvalidNumericArgument(provider, "getPromptWithIntegerArgument", int.class, Double.POSITIVE_INFINITY);
+		assertThat(provider.integerArgument).isNull();
+	}
+
+	@Test
+	public void testCallbackRejectsUnsafeLongConversions() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+
+		assertInvalidNumericArgument(provider, "getPromptWithLongArgument", long.class, 1.5);
+		assertThat(provider.longArgument).isNull();
+
+		assertInvalidNumericArgument(provider, "getPromptWithLongArgument", long.class,
+				BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE));
+		assertThat(provider.longArgument).isNull();
+
+		assertInvalidNumericArgument(provider, "getPromptWithLongArgument", long.class,
+				BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE));
+		assertThat(provider.longArgument).isNull();
+
+		assertInvalidNumericArgument(provider, "getPromptWithLongArgument", long.class, new BigDecimal("42.001"));
+		assertThat(provider.longArgument).isNull();
+
+		assertInvalidNumericArgument(provider, "getPromptWithLongArgument", long.class, Double.NEGATIVE_INFINITY);
+		assertThat(provider.longArgument).isNull();
+	}
+
+	@Test
+	public void testCallbackAcceptsExactNumericConversions() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+
+		BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> integerCallback = createNumericCallback(
+				provider, "getPromptWithIntegerArgument", int.class);
+		GetPromptRequest integerRequest = GetPromptRequest.builder("numeric-argument")
+			.arguments(Map.of("value", 1.0))
+			.build();
+		integerCallback.apply(mock(McpSyncServerExchange.class), integerRequest);
+		assertThat(provider.integerArgument).isEqualTo(1);
+
+		integerRequest = GetPromptRequest.builder("numeric-argument")
+			.arguments(Map.of("value", (float) Integer.MIN_VALUE))
+			.build();
+		integerCallback.apply(mock(McpSyncServerExchange.class), integerRequest);
+		assertThat(provider.integerArgument).isEqualTo(Integer.MIN_VALUE);
+
+		integerRequest = GetPromptRequest.builder("numeric-argument")
+			.arguments(Map.of("value", BigInteger.valueOf(Integer.MAX_VALUE)))
+			.build();
+		integerCallback.apply(mock(McpSyncServerExchange.class), integerRequest);
+		assertThat(provider.integerArgument).isEqualTo(Integer.MAX_VALUE);
+
+		BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> longCallback = createNumericCallback(
+				provider, "getPromptWithLongArgument", long.class);
+		GetPromptRequest longRequest = GetPromptRequest.builder("numeric-argument")
+			.arguments(Map.of("value", new BigDecimal("42.000")))
+			.build();
+		longCallback.apply(mock(McpSyncServerExchange.class), longRequest);
+		assertThat(provider.longArgument).isEqualTo(42L);
+
+		longRequest = GetPromptRequest.builder("numeric-argument")
+			.arguments(Map.of("value", (double) Long.MIN_VALUE))
+			.build();
+		longCallback.apply(mock(McpSyncServerExchange.class), longRequest);
+		assertThat(provider.longArgument).isEqualTo(Long.MIN_VALUE);
+
+		double largeExactInteger = Math.nextDown(Math.scalb(1.0, 63));
+		longRequest = GetPromptRequest.builder("numeric-argument")
+			.arguments(Map.of("value", largeExactInteger))
+			.build();
+		longCallback.apply(mock(McpSyncServerExchange.class), longRequest);
+		assertThat(provider.longArgument).isEqualTo((long) largeExactInteger);
+
+		longRequest = GetPromptRequest.builder("numeric-argument")
+			.arguments(Map.of("value", new BigDecimal("1E3")))
+			.build();
+		longCallback.apply(mock(McpSyncServerExchange.class), longRequest);
+		assertThat(provider.longArgument).isEqualTo(1000L);
+
+		longRequest = GetPromptRequest.builder("numeric-argument")
+			.arguments(Map.of("value", new BigDecimal("1.5E1")))
+			.build();
+		longCallback.apply(mock(McpSyncServerExchange.class), longRequest);
+		assertThat(provider.longArgument).isEqualTo(15L);
+	}
+
+	@Test
+	public void testCallbackWithDeserializedNumericArguments() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+		BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> integerCallback = createNumericCallback(
+				provider, "getPromptWithIntegerArgument", int.class);
+		BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> longCallback = createNumericCallback(
+				provider, "getPromptWithLongArgument", long.class);
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+
+		GetPromptRequest fractionalRequest = deserializeNumericRequest("1.5");
+		assertInvalidNumericRequest(integerCallback, exchange, fractionalRequest);
+		assertThat(provider.integerArgument).isNull();
+
+		GetPromptRequest largeExactIntegerRequest = deserializeNumericRequest("9223372036854774784.0");
+		longCallback.apply(exchange, largeExactIntegerRequest);
+		assertThat(provider.longArgument).isEqualTo(9223372036854774784L);
+
+		provider.longArgument = null;
+		GetPromptRequest outOfRangeRequest = deserializeNumericRequest("9223372036854775808");
+		assertInvalidNumericRequest(longCallback, exchange, outOfRangeRequest);
+		assertThat(provider.longArgument).isNull();
+	}
+
+	private void assertInvalidNumericArgument(TestPromptProvider provider, String methodName, Class<?> parameterType,
+			Number value) throws Exception {
+		BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> callback = createNumericCallback(provider,
+				methodName, parameterType);
+		GetPromptRequest request = GetPromptRequest.builder("numeric-argument")
+			.arguments(Map.of("value", value))
+			.build();
+
+		assertInvalidNumericRequest(callback, mock(McpSyncServerExchange.class), request);
+	}
+
+	private void assertInvalidNumericRequest(
+			BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> callback,
+			McpSyncServerExchange exchange, GetPromptRequest request) {
+		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOfSatisfying(McpError.class,
+				error -> assertThat(error.getJsonRpcError().code()).isEqualTo(ErrorCodes.INVALID_PARAMS));
+	}
+
+	private GetPromptRequest deserializeNumericRequest(String value) throws Exception {
+		return McpJsonDefaults.getMapper()
+			.readValue("{\"name\":\"numeric-argument\",\"arguments\":{\"value\":" + value + "}}",
+					GetPromptRequest.class);
+	}
+
+	private BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> createNumericCallback(
+			TestPromptProvider provider, String methodName, Class<?> parameterType) throws Exception {
+		Method method = TestPromptProvider.class.getMethod(methodName, parameterType);
+		Prompt prompt = createTestPrompt("numeric-argument", "A prompt with a numeric argument");
+		return SyncMcpPromptMethodCallback.builder().method(method).bean(provider).prompt(prompt).build();
 	}
 
 	@Test
@@ -717,6 +872,10 @@ public class SyncMcpPromptMethodCallbackTests {
 
 	private static class TestPromptProvider {
 
+		private Integer integerArgument;
+
+		private Long longArgument;
+
 		@McpPrompt(name = "failing-prompt", description = "A prompt that throws an exception")
 		public GetPromptResult getFailingPrompt(GetPromptRequest request) {
 			throw new RuntimeException("Test exception");
@@ -759,6 +918,20 @@ public class SyncMcpPromptMethodCallbackTests {
 						TextContent.builder("Hello " + name + ", you are " + age + " years old").build())))
 				.description("Individual arguments prompt")
 				.build();
+		}
+
+		@McpPrompt(name = "integer-argument", description = "A prompt with an integer argument")
+		public GetPromptResult getPromptWithIntegerArgument(
+				@McpArg(name = "value", description = "An integer value", required = true) int value) {
+			this.integerArgument = value;
+			return GetPromptResult.builder(List.of()).description("Integer argument prompt").build();
+		}
+
+		@McpPrompt(name = "long-argument", description = "A prompt with a long argument")
+		public GetPromptResult getPromptWithLongArgument(
+				@McpArg(name = "value", description = "A long value", required = true) long value) {
+			this.longArgument = value;
+			return GetPromptResult.builder(List.of()).description("Long argument prompt").build();
 		}
 
 		@McpPrompt(name = "mixed-args", description = "A prompt with mixed argument types")


### PR DESCRIPTION
## Summary

`@McpPrompt` callbacks currently use `Number.intValue()` and
`Number.longValue()`, which can silently truncate fractional values or
overflow out-of-range inputs.

This change:

- converts `int` and `long` arguments exactly and reports unsafe values as
  invalid parameters;
- preserves valid integral values, including floating-point values near large
  integer boundaries;
- adds synchronous, asynchronous, and MCP JSON deserialization coverage.

## Testing

- `./mvnw -Dmaven.build.cache.enabled=false clean package`
- `./mvnw -Dmaven.build.cache.enabled=false -pl mcp/mcp-annotations -am test`
- 1,376 tests run; 0 failures, 0 errors, and 2 existing skips. Checkstyle
  reported 0 violations.

Thanks to @michaelboyles for the clear reproducer.

Fixes #6679
