### PR TITLE
Add tenant scoping to `WeaviateVectorStore`

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.context.annotation.Bean;
  * @author Eddú Meléndez
  * @author Soby Chacko
  * @author Jonghoon Park
+ * @author Taewoong Kim
  */
 @AutoConfiguration
 @ConditionalOnClass({ EmbeddingModel.class, WeaviateVectorStore.class })
@@ -87,6 +88,7 @@ public class WeaviateVectorStoreAutoConfiguration {
 			BatchingStrategy batchingStrategy) {
 		return WeaviateVectorStore.builder(weaviateClient, embeddingModel)
 			.options(mappingPropertiesToOptions(properties))
+			.tenantName(properties.getTenantName())
 			.filterMetadataFields(properties.getFilterField()
 				.entrySet()
 				.stream()

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreProperties.java
@@ -18,6 +18,8 @@ package org.springframework.ai.vectorstore.weaviate.autoconfigure;
 
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.vectorstore.weaviate.WeaviateVectorStore;
 import org.springframework.ai.vectorstore.weaviate.WeaviateVectorStore.ConsistentLevel;
 import org.springframework.ai.vectorstore.weaviate.WeaviateVectorStore.MetadataField;
@@ -28,6 +30,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Christian Tzolov
  * @author Jonghoon Park
+ * @author Taewoong Kim
  */
 @ConfigurationProperties(WeaviateVectorStoreProperties.CONFIG_PREFIX)
 public class WeaviateVectorStoreProperties {
@@ -45,6 +48,12 @@ public class WeaviateVectorStoreProperties {
 	private String contentFieldName = "content";
 
 	private String metaFieldPrefix = "meta_";
+
+	/**
+	 * The Weaviate tenant name used to scope add, delete, and search operations. When
+	 * unset or blank, non-tenant behavior is used.
+	 */
+	private @Nullable String tenantName;
 
 	private ConsistentLevel consistencyLevel = WeaviateVectorStore.ConsistentLevel.ONE;
 
@@ -113,6 +122,17 @@ public class WeaviateVectorStoreProperties {
 	 */
 	public void setMetaFieldPrefix(String metaFieldPrefix) {
 		this.metaFieldPrefix = metaFieldPrefix;
+	}
+
+	/**
+	 * @since 2.0.1
+	 */
+	public @Nullable String getTenantName() {
+		return this.tenantName;
+	}
+
+	public void setTenantName(@Nullable String tenantName) {
+		this.tenantName = tenantName;
 	}
 
 	public ConsistentLevel getConsistencyLevel() {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/test/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/test/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfigurationIT.java
@@ -20,6 +20,10 @@ import java.util.List;
 import java.util.Map;
 
 import io.micrometer.observation.tck.TestObservationRegistry;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.v1.misc.model.MultiTenancyConfig;
+import io.weaviate.client.v1.schema.model.Tenant;
+import io.weaviate.client.v1.schema.model.WeaviateClass;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
@@ -50,9 +54,12 @@ import static org.springframework.ai.test.vectorstore.ObservationTestUtil.assert
  * @author Soby Chacko
  * @author Thomas Vitale
  * @author Jonghoon Park
+ * @author Taewoong Kim
  */
 @Testcontainers
 public class WeaviateVectorStoreAutoConfigurationIT {
+
+	private static final String MULTI_TENANT_OBJECT_CLASS = "SpringAiAutoConfiguredMultiTenant";
 
 	@Container
 	static WeaviateContainer weaviate = new WeaviateContainer("semitechnologies/weaviate:1.31.22")
@@ -191,6 +198,62 @@ public class WeaviateVectorStoreAutoConfigurationIT {
 				assertThat(options.getObjectClass()).isEqualTo("CustomObjectClass");
 				assertThat(options.getContentFieldName()).isEqualTo("customContentFieldName");
 				assertThat(options.getMetaFieldPrefix()).isEqualTo("custom_");
+			});
+	}
+
+	@Test
+	void tenantNamePropertyScopesOperations() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.vectorstore.weaviate.object-class=" + MULTI_TENANT_OBJECT_CLASS,
+					"spring.ai.vectorstore.weaviate.tenant-name=TenantA")
+			.run(context -> {
+				WeaviateClient weaviateClient = context.getBean(WeaviateClient.class);
+				WeaviateVectorStoreProperties properties = context.getBean(WeaviateVectorStoreProperties.class);
+				WeaviateVectorStore vectorStore = context.getBean(WeaviateVectorStore.class);
+
+				weaviateClient.schema().classDeleter().withClassName(MULTI_TENANT_OBJECT_CLASS).run();
+				var createClassResult = weaviateClient.schema()
+					.classCreator()
+					.withClass(WeaviateClass.builder()
+						.className(MULTI_TENANT_OBJECT_CLASS)
+						.vectorizer("none")
+						.multiTenancyConfig(
+								MultiTenancyConfig.builder().enabled(true).autoTenantCreation(false).build())
+						.build())
+					.run();
+				assertThat(createClassResult.hasErrors()).isFalse();
+
+				var createTenantResult = weaviateClient.schema()
+					.tenantsCreator()
+					.withClassName(MULTI_TENANT_OBJECT_CLASS)
+					.withTenants(Tenant.builder().name("TenantA").build())
+					.run();
+				assertThat(createTenantResult.hasErrors()).isFalse();
+
+				Document tenantDocument = new Document("Spring AI auto-configured tenant",
+						Map.of("country", "KR", "year", 2026, "active", true, "price", 3.14));
+				try {
+					assertThat(properties.getTenantName()).isEqualTo("TenantA");
+					assertThat(vectorStore.createObservationContextBuilder("query").build().getNamespace())
+						.isEqualTo("TenantA");
+
+					vectorStore.add(List.of(tenantDocument));
+					assertThat(vectorStore.similaritySearch(SearchRequest.builder()
+						.query("auto-configured tenant")
+						.topK(5)
+						.similarityThresholdAll()
+						.build())).extracting(Document::getId).containsExactly(tenantDocument.getId());
+
+					vectorStore.delete(List.of(tenantDocument.getId()));
+					assertThat(vectorStore.similaritySearch(SearchRequest.builder()
+						.query("auto-configured tenant")
+						.topK(5)
+						.similarityThresholdAll()
+						.build())).isEmpty();
+				}
+				finally {
+					weaviateClient.schema().classDeleter().withClassName(MULTI_TENANT_OBJECT_CLASS).run();
+				}
 			});
 	}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
@@ -158,6 +158,7 @@ public WeaviateClient weaviateClient() {
 public VectorStore vectorStore(WeaviateClient weaviateClient, EmbeddingModel embeddingModel) {
     return WeaviateVectorStore.builder(weaviateClient, embeddingModel)
         .options(options)                              // Optional: use custom options
+        .tenantName("TenantA")                        // Optional: for an existing multi-tenant collection
         .consistencyLevel(ConsistentLevel.QUORUM)      // Optional: defaults to ConsistentLevel.ONE
         .filterMetadataFields(List.of(                 // Optional: fields that can be used in filters
             MetadataField.text("country"),
@@ -265,9 +266,14 @@ You can use the following properties in your Spring Boot configuration to custom
 |`spring.ai.vectorstore.weaviate.object-class`|The class name for storing documents. |SpringAiWeaviate
 |`spring.ai.vectorstore.weaviate.content-field-name`|The field name for content|content
 |`spring.ai.vectorstore.weaviate.meta-field-prefix`|The field prefix for metadata|meta_
+|`spring.ai.vectorstore.weaviate.tenant-name`|The tenant name used to scope operations on an existing multi-tenant collection|-
 |`spring.ai.vectorstore.weaviate.consistency-level`|Desired tradeoff between consistency and speed|ConsistentLevel.ONE
 |`spring.ai.vectorstore.weaviate.filter-field`|Configures metadata fields that can be used in filters. Format: spring.ai.vectorstore.weaviate.filter-field.<field-name>=<field-type>|
 |===
+
+The tenant option scopes adding or upserting documents, deleting them by ID or filter, and similarity searches.
+The collection must have multi-tenancy enabled; tenant creation is controlled by its Weaviate configuration.
+When the tenant name is not configured, the vector store retains its existing non-tenant behavior.
 
 TIP: Object class names should start with an uppercase letter, and field names should start with a lowercase letter.
 See link:https://weaviate.io/developers/weaviate/concepts/data#data-object-concepts[data-object-concepts]

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStore.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStore.java
@@ -44,6 +44,7 @@ import io.weaviate.client.v1.graphql.query.fields.Field;
 import io.weaviate.client.v1.graphql.query.fields.Fields;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -91,6 +92,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Thomas Vitale
  * @author Jonghoon Park
+ * @author Taewoong Kim
  * @since 1.0.0
  */
 public class WeaviateVectorStore extends AbstractObservationVectorStore {
@@ -112,6 +114,8 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 	private final WeaviateVectorStoreOptions options;
 
 	private final ConsistentLevel consistencyLevel;
+
+	private final @Nullable String tenantName;
 
 	/**
 	 * List of metadata fields (as field name and type) that can be used in similarity
@@ -153,6 +157,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 
 		this.weaviateClient = builder.weaviateClient;
 		this.consistencyLevel = builder.consistencyLevel;
+		this.tenantName = builder.tenantName;
 		this.filterMetadataFields = builder.filterMetadataFields;
 		this.filterExpressionConverter = new WeaviateFilterExpressionConverter(
 				this.filterMetadataFields.stream().map(MetadataField::name).toList(),
@@ -258,18 +263,21 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 			}
 		}
 
-		return WeaviateObject.builder()
+		var objectBuilder = WeaviateObject.builder()
 			.className(this.options.getObjectClass())
 			.id(document.getId())
 			.vector(EmbeddingUtils.toFloatArray(embeddings.get(documents.indexOf(document))))
-			.properties(fields)
-			.build();
+			.properties(fields);
+		if (this.tenantName != null) {
+			objectBuilder.tenant(this.tenantName);
+		}
+		return objectBuilder.build();
 	}
 
 	@Override
 	public void doDelete(List<String> documentIds) {
 
-		Result<BatchDeleteResponse> result = this.weaviateClient.batch()
+		var batchDeleter = this.weaviateClient.batch()
 			.objectsBatchDeleter()
 			.withClassName(this.options.getObjectClass())
 			.withConsistencyLevel(this.consistencyLevel.name())
@@ -277,8 +285,11 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 				.path("id")
 				.operator(Operator.ContainsAny)
 				.valueString(documentIds.toArray(new String[0]))
-				.build())
-			.run();
+				.build());
+		if (this.tenantName != null) {
+			batchDeleter.withTenant(this.tenantName);
+		}
+		Result<BatchDeleteResponse> result = batchDeleter.run();
 
 		if (result.hasErrors()) {
 			String errorMessages = result.getError()
@@ -341,6 +352,9 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 			.withWhereFilter(WhereArgument.builder().build()) // adds an empty 'where:{}'
 			// placeholder.
 			.fields(Fields.builder().fields(this.weaviateSimilaritySearchFields).build());
+		if (this.tenantName != null) {
+			queryBuilder.tenant(this.tenantName);
+		}
 
 		String graphQLQuery = queryBuilder.build().buildQuery();
 
@@ -427,9 +441,14 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 	@Override
 	public VectorStoreObservationContext.Builder createObservationContextBuilder(String operationName) {
 
-		return VectorStoreObservationContext.builder(VectorStoreProvider.WEAVIATE.value(), operationName)
+		VectorStoreObservationContext.Builder builder = VectorStoreObservationContext
+			.builder(VectorStoreProvider.WEAVIATE.value(), operationName)
 			.dimensions(this.embeddingModel.dimensions())
 			.collectionName(this.options.getObjectClass());
+		if (this.tenantName != null) {
+			builder.namespace(this.tenantName);
+		}
+		return builder;
 	}
 
 	@Override
@@ -525,6 +544,8 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 
 		private ConsistentLevel consistencyLevel = ConsistentLevel.ONE;
 
+		private @Nullable String tenantName;
+
 		private List<MetadataField> filterMetadataFields = List.of();
 
 		private final WeaviateClient weaviateClient;
@@ -564,6 +585,20 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		public Builder consistencyLevel(ConsistentLevel consistencyLevel) {
 			Assert.notNull(consistencyLevel, "consistencyLevel must not be null");
 			this.consistencyLevel = consistencyLevel;
+			return this;
+		}
+
+		/**
+		 * Configures the tenant used to scope operations on an existing multi-tenant
+		 * collection. This vector store does not manage tenant or collection lifecycle.
+		 * Automatic tenant creation follows the Weaviate collection configuration.
+		 * @param tenantName the tenant name to scope operations to ({@code null} or blank
+		 * keeps the existing non-tenant behavior)
+		 * @return this builder instance
+		 * @since 2.0.1
+		 */
+		public Builder tenantName(@Nullable String tenantName) {
+			this.tenantName = StringUtils.hasText(tenantName) ? tenantName : null;
 			return this;
 		}
 

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreBuilderTests.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreBuilderTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Mark Pollack
  * @author Jonghoon Park
+ * @author Taewoong Kim
  */
 @ExtendWith(MockitoExtension.class)
 class WeaviateVectorStoreBuilderTests {
@@ -65,10 +66,23 @@ class WeaviateVectorStoreBuilderTests {
 		WeaviateVectorStore vectorStore = WeaviateVectorStore.builder(weaviateClient, this.embeddingModel)
 			.options(options)
 			.consistencyLevel(ConsistentLevel.QUORUM)
+			.tenantName("TenantA")
 			.filterMetadataFields(List.of(MetadataField.text("country"), MetadataField.number("year")))
 			.build();
 
 		assertThat(vectorStore).isNotNull();
+		assertThat(vectorStore.createObservationContextBuilder("query").build().getNamespace()).isEqualTo("TenantA");
+	}
+
+	@Test
+	void shouldTreatBlankTenantNameAsNotConfigured() {
+		WeaviateClient weaviateClient = new WeaviateClient(new Config("http", "localhost:8080"));
+
+		WeaviateVectorStore vectorStore = WeaviateVectorStore.builder(weaviateClient, this.embeddingModel)
+			.tenantName(" ")
+			.build();
+
+		assertThat(vectorStore.createObservationContextBuilder("query").build().getNamespace()).isNull();
 	}
 
 	@Test

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreIT.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreIT.java
@@ -27,6 +27,9 @@ import java.util.function.Consumer;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.v1.misc.model.MultiTenancyConfig;
+import io.weaviate.client.v1.schema.model.Tenant;
+import io.weaviate.client.v1.schema.model.WeaviateClass;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -58,9 +61,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Eddú Meléndez
  * @author Soby Chacko
  * @author Thomas Vitale
+ * @author Taewoong Kim
  */
 @Testcontainers
 public class WeaviateVectorStoreIT extends BaseVectorStoreTests {
+
+	private static final String MULTI_TENANT_CLASS = "SpringAiMultiTenant";
 
 	@Container
 	static WeaviateContainer weaviateContainer = new WeaviateContainer(WeaviateImage.DEFAULT_IMAGE)
@@ -244,6 +250,98 @@ public class WeaviateVectorStoreIT extends BaseVectorStoreTests {
 
 			vectorStore.delete(List.of(document.getId()));
 
+		});
+	}
+
+	@Test
+	void multiTenantOperationsAreIsolated() {
+		this.contextRunner.run(context -> {
+			WeaviateClient weaviateClient = context.getBean(WeaviateClient.class);
+			EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+
+			weaviateClient.schema().classDeleter().withClassName(MULTI_TENANT_CLASS).run();
+			var createClassResult = weaviateClient.schema()
+				.classCreator()
+				.withClass(WeaviateClass.builder()
+					.className(MULTI_TENANT_CLASS)
+					.vectorizer("none")
+					.multiTenancyConfig(MultiTenancyConfig.builder().enabled(true).autoTenantCreation(false).build())
+					.build())
+				.run();
+			assertThat(createClassResult.hasErrors()).isFalse();
+
+			var createTenantsResult = weaviateClient.schema()
+				.tenantsCreator()
+				.withClassName(MULTI_TENANT_CLASS)
+				.withTenants(Tenant.builder().name("TenantA").build(), Tenant.builder().name("TenantB").build())
+				.run();
+			assertThat(createTenantsResult.hasErrors()).isFalse();
+
+			WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
+			options.setObjectClass(MULTI_TENANT_CLASS);
+			WeaviateVectorStore tenantAStore = WeaviateVectorStore.builder(weaviateClient, embeddingModel)
+				.options(options)
+				.tenantName("TenantA")
+				.filterMetadataFields(List.of(WeaviateVectorStore.MetadataField.text("country")))
+				.build();
+			WeaviateVectorStore tenantBStore = WeaviateVectorStore.builder(weaviateClient, embeddingModel)
+				.options(options)
+				.tenantName("TenantB")
+				.filterMetadataFields(List.of(WeaviateVectorStore.MetadataField.text("country")))
+				.build();
+
+			String sharedId = UUID.randomUUID().toString();
+			Document tenantADocument = new Document(sharedId, "Tenant A private Spring document",
+					Map.of("country", "KR"));
+			Document tenantBDocument = new Document(sharedId, "Tenant B private Weaviate document",
+					Map.of("country", "BG"));
+			Document updatedTenantADocument = new Document(sharedId, "Tenant A updated private Spring document",
+					Map.of("country", "KR"));
+
+			try {
+				tenantAStore.add(List.of(tenantADocument));
+				tenantBStore.add(List.of(tenantBDocument));
+
+				assertThat(tenantAStore.similaritySearch(SearchRequest.builder().query("private").topK(10).build()))
+					.singleElement()
+					.extracting(Document::getText)
+					.isEqualTo(tenantADocument.getText());
+				assertThat(tenantBStore.similaritySearch(SearchRequest.builder().query("private").topK(10).build()))
+					.singleElement()
+					.extracting(Document::getText)
+					.isEqualTo(tenantBDocument.getText());
+
+				tenantAStore.add(List.of(updatedTenantADocument));
+
+				assertThat(tenantAStore.similaritySearch(SearchRequest.builder().query("private").topK(10).build()))
+					.singleElement()
+					.extracting(Document::getText)
+					.isEqualTo(updatedTenantADocument.getText());
+				assertThat(tenantBStore.similaritySearch(SearchRequest.builder().query("private").topK(10).build()))
+					.singleElement()
+					.extracting(Document::getText)
+					.isEqualTo(tenantBDocument.getText());
+
+				tenantAStore.delete(List.of(sharedId));
+
+				assertThat(tenantAStore.similaritySearch(SearchRequest.builder().query("private").topK(10).build()))
+					.isEmpty();
+				assertThat(tenantBStore.similaritySearch(SearchRequest.builder().query("private").topK(10).build()))
+					.singleElement()
+					.extracting(Document::getText)
+					.isEqualTo(tenantBDocument.getText());
+
+				tenantAStore.add(List.of(tenantADocument));
+				tenantAStore.delete("country == 'KR'");
+
+				assertThat(tenantAStore.similaritySearch(SearchRequest.builder().query("private").topK(10).build()))
+					.isEmpty();
+				assertThat(tenantBStore.similaritySearch(SearchRequest.builder().query("private").topK(10).build()))
+					.hasSize(1);
+			}
+			finally {
+				weaviateClient.schema().classDeleter().withClassName(MULTI_TENANT_CLASS).run();
+			}
 		});
 	}
 


### PR DESCRIPTION
`WeaviateVectorStore` currently has no way to target a tenant in a multi-tenant collection, so add, search, and delete operations cannot be scoped to a configured tenant.

This PR adds an optional `tenantName` builder option and the `spring.ai.vectorstore.weaviate.tenant-name` property to scope add, delete, and similarity search operations to a tenant.

The target collection must already have multi-tenancy enabled. Existing behavior is unchanged when no tenant name is configured.

I also tested this locally with Weaviate 1.31.22