### PR TITLE
Map `audio/mpeg` to the OpenAI mp3 input audio format

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -575,9 +575,7 @@ public final class OpenAiChatModel implements ChatModel {
 										.inputAudio(ChatCompletionContentPartInputAudio.builder()
 											.inputAudio(ChatCompletionContentPartInputAudio.InputAudio.builder()
 												.data(fromAudioData(media.getData()))
-												.format(mimeType.contains("mp3")
-														? ChatCompletionContentPartInputAudio.InputAudio.Format.MP3
-														: ChatCompletionContentPartInputAudio.InputAudio.Format.WAV)
+												.format(toInputAudioFormat(mimeType))
 												.build())
 											.build()
 											.inputAudio())
@@ -957,6 +955,26 @@ public final class OpenAiChatModel implements ChatModel {
 			return Base64.getEncoder().encodeToString(bytes);
 		}
 		throw new IllegalArgumentException("Unsupported audio data type: " + audioData.getClass().getSimpleName());
+	}
+
+	/**
+	 * Resolve the OpenAI audio input format for the given media MIME type. OpenAI accepts
+	 * only {@code mp3} and {@code wav} audio input.
+	 * @param mimeType the MIME type of the audio media
+	 * @return the matching OpenAI audio input format
+	 */
+	ChatCompletionContentPartInputAudio.InputAudio.Format toInputAudioFormat(String mimeType) {
+		String normalizedMimeType = mimeType.toLowerCase(Locale.ROOT);
+		// "audio/mpeg" is the media type registered for MP3 (RFC 3003) and the one
+		// returned by Spring's MimeType detection, while OpenAI names the format "mp3".
+		if (normalizedMimeType.contains("mp3") || normalizedMimeType.contains("mpeg")) {
+			return ChatCompletionContentPartInputAudio.InputAudio.Format.MP3;
+		}
+		if (!normalizedMimeType.contains("wav") && logger.isWarnEnabled()) {
+			logger.warn("OpenAI audio input supports only mp3 and wav, but got '" + mimeType
+					+ "'. Sending it as wav, which the model may reject.");
+		}
+		return ChatCompletionContentPartInputAudio.InputAudio.Format.WAV;
 	}
 
 	private String fromMediaData(org.springframework.util.MimeType mimeType, Object mediaContentData) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.openai;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -39,6 +40,7 @@ import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionAssistantMessageParam;
 import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionContentPart;
+import com.openai.models.chat.completions.ChatCompletionContentPartInputAudio;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionFunctionTool;
 import com.openai.models.chat.completions.ChatCompletionMessage;
@@ -72,6 +74,7 @@ import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel.ResponseFormat;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.util.JsonHelper;
+import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1054,6 +1057,53 @@ class OpenAiChatModelTests {
 			.orElseThrow()
 			.file();
 		assertThat(file.fileData()).contains("data:application/pdf;base64,JVBERi0xLjc=");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "audio/mp3", "audio/mpeg", "audio/MPEG" })
