### PR TITLE
fix: Validate Map generic types for @McpPrompt to prevent ClassCastException

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AbstractMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AbstractMcpPromptMethodCallback.java
@@ -185,6 +185,22 @@ public abstract class AbstractMcpPromptMethodCallback {
 					throw new IllegalArgumentException("Method cannot have more than one Map parameter: "
 							+ method.getName() + " in " + method.getDeclaringClass().getName());
 				}
+				java.lang.reflect.Type genericType = param.getParameterizedType();
+				if (genericType instanceof java.lang.reflect.ParameterizedType parameterizedType) {
+					java.lang.reflect.Type[] typeArgs = parameterizedType.getActualTypeArguments();
+					if (typeArgs.length == 2) {
+						java.lang.reflect.Type keyType = typeArgs[0];
+						java.lang.reflect.Type valueType = typeArgs[1];
+						if (keyType instanceof Class<?> keyClass && !keyClass.isAssignableFrom(String.class)) {
+							throw new IllegalArgumentException("Map parameter must have String as key type: "
+									+ method.getName() + " in " + method.getDeclaringClass().getName());
+						}
+						if (valueType instanceof Class<?> valueClass && !valueClass.isAssignableFrom(Object.class)) {
+							throw new IllegalArgumentException("Map parameter must have Object as value type: "
+									+ method.getName() + " in " + method.getDeclaringClass().getName());
+						}
+					}
+				}
 				hasMapParam = true;
 			}
 			// Other parameter types are assumed to be individual arguments

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallbackTests.java
@@ -417,6 +417,19 @@ public class SyncMcpPromptMethodCallbackTests {
 	}
 
 	@Test
+	public void testInvalidMapGenericArguments() throws Exception {
+		TestPromptProvider provider = new TestPromptProvider();
+		Method method = TestPromptProvider.class.getMethod("invalidMapGenericArguments", Map.class);
+
+		Prompt prompt = createTestPrompt("invalid", "Invalid generic parameters");
+
+		assertThatThrownBy(
+				() -> SyncMcpPromptMethodCallback.builder().method(method).bean(provider).prompt(prompt).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Map parameter must have String as key type");
+	}
+
+	@Test
 	public void testNullRequest() throws Exception {
 		TestPromptProvider provider = new TestPromptProvider();
 		Method method = TestPromptProvider.class.getMethod("getPromptWithRequest", GetPromptRequest.class);
@@ -905,6 +918,10 @@ public class SyncMcpPromptMethodCallbackTests {
 
 		public Mono<GetPromptResult> invalidSyncRequestContextInAsyncMethod(McpSyncRequestContext context) {
 			return Mono.just(GetPromptResult.builder(List.of()).description("Invalid").build());
+		}
+
+		public GetPromptResult invalidMapGenericArguments(Map<java.math.BigInteger, String> args) {
+			return GetPromptResult.builder(List.of()).description("Invalid").build();
 		}
 
 	}


### PR DESCRIPTION
Resolves #6675.

**Description**
Prior to this commit, Map parameters in `@McpPrompt` methods were only checked for assignability to `java.util.Map`. This allowed unsafe wiring of Maps with arbitrary generic types (e.g. `Map<BigInteger, String>`). Because MCP prompt arguments are always provided by the transport layer as `Map<String, Object>`, this would cause a `ClassCastException` at runtime when accessing elements.

This PR adds generic type validation in `AbstractMcpPromptMethodCallback` to explicitly check that if the Map has parameterized type arguments and they resolve to concrete Classes, the key type must be assignable from `String`, and the value type must be assignable from `Object`. Valid uses like raw `Map` or wildcard parameters (e.g. `Map<String, ?>`) continue to be preserved and handled gracefully.

**Changes**
* Updated `AbstractMcpPromptMethodCallback.validateParameters` to parse and check the generic parameterized types of Map parameters.
* Added `testInvalidMapGenericArguments` to `SyncMcpPromptMethodCallbackTests` to verify validation fails on invalid types (`Map<BigInteger, String>`).
