### PR TITLE
Handle unknown finish reasons in `ChatCompletionFinishReason`

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -795,7 +796,7 @@ public class OpenAiApi {
 	public enum ChatCompletionFinishReason {
 
 		/**
-		 * Handles, empty, NULL and unknown values
+		 * Fallback for empty and unknown values
 		 */
 		@JsonProperty("")
 		UNKNOWN,
@@ -823,7 +824,31 @@ public class OpenAiApi {
 		 * Only for compatibility with Mistral AI API.
 		 */
 		@JsonProperty("tool_call")
-		TOOL_CALL
+		TOOL_CALL;
+
+		/**
+		 * Creates a finish reason from its API value.
+		 *
+		 * @param value finish reason from the API
+		 * @return matching finish reason, {@link #UNKNOWN} if the value is not
+		 *         recognized, or {@code null} if the input is {@code null}
+		 */
+		@JsonCreator
+		public static ChatCompletionFinishReason fromValue(String value) {
+			if (value == null) {
+				return null;
+			}
+
+			return switch (value) {
+				case "" -> UNKNOWN;
+				case "stop" -> STOP;
+				case "length" -> LENGTH;
+				case "content_filter" -> CONTENT_FILTER;
+				case "tool_calls" -> TOOL_CALLS;
+				case "tool_call" -> TOOL_CALL;
+				default -> UNKNOWN;
+			};
+		}
 
 	}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiStreamingFinishReasonTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiStreamingFinishReasonTests.java
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
@@ -178,6 +181,28 @@ public class OpenAiStreamingFinishReasonTests {
 		assertThat(choice.delta().reasoningContent()).isEqualTo("test");
 	}
 
+	@ParameterizedTest
+	@ValueSource(strings = { "null", "abort" })
+	void testJsonDeserializationWithUnknownFinishReason(String finishReason) {
+		ChatCompletionChunk chunk = deserializeChunk(finishReason);
+
+		assertThat(chunk.choices()).singleElement()
+			.extracting(ChunkChoice::finishReason)
+			.isEqualTo(ChatCompletionFinishReason.UNKNOWN);
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "stop, STOP", "length, LENGTH", "content_filter, CONTENT_FILTER", "tool_calls, TOOL_CALLS",
+			"tool_call, TOOL_CALL" })
+	void testJsonDeserializationWithKnownFinishReason(String finishReason,
+			ChatCompletionFinishReason expectedFinishReason) {
+		ChatCompletionChunk chunk = deserializeChunk(finishReason);
+
+		assertThat(chunk.choices()).singleElement()
+			.extracting(ChunkChoice::finishReason)
+			.isEqualTo(expectedFinishReason);
+	}
+
 	@Test
 	void testStreamingWithEmptyStringFinishReasonUsingMockWebServer() {
 		// Setup
@@ -243,6 +268,27 @@ public class OpenAiStreamingFinishReasonTests {
 		var choice = chunk.choices().get(0);
 		// The critical test: how does ModelOptionsUtils handle empty string -> enum?
 		assertThat(choice.finishReason()).isEqualTo(ChatCompletionFinishReason.UNKNOWN);
+	}
+
+	private static ChatCompletionChunk deserializeChunk(String finishReason) {
+		String json = """
+				{
+					"id": "chatcmpl-test",
+					"object": "chat.completion.chunk",
+					"created": 1726239401,
+					"model": "openai-compatible-model",
+					"choices": [{
+						"index": 0,
+						"delta": {
+							"role": "assistant",
+							"content": "Hello"
+						},
+						"finish_reason": "%s"
+					}]
+				}
+				""".formatted(finishReason);
+
+		return ModelOptionsUtils.jsonToObject(json, ChatCompletionChunk.class);
 	}
 
 	private void setupChatModel() {


### PR DESCRIPTION
`ChatCompletionFinishReason` currently fails to deserialize unknown finish reasons, such as `"abort"` or the string `"null"`, returned by some OpenAI-compatible APIs
This adds a `@JsonCreator` that keeps the existing values and maps empty or unrecognized strings to `UNKNOWN`. An actual JSON `null` is still deserialized as `null`.

Tests cover supported, empty, unknown, and null values

Targets `1.1.x` since `main` now uses `openai-java`.

Fixes #2645