+	void userMessageMp3MediaMapsToMp3InputAudioFormat(String mimeType) {
+		assertThat(audioInputFormatFor(mimeType)).isEqualTo(ChatCompletionContentPartInputAudio.InputAudio.Format.MP3);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "audio/wav", "audio/x-wav", "audio/vnd.wave" })
+	void userMessageWavMediaMapsToWavInputAudioFormat(String mimeType) {
+		assertThat(audioInputFormatFor(mimeType)).isEqualTo(ChatCompletionContentPartInputAudio.InputAudio.Format.WAV);
+	}
+
+	private ChatCompletionContentPartInputAudio.InputAudio.Format audioInputFormatFor(String mimeType) {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		UserMessage userMessage = UserMessage.builder()
+			.text("What is this recording about?")
+			.media(Media.builder()
+				.mimeType(MimeTypeUtils.parseMimeType(mimeType))
+				.data("audio".getBytes(StandardCharsets.UTF_8))
+				.build())
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt(List.<Message>of(userMessage), options),
+				false);
+
+		ChatCompletionContentPartInputAudio.InputAudio inputAudio = request.messages()
+			.get(0)
+			.user()
+			.orElseThrow()
+			.content()
+			.arrayOfContentParts()
+			.orElseThrow()
+			.get(1)
+			.inputAudio()
+			.orElseThrow()
+			.inputAudio();
+		assertThat(inputAudio.data())
+			.isEqualTo(Base64.getEncoder().encodeToString("audio".getBytes(StandardCharsets.UTF_8)));
+		return inputAudio.format();
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -365,7 +365,7 @@ Refer to the link:https://platform.openai.com/docs/guides/audio[Audio] guide for
 The OpenAI link:https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages[User Message API] can incorporate a list of base64-encoded audio files with the message.
 Spring AI’s link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/Message.java[Message] interface facilitates multimodal AI models by introducing the link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-commons/src/main/java/org/springframework/ai/content/Media.java[Media] type.
 This type encompasses data and details regarding media attachments in messages, utilizing Spring’s `org.springframework.util.MimeType` and a `org.springframework.core.io.Resource` for the raw media data.
-Currently, OpenAI support only the following media types: `audio/mp3` and `audio/wav`.
+Currently, OpenAI support only the following media types: `audio/mp3`, `audio/mpeg` and `audio/wav`.
 
 Below is a code example excerpted from link:https://github.com/spring-projects/spring-ai/blob/c9a3e66f90187ce7eae7eb78c462ec622685de6c/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java#L442[OpenAiChatModelIT.java], illustrating the fusion of user text with an audio file using the `gpt-audio` model.
 


### PR DESCRIPTION
## Summary

The OpenAI audio input format was chosen with `mimeType.contains("mp3")`, falling back to WAV for anything else.
`audio/mpeg` is the media type registered for MP3 (RFC 3003) and does not contain the substring `mp3`, so MP3 audio declared that way was silently sent to OpenAI labeled as `wav`.

This moves the decision into `toInputAudioFormat(String)`, which accepts `audio/mp3` and `audio/mpeg` (case-insensitively) for MP3 and warns when an audio type that is neither MP3 nor WAV is forwarded as WAV.

## Why `audio/mpeg` matters

`Media.Format` exposes no audio constants, so callers build the MIME type themselves, and `audio/mpeg` is what standard detection produces for an `.mp3` file.
Spring AI's own speech documentation uses `audio/mpeg` for MP3 output, so feeding generated speech back in as chat input hits exactly this path.
The failure is silent at the Spring AI layer — the request is built and sent with the wrong format declaration.

The reference documentation previously listed only `audio/mp3` and `audio/wav`; it now lists `audio/mpeg` as well.

## Testing

Two parameterized tests added to `OpenAiChatModelTests`, both going through `createRequest` so they assert on the `ChatCompletionCreateParams` actually sent:

* `userMessageMp3MediaMapsToMp3InputAudioFormat` — `audio/mp3`, `audio/mpeg`, `audio/MPEG`
* `userMessageWavMediaMapsToWavInputAudioFormat` — `audio/wav`, `audio/x-wav`, `audio/vnd.wave`

Both also assert the base64 payload is unchanged.

Verified locally:

* `./mvnw -Dmaven.build.cache.enabled=false -pl models/spring-ai-openai clean package` — `Tests run: 176, Failures: 0, Errors: 0`, checkstyle and `spring-javaformat` pass
* Reverted only the `audio/mpeg` handling and re-ran the new tests: the `audio/mpeg` and `audio/MPEG` cases fail with `expected: mp3 but was: wav`, while the `audio/mp3` and WAV cases pass either way

Integration tests requiring an OpenAI API key were not executed.

## Scope

Only the input audio format resolution and the corresponding documentation line changed. The output audio path and the transcription/speech models are untouched.
