### PR TITLE
Add TokenWindowChatMemory for token-based eviction

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/TokenWindowChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/TokenWindowChatMemory.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.content.MediaContent;
+import org.springframework.ai.tokenizer.TokenCountEstimator;
+import org.springframework.util.Assert;
+
+/**
+ * A chat memory implementation that maintains a token-based window, ensuring that the
+ * total estimated token count of messages does not exceed a specified limit. When the
+ * token count exceeds the maximum, older messages are evicted.
+ * <p>
+ * This complements {@link MessageWindowChatMemory} which evicts by message count. In
+ * production LLM applications, token-based eviction is more accurate because a single
+ * long message may consume more context window than many short messages combined.
+ * <p>
+ * Messages of type {@link SystemMessage} are treated specially: if a new
+ * {@link SystemMessage} is added, all previous {@link SystemMessage} instances are
+ * removed from the memory. Also, if the total token count exceeds the limit, the
+ * {@link SystemMessage} messages are preserved while evicting other types of messages.
+ * Eviction snaps to turn boundaries so that an assistant reply is never kept without the
+ * user message that originated the turn.
+ *
+ * @author JiaWeiDong
+ * @since 2.0.0
+ * @see MessageWindowChatMemory
+ * @see TokenCountEstimator
+ */
+public final class TokenWindowChatMemory implements ChatMemory {
+
+	private static final int DEFAULT_MAX_TOKEN_SIZE = 8192;
+
+	private final ChatMemoryRepository chatMemoryRepository;
+
+	private final TokenCountEstimator tokenCountEstimator;
+
+	private final int maxTokenSize;
+
+	private TokenWindowChatMemory(ChatMemoryRepository chatMemoryRepository, TokenCountEstimator tokenCountEstimator,
+			int maxTokenSize) {
+		Assert.notNull(chatMemoryRepository, "chatMemoryRepository cannot be null");
+		Assert.notNull(tokenCountEstimator, "tokenCountEstimator cannot be null");
+		Assert.isTrue(maxTokenSize > 0, "maxTokenSize must be greater than 0");
+		this.chatMemoryRepository = chatMemoryRepository;
+		this.tokenCountEstimator = tokenCountEstimator;
+		this.maxTokenSize = maxTokenSize;
+	}
+
+	@Override
+	public void add(String conversationId, List<Message> messages) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		Assert.notNull(messages, "messages cannot be null");
+		Assert.noNullElements(messages, "messages cannot contain null elements");
+
+		List<Message> memoryMessages = this.chatMemoryRepository.findByConversationId(conversationId);
+		List<Message> processedMessages = process(memoryMessages, messages);
+		this.chatMemoryRepository.saveAll(conversationId, processedMessages);
+	}
+
+	@Override
+	public List<Message> get(String conversationId) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		return this.chatMemoryRepository.findByConversationId(conversationId);
+	}
+
+	@Override
+	public void clear(String conversationId) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		this.chatMemoryRepository.deleteByConversationId(conversationId);
+	}
+
+	private List<Message> process(List<Message> memoryMessages, List<Message> newMessages) {
+		List<Message> processedMessages = new ArrayList<>();
+
+		Set<Message> memoryMessagesSet = new HashSet<>(memoryMessages);
+		boolean hasNewSystemMessage = newMessages.stream()
+			.filter(SystemMessage.class::isInstance)
+			.anyMatch(message -> !memoryMessagesSet.contains(message));
+
+		memoryMessages.stream()
+			.filter(message -> !(hasNewSystemMessage && message instanceof SystemMessage))
+			.forEach(processedMessages::add);
+
+		processedMessages.addAll(newMessages);
+
+		int totalTokens = estimateTotalTokens(processedMessages);
+		if (totalTokens <= this.maxTokenSize) {
+			return processedMessages;
+		}
+
+		// Collect indices of non-system messages; SystemMessages are always preserved.
+		List<Integer> nonSystemIndices = new ArrayList<>();
+		for (int i = 0; i < processedMessages.size(); i++) {
+			if (!(processedMessages.get(i) instanceof SystemMessage)) {
+				nonSystemIndices.add(i);
+			}
+		}
+
+		// Evict oldest non-system messages until token count is within limit.
+		Set<Integer> removeIndices = new HashSet<>();
+		int currentTokens = totalTokens;
+		int cutIndex = 0;
+
+		while (cutIndex < nonSystemIndices.size() && currentTokens > this.maxTokenSize) {
+			int idx = nonSystemIndices.get(cutIndex);
+			Message message = processedMessages.get(idx);
+			currentTokens -= estimateTokens(message);
+			removeIndices.add(idx);
+			cutIndex++;
+		}
+
+		// Snap the cut forward to the nearest USER message so the kept window always
+		// starts at a complete turn. This prevents keeping an assistant reply or tool
+		// result without the user message that originated its turn.
+		while (cutIndex < nonSystemIndices.size()
+				&& processedMessages.get(nonSystemIndices.get(cutIndex)).getMessageType() != MessageType.USER) {
+			int idx = nonSystemIndices.get(cutIndex);
+			removeIndices.add(idx);
+			cutIndex++;
+		}
+
+		List<Message> trimmedMessages = new ArrayList<>();
+		for (int i = 0; i < processedMessages.size(); i++) {
+			if (!removeIndices.contains(i)) {
+				trimmedMessages.add(processedMessages.get(i));
+			}
+		}
+		return trimmedMessages;
+	}
+
+	private int estimateTotalTokens(List<Message> messages) {
+		int total = 0;
+		for (Message message : messages) {
+			total += estimateTokens(message);
+		}
+		return total;
+	}
+
+	private int estimateTokens(Message message) {
+		if (message instanceof MediaContent mediaContent) {
+			return this.tokenCountEstimator.estimate(mediaContent);
+		}
+		return this.tokenCountEstimator.estimate(message.getText());
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+
+		private ChatMemoryRepository chatMemoryRepository = new InMemoryChatMemoryRepository();
+
+		private @Nullable TokenCountEstimator tokenCountEstimator;
+
+		private int maxTokenSize = DEFAULT_MAX_TOKEN_SIZE;
+
+		private Builder() {
+		}
+
+		public Builder chatMemoryRepository(ChatMemoryRepository chatMemoryRepository) {
+			this.chatMemoryRepository = chatMemoryRepository;
+			return this;
+		}
+
+		public Builder tokenCountEstimator(TokenCountEstimator tokenCountEstimator) {
+			this.tokenCountEstimator = tokenCountEstimator;
+			return this;
+		}
+
+		public Builder maxTokenSize(int maxTokenSize) {
+			this.maxTokenSize = maxTokenSize;
+			return this;
+		}
+
+		public TokenWindowChatMemory build() {
+			Assert.state(this.tokenCountEstimator != null, "tokenCountEstimator must be set");
+			return new TokenWindowChatMemory(this.chatMemoryRepository, this.tokenCountEstimator, this.maxTokenSize);
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/TokenWindowChatMemoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/TokenWindowChatMemoryTests.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.content.MediaContent;
+import org.springframework.ai.tokenizer.TokenCountEstimator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link TokenWindowChatMemory}.
+ *
+ * @author JiaWeiDong
+ */
+public class TokenWindowChatMemoryTests {
+
+	/**
+	 * Simple token estimator that counts the number of characters in the message text.
+	 * This makes test assertions easy to reason about: "Hello" = 5 tokens.
+	 */
+	private static final TokenCountEstimator CHAR_COUNT_ESTIMATOR = new TokenCountEstimator() {
+		@Override
+		public int estimate(String text) {
+			return text == null ? 0 : text.length();
+		}
+
+		@Override
+		public int estimate(MediaContent content) {
+			return estimate(content.getText());
+		}
+
+		@Override
+		public int estimate(Iterable<MediaContent> contents) {
+			int total = 0;
+			for (MediaContent content : contents) {
+				total += estimate(content);
+			}
+			return total;
+		}
+	};
+
+	private final TokenWindowChatMemory chatMemory = TokenWindowChatMemory.builder()
+		.tokenCountEstimator(CHAR_COUNT_ESTIMATOR)
+		.maxTokenSize(50)
+		.build();
+
+	@Test
+	void zeroMaxTokenSizeNotAllowed() {
+		assertThatThrownBy(
+				() -> TokenWindowChatMemory.builder().tokenCountEstimator(CHAR_COUNT_ESTIMATOR).maxTokenSize(0).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("maxTokenSize must be greater than 0");
+	}
+
+	@Test
+	void negativeMaxTokenSizeNotAllowed() {
+		assertThatThrownBy(() -> TokenWindowChatMemory.builder()
+			.tokenCountEstimator(CHAR_COUNT_ESTIMATOR)
+			.maxTokenSize(-1)
+			.build()).isInstanceOf(IllegalArgumentException.class).hasMessage("maxTokenSize must be greater than 0");
+	}
+
+	@Test
+	void tokenCountEstimatorRequired() {
+		assertThatThrownBy(() -> TokenWindowChatMemory.builder().maxTokenSize(100).build())
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("tokenCountEstimator must be set");
+	}
+
+	@Test
+	void handleMultipleMessagesInConversation() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messages = List.of(new UserMessage("Hello"), new AssistantMessage("Hi there"));
+
+		this.chatMemory.add(conversationId, messages);
+
+		assertThat(this.chatMemory.get(conversationId)).containsAll(messages);
+
+		this.chatMemory.clear(conversationId);
+
+		assertThat(this.chatMemory.get(conversationId)).isEmpty();
+	}
+
+	@Test
+	void handleSingleMessageInConversation() {
+		String conversationId = UUID.randomUUID().toString();
+		Message message = new UserMessage("Hello");
+
+		this.chatMemory.add(conversationId, message);
+
+		assertThat(this.chatMemory.get(conversationId)).contains(message);
+
+		this.chatMemory.clear(conversationId);
+
+		assertThat(this.chatMemory.get(conversationId)).isEmpty();
+	}
+
+	@Test
+	void nullConversationIdNotAllowed() {
+		assertThatThrownBy(() -> this.chatMemory.add(null, List.of(new UserMessage("Hello"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> this.chatMemory.add(null, new UserMessage("Hello")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> this.chatMemory.get(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> this.chatMemory.clear(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+	}
+
+	@Test
+	void emptyConversationIdNotAllowed() {
+		assertThatThrownBy(() -> this.chatMemory.add("", List.of(new UserMessage("Hello"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> this.chatMemory.get("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> this.chatMemory.clear("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+	}
+
+	@Test
+	void nullMessagesNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		assertThatThrownBy(() -> this.chatMemory.add(conversationId, (List<Message>) null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages cannot be null");
+	}
+
+	@Test
+	void nullMessageNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		assertThatThrownBy(() -> this.chatMemory.add(conversationId, (Message) null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("message cannot be null");
+	}
+
+	@Test
+	void messagesWithNullElementsNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messagesWithNull = new ArrayList<>();
+		messagesWithNull.add(null);
+
+		assertThatThrownBy(() -> this.chatMemory.add(conversationId, messagesWithNull))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages cannot contain null elements");
+	}
+
+	@Test
+	void noEvictionWhenTokensWithinLimit() {
+		// "Hello" (5) + "Hi" (2) + "How?" (4) = 11 tokens, well within 50 limit
+		TokenWindowChatMemory memory = TokenWindowChatMemory.builder()
+			.tokenCountEstimator(CHAR_COUNT_ESTIMATOR)
+			.maxTokenSize(50)
+			.build();
+
+		String conversationId = UUID.randomUUID().toString();
+		memory.add(conversationId, List.of(new UserMessage("Hello"), new AssistantMessage("Hi")));
+		memory.add(conversationId, List.of(new UserMessage("How?")));
+
+		List<Message> result = memory.get(conversationId);
+
+		assertThat(result).hasSize(3);
+		assertThat(result).containsExactly(new UserMessage("Hello"), new AssistantMessage("Hi"),
+				new UserMessage("How?"));
+	}
+
+	@Test
+	void evictionWhenTokensExceedLimit() {
+		// maxTokenSize = 20
+		// "Message one" (11) + "Response one" (12) = 23 > 20 after second add
+		TokenWindowChatMemory memory = TokenWindowChatMemory.builder()
+			.tokenCountEstimator(CHAR_COUNT_ESTIMATOR)
+			.maxTokenSize(20)
+			.build();
+
+		String conversationId = UUID.randomUUID().toString();
+		memory.add(conversationId, List.of(new UserMessage("Message one"), new AssistantMessage("Response one")));
+
+		// Add more: "Q2" (2) + "A2" (2) = 4, total would be 23+4=27 > 20
+		memory.add(conversationId, List.of(new UserMessage("Q2"), new AssistantMessage("A2")));
+
+		List<Message> result = memory.get(conversationId);
+
+		// After eviction: "Response one" (12) would be orphaned, so turn-boundary
+		// snapping evicts it too. Remaining: "Q2" (2) + "A2" (2) = 4 <= 20
+		assertThat(result).containsExactly(new UserMessage("Q2"), new AssistantMessage("A2"));
+	}
+
+	@Test
+	void systemMessageIsPreservedDuringEviction() {
+		// maxTokenSize = 30
+		// "System" (6) + "Msg1" (4) + "Resp1" (5) + "Msg2" (4) + "Resp2" (5) = 24
+		// Then add "Msg3" (4) + "Resp3" (5) = 9, total = 33 > 30
+		TokenWindowChatMemory memory = TokenWindowChatMemory.builder()
+			.tokenCountEstimator(CHAR_COUNT_ESTIMATOR)
+			.maxTokenSize(30)
+			.build();
+
+		String conversationId = UUID.randomUUID().toString();
+		memory.add(conversationId, List.of(new SystemMessage("System"), new UserMessage("Msg1"),
+				new AssistantMessage("Resp1"), new UserMessage("Msg2"), new AssistantMessage("Resp2")));
+		memory.add(conversationId, List.of(new UserMessage("Msg3"), new AssistantMessage("Resp3")));
+
+		List<Message> result = memory.get(conversationId);
+
+		// SystemMessage preserved. "Msg1"(4)+"Resp1"(5)=9 evicted to get under 30.
+		// Remaining: "System"(6)+"Msg2"(4)+"Resp2"(5)+"Msg3"(4)+"Resp3"(5)=24 <= 30
+		assertThat(result).containsExactly(new SystemMessage("System"), new UserMessage("Msg2"),
+				new AssistantMessage("Resp2"), new UserMessage("Msg3"), new AssistantMessage("Resp3"));
+	}
+
+	@Test
+	void turnBoundarySnappingPreventsOrphanedAssistantMessage() {
+		// maxTokenSize = 15
+		// "Q1"(2) + "A1 is long"(10) + "Q2"(2) + "A2"(2) = 16 > 15
+		// Evicting "Q1"(2) -> 14 <= 15, but "A1 is long" is ASSISTANT -> orphaned
+		// Snap forward to "Q2", evict "A1 is long" too -> "Q2"(2)+"A2"(2) = 4
+		TokenWindowChatMemory memory = TokenWindowChatMemory.builder()
+			.tokenCountEstimator(CHAR_COUNT_ESTIMATOR)
+			.maxTokenSize(15)
+			.build();
+
+		String conversationId = UUID.randomUUID().toString();
+		memory.add(conversationId, List.of(new UserMessage("Q1"), new AssistantMessage("A1 is long"),
+				new UserMessage("Q2"), new AssistantMessage("A2")));
+
+		List<Message> result = memory.get(conversationId);
+
+		assertThat(result).containsExactly(new UserMessage("Q2"), new AssistantMessage("A2"));
+	}
+
+	@Test
+	void longMessageEvictedBeforeShortMessages() {
+		// This is the key advantage over MessageWindowChatMemory:
+		// One long message should consume more "budget" than several short ones.
+		// maxTokenSize = 20
+		// "Short"(5) + "A very long response that takes many tokens"(44) = 49 > 20
+		TokenWindowChatMemory memory = TokenWindowChatMemory.builder()
+			.tokenCountEstimator(CHAR_COUNT_ESTIMATOR)
+			.maxTokenSize(20)
+			.build();
+
+		String conversationId = UUID.randomUUID().toString();
+		memory.add(conversationId,
+				List.of(new UserMessage("Short"), new AssistantMessage("A very long response that takes many tokens")));
+		// Add new turn: "Hi"(2) + "Ok"(2) = 4
+		memory.add(conversationId, List.of(new UserMessage("Hi"), new AssistantMessage("Ok")));
+
+		List<Message> result = memory.get(conversationId);
+
+		// Old turn evicted (token-heavy), new turn kept
+		assertThat(result).containsExactly(new UserMessage("Hi"), new AssistantMessage("Ok"));
+	}
+
+	@Test
+	void oldSystemMessagesAreRemovedWhenNewOneAdded() {
+		TokenWindowChatMemory memory = TokenWindowChatMemory.builder()
+			.tokenCountEstimator(CHAR_COUNT_ESTIMATOR)
+			.maxTokenSize(50)
+			.build();
+
+		String conversationId = UUID.randomUUID().toString();
+		memory.add(conversationId, List.of(new SystemMessage("Old system 1"), new SystemMessage("Old system 2")));
+
+		memory.add(conversationId, List.of(new SystemMessage("New system")));
+
+		List<Message> result = memory.get(conversationId);
+
+		assertThat(result).hasSize(1);
+		assertThat(result).containsExactly(new SystemMessage("New system"));
+	}
+
+	@Test
+	void emptyMessageList() {
+		String conversationId = UUID.randomUUID().toString();
+
+		List<Message> result = this.chatMemory.get(conversationId);
+
+		assertThat(result).isEmpty();
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR adds `TokenWindowChatMemory`, a new `ChatMemory` implementation that evicts messages based on estimated token count rather than message count.

Closes #1815

## Motivation

The `ChatMemory` subsystem currently has 7 storage backends (Redis, JDBC, MongoDB, Cassandra, Neo4j, etc.) but only one eviction strategy — `MessageWindowChatMemory`, which evicts by message count. In production LLM applications, token-based eviction is more accurate because a single long message may consume more context window budget than many short messages combined.

## Design

`TokenWindowChatMemory` mirrors the design of `MessageWindowChatMemory` with the following key differences:

- **Token-based eviction**: Uses `TokenCountEstimator` to estimate the token cost of each message, evicting the oldest messages when the total exceeds `maxTokenSize`.
- **SystemMessage preservation**: System messages are always preserved during eviction (same as `MessageWindowChatMemory`).
- **Turn-boundary snapping**: Eviction snaps forward to the nearest `USER` message boundary, preventing orphaned assistant replies from being kept without the user message that originated the turn.
- **Builder pattern**: Consistent API with `MessageWindowChatMemory.builder()`. `TokenCountEstimator` is required; `ChatMemoryRepository` defaults to `InMemoryChatMemoryRepository`.

## Changes

- `TokenWindowChatMemory.java` — New `ChatMemory` implementation (~200 lines)
- `TokenWindowChatMemoryTests.java` — 17 unit tests covering validation, eviction, SystemMessage preservation, turn-boundary snapping, and edge cases

## Usage

```java
TokenWindowChatMemory memory = TokenWindowChatMemory.builder()
    .tokenCountEstimator(new JTokkitTokenCountEstimator())
    .maxTokenSize(4096)
    .build();
```

All existing tests pass. No changes to existing code.

Signed-off-by: Bowang <417851790@qq.com>