### PR TITLE
Order MongoDB chat memory by message sequence

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/model/chat/memory/repository/mongo/autoconfigure/MongoChatMemoryIndexCreatorAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/model/chat/memory/repository/mongo/autoconfigure/MongoChatMemoryIndexCreatorAutoConfiguration.java
@@ -34,8 +34,8 @@ import org.springframework.data.mongodb.core.index.IndexOperations;
 
 /**
  * Class responsible for creating proper MongoDB indices for the ChatMemory. Creates a
- * main index on the conversationId and timestamp fields, and a TTL index on the timestamp
- * field if the TTL is set in properties.
+ * main index on the conversationId, sequence and timestamp fields, and a TTL index on the
+ * timestamp field if the TTL is set in properties.
  *
  * @author Łukasz Jernaś
  * @see MongoChatMemoryProperties
@@ -70,7 +70,9 @@ public class MongoChatMemoryIndexCreatorAutoConfiguration {
 
 	private void createMainIndex() {
 		var indexOps = this.mongoTemplate.indexOps(Conversation.class);
-		var index = new Index().on("conversationId", Sort.Direction.ASC).on("timestamp", Sort.Direction.DESC);
+		var index = new Index().on("conversationId", Sort.Direction.ASC)
+			.on("sequence", Sort.Direction.ASC)
+			.on("timestamp", Sort.Direction.ASC);
 
 		// Use reflection to handle API differences across Spring Data MongoDB versions
 		createIndexSafely(indexOps, index);

--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/Conversation.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/Conversation.java
@@ -24,13 +24,16 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
- * A record representing a conversation in MongoDB.
+ * A record representing a conversation in MongoDB. The {@code sequence} holds the
+ * position of the message within the conversation and determines the order in which
+ * messages are retrieved. It is {@code null} for documents written before the field was
+ * introduced.
  *
  * @author Lukasz Jernas
  * @since 1.1.0
  */
 @Document("ai_chat_memory")
-public record Conversation(String conversationId, Message message, Instant timestamp) {
+public record Conversation(String conversationId, Message message, Instant timestamp, @Nullable Integer sequence) {
 	public record Message(@Nullable String content, String type, Map<String, Object> metadata) {
 	}
 }

--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
@@ -19,6 +19,7 @@ package org.springframework.ai.chat.memory.repository.mongo;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.IntStream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -57,11 +58,16 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 		return this.mongoTemplate.query(Conversation.class).distinct("conversationId").as(String.class).all();
 	}
 
+	/**
+	 * Messages are ordered by their position within the conversation. Documents written
+	 * before the {@code sequence} field was introduced do not have one and fall back to
+	 * the {@code timestamp} ordering used at the time they were written.
+	 */
 	@Override
 	public List<Message> findByConversationId(String conversationId) {
 		var messages = this.mongoTemplate.query(Conversation.class)
 			.matching(Query.query(Criteria.where("conversationId").is(conversationId))
-				.with(Sort.by("timestamp").ascending()));
+				.with(Sort.by(Sort.Order.asc("sequence"), Sort.Order.asc("timestamp"))));
 		return messages.stream().map(MongoChatMemoryRepository::mapMessage).filter(Objects::nonNull).toList();
 	}
 
@@ -77,11 +83,13 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 							+ conversationId);
 		}
 		deleteByConversationId(conversationId);
-		var conversations = persistableMessages.stream()
-			.map(message -> new Conversation(conversationId,
+		var timestamp = Instant.now();
+		var conversations = IntStream.range(0, persistableMessages.size()).mapToObj(sequence -> {
+			var message = persistableMessages.get(sequence);
+			return new Conversation(conversationId,
 					new Conversation.Message(message.getText(), message.getMessageType().name(), message.getMetadata()),
-					Instant.now()))
-			.toList();
+					timestamp, sequence);
+		}).toList();
 		this.mongoTemplate.insert(conversations, Conversation.class);
 	}
 

--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/test/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/test/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepositoryIT.java
@@ -16,9 +16,14 @@
 
 package org.springframework.ai.chat.memory.repository.mongo;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+import org.bson.Document;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -40,6 +45,7 @@ import org.springframework.boot.mongodb.autoconfigure.MongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -139,6 +145,56 @@ public class MongoChatMemoryRepositoryIT {
 	}
 
 	@Test
