### PR TITLE
Use the negotiated protocol version on streamable HTTP reconnect

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransport.java
@@ -54,6 +54,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.context.ContextView;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
@@ -127,6 +128,10 @@ public final class WebClientStreamableHttpTransport implements McpClientTranspor
 
 	private final String latestSupportedProtocolVersion;
 
+	private final AtomicReference<@Nullable String> negotiatedProtocolVersion = new AtomicReference<>();
+
+	private final AtomicReference<Boolean> reconnectPendingAfterInitialization = new AtomicReference<>(false);
+
 	private WebClientStreamableHttpTransport(McpJsonMapper jsonMapper, WebClient.Builder webClientBuilder,
 			String endpoint, boolean resumableStreams, boolean openConnectionOnStartup,
 			List<String> supportedProtocolVersions) {
@@ -185,6 +190,15 @@ public final class WebClientStreamableHttpTransport implements McpClientTranspor
 					})
 					.then();
 		return new DefaultMcpTransportSession(onClose);
+	}
+
+	private String resolveProtocolVersion(ContextView ctx) {
+		String protocolVersion = ctx.getOrDefault(McpAsyncClient.NEGOTIATED_PROTOCOL_VERSION, null);
+		if (protocolVersion != null) {
+			this.negotiatedProtocolVersion.set(protocolVersion);
+			return protocolVersion;
+		}
+		return Objects.requireNonNullElse(this.negotiatedProtocolVersion.get(), this.latestSupportedProtocolVersion);
 	}
 
 	@Override
@@ -255,9 +269,7 @@ public final class WebClientStreamableHttpTransport implements McpClientTranspor
 			Disposable connection = this.webClient.get()
 				.uri(this.endpoint)
 				.accept(MediaType.TEXT_EVENT_STREAM)
