### PR TITLE
fix: GoogleGenAiChatModel throws NoSuchElementException on Vertex Gemma MaaS

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -430,8 +430,8 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 					Usage currentUsage = (usage.isPresent()) ? getDefaultUsage(usage.get(), options)
 							: getDefaultUsage(null, options);
 					Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
-					ChatResponse chatResponse = new ChatResponse(generations,
-							toChatResponseMetadata(cumulativeUsage, generateContentResponse.modelVersion().get()));
+					ChatResponse chatResponse = new ChatResponse(generations, toChatResponseMetadata(cumulativeUsage,
+							generateContentResponse.modelVersion().orElse(geminiRequest.modelName())));
 
 					observationContext.setResponse(chatResponse);
 					return chatResponse;
@@ -489,8 +489,8 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 					Usage currentUsage = usage.isPresent() ? getDefaultUsage(usage.get(), options)
 							: getDefaultUsage(null, options);
 					Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
-					ChatResponse chatResponse = new ChatResponse(generations,
-							toChatResponseMetadata(cumulativeUsage, response.modelVersion().get()));
+					ChatResponse chatResponse = new ChatResponse(generations, toChatResponseMetadata(cumulativeUsage,
+							response.modelVersion().orElse(request.modelName())));
 					return Flux.just(chatResponse);
 				});
 

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelExtendedUsageTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelExtendedUsageTests.java
@@ -442,4 +442,26 @@ public class GoogleGenAiChatModelExtendedUsageTests {
 		assertThat(genAiUsage.getCachedContentTokenCount()).isNull();
 	}
 
+	@Test
+	void testResponseWithoutModelVersion() {
+		// Create mock response without modelVersion (like Vertex Gemma MaaS)
+		Content responseContent = Content.builder().parts(Part.builder().text("Response").build()).build();
+
+		Candidate candidate = Candidate.builder().content(responseContent).index(0).build();
+
+		GenerateContentResponse mockResponse = GenerateContentResponse.builder()
+			.candidates(List.of(candidate))
+			// Notice: .modelVersion(...) is NOT set
+			.build();
+
+		this.chatModel.setMockGenerateContentResponse(mockResponse);
+
+		UserMessage userMessage = new UserMessage("Test absent modelVersion");
+		Prompt prompt = new Prompt(List.of(userMessage));
+		ChatResponse response = this.chatModel.call(prompt);
+
+		// Should fall back to request model name and not throw NPE
+		assertThat(response.getMetadata().getModel()).isEqualTo("gemini-2.0-flash-thinking-exp");
+	}
+
 }


### PR DESCRIPTION
Resolves #6665.

**Description**
`GoogleGenAiChatModel` currently throws `NoSuchElementException` when calling `.get()` on the `modelVersion` field in `GenerateContentResponse` if the model does not include it (e.g. Vertex Gemma MaaS models).

This PR guards against `NoSuchElementException` by replacing the unguarded `.get()` with `.orElse(request.modelName())` so that the metadata parsing gracefully falls back to the requested model name (or remains valid) instead of terminating a successful model generation call with an exception.

**Changes**
* Updated `GoogleGenAiChatModel.internalCall()` to use `generateContentResponse.modelVersion().orElse(geminiRequest.modelName())`.
* Updated `GoogleGenAiChatModel.internalStream()` to use `response.modelVersion().orElse(request.modelName())`.
* Added `testResponseWithoutModelVersion()` to `GoogleGenAiChatModelExtendedUsageTests` simulating the Gemma MaaS response payload.
