### PR TITLE
Validate id column uniqueness in MariaDBSchemaValidator

### DIFF
--- a/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
+++ b/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
@@ -109,24 +109,32 @@ public class MariaDBSchemaValidator {
 
 			// Check each column against expected fields
 			List<String> availableColumns = new ArrayList<>();
+			String rawIdColumnName = null;
 			for (Map<String, Object> column : columns) {
 				String columnName = (String) column.get("COLUMN_NAME");
 				Assert.state(columnName != null, "COLUMN_NAME result should not be null");
-				columnName = validateAndEnquoteIdentifier(columnName, false);
-				availableColumns.add(columnName);
+				String quotedColumnName = validateAndEnquoteIdentifier(columnName, false);
+				availableColumns.add(quotedColumnName);
+				if (quotedColumnName.equals(idFieldName)) {
+					rawIdColumnName = columnName;
+				}
 			}
-
-			// TODO ensure id is a primary key for batch update
 
 			expectedColumns.removeAll(availableColumns);
 
-			if (expectedColumns.isEmpty()) {
-				logger.info("MariaDB VectorStore schema validation successful");
-			}
-			else {
+			if (!expectedColumns.isEmpty()) {
 				throw new IllegalStateException("Missing fields " + expectedColumns);
 			}
 
+			Assert.state(rawIdColumnName != null, "id column must be present after passing schema validation");
+			if (!isSoleUniqueOrPrimaryKeyColumn(schemaName, tableName, rawIdColumnName)) {
+				throw new IllegalStateException(String
+					.format("Column '%s' must be the sole column of a PRIMARY KEY or UNIQUE constraint on table '%s' "
+							+ "so that 'INSERT ... ON DUPLICATE KEY UPDATE' can detect duplicates during batch updates",
+							idFieldName, tableName));
+			}
+
+			logger.info("MariaDB VectorStore schema validation successful");
 		}
 		catch (DataAccessException | IllegalStateException e) {
 			if (logger.isErrorEnabled()) {
@@ -150,6 +158,26 @@ public class MariaDBSchemaValidator {
 			}
 			throw new IllegalStateException(e);
 		}
+	}
+
+	/**
+	 * Checks whether the given column is, on its own, guaranteed to be unique i.e. it is
+	 * the sole column of either the table's PRIMARY KEY or a UNIQUE constraint.
+	 * <p>
+	 * A column that is merely part of a multi-column PRIMARY KEY or UNIQUE constraint is
+	 * intentionally excluded, since the column's value alone does not guarantee
+	 * uniqueness in that case, and 'INSERT ... ON DUPLICATE KEY UPDATE' would not detect
+	 * a "duplicate" row that only matches on that column.
+	 */
+	private boolean isSoleUniqueOrPrimaryKeyColumn(@Nullable String schemaName, String tableName,
+			String rawColumnName) {
+		String query = "SELECT s.INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS s "
+				+ "WHERE s.TABLE_SCHEMA = ? AND s.TABLE_NAME = ? AND s.NON_UNIQUE = 0 " + "GROUP BY s.INDEX_NAME "
+				+ "HAVING COUNT(*) = 1 AND SUM(s.COLUMN_NAME = ?) = 1";
+
+		List<Map<String, @Nullable Object>> matches = this.jdbcTemplate.queryForList(query, schemaName, tableName,
+				rawColumnName);
+		return !matches.isEmpty();
 	}
 
 	/**

--- a/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidatorIT.java
+++ b/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidatorIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.mariadb;
+
+import java.util.function.Consumer;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Integration tests for {@link MariaDBSchemaValidator}, run against a real MariaDB
+ * instance so that the SQL used to inspect {@code INFORMATION_SCHEMA} is verified against
+ * actual server behavior rather than a mocked {@link JdbcTemplate}.
+ *
+ * @author dev-xong
+ */
+@Testcontainers
+class MariaDBSchemaValidatorIT {
+
+	private static final String SCHEMA_NAME = "testdb";
+
+	@Container
+	@SuppressWarnings("resource")
+	static MariaDBContainer<?> mariadbContainer = new MariaDBContainer<>(MariaDBImage.DEFAULT_IMAGE)
+		.withUsername("mariadb")
+		.withPassword("mariadbpwd")
+		.withDatabaseName(SCHEMA_NAME);
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(TestApplication.class);
+
+	@Test
+	void validatesSuccessfullyWhenIdIsSolePrimaryKey() {
+		withSchemaValidator("""
+				CREATE TABLE vector_store (
+					id VARCHAR(36) NOT NULL PRIMARY KEY,
+					content TEXT,
+					metadata JSON,
+					embedding VECTOR(1024) NOT NULL,
+					VECTOR INDEX (embedding)
+				) ENGINE=InnoDB""", schemaValidator -> assertThatNoException().isThrownBy(() -> schemaValidator
+			.validateTableSchema(SCHEMA_NAME, "vector_store", "id", "content", "metadata", "embedding", 1024)));
+	}
+
+	@Test
+	void validatesSuccessfullyWhenIdIsSoleUniqueColumn() {
+		withSchemaValidator("""
+				CREATE TABLE vector_store (
+					id VARCHAR(36) NOT NULL UNIQUE,
+					content TEXT,
+					metadata JSON,
+					embedding VECTOR(1024) NOT NULL,
+					VECTOR INDEX (embedding)
+				) ENGINE=InnoDB""", schemaValidator -> assertThatNoException().isThrownBy(() -> schemaValidator
+			.validateTableSchema(SCHEMA_NAME, "vector_store", "id", "content", "metadata", "embedding", 1024)));
+	}
+
+	@Test
+	void rejectsWhenIdHasNoUniqueConstraint() {
+		withSchemaValidator("""
+				CREATE TABLE vector_store (
+					id VARCHAR(36) NOT NULL,
+					content TEXT,
+					metadata JSON,
+					embedding VECTOR(1024) NOT NULL,
+					VECTOR INDEX (embedding)
+				) ENGINE=InnoDB""",
+				schemaValidator -> assertThatIllegalStateException()
+					.isThrownBy(() -> schemaValidator.validateTableSchema(SCHEMA_NAME, "vector_store", "id", "content",
+							"metadata", "embedding", 1024))
+					.withMessageContaining("sole column"));
+	}
+
+	@Test
+	void rejectsWhenIdIsPartOfCompositePrimaryKey() {
+		withSchemaValidator("""
+				CREATE TABLE vector_store (
+					id VARCHAR(36) NOT NULL,
+					tenant_id VARCHAR(36) NOT NULL,
+					content TEXT,
+					metadata JSON,
+					embedding VECTOR(1024) NOT NULL,
+					PRIMARY KEY (id, tenant_id),
+					VECTOR INDEX (embedding)
+				) ENGINE=InnoDB""",
+				schemaValidator -> assertThatIllegalStateException()
+					.isThrownBy(() -> schemaValidator.validateTableSchema(SCHEMA_NAME, "vector_store", "id", "content",
+							"metadata", "embedding", 1024))
+					.withMessageContaining("sole column"));
+	}
+
+	@Test
+	void rejectsWhenIdIsPartOfCompositeUniqueConstraint() {
+		withSchemaValidator("""
+				CREATE TABLE vector_store (
+					id VARCHAR(36) NOT NULL,
+					tenant_id VARCHAR(36) NOT NULL,
+					content TEXT,
+					metadata JSON,
+					embedding VECTOR(1024) NOT NULL,
+					UNIQUE KEY ux_id_tenant (id, tenant_id),
+					VECTOR INDEX (embedding)
+				) ENGINE=InnoDB""",
+				schemaValidator -> assertThatIllegalStateException()
+					.isThrownBy(() -> schemaValidator.validateTableSchema(SCHEMA_NAME, "vector_store", "id", "content",
+							"metadata", "embedding", 1024))
+					.withMessageContaining("sole column"));
+	}
+
+	private void withSchemaValidator(String createTableSql, Consumer<MariaDBSchemaValidator> assertions) {
+		this.contextRunner.run(context -> {
+			JdbcTemplate jdbcTemplate = context.getBean(JdbcTemplate.class);
+			jdbcTemplate.execute("DROP TABLE IF EXISTS vector_store");
+			jdbcTemplate.execute(createTableSql);
+			assertions.accept(new MariaDBSchemaValidator(jdbcTemplate));
+		});
+	}
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration(exclude = DataSourceAutoConfiguration.class)
+	public static class TestApplication {
+
+		@Bean
+		public JdbcTemplate jdbcTemplate(DataSource dataSource) {
+			return new JdbcTemplate(dataSource);
+		}
+
+		@Bean
+		public DataSourceProperties dataSourceProperties() {
+			DataSourceProperties properties = new DataSourceProperties();
+			properties.setUrl(mariadbContainer.getJdbcUrl());
+			properties.setUsername(mariadbContainer.getUsername());
+			properties.setPassword(mariadbContainer.getPassword());
+			return properties;
+		}
+
+		@Bean
+		public HikariDataSource dataSource(DataSourceProperties dataSourceProperties) {
+			return dataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Implements the TODO left in `MariaDBSchemaValidator#validateTableSchema` (ensure id is a primary key for batch update).
`MariaDBVectorStore`'s batch upsert uses `INSERT ... ON DUPLICATE KEY UPDATE`, which only behaves as "insert or update on duplicate" when the `id` column is backed by a single-column PRIMARY KEY or UNIQUE constraint. Without that, duplicate rows kept getting inserted instead of updated. This change catches that misconfiguration during schema validation.

## Changes

- Added `isSoleUniqueOrPrimaryKeyColumn`, which queries `INFORMATION_SCHEMA.STATISTICS` to check whether the `id` column is the sole column of a PRIMARY KEY or UNIQUE index.
- Added a validation step in `validateTableSchema` that throws `IllegalStateException` when this condition isn't met.

## Why not COLUMNS.COLUMN_KEY?

An earlier approach considered simply checking whether `INFORMATION_SCHEMA.COLUMNS.COLUMN_KEY` equals `'PRI'`, but that was rejected for two reasons:

1. Misses UNIQUE constraints: `ON DUPLICATE KEY UPDATE` works the same way for UNIQUE constraints as for the PRIMARY KEY, so checking only `'PRI'` would wrongly reject valid schemas.
2. False pass on composite keys: `COLUMN_KEY` reports `'PRI'`/`'UNI'` even when a column is merely part of a composite PRIMARY KEY/UNIQUE constraint. For example, in a table with `PRIMARY KEY (id, tenant_id)`, `id` shows `COLUMN_KEY = 'PRI'`, even though `id` alone doesn't guarantee uniqueness — this case should fail validation but wouldn't have.

To address this, the check was rewritten as a query against `INFORMATION_SCHEMA.STATISTICS` that directly verifies "does a unique index made up of exactly this one column exist?"

```sql
SELECT s.INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS s
WHERE s.TABLE_SCHEMA = ? AND s.TABLE_NAME = ? AND s.NON_UNIQUE = 0
GROUP BY s.INDEX_NAME
HAVING COUNT(*) = 1 AND SUM(s.COLUMN_NAME = ?) = 1
```

- `NON_UNIQUE = 0`: includes both PRIMARY and UNIQUE indexes
- `HAVING COUNT(*) = 1`: only single-column indexes (excludes composite keys)
- `SUM(COLUMN_NAME = ?) = 1`: confirms the matched column is the `id` under validation

## Notes

- `idFieldName` is already a quoted identifier, so a separate raw (unquoted) column name (`rawIdColumnName`) is kept around to compare against `INFORMATION_SCHEMA.STATISTICS.COLUMN_NAME`, which returns raw names.
- Columns that are part of a composite PRIMARY KEY/UNIQUE constraint are intentionally excluded from passing validation (documented in the Javadoc).

## Behavior change

When schema validation is enabled (`schemaValidation = true`), existing tables without a single-column PRIMARY KEY or UNIQUE constraint on `id` will now fail schema validation at startup instead of silently duplicating rows at runtime during batch upsert.

## Tests

Added 5 scenarios to `MariaDBSchemaValidatorIT`

- [x]  `id` is the sole PRIMARY KEY → passes (`validatesSuccessfullyWhenIdIsSolePrimaryKey`)
- [x]  `id` is a sole UNIQUE column → passes (`validatesSuccessfullyWhenIdIsSoleUniqueColumn`)
- [x]  `id` has no unique constraint at all → throws (`rejectsWhenIdHasNoUniqueConstraint`)
- [x]  `id` is part of a composite PRIMARY KEY → throws (`rejectsWhenIdIsPartOfCompositePrimaryKey`)
- [x]  `id` is part of a composite UNIQUE index → throws (`rejectsWhenIdIsPartOfCompositeUniqueConstraint`)