### PR TITLE
Refine documentation about MCP transport security

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -16,6 +16,16 @@ The MCP Server Boot Starters offer:
 * Change notification capabilities
 * xref:api/mcp/mcp-annotations-server.adoc[Annotation-based server development] with automatic bean scanning and registration
 
+[WARNING]
+====
+The HTTP-based server transports (SSE, Streamable-HTTP, and Stateless) expose an unauthenticated JSON-RPC endpoint by default.
+The starters do not apply any authentication or authorization on their own, so any client that can reach the endpoint can list and invoke every registered tool, resource, and prompt.
+Before exposing an MCP server beyond localhost, you must place a security boundary in front of it.
+See <<securing-the-mcp-server>> for details.
+
+This does not apply to the `STDIO` transport, which runs in-process and is not network-accessible.
+====
+
 == MCP Server Boot Starters
 
 MCP Servers support multiple protocol and transport mechanisms.
@@ -69,6 +79,16 @@ MCP provides several protocol types including:
 * xref:api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc[**Streamable-HTTP**] - The link:https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http[Streamable HTTP transport] allows MCP servers to operate as independent processes that can handle multiple client connections using HTTP POST and GET requests, with optional Server-Sent Events (SSE) streaming for multiple server messages. It replaces the SSE transport. To enable the `STREAMABLE` protocol, set `spring.ai.mcp.server.protocol=STREAMABLE`.
 * xref:api/mcp/mcp-stateless-server-boot-starter-docs.adoc[**Stateless**] - Stateless MCP servers are designed for simplified deployments where session state is not maintained between requests.
 They are ideal for microservices architectures and cloud-native deployments. To enable the `STATELESS` protocol, set `spring.ai.mcp.server.protocol=STATELESS`.
+
+[[securing-the-mcp-server]]
+== Securing the MCP Server
+
+The MCP server transports are intentionally authentication-agnostic: the auto-configuration wires up the endpoint but does not enforce authentication or authorization.
+As with any other Spring web endpoint, securing an HTTP-based MCP server (SSE, Streamable-HTTP, or Stateless) is the responsibility of a dedicated security layer that you add in front of it — it is not provided by the transport.
+Examples of security libraries are Spring Security and link:https://github.com/spring-ai-community/mcp-security[MCP Security]
+
+IMPORTANT: With the default configuration the MCP endpoint (`POST /mcp` by default) accepts all requests, allowing any network-accessible client to enumerate and invoke your registered tools, resources, and prompts without credentials.
+Treat the registration of a tool, resource, or prompt as a decision to expose it, and secure the endpoint before deploying beyond localhost.
 
 == Sync/Async Server API Options
 


### PR DESCRIPTION
Make it clear that the autoconfiguiration is not secure by default and steps should be taken to secure any mcp endpoints.