-				.header(HttpHeaders.PROTOCOL_VERSION,
-						Objects.requireNonNullElse(ctx.getOrDefault(McpAsyncClient.NEGOTIATED_PROTOCOL_VERSION,
-								this.latestSupportedProtocolVersion), this.latestSupportedProtocolVersion))
+				.header(HttpHeaders.PROTOCOL_VERSION, this.resolveProtocolVersion(ctx))
 				.headers(httpHeaders -> {
 					transportSession.sessionId().ifPresent(id -> httpHeaders.add(HttpHeaders.MCP_SESSION_ID, id));
 					if (stream != null) {
@@ -341,96 +353,110 @@ public final class WebClientStreamableHttpTransport implements McpClientTranspor
 			// If it doesn't, nothing actually happens here, that's just the way it is...
 			final AtomicReference<@Nullable Disposable> disposableRef = new AtomicReference<>();
 
-			Disposable connection = Flux.deferContextual(ctx -> this.webClient.post()
-				.uri(this.endpoint)
-				.contentType(MediaType.APPLICATION_JSON)
-				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
-				.header(HttpHeaders.PROTOCOL_VERSION,
-						Objects.requireNonNullElse(ctx.getOrDefault(McpAsyncClient.NEGOTIATED_PROTOCOL_VERSION,
-								this.latestSupportedProtocolVersion), this.latestSupportedProtocolVersion))
-				.headers(httpHeaders -> transportSession.sessionId()
-					.ifPresent(id -> httpHeaders.add(HttpHeaders.MCP_SESSION_ID, id)))
-				.bodyValue(jsonText)
-				.exchangeToFlux(response -> {
-					if (transportSession
-						.markInitialized(response.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID))) {
-						// Once we have a session, we try to open an async stream for
-						// the server to send notifications and requests out-of-band.
-						reconnect((McpTransportStream<Disposable>) null).contextWrite(sink.contextView()).subscribe();
-					}
-
-					String sessionRepresentation = sessionIdOrPlaceholder(transportSession);
-
-					// The spec mentions only ACCEPTED, but the existing SDKs can return
-					// 200 OK for notifications
-					if (response.statusCode().is2xxSuccessful()) {
-						Optional<MediaType> contentType = response.headers().contentType();
-						long contentLength = response.headers().contentLength().orElse(-1);
-						// Existing SDKs consume notifications with no response body nor
-						// content type
-						if (contentType.isEmpty() || contentLength == 0
-								|| response.statusCode().equals(HttpStatus.ACCEPTED)) {
-							if (logger.isTraceEnabled()) {
-								logger.trace(
-										"Message was successfully sent via POST for session " + sessionRepresentation);
-							}
-							// signal the caller that the message was successfully
-							// delivered
-							sink.success();
-							// communicate to downstream there is no streamed data coming
-							return Flux.empty();
-						}
-						else {
-							MediaType mediaType = contentType.get();
-							if (mediaType.isCompatibleWith(MediaType.TEXT_EVENT_STREAM)) {
-								logger.debug("Established SSE stream via POST");
-								// communicate to caller that the message was delivered
-								sink.success();
-								// starting a stream
-								return newEventStream(response, sessionRepresentation);
-							}
-							else if (mediaType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
-								if (logger.isTraceEnabled()) {
-									logger.trace("Received response to POST for session " + sessionRepresentation);
-								}
-								// communicate to caller the message was delivered
-								sink.success();
-								return directResponseFlux(message, response);
+			Disposable connection = Flux.deferContextual(ctx -> {
+				String protocolVersion = this.resolveProtocolVersion(ctx);
+				if (Boolean.TRUE.equals(this.reconnectPendingAfterInitialization.getAndSet(false))) {
+					reconnect((McpTransportStream<Disposable>) null).contextWrite(ctx).subscribe();
+				}
+				return this.webClient.post()
+					.uri(this.endpoint)
+					.contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+					.header(HttpHeaders.PROTOCOL_VERSION, protocolVersion)
+					.headers(httpHeaders -> transportSession.sessionId()
+						.ifPresent(id -> httpHeaders.add(HttpHeaders.MCP_SESSION_ID, id)))
+					.bodyValue(jsonText)
+					.exchangeToFlux(response -> {
+						if (transportSession
+							.markInitialized(response.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID))) {
+							// Once we have a session, we try to open an async stream for
+							// the server to send notifications and requests out-of-band.
+							if (this.negotiatedProtocolVersion.get() != null) {
+								reconnect((McpTransportStream<Disposable>) null).contextWrite(ctx).subscribe();
 							}
 							else {
-								if (logger.isWarnEnabled()) {
-									logger.warn("Unknown media type " + contentType + " returned for POST in session "
-											+ sessionRepresentation);
-								}
-								return Flux.error(new RuntimeException("Unknown media type returned: " + contentType));
+								this.reconnectPendingAfterInitialization.set(true);
 							}
 						}
-					}
-					else {
-						if (isNotFound(response) && !sessionRepresentation.equals(MISSING_SESSION_ID)) {
-							return mcpSessionNotFoundError(sessionRepresentation);
+
+						String sessionRepresentation = sessionIdOrPlaceholder(transportSession);
+
+						// The spec mentions only ACCEPTED, but the existing SDKs can
+						// return
+						// 200 OK for notifications
+						if (response.statusCode().is2xxSuccessful()) {
+							Optional<MediaType> contentType = response.headers().contentType();
+							long contentLength = response.headers().contentLength().orElse(-1);
+							// Existing SDKs consume notifications with no response body
+							// nor
+							// content type
+							if (contentType.isEmpty() || contentLength == 0
+									|| response.statusCode().equals(HttpStatus.ACCEPTED)) {
+								if (logger.isTraceEnabled()) {
+									logger.trace("Message was successfully sent via POST for session "
+											+ sessionRepresentation);
+								}
+								// signal the caller that the message was successfully
+								// delivered
+								sink.success();
+								// communicate to downstream there is no streamed data
+								// coming
+								return Flux.empty();
+							}
+							else {
+								MediaType mediaType = contentType.get();
+								if (mediaType.isCompatibleWith(MediaType.TEXT_EVENT_STREAM)) {
+									logger.debug("Established SSE stream via POST");
+									// communicate to caller that the message was
+									// delivered
+									sink.success();
+									// starting a stream
+									return newEventStream(response, sessionRepresentation);
+								}
+								else if (mediaType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
+									if (logger.isTraceEnabled()) {
+										logger.trace("Received response to POST for session " + sessionRepresentation);
+									}
+									// communicate to caller the message was delivered
+									sink.success();
+									return directResponseFlux(message, response);
+								}
+								else {
+									if (logger.isWarnEnabled()) {
+										logger.warn("Unknown media type " + contentType
+												+ " returned for POST in session " + sessionRepresentation);
+									}
+									return Flux
+										.error(new RuntimeException("Unknown media type returned: " + contentType));
+								}
+							}
 						}
-						return this.extractError(response, sessionRepresentation);
-					}
-				})).flatMap(jsonRpcMessage -> requestHandler.apply(Mono.just(jsonRpcMessage))).onErrorComplete(t -> {
-					// handle the error first
-					try {
-						this.handleException(t);
-					}
-					catch (Exception e) {
-						if (logger.isErrorEnabled()) {
-							logger.error("Error handling exception " + t.getMessage(), e);
+						else {
+							if (isNotFound(response) && !sessionRepresentation.equals(MISSING_SESSION_ID)) {
+								return mcpSessionNotFoundError(sessionRepresentation);
+							}
+							return this.extractError(response, sessionRepresentation);
 						}
+					});
+			}).flatMap(jsonRpcMessage -> requestHandler.apply(Mono.just(jsonRpcMessage))).onErrorComplete(t -> {
+				// handle the error first
+				try {
+					this.handleException(t);
+				}
+				catch (Exception e) {
+					if (logger.isErrorEnabled()) {
+						logger.error("Error handling exception " + t.getMessage(), e);
 					}
-					// inform the caller of sendMessage
-					sink.error(t);
-					return true;
-				}).doFinally(s -> {
-					@Nullable Disposable ref = disposableRef.getAndSet(null);
-					if (ref != null) {
-						transportSession.removeConnection(ref);
-					}
-				}).contextWrite(sink.contextView()).subscribe();
+				}
+				// inform the caller of sendMessage
+				sink.error(t);
+				return true;
+			}).doFinally(s -> {
+				@Nullable Disposable ref = disposableRef.getAndSet(null);
+				if (ref != null) {
+					transportSession.removeConnection(ref);
+				}
+			}).contextWrite(sink.contextView()).subscribe();
 			disposableRef.set(connection);
 			transportSession.addConnection(connection);
 		});

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableHttpVersionNegotiationIT.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableHttpVersionNegotiationIT.java
@@ -39,7 +39,6 @@ import reactor.netty.http.server.HttpServer;
 import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
 import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.ai.mcp.utils.McpTestRequestRecordingExchangeFilterFunction;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -157,13 +156,17 @@ class WebFluxStreamableHttpVersionNegotiationIT {
 
 			McpSchema.CallToolResult response = client.callTool(McpSchema.CallToolRequest.builder("test-tool").build());
 
+			Awaitility.await()
+				.atMost(Duration.ofSeconds(5))
+				.until(() -> this.recordingFilterFunction.getCalls()
+					.stream()
+					.filter(c -> !c.body().contains("\"method\":\"initialize\""))
+					.count() >= 3);
+
 			var calls = this.recordingFilterFunction.getCalls();
-			// Initialize tells the server the Client's latest supported version
-			// FIXME: Set the correct protocol version on GET /mcp
-			assertThat(calls)
-				.filteredOn(c -> !c.body().contains("\"method\":\"initialize\"") && c.method().equals(HttpMethod.POST))
-				// POST notification/initialized ; POST tools/call
-				.hasSize(2)
+			assertThat(calls).filteredOn(c -> !c.body().contains("\"method\":\"initialize\""))
+				// GET /mcp ; POST notification/initialized ; POST tools/call
+				.hasSize(3)
 				.map(McpTestRequestRecordingExchangeFilterFunction.Call::headers)
 				.allSatisfy(headers -> assertThat(headers).containsEntry("mcp-protocol-version",
 						ProtocolVersions.MCP_2025_11_25));


### PR DESCRIPTION
Resolves #6573.

## Problem

`WebFluxStreamableHttpVersionNegotiationIT` carries this on `main`, with the assertion filtered down to `POST` so it can pass:

```java
// FIXME: Set the correct protocol version on GET /mcp
assertThat(calls)
    .filteredOn(c -> !c.body().contains("\"method\":\"initialize\"") && c.method().equals(HttpMethod.POST))
    .hasSize(2)
```

When the server negotiates an older version, the background `GET /mcp` reconnect still sends the client's latest supported version. `reconnect(...)` reads `NEGOTIATED_PROTOCOL_VERSION` from the Reactor context, but it is subscribed while the `initialize` exchange is still in flight, so the value is not there yet and it falls back to `latestSupportedProtocolVersion`.

## Changes

- persist the negotiated version in `WebClientStreamableHttpTransport` and fall back to it when the context has none
- defer the post-initialization reconnect until the negotiated version is known
- drop the FIXME and the `HttpMethod.POST` filter, so the assertion covers `GET /mcp` as well

## Testing

```
./mvnw -Dmaven.build.cache.enabled=false -Pintegration-tests \
  -pl mcp/transport/mcp-spring-webflux \
  -Dit.test=WebFluxStreamableHttpVersionNegotiationIT -DfailIfNoTests=false verify
```

Reverting only the production file makes `usesServerSupportedVersion` fail with the defect itself: the `GET` carries `mcp-protocol-version: 2263-03-18` while both `POST`s carry the negotiated `2025-11-25`. With the fix, both tests pass.

## Notes

Most of the diff is re-indentation, because the `Flux.deferContextual` lambda became a block. `git diff -w`, or GitHub's "Hide whitespace", shows `+41/-18` rather than `+108/-85`.

Two decisions I would rather leave to you:

- whether `negotiatedProtocolVersion` should be cleared when the session closes
- whether deferring the reconnect to the next `sendMessage` is acceptable, since it relies on the client sending `notifications/initialized` after `initialize`

Not addressed here: the session-delete `DELETE` in `createTransportSession()` still sends `latestSupportedProtocolVersion` unconditionally. Happy to cover it in a follow-up.
