### PR TITLE
Preserve AssistantMessage subclass fields on copy

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -1584,7 +1584,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 			@Override
 			public AnthropicAssistantMessage build() {
-				Assert.hasText(this.content, "content cannot be null or empty");
+				Assert.notNull(this.content, "content cannot be null");
 				return new AnthropicAssistantMessage(this.content, this.toolCalls, this.thinkingContents);
 			}
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -147,6 +147,7 @@ import org.springframework.util.MimeType;
  * @author Ilayaperumal Gopinathan
  * @author Jewoo Shin
  * @author Seeun Kim
+ * @author guan xu
  * @since 1.0.0
  * @see AnthropicChatOptions
  * @see <a href="https://docs.anthropic.com/en/api/messages">Anthropic Messages API</a>
@@ -1555,9 +1556,38 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		}
 
 		@Override
+		public Builder mutate() {
+			return builder().content(getText()).toolCalls(getToolCalls()).thinkingContents(getThinkingContents());
+		}
+
+		@Override
 		public String toString() {
 			return "AnthropicAssistantMessage [messageType=" + getMessageType() + ", toolCalls=" + getToolCalls()
 					+ ", textContent=" + getText() + ", thinkingContents=" + this.thinkingContents.size() + "]";
+		}
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		static final class Builder extends AssistantMessage.Builder<Builder> {
+
+			private List<AnthropicThinkingContent> thinkingContents = List.of();
+
+			private Builder() {
+			}
+
+			Builder thinkingContents(List<AnthropicThinkingContent> thinkingContents) {
+				this.thinkingContents = thinkingContents;
+				return self();
+			}
+
+			@Override
+			public AnthropicAssistantMessage build() {
+				Assert.hasText(this.content, "content cannot be null or empty");
+				return new AnthropicAssistantMessage(this.content, this.toolCalls, this.thinkingContents);
+			}
+
 		}
 
 	}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicAssistantMessageTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicAssistantMessageTests.java
