### PR TITLE
Parse `long` literals in `FilterExpressionTextParser`

### DIFF
--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
@@ -231,7 +231,14 @@ public class FilterExpressionTextParser {
 
 		@Override
 		public Filter.Operand visitIntegerConstant(FiltersParser.IntegerConstantContext ctx) {
-			return new Filter.Value(Integer.valueOf(ctx.getText()));
+			String text = ctx.getText();
+			try {
+				return new Filter.Value(Integer.valueOf(text));
+			}
+			catch (NumberFormatException ex) {
+				// Fall back to Long for literals that exceed the int range (gh-4705).
+				return new Filter.Value(Long.valueOf(text));
+			}
 		}
 
 		@Override

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParserTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParserTests.java
@@ -67,6 +67,21 @@ public class FilterExpressionTextParserTests {
 	}
 
 	@Test
+	public void testLongValueLiteral() {
+		// id == 9223372036854775807 (Long.MAX_VALUE, exceeds the int range)
+		Expression exp = this.parser.parse("id == " + Long.MAX_VALUE);
+		assertThat(exp).isEqualTo(new Expression(EQ, new Key("id"), new Value(Long.MAX_VALUE)));
+
+		// id == -9223372036854775808 (Long.MIN_VALUE)
+		exp = this.parser.parse("id == " + Long.MIN_VALUE);
+		assertThat(exp).isEqualTo(new Expression(EQ, new Key("id"), new Value(Long.MIN_VALUE)));
+
+		// Values within the int range are still parsed as Integer
+		exp = this.parser.parse("year == 2020");
+		assertThat(((Value) exp.right()).value()).isInstanceOf(Integer.class).isEqualTo(2020);
+	}
+
+	@Test
 	public void tesEqAndGte() {
 		// genre == "drama" AND year >= 2020
 		Expression exp = this.parser.parse("genre == 'drama' && year >= 2020");


### PR DESCRIPTION
**What**

`FilterExpressionTextParser` parsed every bare integer literal as `Integer`, so a filter expression whose value exceeds the int range — e.g. a `long` metadata id used when deleting by id — failed with:

```
java.lang.NumberFormatException: For input string: "9223372036854775807"
```

**Fix**

`visitIntegerConstant` now falls back to `Long` when the literal doesn't fit in an `int`, while still returning `Integer` for smaller values (backward compatible). Literals with an explicit `L` suffix keep going through the existing `visitLongConstant` path, and values inside `IN`/`NIN` arrays are covered too since they delegate to the same visitor.

**Tests**

Added `testLongValueLiteral` covering `Long.MAX_VALUE` / `Long.MIN_VALUE` and asserting that in-range values still parse as `Integer`. All 16 parser tests pass locally:

```
./mvnw -pl spring-ai-vector-store -am -Dtest=FilterExpressionTextParserTests -Dsurefire.failIfNoSpecifiedTests=false test
```

Fixes #4705
