### PR TITLE
Use configured MCP mapper for annotated tools

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerSpecificationFactoryAutoConfiguration.java
@@ -16,19 +16,26 @@
 
 package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpServerFeatures;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.mcp.annotation.McpComplete;
 import org.springframework.ai.mcp.annotation.McpPrompt;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.provider.tool.AsyncMcpToolProvider;
+import org.springframework.ai.mcp.annotation.provider.tool.SyncMcpToolProvider;
+import org.springframework.ai.mcp.annotation.spring.AnnotationProviderUtil;
 import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration.ServerMcpAnnotatedBeans;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -45,6 +52,28 @@ import org.springframework.context.annotation.Configuration;
 		havingValue = "true", matchIfMissing = true)
 @Conditional(McpServerAutoConfiguration.NonStatelessServerCondition.class)
 public class McpServerSpecificationFactoryAutoConfiguration {
+
+	private static SyncMcpToolProvider syncToolProvider(List<Object> toolObjects, JsonMapper jsonMapper) {
+		var provider = new SyncMcpToolProvider(toolObjects) {
+			@Override
+			protected Method[] doGetClassMethods(Object bean) {
+				return AnnotationProviderUtil.beanMethods(bean);
+			}
+		};
+		provider.setJsonMapper(new JacksonMcpJsonMapper(jsonMapper));
+		return provider;
+	}
+
+	private static AsyncMcpToolProvider asyncToolProvider(List<Object> toolObjects, JsonMapper jsonMapper) {
+		var provider = new AsyncMcpToolProvider(toolObjects) {
+			@Override
+			protected Method[] doGetClassMethods(Object bean) {
+				return AnnotationProviderUtil.beanMethods(bean);
+			}
+		};
+		provider.setJsonMapper(new JacksonMcpJsonMapper(jsonMapper));
+		return provider;
+	}
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
@@ -85,9 +114,10 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpServerFeatures.SyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations,
+				@Qualifier("mcpServerJsonMapper") JsonMapper jsonMapper) {
 			List<Object> beansByAnnotation = beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class);
-			return SyncMcpAnnotationProviders.toolSpecifications(beansByAnnotation);
+			return syncToolProvider(beansByAnnotation, jsonMapper).getToolSpecifications();
 		}
 
 	}
@@ -127,9 +157,10 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpServerFeatures.AsyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
-			return AsyncMcpAnnotationProviders
-				.toolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations,
+				@Qualifier("mcpServerJsonMapper") JsonMapper jsonMapper) {
+			return asyncToolProvider(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class), jsonMapper)
+				.getToolSpecifications();
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
@@ -16,14 +16,20 @@
 
 package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.mcp.annotation.McpComplete;
 import org.springframework.ai.mcp.annotation.McpPrompt;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.provider.tool.AsyncStatelessMcpToolProvider;
+import org.springframework.ai.mcp.annotation.provider.tool.SyncStatelessMcpToolProvider;
+import org.springframework.ai.mcp.annotation.spring.AnnotationProviderUtil;
 import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration;
@@ -31,6 +37,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisa
 import org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration.ServerMcpAnnotatedBeans;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -47,6 +54,28 @@ import org.springframework.context.annotation.Configuration;
 		McpServerStatelessAutoConfiguration.EnabledStatelessServerCondition.class,
 		StatelessToolCallbackConverterAutoConfiguration.ToolCallbackConverterCondition.class })
 public class StatelessServerSpecificationFactoryAutoConfiguration {
+
+	private static SyncStatelessMcpToolProvider syncToolProvider(List<Object> toolObjects, JsonMapper jsonMapper) {
+		var provider = new SyncStatelessMcpToolProvider(toolObjects) {
+			@Override
+			protected Method[] doGetClassMethods(Object bean) {
+				return AnnotationProviderUtil.beanMethods(bean);
+			}
+		};
+		provider.setJsonMapper(new JacksonMcpJsonMapper(jsonMapper));
+		return provider;
+	}
+
+	private static AsyncStatelessMcpToolProvider asyncToolProvider(List<Object> toolObjects, JsonMapper jsonMapper) {
+		var provider = new AsyncStatelessMcpToolProvider(toolObjects) {
+			@Override
+			protected Method[] doGetClassMethods(Object bean) {
+				return AnnotationProviderUtil.beanMethods(bean);
+			}
+		};
+		provider.setJsonMapper(new JacksonMcpJsonMapper(jsonMapper));
+		return provider;
+	}
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
@@ -83,10 +112,12 @@ public class StatelessServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations,
+				@Qualifier("mcpServerJsonMapper") JsonMapper jsonMapper) {
 			List<Object> beansByAnnotation = beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class);