@@ -33,9 +33,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AnthropicAssistantMessageTests {
 
 	@Test
-	void copyPreservesThinkingContents() {
+	void copyPreservesAnthropicAssistantMessageWithEmptyContent() {
 		AnthropicChatModel.AnthropicAssistantMessage original = AnthropicChatModel.AnthropicAssistantMessage.builder()
-			.content("hello")
+			.content("")
 			.thinkingContents(List.of(AnthropicChatModel.AnthropicThinkingContent.thinking("think", "sig")))
 			.build();
 
@@ -43,6 +43,7 @@ class AnthropicAssistantMessageTests {
 			.copy();
 
 		assertThat(copy).isNotSameAs(original);
+		assertThat(copy.getText()).isEmpty();
 		assertThat(copy.getThinkingContents()).hasSize(1);
 		assertThat(copy.getThinkingContents().get(0).thinking()).isEqualTo("think");
 		assertThat(copy.getThinkingContents().get(0).signature()).isEqualTo("sig");
@@ -61,7 +62,12 @@ class AnthropicAssistantMessageTests {
 		Message copied = copy.getInstructions().get(0);
 		assertThat(copied).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
 		AnthropicChatModel.AnthropicAssistantMessage anthropicCopy = (AnthropicChatModel.AnthropicAssistantMessage) copied;
+
+		assertThat(anthropicCopy).isNotSameAs(original);
 		assertThat(anthropicCopy.getThinkingContents()).hasSize(2);
+		assertThat(anthropicCopy.getThinkingContents().get(0).thinking()).isEqualTo("think");
+		assertThat(anthropicCopy.getThinkingContents().get(0).signature()).isEqualTo("sig");
+		assertThat(anthropicCopy.getThinkingContents().get(1).redactedData()).isEqualTo("data");
 	}
 
 }

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicAssistantMessageTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicAssistantMessageTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AnthropicChatModel.AnthropicAssistantMessage}.
+ *
+ * @author guan xu
+ */
+class AnthropicAssistantMessageTests {
+
+	@Test
+	void copyPreservesThinkingContents() {
+		AnthropicChatModel.AnthropicAssistantMessage original = AnthropicChatModel.AnthropicAssistantMessage.builder()
+			.content("hello")
+			.thinkingContents(List.of(AnthropicChatModel.AnthropicThinkingContent.thinking("think", "sig")))
+			.build();
+
+		AnthropicChatModel.AnthropicAssistantMessage copy = (AnthropicChatModel.AnthropicAssistantMessage) original
+			.copy();
+
+		assertThat(copy).isNotSameAs(original);
+		assertThat(copy.getThinkingContents()).hasSize(1);
+		assertThat(copy.getThinkingContents().get(0).thinking()).isEqualTo("think");
+		assertThat(copy.getThinkingContents().get(0).signature()).isEqualTo("sig");
+	}
+
+	@Test
+	void promptCopyPreservesAnthropicAssistantMessage() {
+		AnthropicChatModel.AnthropicAssistantMessage original = AnthropicChatModel.AnthropicAssistantMessage.builder()
+			.content("hello")
+			.thinkingContents(List.of(AnthropicChatModel.AnthropicThinkingContent.thinking("think", "sig"),
+					AnthropicChatModel.AnthropicThinkingContent.redacted("data")))
+			.build();
+
+		Prompt copy = new Prompt(List.of(original)).copy();
+
+		Message copied = copy.getInstructions().get(0);
+		assertThat(copied).isInstanceOf(AnthropicChatModel.AnthropicAssistantMessage.class);
+		AnthropicChatModel.AnthropicAssistantMessage anthropicCopy = (AnthropicChatModel.AnthropicAssistantMessage) copied;
+		assertThat(anthropicCopy.getThinkingContents()).hasSize(2);
+	}
+
+}

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockAssistantMessage.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockAssistantMessage.java
@@ -39,6 +39,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Jewoo Shin
  * @author Soby Chacko
+ * @author guan xu
  * @see BedrockReasoningContent
  */
 final class BedrockAssistantMessage extends AssistantMessage {
@@ -57,6 +58,15 @@ final class BedrockAssistantMessage extends AssistantMessage {
 
 	boolean hasReasoningContents() {
 		return !CollectionUtils.isEmpty(this.reasoningContents);
+	}
+
+	@Override
+	public Builder mutate() {
+		return builder().content(getText())
+			.properties(getMetadata())
+			.toolCalls(getToolCalls())
+			.media(getMedia())
+			.reasoningContents(getReasoningContents());
 	}
 
 	@Override

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockAssistantMessageTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockAssistantMessageTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link BedrockAssistantMessage}.
+ *
+ * @author guan xu
+ */
+class BedrockAssistantMessageTests {
+
+	@Test
+	void copyPreservesReasoningContents() {
+		List<BedrockReasoningContent> reasoningContents = Collections.singletonList(null);
+		BedrockAssistantMessage original = BedrockAssistantMessage.builder()
+			.content("hello")
+			.reasoningContents(reasoningContents)
+			.build();
+
+		BedrockAssistantMessage copy = (BedrockAssistantMessage) original.copy();
+
+		assertThat(copy).isNotSameAs(original);
+		assertThat(copy.getReasoningContents()).hasSize(1);
+	}
+
+	@Test
+	void promptCopyPreservesBedrockAssistantMessage() {
+		List<BedrockReasoningContent> reasoningContents = Collections.singletonList(null);
+		BedrockAssistantMessage original = BedrockAssistantMessage.builder()
+			.content("hello")
+			.reasoningContents(reasoningContents)
+			.build();
+
+		Prompt copy = new Prompt(List.of(original)).copy();
+
+		Message copied = copy.getInstructions().get(0);
+		assertThat(copied).isInstanceOf(BedrockAssistantMessage.class);
+		assertThat(((BedrockAssistantMessage) copied).getReasoningContents()).hasSize(1);
+	}
+
+}

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekAssistantMessage.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekAssistantMessage.java
@@ -26,9 +26,18 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.content.Media;
 
 /**
+ * DeepSeek-specific {@link AssistantMessage} that extends the standard assistant message
+ * with DeepSeek reasoning model capabilities.
+ * <p>
+ * In addition to the regular assistant content, DeepSeek reasoning models (such as
+ * {@code deepseek-reasoner}) may emit a {@link #getReasoningContent() reasoning content}
+ * that exposes the model's chain-of-thought, and a {@link #getPrefix() prefix} flag that
+ * indicates whether the provided content should be treated as a completion prefix.
+ *
  * @author Mark Pollack
  * @author Soby Chacko
  * @author Sun Yuhan
+ * @author guan xu
  */
 public class DeepSeekAssistantMessage extends AssistantMessage {
 
@@ -68,6 +77,16 @@ public class DeepSeekAssistantMessage extends AssistantMessage {
 
 	public void setReasoningContent(@Nullable String reasoningContent) {
 		this.reasoningContent = reasoningContent;
+	}
+
+	@Override
+	public Builder mutate() {
+		return builder().content(getText())
+			.properties(getMetadata())
+			.toolCalls(getToolCalls())
+			.media(getMedia())
+			.reasoningContent(getReasoningContent())
+			.prefix(getPrefix());
 	}
 
 	@Override

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekAssistantMessageTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekAssistantMessageTests.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  * Unit tests for {@link DeepSeekAssistantMessage}.
  *
  * @author Sun Yuhan
+ * @author guan xu
  */
 class DeepSeekAssistantMessageTests {
 
@@ -200,6 +203,36 @@ class DeepSeekAssistantMessageTests {
 		assertThat(message.getMetadata()).containsAllEntriesOf(properties);
 		assertThat(message.getToolCalls()).isEqualTo(toolCalls);
 		assertThat(message.getMedia()).isEqualTo(media);
+	}
+
+	@Test
+	public void copyPreservesReasoningContentAndPrefix() {
+		DeepSeekAssistantMessage original = new DeepSeekAssistantMessage.Builder().content("hello")
+			.reasoningContent("thoughts")
+			.prefix(true)
+			.build();
+
+		DeepSeekAssistantMessage copy = (DeepSeekAssistantMessage) original.copy();
+
+		assertThat(copy).isNotSameAs(original);
+		assertThat(copy.getReasoningContent()).isEqualTo("thoughts");
+		assertThat(copy.getPrefix()).isTrue();
+	}
+
+	@Test
+	public void promptCopyPreservesDeepSeekAssistantMessage() {
+		DeepSeekAssistantMessage original = new DeepSeekAssistantMessage.Builder().content("hello")
+			.reasoningContent("thoughts")
+			.prefix(true)
+			.build();
+
+		Prompt copy = new Prompt(List.of(original)).copy();
+
+		Message copied = copy.getInstructions().get(0);
+		assertThat(copied).isInstanceOf(DeepSeekAssistantMessage.class);
+		DeepSeekAssistantMessage deepSeekCopy = (DeepSeekAssistantMessage) copied;
+		assertThat(deepSeekCopy.getReasoningContent()).isEqualTo("thoughts");
+		assertThat(deepSeekCopy.getPrefix()).isTrue();
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
@@ -36,6 +36,7 @@ import org.springframework.util.CollectionUtils;
  * @author Mark Pollack
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author guan xu
  * @since 1.0.0
  */
 public class AssistantMessage extends AbstractMessage implements MediaContent {
@@ -68,6 +69,14 @@ public class AssistantMessage extends AbstractMessage implements MediaContent {
 	@Override
 	public List<Media> getMedia() {
 		return this.media;
+	}
+
+	public AssistantMessage copy() {
+		return mutate().build();
+	}
+
+	public Builder<?> mutate() {
+		return builder().content(getText()).properties(getMetadata()).toolCalls(getToolCalls()).media(getMedia());
 	}
 
 	@Override

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
@@ -42,6 +42,7 @@ import org.springframework.util.Assert;
  * @author luocongqiu
  * @author Thomas Vitale
  * @author Sebastien Deleuze
+ * @author guan xu
  */
 public class Prompt implements ModelRequest<List<Message>> {
 
@@ -203,11 +204,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 				messagesCopy.add(systemMessage.copy());
 			}
 			else if (message instanceof AssistantMessage assistantMessage) {
-				messagesCopy.add(AssistantMessage.builder()
-					.content(Objects.requireNonNullElse(assistantMessage.getText(), ""))
-					.properties(assistantMessage.getMetadata())
-					.toolCalls(assistantMessage.getToolCalls())
-					.build());
+				messagesCopy.add(assistantMessage.copy());
 			}
 			else if (message instanceof ToolResponseMessage toolResponseMessage) {
 				messagesCopy.add(ToolResponseMessage.builder()

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/messages/AssistantMessageTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/messages/AssistantMessageTests.java
@@ -16,14 +16,22 @@
 
 package org.springframework.ai.chat.messages;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for {@link AssistantMessage}.
  *
  * @author Thomas Vitale
+ * @author guan xu
  */
 class AssistantMessageTests {
 
@@ -46,6 +54,86 @@ class AssistantMessageTests {
 		assertThatThrownBy(() -> AssistantMessage.builder().toolCalls(null).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Tool calls must not be null");
+	}
+
+	@Test
+	void copyPreservesContentPropertiesAndToolCalls() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id", "function", "name", "{}");
+		AssistantMessage original = AssistantMessage.builder()
+			.content("hello")
+			.properties(Map.of("k", "v"))
+			.toolCalls(List.of(toolCall))
+			.build();
+
+		AssistantMessage copy = original.copy();
+
+		assertThat(copy).isNotSameAs(original);
+		assertThat(copy.getText()).isEqualTo("hello");
+		assertThat(copy.getMetadata()).containsEntry("k", "v");
+		assertThat(copy.getToolCalls()).containsExactly(toolCall);
+	}
+
+	@Test
+	void promptCopyPreservesAssistantMessageSubclassViaPolymorphicMutate() {
+		TestAssistantMessage original = TestAssistantMessage.builder().content("hello").marker("m").build();
+
+		Prompt copy = new Prompt(List.of(original)).copy();
+
+		Message copied = copy.getInstructions().get(0);
+		assertThat(copied).isInstanceOf(TestAssistantMessage.class);
+		assertThat(((TestAssistantMessage) copied).getMarker()).isEqualTo("m");
+	}
+
+	/**
+	 * A minimal {@link AssistantMessage} subclass that carries an extra field and
+	 * overrides {@code mutate()} to preserve it.
+	 */
+	static final class TestAssistantMessage extends AssistantMessage {
+
+		private final String marker;
+
+		private TestAssistantMessage(String content, String marker, Map<String, Object> properties,
+				List<ToolCall> toolCalls, List<Media> media) {
+			super(content, properties, toolCalls, media);
+			this.marker = marker;
+		}
+
+		String getMarker() {
+			return this.marker;
+		}
+
+		@Override
+		public TestBuilder mutate() {
+			return builder().content(getText())
+				.properties(getMetadata())
+				.toolCalls(getToolCalls())
+				.media(getMedia())
+				.marker(getMarker());
+		}
+
+		public static TestBuilder builder() {
+			return new TestBuilder();
+		}
+
+		static final class TestBuilder extends AssistantMessage.Builder<TestBuilder> {
+
+			private String marker;
+
+			private TestBuilder() {
+			}
+
+			TestBuilder marker(String marker) {
+				this.marker = marker;
+				return self();
+			}
+
+			@Override
+			public TestAssistantMessage build() {
+				return new TestAssistantMessage(this.content, this.marker, this.properties, this.toolCalls, this.media);
+			}
+
+		}
+
 	}
 
 }


### PR DESCRIPTION
# Root Cause

`Prompt.instructionsCopy()` rebuilt every `AssistantMessage` using the base `AssistantMessage.builder()`, which downcast provider-specific subclasses (DeepSeek, Bedrock, Anthropic) to a plain `AssistantMessage`, silently dropping their extra state:
- **DeepSeek**: `reasoningContent` and `prefix`
- **Bedrock**: `reasoningContents`
- **Anthropic**: `thinkingContents`

It also dropped `media` for all assistant messages. As a result, multi-turn and tool-calling flows that route through `Prompt.copy()` / `mutate()` (e.g., `DeepSeekChatModel.buildRequestPrompt` when no per-call options are set) silently lost reasoning context on subsequent requests.

# Fix

Following the same pattern as `UserMessage` / `SystemMessage`, `AssistantMessage` now exposes `copy()` backed by `mutate().build()`, and each stateful subclass overrides `mutate()` to carry its own fields through the copy:
- **`AssistantMessage`**: `copy()` + `mutate()` preserving `content`, `metadata`, `toolCalls`, and `media`.
- **`DeepSeekAssistantMessage`**: preserves `reasoningContent` and `prefix`.
- **`BedrockAssistantMessage`**: preserves `reasoningContents`.
- **`AnthropicChatModel.AnthropicAssistantMessage`**: adds a `Builder` and overrides `mutate()` to preserve `thinkingContents`.

`Prompt.instructionsCopy()` now delegates to `assistantMessage.copy()`, so subclass identity and fields are fully preserved.

# Tests

All unit tests pass, covering `AssistantMessage.copy()` across the base class and each subclass. Run them with:
```sh
./mvnw -am -pl spring-ai-model -Dtest=org.springframework.ai.chat.messages.AssistantMessageTests -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.build.cache.enabled=false test
./mvnw -am -pl models/spring-ai-deepseek -Dtest=org.springframework.ai.deepseek.DeepSeekAssistantMessageTests -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.build.cache.enabled=false test
./mvnw -am -pl models/spring-ai-bedrock-converse -Dtest=org.springframework.ai.bedrock.converse.BedrockAssistantMessageTests -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.build.cache.enabled=false test
./mvnw -am -pl models/spring-ai-anthropic -Dtest=org.springframework.ai.anthropic.AnthropicAssistantMessageTests -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.build.cache.enabled=false test
```

# Related Issue
Follow up #6638, rerun `DeepSeekChatModelIT#prefixCompletionTest` and now the unit test pass.
```sh
./mvnw -am -pl models/spring-ai-deepseek -Dtest=org.springframework.ai.deepseek.chat.DeepSeekChatModelIT#prefixCompletionTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.build.cache.enabled=false test
```

<img width="1420" height="581" alt="image" src="https://github.com/user-attachments/assets/c0934ccf-70db-4649-8f2e-46b7e7ec568f" />