### PR TITLE
Fix inaccurate Content interface Javadoc

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/content/Content.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/content/Content.java
@@ -22,8 +22,8 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Data structure that contains content and metadata. Common parent for the
- * {@link org.springframework.ai.document.Document} and the
- * {@link org.springframework.ai.chat.messages.Message} classes.
+ * {@link org.springframework.ai.chat.messages.Message} and {@link MediaContent}
+ * types.
  *
  * @author Mark Pollack
  * @author Christian Tzolov


### PR DESCRIPTION
The `Content` interface Javadoc claimed to be the common parent for both `Document` and `Message`. However, `Document` does not implement `Content`; only `Message` (and `MediaContent`) extend it.

This updates the Javadoc to reference the actual subtypes.

Fixes #6692