### PR TITLE
Add instructions option to OpenAiAudioSpeechModel

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechProperties.java
@@ -45,6 +45,8 @@ public class OpenAiAudioSpeechProperties extends AbstractOpenAiProperties {
 
 	private @Nullable Double speed;
 
+	private @Nullable String instructions;
+
 	public @Nullable String getModel() {
 		return this.model;
 	}
@@ -85,6 +87,14 @@ public class OpenAiAudioSpeechProperties extends AbstractOpenAiProperties {
 		this.speed = speed;
 	}
 
+	public @Nullable String getInstructions() {
+		return this.instructions;
+	}
+
+	public void setInstructions(@Nullable String instructions) {
+		this.instructions = instructions;
+	}
+
 	public OpenAiAudioSpeechOptions toOptions() {
 		return OpenAiAudioSpeechOptions.builder()
 			.model(this.getModel())
@@ -92,6 +102,7 @@ public class OpenAiAudioSpeechProperties extends AbstractOpenAiProperties {
 			.voice(this.voice)
 			.responseFormat(this.responseFormat)
 			.speed(this.speed)
+			.instructions(this.instructions)
 			.build();
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
@@ -137,6 +137,10 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 			paramsBuilder.speed(mergedOptions.getSpeed());
 		}
 
+		if (StringUtils.hasText(mergedOptions.getInstructions())) {
+			paramsBuilder.instructions(mergedOptions.getInstructions());
+		}
+
 		SpeechCreateParams params = paramsBuilder.build();
 
 		com.openai.core.http.HttpResponse httpResponse = this.openAiClient.audio().speech().create(params);

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechOptions.java
@@ -117,12 +117,15 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 
 	private final Double speed;
 
+	private final @Nullable String instructions;
+
 	protected OpenAiAudioSpeechOptions(@Nullable String baseUrl, @Nullable String apiKey,
 			@Nullable Credential credential, @Nullable String model, @Nullable String microsoftDeploymentName,
 			@Nullable AzureOpenAIServiceVersion microsoftFoundryServiceVersion, @Nullable String organizationId,
 			@Nullable Boolean isMicrosoftFoundry, @Nullable Boolean isGitHubModels, @Nullable Duration timeout,
 			@Nullable Integer maxRetries, @Nullable Proxy proxy, @Nullable Map<String, String> customHeaders,
-			@Nullable String input, @Nullable String voice, @Nullable String responseFormat, @Nullable Double speed) {
+			@Nullable String input, @Nullable String voice, @Nullable String responseFormat, @Nullable Double speed,
+			@Nullable String instructions) {
 		super(baseUrl, apiKey, credential, model != null ? model : DEFAULT_SPEECH_MODEL, microsoftDeploymentName,
 				microsoftFoundryServiceVersion, organizationId, isMicrosoftFoundry, isGitHubModels, timeout, maxRetries,
 				proxy, customHeaders);
@@ -130,6 +133,7 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 		this.voice = voice != null ? voice : DEFAULT_VOICE;
 		this.responseFormat = responseFormat != null ? responseFormat : DEFAULT_RESPONSE_FORMAT;
 		this.speed = speed != null ? speed : DEFAULT_SPEED;
+		this.instructions = instructions;
 	}
 
 	public static Builder builder() {
@@ -147,6 +151,10 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 
 	public String getResponseFormat() {
 		return this.responseFormat;
+	}
+
+	public @Nullable String getInstructions() {
+		return this.instructions;
 	}
 
 	@Override
@@ -170,12 +178,12 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 		OpenAiAudioSpeechOptions that = (OpenAiAudioSpeechOptions) o;
 		return Objects.equals(getModel(), that.getModel()) && Objects.equals(this.input, that.input)
 				&& Objects.equals(this.voice, that.voice) && Objects.equals(this.responseFormat, that.responseFormat)
-				&& Objects.equals(this.speed, that.speed);
+				&& Objects.equals(this.speed, that.speed) && Objects.equals(this.instructions, that.instructions);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(getModel(), this.input, this.voice, this.responseFormat, this.speed);
+		return Objects.hash(getModel(), this.input, this.voice, this.responseFormat, this.speed, this.instructions);
 	}
 
 	public static final class Builder extends AbstractBuilder<OpenAiAudioSpeechOptions, Builder> {
@@ -187,6 +195,8 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 		private @Nullable String responseFormat;
 
 		private @Nullable Double speed;
+
+		private @Nullable String instructions;
 
 		private Builder() {
 		}
@@ -212,6 +222,7 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 			this.voice = fromOptions.getVoice();
 			this.responseFormat = fromOptions.getResponseFormat();
 			this.speed = fromOptions.getSpeed();
+			this.instructions = fromOptions.getInstructions();
 			return this;
 		}
 
@@ -273,6 +284,9 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 					this.input = castFrom.getInput();
 				}
 				this.responseFormat = castFrom.getResponseFormat();
+				if (castFrom.getInstructions() != null) {
+					this.instructions = castFrom.getInstructions();
+				}
 			}
 			return this;
 		}
@@ -307,12 +321,22 @@ public class OpenAiAudioSpeechOptions extends AbstractOpenAiOptions implements T
 			return this;
 		}
 
