### PR TITLE
Preserve Oracle vector store metadata

### DIFF
--- a/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
+++ b/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
@@ -231,6 +231,9 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 				else if (o instanceof Boolean) {
 					gen.write(key, (Boolean) o);
 				}
+				else if (o instanceof OracleJsonValue oracleJsonValue) {
+					gen.write(key, oracleJsonValue);
+				}
 			}
 			gen.writeEnd();
 		}

--- a/vector-stores/spring-ai-oracle-store/src/test/java/org/springframework/ai/vectorstore/oracle/OracleVectorStoreIT.java
+++ b/vector-stores/spring-ai-oracle-store/src/test/java/org/springframework/ai/vectorstore/oracle/OracleVectorStoreIT.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import javax.sql.DataSource;
 
 import oracle.jdbc.pool.OracleDataSource;
+import oracle.sql.json.OracleJsonValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -284,6 +285,49 @@ public class OracleVectorStoreIT extends BaseVectorStoreTests {
 				assertThat(resultDoc.getId()).isEqualTo(document.getId());
 				assertThat(resultDoc.getText()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
 				assertThat(resultDoc.getMetadata()).containsKeys("meta2", DocumentMetadata.DISTANCE.value());
+
+				dropTable(context, ((OracleVectorStore) vectorStore).getTableName());
+			});
+	}
+
+	@Test
+	void shouldPreserveMetadataWhenRetrievedDocumentIsAddedAgain() {
+		this.contextRunner
+			.withPropertyValues("test.spring.ai.vectorstore.oracle.distanceType=COSINE",
+					"test.spring.ai.vectorstore.oracle.searchAccuracy=" + OracleVectorStore.DEFAULT_SEARCH_ACCURACY)
+			.run(context -> {
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				Document original = new Document(UUID.randomUUID().toString(), "Spring AI Oracle metadata round trip",
+						Map.of("conversationId", "conversation-123"));
+
+				vectorStore.add(List.of(original));
+
+				SearchRequest searchRequest = SearchRequest.builder()
+					.query("Spring AI Oracle metadata round trip")
+					.topK(1)
+					.similarityThresholdAll()
+					.build();
+
+				List<Document> firstResults = vectorStore.similaritySearch(searchRequest);
+
+				assertThat(firstResults).hasSize(1);
+
+				Document retrieved = firstResults.get(0);
+
+				assertThat(retrieved.getId()).isEqualTo(original.getId());
+				assertThat(retrieved.getMetadata().get("conversationId")).isInstanceOfSatisfying(OracleJsonValue.class,
+						value -> assertThat(value.asJsonString().getString()).isEqualTo("conversation-123"));
+
+				// Re-add the document returned by OracleVectorStore.
+				vectorStore.add(List.of(retrieved));
+
+				List<Document> secondResults = vectorStore.similaritySearch(searchRequest);
+
+				assertThat(secondResults).hasSize(1);
+				assertThat(secondResults.get(0).getMetadata().get("conversationId")).isInstanceOfSatisfying(
+						OracleJsonValue.class,
+						value -> assertThat(value.asJsonString().getString()).isEqualTo("conversation-123"));
 
 				dropTable(context, ((OracleVectorStore) vectorStore).getTableName());
 			});


### PR DESCRIPTION
Fixes #3838

### Problem

`OracleVectorStore` does not preserve user-defined metadata when a document returned by `similaritySearch()` is added to the vector store again.

When metadata is initially added, values such as strings are represented using standard Java types:

```java
Map.of("conversationId", "conversation-123")
```

After the document is stored in Oracle and retrieved through `similaritySearch()`, metadata values read from the Oracle JSON column are represented as `OracleJsonValue` implementations.

For example, a string metadata value is returned as an Oracle JSON string value rather than a standard Java `String`.

When the retrieved `Document` is added again, `OracleVectorStore.toJson()` only serializes a limited set of Java scalar types:

- `String`
- `Integer`
- `Float`
- `Double`
- `Boolean`

Because `OracleJsonValue` was not handled, those metadata entries were silently skipped during serialization.

As a result, the following round trip removed the original user-defined metadata:

```text
Add document
→ Retrieve document from Oracle
→ Add the retrieved document again
→ Retrieve it again
```

Before this change, the second retrieval contained only generated metadata such as:

```text
{"distance"=0.0}
```

The original `conversationId` entry was no longer present.

### Changes

This change adds support for serializing `OracleJsonValue` instances directly through `OracleJsonGenerator`.

```java
else if (o instanceof OracleJsonValue oracleJsonValue) {
    gen.write(key, oracleJsonValue);
}
```

This allows metadata returned by Oracle to be written back without being silently discarded.

### Testing

Added an integration test that:

1. Stores a document with user-defined metadata.
2. Retrieves the document through `similaritySearch()`.
3. Verifies that the metadata was returned as an `OracleJsonValue`.
4. Adds the retrieved document to `OracleVectorStore` again.
5. Retrieves the document a second time.
6. Verifies that the original metadata is still present.

The regression test fails before the fix because the metadata is removed, and passes after `OracleJsonValue` serialization is supported.