### PR TITLE
Preserve tool schema property order in Converse API

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
@@ -19,6 +19,7 @@ package org.springframework.ai.bedrock.converse.api;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -100,7 +101,8 @@ public final class ConverseApiUtils {
 	private static Document convertMapToDocument(Map<String, Object> value) {
 		Map<String, Document> attr = value.entrySet()
 			.stream()
-			.collect(Collectors.toMap(e -> e.getKey(), e -> convertObjectToDocument(e.getValue())));
+			.collect(Collectors.toMap(Map.Entry::getKey, e -> convertObjectToDocument(e.getValue()), (a, b) -> b,
+					LinkedHashMap::new));
 
 		return Document.fromMap(attr);
 	}

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse.api;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.document.Document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConverseApiUtils}.
+ *
+ * @author yqz
+ */
+class ConverseApiUtilsTests {
+
+	@Test
+	void convertMapPreservesKeyOrder() {
+		Map<String, Object> source = new LinkedHashMap<>();
+		source.put("evidenceText", "text");
+		source.put("justification", "reason");
+		source.put("valid", true);
+
+		Document document = ConverseApiUtils.convertObjectToDocument(source);
+
+		assertThat(document.asMap().keySet()).containsExactly("evidenceText", "justification", "valid");
+	}
+
+	@Test
+	void convertNestedMapPreservesKeyOrder() {
+		Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("zebra", "z");
+		properties.put("apple", "a");
+		properties.put("mango", "m");
+
+		Map<String, Object> schema = new LinkedHashMap<>();
+		schema.put("type", "object");
+		schema.put("properties", properties);
+
+		Document document = ConverseApiUtils.convertObjectToDocument(schema);
+
+		assertThat(document.asMap().keySet()).containsExactly("type", "properties");
+		assertThat(document.asMap().get("properties").asMap().keySet()).containsExactly("zebra", "apple", "mango");
+	}
+
+}


### PR DESCRIPTION
`ConverseApiUtils#convertMapToDocument` collected map entries with a plain `Collectors.toMap(...)`, which returns a `HashMap` and therefore discards the insertion order of the source map (preserved by Jackson as a `LinkedHashMap`).

As a result, the `properties` of a tool's `inputSchema` were sent to Bedrock in an arbitrary, `hashCode`-driven order instead of the declared order.

This change collects into a `LinkedHashMap` so the declaration order is preserved, and adds a test covering both top-level and nested maps.

Fixes #6696