+		/**
+		 * Sets control instructions for the voice delivery (e.g. tone, pace). Only
+		 * supported by models such as {@code gpt-4o-mini-tts}; ignored by {@code tts-1}
+		 * and {@code tts-1-hd}.
+		 */
+		public Builder instructions(@Nullable String instructions) {
+			this.instructions = instructions;
+			return this;
+		}
+
 		@Override
 		public OpenAiAudioSpeechOptions build() {
 			return new OpenAiAudioSpeechOptions(this.baseUrl, this.apiKey, this.credential, this.model,
 					this.microsoftDeploymentName, this.microsoftFoundryServiceVersion, this.organizationId,
 					this.isMicrosoftFoundry, this.isGitHubModels, this.timeout, this.maxRetries, this.proxy,
-					this.customHeaders, this.input, this.voice, this.responseFormat, this.speed);
+					this.customHeaders, this.input, this.voice, this.responseFormat, this.speed, this.instructions);
 		}
 
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelIT.java
@@ -162,6 +162,24 @@ class OpenAiAudioSpeechModelIT {
 	}
 
 	@Test
+	void testInstructionsOption() {
+		OpenAiAudioSpeechOptions options = OpenAiAudioSpeechOptions.builder()
+			.model("gpt-4o-mini-tts")
+			.voice(OpenAiAudioSpeechOptions.Voice.VERSE)
+			.instructions("Friendly; warm tone; natural pauses; ~1.1x feel")
+			.build();
+
+		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().options(options).build();
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt("Today is a wonderful day to build something people love!");
+
+		TextToSpeechResponse response = model.call(prompt);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).hasSize(1);
+		assertThat(response.getResult().getOutput()).isNotEmpty();
+	}
+
+	@Test
 	void testRateLimitMetadata() {
 		// Verify that SDK extracts rate limit metadata from response headers
 		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().build();

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
@@ -164,6 +164,17 @@ class OpenAiAudioSpeechModelTests {
 	}
 
 	@Test
+	void testOptionsBuilderWithInstructions() {
+		OpenAiAudioSpeechOptions options = OpenAiAudioSpeechOptions.builder()
+			.model("gpt-4o-mini-tts")
+			.voice(OpenAiAudioSpeechOptions.Voice.VERSE)
+			.instructions("Friendly; warm tone; natural pauses")
+			.build();
+
+		assertThat(options.getInstructions()).isEqualTo("Friendly; warm tone; natural pauses");
+	}
+
+	@Test
 	void testAllVoiceConstants() {
 		assertThat(OpenAiAudioSpeechOptions.Voice.ALLOY.getValue()).isEqualTo("alloy");
 		assertThat(OpenAiAudioSpeechOptions.Voice.ECHO.getValue()).isEqualTo("echo");

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/speech/OpenAiAudioSpeechOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/speech/OpenAiAudioSpeechOptionsTests.java
@@ -50,6 +50,24 @@ class OpenAiAudioSpeechOptionsTests {
 	}
 
 	@Test
+	void instructionsAreSetAndMerged() {
+		OpenAiAudioSpeechOptions defaultOptions = OpenAiAudioSpeechOptions.builder()
+			.instructions("default-instructions")
+			.build();
+
+		OpenAiAudioSpeechOptions requestOptions = OpenAiAudioSpeechOptions.builder()
+			.instructions("request-instructions")
+			.build();
+
+		OpenAiAudioSpeechOptions mergedOptions = OpenAiAudioSpeechOptions.builder()
+			.from(defaultOptions)
+			.merge(requestOptions)
+			.build();
+
+		assertThat(mergedOptions.getInstructions()).isEqualTo("request-instructions");
+	}
+
+	@Test
 	void testOptionsBuilderMergeCustomHeaders() {
 		OpenAiAudioSpeechOptions defaultOptions = OpenAiAudioSpeechOptions.builder()
 			.customHeaders(Map.of("default-header", "default-value"))

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
@@ -94,6 +94,7 @@ The prefix `spring.ai.openai.audio.speech` is used as the property prefix that l
 | spring.ai.openai.audio.speech.voice | The voice to use for synthesis. For OpenAI's TTS API, One of the available voices for the chosen model: alloy, echo, fable, onyx, nova, and shimmer. | alloy
 | spring.ai.openai.audio.speech.response-format | The format of the audio output. Supported formats are mp3, opus, aac, flac, wav, and pcm. | mp3
 | spring.ai.openai.audio.speech.speed | The speed of the voice synthesis. The acceptable range is from 0.25 (slowest) to 4.0 (fastest). | 1.0
+| spring.ai.openai.audio.speech.instructions | Control instructions for the voice delivery (e.g. tone, pace). Only supported by models such as `gpt-4o-mini-tts`; ignored by `tts-1` and `tts-1-hd`. | -
 |====
 
 NOTE: You can override the common `spring.ai.openai.base-url`, `spring.ai.openai.api-key`, `spring.ai.openai.organization-id` and `spring.ai.openai.project-id` properties.
@@ -118,6 +119,7 @@ OpenAiAudioSpeechOptions speechOptions = OpenAiAudioSpeechOptions.builder()
     .voice(OpenAiAudioApi.SpeechRequest.Voice.ALLOY)
     .responseFormat(OpenAiAudioApi.SpeechRequest.AudioResponseFormat.MP3)
     .speed(1.0)
+    .instructions("Friendly; warm tone; natural pauses")
     .build();
 
 TextToSpeechPrompt speechPrompt = new TextToSpeechPrompt("Hello, this is a text-to-speech example.", speechOptions);


### PR DESCRIPTION
Add an optional instructions field to OpenAiAudioSpeechOptions to control the voice delivery (tone, pace) for models that support it. 
The value is forwarded to the OpenAI SDK's SpeechCreateParams only when set, so tts-1 and tts-1-hd remain unaffected and backward compatible.

Fixes #4388