+	void messagesAreStoredWithTheirPositionInTheConversation() {
+		var conversationId = UUID.randomUUID().toString();
+		var messages = List.<Message>of(new UserMessage("First message"), new AssistantMessage("Second message"),
+				new UserMessage("Third message"));
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		var stored = this.mongoTemplate.query(Conversation.class)
+			.matching(Query.query(Criteria.where("conversationId").is(conversationId))
+				.with(Sort.by("sequence").ascending()))
+			.all();
+
+		assertThat(stored).extracting(Conversation::sequence).containsExactly(0, 1, 2);
+		assertThat(stored).extracting(conversation -> conversation.message().content())
+			.containsExactly("First message", "Second message", "Third message");
+	}
+
+	@Test
+	void messageOrderIsPreservedAcrossSaves() {
+		var conversationId = UUID.randomUUID().toString();
+		var messages = new ArrayList<Message>(
+				List.of(new UserMessage("First message"), new AssistantMessage("Second message")));
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		messages.add(new UserMessage("Third message"));
+		messages.add(new AssistantMessage("Fourth message"));
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEqualTo(messages);
+	}
+
+	@Test
+	void documentsWithoutSequenceAreOrderedByTimestamp() {
+		var conversationId = UUID.randomUUID().toString();
+		var timestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+		this.mongoTemplate.insert(
+				List.of(legacyDocument(conversationId, "First message", "USER", timestamp),
+						legacyDocument(conversationId, "Second message", "ASSISTANT", timestamp.plusMillis(1)),
+						legacyDocument(conversationId, "Third message", "USER", timestamp.plusMillis(2))),
+				"ai_chat_memory");
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+
+		assertThat(results).extracting(Message::getText)
+			.containsExactly("First message", "Second message", "Third message");
+	}
+
+	@Test
 	void toolResponseMessagesAreFilteredOnSave() {
 		var conversationId = UUID.randomUUID().toString();
 		var user = new UserMessage("Hello");
@@ -185,6 +241,13 @@ public class MongoChatMemoryRepositoryIT {
 			.all();
 
 		assertThat(results.size()).isZero();
+	}
+
+	private static Document legacyDocument(String conversationId, String content, String type, Instant timestamp) {
+		return new Document().append("conversationId", conversationId)
+			.append("message",
+					new Document().append("content", content).append("type", type).append("metadata", new Document()))
+			.append("timestamp", Date.from(timestamp));
 	}
 
 	@SpringBootConfiguration

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -409,7 +409,9 @@ The Neo4j repository will automatically ensure that indexes are created for conv
 
 `MongoChatMemoryRepository` is a built-in implementation that uses MongoDB to store messages. It is suitable for applications that require a flexible, document-oriented database for chat memory persistence.
 
-Messages are retrieved in ascending timestamp order (oldest-to-newest), which is the expected format for LLM conversation history. This ordering is consistent across all chat memory repository implementations.
+Messages are retrieved in ascending order (oldest-to-newest), which is the expected format for LLM conversation history.
+Ordering is maintained by a `sequence` field that records each message's position within its conversation.
+This ordering is consistent across all chat memory repository implementations.
 
 [WARNING]
 ====
@@ -481,6 +483,9 @@ ChatMemory chatMemory = MessageWindowChatMemory.builder()
 
 ==== Collection Initialization
 The auto-configuration will automatically create the `ai_chat_memory` collection on startup if it does not already exist.
+
+NOTE: As of 2.0.1, documents carry a `sequence` field that determines message ordering, and the main index covers `conversationId`, `sequence` and `timestamp`.
+Conversations written by earlier versions have no `sequence` field and keep their previous `timestamp` ordering until they are saved again, so no migration is required; see xref:upgrade-notes.adoc[] for details.
 
 === RedisChatMemoryRepository
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -156,6 +156,46 @@ public class CustomTranscriptionModel implements TranscriptionModel {
 
 If streaming is not needed, no action is required — the default implementation is inherited automatically.
 
+=== MongoDB Chat Memory `sequence` Field
+
+Documents in the `ai_chat_memory` collection gain a `sequence` field that determines message ordering within a conversation.
+Previously, ordering relied on the `timestamp` field.
+MongoDB stores `java.time.Instant` with millisecond precision and `saveAll()` writes the whole conversation in a single batch, so all of its messages usually end up with the same timestamp, and MongoDB does not guarantee a consistent order for documents with equal sort keys.
+A dedicated integer sequence orders the conversation deterministically, the same approach the JDBC repository uses.
+
+The `timestamp` field is retained and still records when the conversation was written, so the optional TTL index is unaffected.
+It is also the secondary sort key: documents written by earlier versions have no `sequence` field, so they all tie on it and fall back to the `timestamp` ordering they were written with.
+Existing conversations are therefore read back exactly as before the upgrade, and are ordered by `sequence` from their next save onwards.
+
+==== Impact
+
+- The main index created by `MongoChatMemoryIndexCreatorAutoConfiguration` now covers `conversationId`, `sequence` and `timestamp` instead of `conversationId` and `timestamp`.
+Applications relying on the auto-configuration pick this up on startup; the previous index is not dropped automatically.
+- `Conversation` gains a nullable `sequence` record component.
+Code constructing it directly must pass the message position, and code reading it must handle the `null` that documents written by earlier versions map to.
+
+==== Migration
+
+No action is required.
+Existing documents keep their previous ordering behaviour, and a conversation gains explicit sequence numbers the next time a message is added to it.
+
+Backfilling is optional and only worthwhile for conversations that are no longer active.
+Note that it can only reconstruct the order from the existing `timestamp` values, which is the ordering this change replaces, so it does not recover an order that was already wrong:
+
+[source,javascript]
+----
+db.ai_chat_memory.aggregate([
+    { $sort: { conversationId: 1, timestamp: 1, _id: 1 } },
+    { $group: { _id: "$conversationId", ids: { $push: "$_id" } } }
+]).forEach(function (conversation) {
+    conversation.ids.forEach(function (id, sequence) {
+        db.ai_chat_memory.updateOne({ _id: id }, { $set: { sequence: sequence } });
+    });
+});
+----
+
+The previous index can be dropped with `db.ai_chat_memory.dropIndex({ conversationId: 1, timestamp: -1 })` once the new one is in place.
+
 [[upgrading-to-2-0-0]]
 == Upgrading to 2.0.0
 


### PR DESCRIPTION
`MongoChatMemoryRepository` orders a conversation by its `timestamp` field alone. MongoDB stores `java.time.Instant` as a BSON date with millisecond precision, and `saveAll()` writes the whole conversation in a single batch, so all of its messages end up with the same timestamp.

Sorting on duplicate keys has no defined order. From the manual: "When sorting on a field which contains duplicate values, documents containing those values may be returned in any order [...] If consistent sort order is desired, include at least one field in your sort that contains unique values." So a conversation can come back with its turns out of order, and since every save rewrites the whole conversation, a bad read is written straight back.

Checked against mongo:8.0.6 by replaying the current write path with 20 messages: 20 distinct `Instant`s go in, differing in nanoseconds, and 1 distinct value comes back out, on every run.

Every other repository keeps an explicit ordering key — JDBC `sequence_id`, Neo4j `idx`, Redis a counter, Cassandra a native list. This adds the same for MongoDB: each document stores its position in a `sequence` field, and reads sort on it. The equivalent problem was fixed for JDBC in #4740.

Existing data is unaffected. `sequence` is nullable and `timestamp` remains the secondary sort key, so documents written by earlier versions all tie on `sequence` and keep the exact ordering they had; they get real sequence numbers on their next save. No migration is required, and the upgrade notes cover an optional backfill.

The auto-configured main index becomes `conversationId`, `sequence`, `timestamp` so the sort stays index-covered.

Verified with `MongoChatMemoryRepositoryIT` (13 tests) and `MongoChatMemoryAutoConfigurationIT` (2 tests), including one that reads raw pre-upgrade documents to pin the compatibility behaviour.
