### PR TITLE
Fix `S3VectorStore` search result IDs and list metadata

### DIFF
--- a/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/DocumentUtils.java
+++ b/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/DocumentUtils.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.core.document.Document;
  * Helper class to convert from AWS SDK Document to Object and vice versa.
  *
  * @author Matej Nedic
+ * @author Taewoong Kim
  */
 public final class DocumentUtils {
 
@@ -121,7 +122,7 @@ public final class DocumentUtils {
 			List<Document> docs = document.asList();
 			List<Object> listMetadata = new ArrayList<>(docs.size());
 			for (Document item : docs) {
-				listMetadata.add(fromDocument(item));
+				listMetadata.add(fromDocumentToObject(item));
 			}
 			return listMetadata;
 		}

--- a/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/S3VectorStore.java
+++ b/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/S3VectorStore.java
@@ -53,6 +53,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Matej Nedic
  * @author Jewoo Shin
+ * @author Taewoong Kim
  */
 public class S3VectorStore extends AbstractObservationVectorStore implements InitializingBean {
 
@@ -181,7 +182,7 @@ public class S3VectorStore extends AbstractObservationVectorStore implements Ini
 		if (vector.distance() != null) {
 			metadata.put("SPRING_AI_S3_DISTANCE", vector.distance());
 		}
-		return Document.builder().metadata(metadata).text(vector.key()).build();
+		return Document.builder().id(vector.key()).metadata(metadata).text(vector.key()).build();
 	}
 
 	private boolean matchesFilter(ListOutputVector vector, Filter.Expression filterExpression) {

--- a/vector-stores/spring-ai-s3-vector-store/src/test/java/S3VectorStoreTests.java
+++ b/vector-stores/spring-ai-s3-vector-store/src/test/java/S3VectorStoreTests.java
@@ -27,9 +27,12 @@ import software.amazon.awssdk.services.s3vectors.model.DeleteVectorsRequest;
 import software.amazon.awssdk.services.s3vectors.model.ListOutputVector;
 import software.amazon.awssdk.services.s3vectors.model.ListVectorsRequest;
 import software.amazon.awssdk.services.s3vectors.model.ListVectorsResponse;
+import software.amazon.awssdk.services.s3vectors.model.QueryOutputVector;
 import software.amazon.awssdk.services.s3vectors.model.QueryVectorsRequest;
+import software.amazon.awssdk.services.s3vectors.model.QueryVectorsResponse;
 
 import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
 import org.springframework.ai.vectorstore.s3.DocumentUtils;
 import org.springframework.ai.vectorstore.s3.S3VectorStore;
@@ -44,8 +47,48 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Jewoo Shin
+ * @author Taewoong Kim
  */
 class S3VectorStoreTests {
+
+	@Test
+	void similaritySearchPreservesVectorKeyAsDocumentId() {
+		S3VectorsClient s3VectorsClient = mock(S3VectorsClient.class);
+		when(s3VectorsClient.queryVectors(any(QueryVectorsRequest.class))).thenReturn(QueryVectorsResponse.builder()
+			.vectors(QueryOutputVector.builder().key("document-id").metadata(Document.fromMap(Map.of())).build())
+			.build());
+		EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+		when(embeddingModel.embed("test query")).thenReturn(new float[] { 0.1f, 0.2f, 0.3f });
+		S3VectorStore vectorStore = new S3VectorStore.Builder(s3VectorsClient, embeddingModel)
+			.vectorBucketName("test-vector-bucket")
+			.indexName("test-index")
+			.build();
+
+		assertThat(vectorStore.similaritySearch(SearchRequest.builder().query("test query").topK(1).build()))
+			.singleElement()
+			.satisfies(document -> assertThat(document.getId()).isEqualTo("document-id"));
+	}
+
+	@Test
+	void similaritySearchPreservesScalarListMetadata() {
+		S3VectorsClient s3VectorsClient = mock(S3VectorsClient.class);
+		when(s3VectorsClient.queryVectors(any(QueryVectorsRequest.class))).thenReturn(QueryVectorsResponse.builder()
+			.vectors(QueryOutputVector.builder()
+				.key("document-id")
+				.metadata(Document.fromMap(Map.of("tags", DocumentUtils.toDocument(List.of("java", "spring")))))
+				.build())
+			.build());
+		EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+		when(embeddingModel.embed("test query")).thenReturn(new float[] { 0.1f, 0.2f, 0.3f });
+		S3VectorStore vectorStore = new S3VectorStore.Builder(s3VectorsClient, embeddingModel)
+			.vectorBucketName("test-vector-bucket")
+			.indexName("test-index")
+			.build();
+
+		assertThat(vectorStore.similaritySearch(SearchRequest.builder().query("test query").topK(1).build()))
+			.singleElement()
+			.satisfies(document -> assertThat(document.getMetadata()).containsEntry("tags", List.of("java", "spring")));
+	}
 
 	@Test
 	void filterDeleteListsVectorsWithMetadataAndDeletesMatchingKeys() {


### PR DESCRIPTION
Documents returned by `S3VectorStore.similaritySearch()` currently receive a generated UUID instead of their S3 vector key. As a result, deleting a returned document by its own ID completes without an error but leaves the original vector in S3.

It also fails to return documents with common list metadata such as `tags: ["java", "spring"]`.
Each list item is treated as an object during result conversion, causing:

```text
UnsupportedOperationException: A Document String cannot be converted to a Map.
```

I also verified the behavior against AWS S3 Vectors using the following document:

```java
Document document = Document.builder()
	.id("spring-ai-document-1")
	.text("Spring AI vector store example")
	.metadata(Map.of(
			"category", "documentation",
			"tags", List.of("java", "spring")))
	.build();

vectorStore.add(List.of(document));
```

The resulting vector is stored in AWS S3 Vectors as follows:

<img width="1186" height="454" alt="s3_meta" src="https://github.com/user-attachments/assets/776a30da-e609-4543-ae53-c396e1cb3123" />


This change preserves the S3 vector key as `Document.id` and converts list elements according to their actual type.
After the change, list metadata is returned unchanged and deleting by the ID from `similaritySearch()` removes the original vector.