-			List<McpStatelessServerFeatures.SyncToolSpecification> syncToolSpecifications = SyncMcpAnnotationProviders
-				.statelessToolSpecifications(beansByAnnotation);
+			List<McpStatelessServerFeatures.SyncToolSpecification> syncToolSpecifications = syncToolProvider(
+					beansByAnnotation, jsonMapper)
+				.getToolSpecifications();
 			return syncToolSpecifications;
 		}
 
@@ -126,9 +157,10 @@ public class StatelessServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpStatelessServerFeatures.AsyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
-			return AsyncMcpAnnotationProviders
-				.statelessToolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations,
+				@Qualifier("mcpServerJsonMapper") JsonMapper jsonMapper) {
+			return asyncToolProvider(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class), jsonMapper)
+				.getToolSpecifications();
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpToolInputSchemaIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpToolInputSchemaIT.java
@@ -19,15 +19,21 @@ package org.springframework.ai.mcp.server.common.autoconfigure;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.method.tool.utils.McpJsonSchemaGenerator;
@@ -36,6 +42,8 @@ import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpSer
 import org.springframework.ai.util.JacksonUtils;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -157,6 +165,47 @@ public class McpToolInputSchemaIT {
 			});
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	void annotatedToolUsesConfiguredMcpJsonMapper() {
+		this.contextRunner
+			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
+					McpServerSpecificationFactoryAutoConfiguration.class, SnakeCaseJsonMapperConfiguration.class)
+			.withBean(MapperToolComponent.class)
+			.run(context -> {
+				List<SyncToolSpecification> tools = (List<SyncToolSpecification>) context.getBean("toolSpecs");
+
+				assertThat(tools).hasSize(1);
+				var result = tools.get(0)
+					.callHandler()
+					.apply(null, CallToolRequest.builder("mapper_tool").arguments(Map.of()).build());
+
+				assertThat(result.content()).singleElement().isInstanceOf(TextContent.class);
+				assertThat(((TextContent) result.content().get(0)).text())
+					.isEqualTo("{\"display_name\":\"Spring AI\"}");
+			});
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void annotatedToolUsesDefaultMcpJsonMapper() {
+		this.contextRunner
+			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
+					McpServerSpecificationFactoryAutoConfiguration.class)
+			.withBean(MapperToolComponent.class)
+			.run(context -> {
+				List<SyncToolSpecification> tools = (List<SyncToolSpecification>) context.getBean("toolSpecs");
+
+				assertThat(tools).hasSize(1);
+				var result = tools.get(0)
+					.callHandler()
+					.apply(null, CallToolRequest.builder("mapper_tool").arguments(Map.of()).build());
+
+				assertThat(result.content()).singleElement().isInstanceOf(TextContent.class);
+				assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("{\"displayName\":\"Spring AI\"}");
+			});
+	}
+
 	private static List<String> requiredList(JsonNode node) {
 		List<String> result = new ArrayList<>();
 		JsonNode arr = node.get("required");
@@ -218,6 +267,29 @@ public class McpToolInputSchemaIT {
 		@McpTool(name = "create_jira_issue", description = "Create a Jira issue")
 		public String createJiraIssue(JiraCreateIssueRequest request) {
 			return "created: " + request.summary();
+		}
+
+	}
+
+	record MapperToolResult(String displayName) {
+	}
+
+	@Component
+	static class MapperToolComponent {
+
+		@McpTool(name = "mapper_tool", description = "Return a mapped result")
+		public MapperToolResult mapperTool() {
+			return new MapperToolResult("Spring AI");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class SnakeCaseJsonMapperConfiguration {
+
+		@Bean(name = "mcpServerJsonMapper")
+		JsonMapper mcpServerJsonMapper() {
+			return JsonMapper.builder().propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE).build();
 		}
 
 	}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -28,7 +28,6 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.context.McpRequestContextTypes;
-import org.springframework.ai.util.JsonHelper;
 
 /**
  * Abstract base class for creating Function callbacks around async tool methods.
@@ -44,8 +43,6 @@ import org.springframework.ai.util.JsonHelper;
  */
 public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpRequestContextTypes<?>>
 		extends AbstractMcpToolMethodCallback<T, RC> {
-
-	private static final JsonHelper jsonHelper = new JsonHelper();
 
 	/**
 	 * @deprecated no longer consulted. Exception handling now follows the {@code @Tool}
@@ -91,7 +88,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			// Handle Mono<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return monoResult
-					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
+					.then(Mono.just(CallToolResult.builder().addTextContent(getJsonHelper().toJson("Done")).build()))
 					.onErrorResume(this::toErrorResultOrPropagate);
 			}
 
@@ -111,7 +108,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			// Handle Mono<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return fluxResult
-					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
+					.then(Mono.just(CallToolResult.builder().addTextContent(getJsonHelper().toJson("Done")).build()))
 					.onErrorResume(this::toErrorResultOrPropagate);
 			}
 
@@ -132,7 +129,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			// Handle Mono<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return monoFromPublisher
-					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
+					.then(Mono.just(CallToolResult.builder().addTextContent(getJsonHelper().toJson("Done")).build()))
 					.onErrorResume(this::toErrorResultOrPropagate);
 			}
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.jspecify.annotations.Nullable;
@@ -50,7 +52,7 @@ import org.springframework.ai.util.JsonHelper;
  */
 public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestContextTypes<?>> {
 
-	private static final JsonHelper jsonHelper = new JsonHelper();
+	private JsonHelper jsonHelper = new JsonHelper();
 
 	protected final Method toolMethod;
 
@@ -153,12 +155,27 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 		}
 
 		if (type instanceof Class<?>) {
-			return jsonHelper.convertToTypedObject(value, (Class<?>) type);
+			return this.jsonHelper.convertToTypedObject(value, (Class<?>) type);
 		}
 
 		// For generic types, use the fromJson method that accepts Type
-		String json = jsonHelper.toJson(value, true);
-		return jsonHelper.fromJson(json, type);
+		String json = this.jsonHelper.toJson(value, true);
+		return this.jsonHelper.fromJson(json, type);
+	}
+
+	protected JsonHelper getJsonHelper() {
+		return this.jsonHelper;
+	}
+
+	/**
+	 * Configure the JSON mapper used to convert annotated tool arguments and results.
+	 * @param jsonMapper the JSON mapper
+	 * @since 2.0.1
+	 */
+	public void setJsonMapper(McpJsonMapper jsonMapper) {
+		if (jsonMapper instanceof JacksonMcpJsonMapper jacksonJsonMapper) {
+			this.jsonHelper = new JsonHelper(jacksonJsonMapper.getJsonMapper());
+		}
 	}
 
 	/**
@@ -177,12 +194,12 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 		Type returnType = this.toolMethod.getGenericReturnType();
 
 		if (this.returnMode == ReturnMode.VOID || returnType == Void.TYPE || returnType == void.class) {
-			return CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build();
+			return CallToolResult.builder().addTextContent(this.jsonHelper.toJson("Done")).build();
 		}
 
 		if (this.returnMode == ReturnMode.STRUCTURED) {
-			String jsonOutput = jsonHelper.toJson(result);
-			Object structuredOutput = jsonHelper.fromJson(jsonOutput, Object.class);
+			String jsonOutput = this.jsonHelper.toJson(result);
+			Object structuredOutput = this.jsonHelper.fromJson(jsonOutput, Object.class);
 			return CallToolResult.builder().structuredContent(structuredOutput).build();
 		}
 
@@ -198,7 +215,7 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 		}
 
 		// For other types, serialize to JSON
-		return CallToolResult.builder().addTextContent(jsonHelper.toJson(result)).build();
+		return CallToolResult.builder().addTextContent(this.jsonHelper.toJson(result)).build();
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -19,18 +19,13 @@ package org.springframework.ai.mcp.annotation.provider.tool;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import reactor.core.publisher.Mono;
 
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
@@ -142,8 +137,8 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 							: ReactiveUtils.isReactiveReturnTypeOfVoid(mcpToolMethod) ? ReturnMode.VOID
 									: ReturnMode.TEXT;
 
-					BiFunction<McpAsyncServerExchange, CallToolRequest, Mono<CallToolResult>> methodCallback = new AsyncMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject);
+					var methodCallback = new AsyncMcpToolMethodCallback(returnMode, mcpToolMethod, toolObject);
+					methodCallback.setJsonMapper(this.getJsonMapper());
 
 					AsyncToolSpecification toolSpec = AsyncToolSpecification.builder()
 						.tool(tool)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -19,18 +19,14 @@ package org.springframework.ai.mcp.annotation.provider.tool;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import reactor.core.publisher.Mono;
 
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
@@ -147,8 +143,8 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 							: ReactiveUtils.isReactiveReturnTypeOfVoid(mcpToolMethod) ? ReturnMode.VOID
 									: ReturnMode.TEXT;
 
-					BiFunction<McpTransportContext, CallToolRequest, Mono<CallToolResult>> methodCallback = new AsyncStatelessMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject);
+					var methodCallback = new AsyncStatelessMcpToolMethodCallback(returnMode, mcpToolMethod, toolObject);
+					methodCallback.setJsonMapper(this.getJsonMapper());
 
 					AsyncToolSpecification toolSpec = AsyncToolSpecification.builder()
 						.tool(tool)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
@@ -19,13 +19,10 @@ package org.springframework.ai.mcp.annotation.provider.tool;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
-import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
@@ -138,8 +135,8 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 							: (methodReturnType == Void.TYPE || methodReturnType == void.class ? ReturnMode.VOID
 									: ReturnMode.TEXT);
 
-					BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> methodCallback = new SyncMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject);
+					var methodCallback = new SyncMcpToolMethodCallback(returnMode, mcpToolMethod, toolObject);
+					methodCallback.setJsonMapper(this.getJsonMapper());
 
 					var toolSpec = SyncToolSpecification.builder().tool(tool).callHandler(methodCallback).build();
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
@@ -19,13 +19,11 @@ package org.springframework.ai.mcp.annotation.provider.tool;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
@@ -142,8 +140,8 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 							: (methodReturnType == Void.TYPE || methodReturnType == void.class ? ReturnMode.VOID
 									: ReturnMode.TEXT);
 
-					BiFunction<McpTransportContext, CallToolRequest, CallToolResult> methodCallback = new SyncStatelessMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject);
+					var methodCallback = new SyncStatelessMcpToolMethodCallback(returnMode, mcpToolMethod, toolObject);
+					methodCallback.setJsonMapper(this.getJsonMapper());
 
 					var toolSpec = SyncToolSpecification.builder().tool(tool).callHandler(methodCallback).build();
 


### PR DESCRIPTION
## Summary

Fixes #4479.

Annotation-based MCP tool callbacks did not use the configured
`mcpServerJsonMapper` when converting tool arguments and results.

As a result, custom Jackson configurations (for example,
snake_case property naming strategies) were ignored for
methods annotated with `@McpTool`.

This change propagates the configured `McpJsonMapper`
from the annotation-based providers to generated tool callbacks.

## Root Cause

The MCP server auto-configuration correctly created providers
using the configured mapper, but the generated callbacks
continued using their default JSON helper.

## Solution

- Reuse the configured `McpJsonMapper`
- Pass it to generated callbacks
- Preserve existing behavior when no custom mapper is configured
- Avoid introducing new `JsonMapper` overloads or constructors

## Tests

Executed:

- `McpToolInputSchemaIT`
- MCP annotation module tests
- `git diff --check`

Targeted MCP tests passed.

## Limitations

`./mvnw clean package` did not complete successfully on my
local Windows environment because the build stopped on
assertion failures in unrelated modules before reaching
the modified MCP modules.

The targeted MCP regression tests completed successfully.