### PR TITLE
Make `JsonSchemaGenerator` thread-safe for concurrent use

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -114,6 +114,12 @@ public final class JsonSchemaGenerator {
 	private JsonSchemaGenerator() {
 	}
 
+	private static ObjectNode generateSchema(SchemaGenerator generator, Type type) {
+		synchronized (generator) {
+			return generator.generateSchema(type);
+		}
+	}
+
 	/**
 	 * Generate a JSON Schema for a method's input parameters.
 	 */
@@ -139,7 +145,7 @@ public final class JsonSchemaGenerator {
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);
 			}
-			ObjectNode parameterNode = SUBTYPE_SCHEMA_GENERATOR.generateSchema(parameterType);
+			ObjectNode parameterNode = generateSchema(SUBTYPE_SCHEMA_GENERATOR, parameterType);
 			// Remove OpenAPI format as some LLMs (like Mistral) don't handle them.
 			parameterNode.remove("format");
 			String parameterDescription = getMethodParameterDescription(method, i);
@@ -162,7 +168,7 @@ public final class JsonSchemaGenerator {
 	 */
 	public static String generateForType(Type type, SchemaOption... schemaOptions) {
 		Assert.notNull(type, "type cannot be null");
-		ObjectNode schema = TYPE_SCHEMA_GENERATOR.generateSchema(type);
+		ObjectNode schema = generateSchema(TYPE_SCHEMA_GENERATOR, type);
 		if ((type == Void.class) && !schema.has("properties")) {
 			schema.putObject("properties");
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -21,7 +21,14 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -670,9 +677,53 @@ class JsonSchemaGeneratorTests {
 	}
 
 	@Test
+	void generateSchemaForTypeCanRunConcurrently() throws Exception {
+		List<String> schemas = generateConcurrently(() -> JsonSchemaGenerator.generateForType(Person.class));
+
+		assertThat(schemas).hasSize(240);
+		assertThat(schemas).allSatisfy(schema -> assertThat(schema).contains("\"properties\""));
+	}
+
+	@Test
+	void generateSchemaForMethodInputCanRunConcurrently() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("complexMethod", List.class, TestData.class,
+				MoreTestData.class);
+
+		List<String> schemas = generateConcurrently(() -> JsonSchemaGenerator.generateForMethodInput(method));
+
+		assertThat(schemas).hasSize(240);
+		assertThat(schemas).allSatisfy(schema -> assertThat(schema).contains("\"properties\""));
+	}
+
+	@Test
 	void throwExceptionWhenTypeIsNull() {
 		assertThatThrownBy(() -> JsonSchemaGenerator.generateForType(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("type cannot be null");
+	}
+
+	private static List<String> generateConcurrently(Callable<String> generator) throws Exception {
+		int threadCount = 12;
+		int callCount = 240;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		try {
+			List<Future<String>> futures = new ArrayList<>();
+			for (int i = 0; i < callCount; i++) {
+				futures.add(executor.submit(() -> {
+					start.await();
+					return generator.call();
+				}));
+			}
+			start.countDown();
+			List<String> schemas = new ArrayList<>();
+			for (Future<String> future : futures) {
+				schemas.add(future.get(30, TimeUnit.SECONDS));
+			}
+			return schemas;
+		}
+		finally {
+			executor.shutdownNow();
+		}
 	}
 
 	static class TestMethods {


### PR DESCRIPTION
## Description

`JsonSchemaGenerator` in 1.1.x shares static Victools `SchemaGenerator` instances without synchronization. Concurrent `FunctionToolCallback` construction (or any concurrent `generateForType` / `generateForMethodInput` use) can fail with `ConcurrentModificationException` or Jackson creator-discovery errors.

Victools documents `SchemaGenerator` as not thread-safe. This backports the guard already present on `main` / 2.0.x (`synchronized` on the shared generator before `generateSchema`) and adds concurrent regression tests.

Fixes #6712

## Related Issues

- Fixes #6712
- Related: #6207 (fixed on main via #6217)

## Change Overview

- Add private `generateSchema(SchemaGenerator, Type)` that synchronizes on the generator instance
- Route `generateForType` and `generateForMethodInput` through that helper
- Add concurrent tests (12 threads × 240 calls) for both entry points

## Testing

```shell
./mvnw -pl spring-ai-model -am clean test \
  -Dtest=JsonSchemaGeneratorTests \
  -Dsurefire.failIfNoSpecifiedTests=false
```

- JDK 17
- `JsonSchemaGeneratorTests`: 25 tests, 0 failures (includes `generateSchemaForTypeCanRunConcurrently` and `generateSchemaForMethodInputCanRunConcurrently`)

## Checklist

- [x] Existing PR search (no open PR for #6712; closed #6217/#6223/#6236 targeted main)
- [x] DCO sign-off on commit
- [x] Commit title without conventional `fix:`/`feat:` prefix
- [x] Tests added