### PR TITLE
Refine contribution

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -893,8 +893,8 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	}
 
 	/**
-	 * Validates ThinkingLevel compatibility with the model. Gemini 3 Pro only supports
-	 * LOW and HIGH. Gemini 3 Flash supports all levels.
+	 * Validates ThinkingLevel compatibility with the model. Gemini 3.1 Pro doesn't
+	 * support MINIMAL. Gemini 3 Flash supports all levels.
 	 * @param level the thinking level to validate
 	 * @param modelName the model name
 	 * @throws IllegalArgumentException if the level is not supported for the model


### PR DESCRIPTION
Edit a JavaDoc that declared that Gemini Pro 3 only supports LOW and HIGH thinking levels. Gemini Pro 3 is not available now, Gemini 3.1 Pro supports LOW, MEDIUM, HIGH

See: gh-6339