### PR TITLE
Skip empty text content blocks for Bedrock user messages

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -288,7 +288,12 @@ public class BedrockProxyChatModel implements ChatModel {
 				List<ContentBlock> contents = new ArrayList<>();
 				if (message instanceof UserMessage) {
 					var userMessage = (UserMessage) message;
-					contents.add(ContentBlock.fromText(userMessage.getText()));
+					// The Converse API rejects empty text content blocks, so only send
+					// the text when there is any. A user message may legitimately carry
+					// media only (gh-6695).
+					if (StringUtils.hasText(userMessage.getText())) {
+						contents.add(ContentBlock.fromText(userMessage.getText()));
+					}
 
 					if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 						List<ContentBlock> mediaContent = userMessage.getMedia()

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -415,6 +415,58 @@ class BedrockProxyChatModelTest {
 		assertThat(tools.get(1).cachePoint().ttlAsString()).isEqualTo("1h");
 	}
 
+	// -------------------------------------------------------------------------
+	// Empty user message text (gh-6695)
+	// -------------------------------------------------------------------------
+
+	@Test
+	void mediaOnlyUserMessageOmitsEmptyTextContentBlock() {
+		BedrockProxyChatModel model = newModel();
+
+		Prompt prompt = new Prompt(List.of(UserMessage.builder().text("").media(pngMedia()).build()),
+				BedrockChatOptions.builder().build());
+
+		List<ContentBlock> contents = model.createRequest(prompt).messages().get(0).content();
+
+		assertThat(contents).hasSize(1);
+		assertThat(contents.get(0).image()).isNotNull();
+		assertThat(contents).noneMatch(content -> content.text() != null);
+	}
+
+	@Test
+	void blankUserMessageTextOmitsEmptyTextContentBlock() {
+		BedrockProxyChatModel model = newModel();
+
+		Prompt prompt = new Prompt(List.of(UserMessage.builder().text("   \n\t").media(pngMedia()).build()),
+				BedrockChatOptions.builder().build());
+
+		List<ContentBlock> contents = model.createRequest(prompt).messages().get(0).content();
+
+		assertThat(contents).hasSize(1);
+		assertThat(contents.get(0).image()).isNotNull();
+	}
+
+	@Test
+	void userMessageWithTextAndMediaKeepsBothContentBlocks() {
+		BedrockProxyChatModel model = newModel();
+
+		Prompt prompt = new Prompt(List.of(UserMessage.builder().text("Describe the image").media(pngMedia()).build()),
+				BedrockChatOptions.builder().build());
+
+		List<ContentBlock> contents = model.createRequest(prompt).messages().get(0).content();
+
+		assertThat(contents).hasSize(2);
+		assertThat(contents.get(0).text()).isEqualTo("Describe the image");
+		assertThat(contents.get(1).image()).isNotNull();
+	}
+
+	private static Media pngMedia() {
+		return Media.builder()
+			.mimeType(MimeType.valueOf("image/png"))
+			.data(new byte[] { (byte) 0x89, 'P', 'N', 'G' })
+			.build();
+	}
+
 	public record WeatherRequest(String location, String unit) {
 	}
 


### PR DESCRIPTION
## Summary

`BedrockProxyChatModel` always added a text `ContentBlock` for a `UserMessage`, even when the message had no text.
The Converse API rejects an empty text content block, so a user message that carries only media failed with an HTTP 400.

The assistant message branch of the same method already guards with `StringUtils.hasText(...)`; this applies the same guard to the user message branch.

Fixes #6695

## Reproduction

From the issue: a prompt whose user message has `text("")` and one image, sent to a vision-capable model through Bedrock, is rejected by the API. The same request without the empty text block succeeds.

```java
UserMessage.builder()
    .text("")
    .media(Media.builder().mimeType(MediaType.IMAGE_PNG).data(pngBytes).build())
    .build()
```

## Testing

Three tests added to `BedrockProxyChatModelTest`, all going through `createRequest`, so they assert on the actual `ConverseRequest` payload:

* `mediaOnlyUserMessageOmitsEmptyTextContentBlock` — empty text plus image yields a single image block and no text block
* `blankUserMessageTextOmitsEmptyTextContentBlock` — whitespace-only text is treated the same way
* `userMessageWithTextAndMediaKeepsBothContentBlocks` — regression guard: text plus image still yields both blocks in order

Verified locally:

* `./mvnw -Dmaven.build.cache.enabled=false -pl models/spring-ai-bedrock-converse clean package` — `Tests run: 87, Failures: 0, Errors: 0`, checkstyle and `spring-javaformat` pass
* Reverted the main-code change and re-ran only the three new tests: the two empty-text tests fail (`Tests run: 3, Failures: 2`) and the regression guard passes, confirming the tests cover the reported defect

`BedrockProxyChatModelIT` requires AWS credentials and was not executed.

## Note on the all-empty case

A user message with neither text nor media now produces a message with an empty content list. That request was already rejected by the API before this change (as an empty text block), so this is not a regression, and it is out of scope here.
