### PR TITLE
Add alias for removed functions page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ tmp
 
 
 plans
+

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1,4 +1,6 @@
 [[Tools]]
+:page-aliases: api/functions.adoc
+
 = Tool Calling
 
 _Tool calling_ — the ability for an AI model to invoke application-defined functions and act on their results — is the essential building block of agentic AI systems. A model that can only generate text is a chatbot; a model that can discover information, take action, and loop until a goal is reached is an agent.


### PR DESCRIPTION
Fixes #6601

## Problem

The old Tool Calling documentation URL:

/reference/api/functions.html

returns a 404 after the removal of the old `api/functions.adoc` page during the FunctionCallback → ToolCallback migration.

## Solution

Added a page alias to the current Tool Calling documentation page:

:page-aliases: api/functions.adoc

This preserves the old URL and redirects it to:

/reference/api/tools.html

## Verification

- Generated the Antora documentation locally.
- Confirmed the generated `.htaccess` contains:

Redirect 301 .../api/functions.html .../api/tools.html

- Confirmed the current Tool Calling page remains available.

## Note

The stale link displayed on spring.io/projects/spring-ai is managed outside this repository, so this PR only addresses the documentation URL preservation inside Spring AI docs.