### PR TITLE
Make AnthropicChatModel internal methods private

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -304,7 +304,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	 * chunks and the final response with tool call information or the model's final
 	 * answer.
 	 */
-	public Flux<ChatResponse> internalStream(Prompt prompt, @Nullable ChatResponse previousChatResponse) {
+	private Flux<ChatResponse> internalStream(Prompt prompt, @Nullable ChatResponse previousChatResponse) {
 
 		return Flux.deferContextual(contextView -> {
 			MessageCreateParams request = createRequest(prompt, true);
@@ -541,7 +541,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	 * turn.
 	 * @return The final {@link ChatResponse} after all tool calls (if any) are resolved.
 	 */
-	public ChatResponse internalCall(Prompt prompt, @Nullable ChatResponse previousChatResponse) {
+	private ChatResponse internalCall(Prompt prompt, @Nullable ChatResponse previousChatResponse) {
 
 		MessageCreateParams request = createRequest(prompt, false);
 


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc

## Description

`AnthropicChatModel.internalStream` (and `internalCall`) were left `public` after the model internal methods were supposed to be `private` (see upgrade notes). Other chat model implementations already use `private`.

This change restricts both methods to `private`, matching:

* upgrade notes: "All `internalCall` and `internalStream` methods in model classes have been changed to `private`"
* OpenAI, Ollama, Bedrock Converse, Mistral, DeepSeek, Google GenAI

Maintainer @guanxuc confirmed on #6700 that these should be private.

No external callers needed adjustment; both methods are only used within `AnthropicChatModel` (`call`/`stream` and recursive tool-call loops).

Fixes #6700

## Testing

```
./mvnw -pl models/spring-ai-anthropic -am test -DskipITs
```

Results: **124 tests, 0 failures, 0 errors** (JDK 17.0.19)

## AI assistance

Created with AI assistance and reviewed by a human.