### PR TITLE
Support audio streaming in OpenAiAudioSpeechModel

### DIFF
--- a/models/spring-ai-openai/pom.xml
+++ b/models/spring-ai-openai/pom.xml
@@ -111,6 +111,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
@@ -18,12 +18,15 @@ package org.springframework.ai.openai;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
 import com.openai.client.OpenAIClient;
 import com.openai.core.http.Headers;
+import com.openai.core.http.HttpResponse;
 import com.openai.models.audio.speech.SpeechCreateParams;
 import com.openai.models.audio.speech.SpeechModel;
 import io.micrometer.observation.ObservationRegistry;
@@ -31,6 +34,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.SynchronousSink;
+import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.audio.tts.Speech;
 import org.springframework.ai.audio.tts.TextToSpeechModel;
@@ -56,6 +61,8 @@ import org.springframework.util.StringUtils;
 public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 
 	private static final Log logger = LogFactory.getLog(OpenAiAudioSpeechModel.class);
+
+	private static final int STREAM_CHUNK_SIZE = 8192;
 
 	private final OpenAIClient openAiClient;
 
@@ -100,20 +107,105 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 	public TextToSpeechResponse call(TextToSpeechPrompt prompt) {
 		Assert.notNull(prompt, "Prompt must not be null");
 
-		// Merge request options with default options
-		OpenAiAudioSpeechOptions mergedOptions = OpenAiAudioSpeechOptions.builder()
-			.from(this.options)
-			.merge(prompt.getOptions())
-			.build();
-
+		OpenAiAudioSpeechOptions mergedOptions = mergeOptions(prompt);
 		String inputText = getInputText(prompt, mergedOptions);
+		traceRequest("Calling", mergedOptions);
 
+		SpeechCreateParams params = buildSpeechCreateParams(mergedOptions, inputText, false);
+
+		HttpResponse httpResponse = this.openAiClient.audio().speech().create(params);
+		Headers headers = httpResponse.headers();
+
+		byte[] audioBytes;
+		try (InputStream inputStream = httpResponse.body()) {
+			audioBytes = inputStream.readAllBytes();
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to read audio speech response", e);
+		}
+
+		if (audioBytes.length == 0) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("No speech response returned for prompt: " + prompt);
+			}
+			return new TextToSpeechResponse(List.of(new Speech(new byte[0])));
+		}
+
+		Speech speech = new Speech(audioBytes);
+		OpenAiAudioSpeechResponseMetadata metadata = OpenAiAudioSpeechResponseMetadata.from(headers);
+
+		return new TextToSpeechResponse(List.of(speech), metadata);
+	}
+
+	@Override
+	public Flux<TextToSpeechResponse> stream(TextToSpeechPrompt prompt) {
+		Assert.notNull(prompt, "Prompt must not be null");
+
+		return Flux
+			.<TextToSpeechResponse, SpeechStreamState>generate(() -> openSpeechStream(prompt), this::emitNextChunk,
+					SpeechStreamState::close)
+			.subscribeOn(Schedulers.boundedElastic());
+	}
+
+	private SpeechStreamState openSpeechStream(TextToSpeechPrompt prompt) {
+		OpenAiAudioSpeechOptions mergedOptions = mergeOptions(prompt);
+		String inputText = getInputText(prompt, mergedOptions);
+		traceRequest("Streaming", mergedOptions);
+
+		SpeechCreateParams params = buildSpeechCreateParams(mergedOptions, inputText, true);
+
+		HttpResponse httpResponse = this.openAiClient.audio().speech().create(params);
+		InputStream inputStream = httpResponse.body();
+		OpenAiAudioSpeechResponseMetadata metadata = OpenAiAudioSpeechResponseMetadata.from(httpResponse.headers());
+
+		return new SpeechStreamState(httpResponse, inputStream, metadata);
+	}
+
+	private SpeechStreamState emitNextChunk(SpeechStreamState state, SynchronousSink<TextToSpeechResponse> sink) {
+		byte[] buffer = new byte[STREAM_CHUNK_SIZE];
+		int bytesRead;
+		try {
+			bytesRead = state.inputStream().read(buffer);
+		}
+		catch (InterruptedIOException e) {
+			// The blocking read was interrupted because the downstream subscriber
+			// cancelled (e.g. a consumer stopped reading early). This is a normal
+			// shutdown path, not a failure, so complete quietly instead of raising
+			// sink.error(), which would otherwise surface as a spurious "dropped
+			// error" once nothing is left to receive it.
+			Thread.currentThread().interrupt();
+			sink.complete();
+			return state;
+		}
+		catch (IOException e) {
+			sink.error(new RuntimeException("Failed to read audio speech stream", e));
+			return state;
+		}
+
+		if (bytesRead == -1) {
+			sink.complete();
+			return state;
+		}
+
+		byte[] chunk = (bytesRead == buffer.length) ? buffer : Arrays.copyOf(buffer, bytesRead);
+		sink.next(new TextToSpeechResponse(List.of(new Speech(chunk)), state.metadata()));
+		return state;
+	}
+
+	private OpenAiAudioSpeechOptions mergeOptions(TextToSpeechPrompt prompt) {
+		return OpenAiAudioSpeechOptions.builder().from(this.options).merge(prompt.getOptions()).build();
+	}
+
+	private void traceRequest(String verb, OpenAiAudioSpeechOptions mergedOptions) {
 		if (logger.isTraceEnabled()) {
-			logger.trace("Calling OpenAI SDK audio speech with model: " + mergedOptions.getModel() + ", voice: "
+			logger.trace(verb + " OpenAI SDK audio speech with model: " + mergedOptions.getModel() + ", voice: "
 					+ mergedOptions.getVoice() + ", format: " + mergedOptions.getResponseFormat() + ", speed: "
 					+ mergedOptions.getSpeed());
 		}
+	}
 
+	private SpeechCreateParams buildSpeechCreateParams(OpenAiAudioSpeechOptions mergedOptions, String inputText,
+			boolean streaming) {
 		String model;
 		if (mergedOptions.getDeploymentName() != null) {
 			model = mergedOptions.getDeploymentName();
@@ -141,37 +233,11 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 			paramsBuilder.instructions(mergedOptions.getInstructions());
 		}
 
-		SpeechCreateParams params = paramsBuilder.build();
-
-		com.openai.core.http.HttpResponse httpResponse = this.openAiClient.audio().speech().create(params);
-		Headers headers = httpResponse.headers();
-
-		byte[] audioBytes;
-		try (InputStream inputStream = httpResponse.body()) {
-			audioBytes = inputStream.readAllBytes();
-		}
-		catch (IOException e) {
-			throw new RuntimeException("Failed to read audio speech response", e);
+		if (streaming) {
+			paramsBuilder.streamFormat(SpeechCreateParams.StreamFormat.AUDIO);
 		}
 
-		if (audioBytes.length == 0) {
-			if (logger.isWarnEnabled()) {
-				logger.warn("No speech response returned for prompt: " + prompt);
-			}
-			return new TextToSpeechResponse(List.of(new Speech(new byte[0])));
-		}
-
-		Speech speech = new Speech(audioBytes);
-		OpenAiAudioSpeechResponseMetadata metadata = OpenAiAudioSpeechResponseMetadata.from(headers);
-
-		return new TextToSpeechResponse(List.of(speech), metadata);
-	}
-
-	@Override
-	public Flux<TextToSpeechResponse> stream(TextToSpeechPrompt prompt) {
-		// TODO: The OpenAI SDK audio().speech() API does not support streaming yet.
-		// Return the full response as a single element Flux.
-		return Flux.just(call(prompt));
+		return paramsBuilder.build();
 	}
 
 	/**
@@ -197,6 +263,19 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 			return options.getInput();
 		}
 		return prompt.getInstructions().getText();
+	}
+
+	/**
+	 * Holds the open HTTP response and its still-open body {@link InputStream} for the
+	 * duration of a {@link #stream(TextToSpeechPrompt)} subscription.
+	 */
+	private record SpeechStreamState(HttpResponse httpResponse, InputStream inputStream,
+			OpenAiAudioSpeechResponseMetadata metadata) {
+
+		void close() {
+			this.httpResponse.close();
+		}
+
 	}
 
 	/**

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
@@ -36,6 +36,7 @@ import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.SynchronousSink;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.audio.tts.Speech;
@@ -65,9 +66,21 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 
 	private static final int STREAM_CHUNK_SIZE = 8192;
 
+	/**
+	 * Default {@link #stream(TextToSpeechPrompt)} scheduler, used unless a
+	 * {@link Builder#streamScheduler(Scheduler) custom one} is set. A dedicated pool,
+	 * sized like Reactor's shared {@link Schedulers#boundedElastic()}, so long-lived
+	 * streams don't contend with unrelated blocking work elsewhere in the app.
+	 */
+	private static final Scheduler DEFAULT_STREAM_SCHEDULER = Schedulers.newBoundedElastic(
+			Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE, Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE,
+			"openai-audio-speech");
+
 	private final OpenAIClient openAiClient;
 
 	private final OpenAiAudioSpeechOptions options;
+
+	private final Scheduler streamScheduler;
 
 	private OpenAiAudioSpeechModel(Builder builder) {
 		this.options = Objects.requireNonNullElseGet(builder.options, () -> OpenAiAudioSpeechOptions.builder().build());
@@ -79,6 +92,7 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
 						this.options.getCustomHeaders(), ObservationRegistry.NOOP, null,
 						builder.httpClientCustomizers));
+		this.streamScheduler = Objects.requireNonNullElse(builder.streamScheduler, DEFAULT_STREAM_SCHEDULER);
 	}
 
 	/**
@@ -152,7 +166,7 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 						state.close();
 					}
 				})
-			.subscribeOn(Schedulers.boundedElastic())
+			.subscribeOn(this.streamScheduler)
 			// After subscribeOn() so this runs before its worker is disposed -
 			// i.e. before the blocking call in progress gets interrupted -
 			// guaranteeing `cancelled` is already set when that's observed.
@@ -326,6 +340,8 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 
 		private @Nullable OpenAiAudioSpeechOptions options;
 
+		private @Nullable Scheduler streamScheduler;
+
 		private List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers = new ArrayList<>();
 
 		/**
@@ -342,6 +358,7 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 		private Builder(OpenAiAudioSpeechModel model) {
 			this.openAiClient = model.openAiClient;
 			this.options = model.options;
+			this.streamScheduler = model.streamScheduler;
 		}
 
 		/**
@@ -363,6 +380,20 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 			if (options != null) {
 				this.options = options;
 			}
+			return this;
+		}
+
+		/**
+		 * Sets the {@link Scheduler} for
+		 * {@link OpenAiAudioSpeechModel#stream(TextToSpeechPrompt)}. Defaults to a
+		 * dedicated pool; override to share a scheduler across components or size it for
+		 * expected concurrent-stream load.
+		 * @param streamScheduler The scheduler to use, or {@code null} to restore the
+		 * default
+		 * @return This builder
+		 */
+		public Builder streamScheduler(@Nullable Scheduler streamScheduler) {
+			this.streamScheduler = streamScheduler;
 			return this;
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
@@ -18,15 +18,16 @@ package org.springframework.ai.openai;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InterruptedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.openai.client.OpenAIClient;
 import com.openai.core.http.Headers;
 import com.openai.core.http.HttpResponse;
+import com.openai.errors.OpenAIIoException;
 import com.openai.models.audio.speech.SpeechCreateParams;
 import com.openai.models.audio.speech.SpeechModel;
 import io.micrometer.observation.ObservationRegistry;
@@ -141,44 +142,82 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 	public Flux<TextToSpeechResponse> stream(TextToSpeechPrompt prompt) {
 		Assert.notNull(prompt, "Prompt must not be null");
 
-		return Flux
-			.<TextToSpeechResponse, SpeechStreamState>generate(() -> openSpeechStream(prompt), this::emitNextChunk,
-					SpeechStreamState::close)
-			.subscribeOn(Schedulers.boundedElastic());
+		// Lets openSpeechStream/emitNextChunk tell a deliberate cancellation
+		// apart from a genuine I/O failure.
+		AtomicBoolean cancelled = new AtomicBoolean(false);
+
+		return Flux.<TextToSpeechResponse, SpeechStreamState>generate(() -> openSpeechStream(prompt, cancelled),
+				(state, sink) -> emitNextChunk(state, sink, cancelled), state -> {
+					if (state != null) {
+						state.close();
+					}
+				})
+			.subscribeOn(Schedulers.boundedElastic())
+			// After subscribeOn() so this runs before its worker is disposed -
+			// i.e. before the blocking call in progress gets interrupted -
+			// guaranteeing `cancelled` is already set when that's observed.
+			.doOnCancel(() -> cancelled.set(true));
 	}
 
-	private SpeechStreamState openSpeechStream(TextToSpeechPrompt prompt) {
+	private @Nullable SpeechStreamState openSpeechStream(TextToSpeechPrompt prompt, AtomicBoolean cancelled) {
 		OpenAiAudioSpeechOptions mergedOptions = mergeOptions(prompt);
 		String inputText = getInputText(prompt, mergedOptions);
 		traceRequest("Streaming", mergedOptions);
 
 		SpeechCreateParams params = buildSpeechCreateParams(mergedOptions, inputText, true);
 
-		HttpResponse httpResponse = this.openAiClient.audio().speech().create(params);
+		HttpResponse httpResponse;
+		try {
+			httpResponse = this.openAiClient.audio().speech().create(params);
+		}
+		catch (OpenAIIoException e) {
+			// The SDK wraps IOException - including one from this thread being
+			// interrupted on cancellation - into OpenAIIoException; `cancelled`
+			// tells that apart from a genuine connection failure.
+			if (Thread.interrupted()) {
+				Thread.currentThread().interrupt();
+			}
+			if (cancelled.get()) {
+				// No response ever arrived, so there's nothing to stream.
+				// Flux.generate supports a null state for this (see
+				// emitNextChunk's null check below).
+				return null;
+			}
+			throw e;
+		}
 		InputStream inputStream = httpResponse.body();
 		OpenAiAudioSpeechResponseMetadata metadata = OpenAiAudioSpeechResponseMetadata.from(httpResponse.headers());
 
 		return new SpeechStreamState(httpResponse, inputStream, metadata);
 	}
 
-	private SpeechStreamState emitNextChunk(SpeechStreamState state, SynchronousSink<TextToSpeechResponse> sink) {
+	private @Nullable SpeechStreamState emitNextChunk(@Nullable SpeechStreamState state,
+			SynchronousSink<TextToSpeechResponse> sink, AtomicBoolean cancelled) {
+		if (state == null) {
+			// Cancelled before openSpeechStream obtained a response.
+			sink.complete();
+			return null;
+		}
+
 		byte[] buffer = new byte[STREAM_CHUNK_SIZE];
 		int bytesRead;
 		try {
 			bytesRead = state.inputStream().read(buffer);
 		}
-		catch (InterruptedIOException e) {
-			// The blocking read was interrupted because the downstream subscriber
-			// cancelled (e.g. a consumer stopped reading early). This is a normal
-			// shutdown path, not a failure, so complete quietly instead of raising
-			// sink.error(), which would otherwise surface as a spurious "dropped
-			// error" once nothing is left to receive it.
-			Thread.currentThread().interrupt();
-			sink.complete();
-			return state;
-		}
 		catch (IOException e) {
-			sink.error(new RuntimeException("Failed to read audio speech stream", e));
+			// A blocked read can fail from cancellation (this thread gets
+			// interrupted) or from a genuine fault like a socket timeout -
+			// SocketTimeoutException is itself an InterruptedIOException, so
+			// the exception type alone can't tell them apart; `cancelled` can.
+			if (Thread.interrupted()) {
+				Thread.currentThread().interrupt();
+			}
+			if (cancelled.get()) {
+				sink.complete();
+			}
+			else {
+				sink.error(new RuntimeException("Failed to read audio speech stream", e));
+			}
 			return state;
 		}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelIT.java
@@ -16,12 +16,19 @@
 
 package org.springframework.ai.openai.audio;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.audio.tts.Speech;
@@ -130,17 +137,72 @@ class OpenAiAudioSpeechModelIT {
 	@Test
 	void testStreamingBehavior() {
 		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().build();
-		TextToSpeechPrompt prompt = new TextToSpeechPrompt("Today is a wonderful day to build something people love!");
+		// Long enough input that the audio response spans multiple 8KB chunks.
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt(
+				"Today is a wonderful day to build something people love! " + "Streaming lets us start playing "
+						+ "audio back before the whole response has finished generating, which matters a lot "
+						+ "for real-time voice experiences.");
 
 		Flux<TextToSpeechResponse> responseFlux = model.stream(prompt);
 
 		assertThat(responseFlux).isNotNull();
-		List<TextToSpeechResponse> responses = responseFlux.collectList().block();
+		List<TextToSpeechResponse> responses = responseFlux.collectList().block(Duration.ofSeconds(30));
 		assertThat(responses).isNotNull();
 
-		// SDK doesn't support true streaming - should return single response
-		assertThat(responses).hasSize(1);
-		assertThat(responses.get(0).getResult().getOutput()).isNotEmpty();
+		// The audio is now delivered as multiple chunks as they arrive from OpenAI,
+		// rather than as a single, fully-buffered response.
+		assertThat(responses.size()).isGreaterThan(1);
+
+		int totalBytes = 0;
+		for (TextToSpeechResponse response : responses) {
+			byte[] chunk = response.getResult().getOutput();
+			assertThat(chunk).isNotEmpty();
+			totalBytes += chunk.length;
+		}
+		assertThat(totalBytes).isGreaterThan(8192);
+	}
+
+	@Test
+	void testStreamAsInputStream() throws IOException {
+		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().build();
+		String text = "Today is a wonderful day to build something people love! Bridging a reactive "
+				+ "stream into a blocking InputStream lets us hand audio off to APIs that only "
+				+ "understand java.io, without buffering the whole response in memory first.";
+
+		Flux<byte[]> audioByteFlux = model.stream(text);
+
+		int totalBytes = 0;
+		try (InputStream audioInputStream = new FluxInputStream(audioByteFlux)) {
+			byte[] buffer = new byte[4096];
+			int bytesRead;
+			while ((bytesRead = audioInputStream.read(buffer)) != -1) {
+				assertThat(bytesRead).isGreaterThan(0);
+				totalBytes += bytesRead;
+			}
+		}
+
+		// 8192 is the model's internal streaming chunk size; a total larger than
+		// that confirms multiple chunks were actually bridged through the
+		// InputStream rather than a single, fully-buffered response.
+		assertThat(totalBytes).isGreaterThan(8192);
+	}
+
+	@Test
+	void testStreamAsInputStreamEarlyClose() throws IOException {
+		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().build();
+		Flux<byte[]> audioByteFlux = model
+			.stream("Today is a wonderful day to build something people love! " + "This sentence is long enough "
+					+ "that its audio spans several streamed chunks, so closing early actually "
+					+ "cancels an in-flight stream instead of one that had already finished.");
+
+		// Reading only the first few bytes and closing early must not hang or
+		// throw: FluxInputStream#close() cancels the upstream subscription rather
+		// than draining it, which is what lets the underlying OpenAI HTTP
+		// connection be released immediately instead of waiting for EOF.
+		try (InputStream audioInputStream = new FluxInputStream(audioByteFlux)) {
+			byte[] firstBytes = audioInputStream.readNBytes(16);
+			assertThat(firstBytes).hasSize(16);
+		}
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
@@ -234,6 +296,132 @@ class OpenAiAudioSpeechModelIT {
 		assertThat(response).isNotNull();
 		assertThat(response.getResults()).hasSize(1);
 		assertThat(response.getResult().getOutput()).isNotEmpty();
+	}
+
+	/**
+	 * Bridges a {@code Flux<byte[]>} into a blocking {@link InputStream}, for handing
+	 * streamed audio off to APIs that only understand {@code java.io}.
+	 * <p>
+	 * Two practices matter here that a naive {@code Flux#toIterable()}-based bridge would
+	 * not give us:
+	 * <ul>
+	 * <li>Backpressure: exactly one chunk is requested at a time (see
+	 * {@code hookOnNext}), so we never buffer further ahead than the {@code InputStream}
+	 * consumer actually reads.</li>
+	 * <li>Cancellable {@link #close()}: closing the stream before it reaches EOF disposes
+	 * the subscriber, which cancels the upstream {@link Flux}. For
+	 * {@link OpenAiAudioSpeechModel}, that cancellation propagates down to the
+	 * {@code Flux.generate} state disposer and closes the underlying OpenAI HTTP
+	 * response/connection immediately, instead of leaking it until the response would
+	 * otherwise have completed.</li>
+	 * </ul>
+	 */
+	private static final class FluxInputStream extends InputStream {
+
+		private static final byte[] END_OF_STREAM = new byte[0];
+
+		private final BlockingQueue<Object> queue = new ArrayBlockingQueue<>(1);
+
+		private final BaseSubscriber<byte[]> subscriber;
+
+		private byte[] current = END_OF_STREAM;
+
+		private int position = 0;
+
+		private boolean finished = false;
+
+		FluxInputStream(Flux<byte[]> source) {
+			this.subscriber = new BaseSubscriber<byte[]>() {
+
+				@Override
+				protected void hookOnSubscribe(Subscription subscription) {
+					request(1);
+				}
+
+				@Override
+				protected void hookOnNext(byte[] chunk) {
+					offer(chunk);
+					request(1);
+				}
+
+				@Override
+				protected void hookOnComplete() {
+					offer(END_OF_STREAM);
+				}
+
+				@Override
+				protected void hookOnError(Throwable error) {
+					offer(error);
+				}
+
+			};
+			source.subscribe(this.subscriber);
+		}
+
+		private void offer(Object item) {
+			try {
+				this.queue.put(item);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		@Override
+		public int read() throws IOException {
+			if (!ensureChunkAvailable()) {
+				return -1;
+			}
+			return this.current[this.position++] & 0xFF;
+		}
+
+		@Override
+		public int read(byte[] b, int off, int len) throws IOException {
+			if (len == 0) {
+				return 0;
+			}
+			if (!ensureChunkAvailable()) {
+				return -1;
+			}
+			int available = this.current.length - this.position;
+			int toCopy = Math.min(available, len);
+			System.arraycopy(this.current, this.position, b, off, toCopy);
+			this.position += toCopy;
+			return toCopy;
+		}
+
+		private boolean ensureChunkAvailable() throws IOException {
+			while (this.position >= this.current.length) {
+				if (this.finished) {
+					return false;
+				}
+				Object item;
+				try {
+					item = this.queue.take();
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IOException("Interrupted while waiting for the next audio chunk", e);
+				}
+				if (item == END_OF_STREAM) {
+					this.finished = true;
+					return false;
+				}
+				if (item instanceof Throwable error) {
+					this.finished = true;
+					throw new IOException("Audio stream failed", error);
+				}
+				this.current = (byte[]) item;
+				this.position = 0;
+			}
+			return true;
+		}
+
+		@Override
+		public void close() {
+			this.subscriber.dispose();
+		}
+
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.openai.client.OpenAIClient;
 import com.openai.core.http.Headers;
@@ -46,6 +47,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.Disposable;
 import reactor.core.publisher.Hooks;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.audio.tts.TextToSpeechOptions;
 import org.springframework.ai.audio.tts.TextToSpeechPrompt;
@@ -233,6 +236,43 @@ class OpenAiAudioSpeechModelTests {
 		assertThat(paramsCaptor.getValue().streamFormat()).contains(SpeechCreateParams.StreamFormat.AUDIO);
 
 		verify(httpResponse).close();
+	}
+
+	@Test
+	void testStreamUsesCustomScheduler() {
+		byte[] audioBytes = new byte[100];
+		new Random(13).nextBytes(audioBytes);
+
+		AudioService audioService = mock(AudioService.class);
+		SpeechService speechService = mock(SpeechService.class);
+		HttpResponse httpResponse = mock(HttpResponse.class);
+		Headers headers = mock(Headers.class);
+
+		when(this.mockClient.audio()).thenReturn(audioService);
+		when(audioService.speech()).thenReturn(speechService);
+		when(speechService.create(any(SpeechCreateParams.class))).thenReturn(httpResponse);
+		when(httpResponse.body()).thenReturn(new ByteArrayInputStream(audioBytes));
+		when(httpResponse.headers()).thenReturn(headers);
+		when(headers.values(anyString())).thenReturn(List.of());
+
+		Scheduler customScheduler = Schedulers.newSingle("custom-speech-scheduler-test");
+		try {
+			OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder()
+				.openAiClient(this.mockClient)
+				.streamScheduler(customScheduler)
+				.build();
+			TextToSpeechPrompt prompt = new TextToSpeechPrompt("Testing custom scheduler usage");
+
+			AtomicReference<String> threadName = new AtomicReference<>();
+			model.stream(prompt)
+				.doOnNext(response -> threadName.set(Thread.currentThread().getName()))
+				.blockLast(Duration.ofSeconds(5));
+
+			assertThat(threadName.get()).startsWith("custom-speech-scheduler-test");
+		}
+		finally {
+			customScheduler.dispose();
+		}
 	}
 
 	@Test

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
@@ -18,21 +18,34 @@ package org.springframework.ai.openai.audio;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.openai.client.OpenAIClient;
 import com.openai.core.http.Headers;
 import com.openai.core.http.HttpResponse;
+import com.openai.errors.OpenAIIoException;
 import com.openai.models.audio.speech.SpeechCreateParams;
 import com.openai.services.blocking.AudioService;
 import com.openai.services.blocking.audio.SpeechService;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.Disposable;
+import reactor.core.publisher.Hooks;
 
 import org.springframework.ai.audio.tts.TextToSpeechOptions;
 import org.springframework.ai.audio.tts.TextToSpeechPrompt;
@@ -45,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -219,6 +233,191 @@ class OpenAiAudioSpeechModelTests {
 		assertThat(paramsCaptor.getValue().streamFormat()).contains(SpeechCreateParams.StreamFormat.AUDIO);
 
 		verify(httpResponse).close();
+	}
+
+	@Test
+	void testStreamPropagatesSocketTimeoutAsError() throws IOException {
+		byte[] firstChunk = new byte[100];
+		new Random(7).nextBytes(firstChunk);
+
+		AudioService audioService = mock(AudioService.class);
+		SpeechService speechService = mock(SpeechService.class);
+		HttpResponse httpResponse = mock(HttpResponse.class);
+		Headers headers = mock(Headers.class);
+		InputStream inputStream = mock(InputStream.class);
+
+		when(this.mockClient.audio()).thenReturn(audioService);
+		when(audioService.speech()).thenReturn(speechService);
+		when(speechService.create(any(SpeechCreateParams.class))).thenReturn(httpResponse);
+		when(httpResponse.body()).thenReturn(inputStream);
+		when(httpResponse.headers()).thenReturn(headers);
+		when(headers.values(anyString())).thenReturn(List.of());
+		// SocketTimeoutException extends InterruptedIOException, so it must not
+		// be mistaken for a deliberate cancellation.
+		when(inputStream.read(any(byte[].class))).thenAnswer(invocation -> {
+			byte[] buffer = invocation.getArgument(0);
+			System.arraycopy(firstChunk, 0, buffer, 0, firstChunk.length);
+			return firstChunk.length;
+		}).thenThrow(new SocketTimeoutException("Read timed out"));
+
+		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().openAiClient(this.mockClient).build();
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt("Testing timeout handling");
+
+		assertThatThrownBy(() -> model.stream(prompt).collectList().block(Duration.ofSeconds(5)))
+			.hasCauseInstanceOf(SocketTimeoutException.class);
+
+		verify(httpResponse).close();
+	}
+
+	@Test
+	void testCancellationDuringReadCompletesWithoutError() throws Exception {
+		byte[] firstChunk = new byte[100];
+		new Random(11).nextBytes(firstChunk);
+
+		AudioService audioService = mock(AudioService.class);
+		SpeechService speechService = mock(SpeechService.class);
+		HttpResponse httpResponse = mock(HttpResponse.class);
+		Headers headers = mock(Headers.class);
+		InputStream inputStream = mock(InputStream.class);
+
+		CountDownLatch secondReadStarted = new CountDownLatch(1);
+		CountDownLatch releaseSecondRead = new CountDownLatch(1);
+
+		when(this.mockClient.audio()).thenReturn(audioService);
+		when(audioService.speech()).thenReturn(speechService);
+		when(speechService.create(any(SpeechCreateParams.class))).thenReturn(httpResponse);
+		when(httpResponse.body()).thenReturn(inputStream);
+		when(httpResponse.headers()).thenReturn(headers);
+		when(headers.values(anyString())).thenReturn(List.of());
+		when(inputStream.read(any(byte[].class))).thenAnswer(invocation -> {
+			byte[] buffer = invocation.getArgument(0);
+			System.arraycopy(firstChunk, 0, buffer, 0, firstChunk.length);
+			return firstChunk.length;
+		}).thenAnswer(invocation -> {
+			// Block for real, so this exercises Reactor's actual cancellation
+			// machinery instead of racing real I/O timing like the IT test does.
+			secondReadStarted.countDown();
+			try {
+				releaseSecondRead.await(5, TimeUnit.SECONDS);
+				throw new IllegalStateException("Test did not interrupt the blocked read in time");
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new InterruptedIOException("Interrupted while reading");
+			}
+		});
+
+		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().openAiClient(this.mockClient).build();
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt("Testing cancellation while a read is blocked");
+
+		List<Throwable> droppedErrors = new CopyOnWriteArrayList<>();
+		AtomicBoolean errorReceived = new AtomicBoolean(false);
+		AtomicInteger nextCount = new AtomicInteger(0);
+
+		Hooks.onErrorDropped(droppedErrors::add);
+		try {
+			Disposable subscription = model.stream(prompt)
+				.subscribe(response -> nextCount.incrementAndGet(), error -> errorReceived.set(true));
+
+			assertThat(secondReadStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+			// dispose() → SubscribeOnSubscriber.cancel() → (a) doOnCancel's callback sets
+			// cancelled=true synchronously, then (b) worker.dispose() interrupts the
+			// boundedElastic thread. That interrupt wakes releaseSecondRead.await(...)
+			// with an InterruptedException, which the mock converts to
+			// InterruptedIOException — mimicking what OkHttp actually
+			// does. emitNextChunk catches that, sees cancelled.get() == true, and calls
+			// sink.complete() instead of sink.error().
+			subscription.dispose();
+
+			// close() runs after emitNextChunk's catch block returns, so waiting
+			// for it also guarantees the assertions below have already settled.
+			verify(httpResponse, timeout(5000)).close();
+
+			assertThat(nextCount.get()).isEqualTo(1);
+			assertThat(errorReceived.get()).isFalse();
+			assertThat(droppedErrors).isEmpty();
+		}
+		finally {
+			Hooks.resetOnErrorDropped();
+		}
+	}
+
+	@Test
+	void testStreamPropagatesOpenAIIoExceptionWhenNotCancelled() {
+		AudioService audioService = mock(AudioService.class);
+		SpeechService speechService = mock(SpeechService.class);
+
+		when(this.mockClient.audio()).thenReturn(audioService);
+		when(audioService.speech()).thenReturn(speechService);
+		when(speechService.create(any(SpeechCreateParams.class)))
+			.thenThrow(new OpenAIIoException("Connection reset", new IOException("Connection reset")));
+
+		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().openAiClient(this.mockClient).build();
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt("Testing a genuine connection failure");
+
+		assertThatThrownBy(() -> model.stream(prompt).collectList().block(Duration.ofSeconds(5)))
+			.isInstanceOf(OpenAIIoException.class)
+			.hasMessageContaining("Connection reset");
+	}
+
+	@Test
+	void testCancellationDuringConnectCompletesWithoutError() throws Exception {
+		AudioService audioService = mock(AudioService.class);
+		SpeechService speechService = mock(SpeechService.class);
+
+		CountDownLatch createStarted = new CountDownLatch(1);
+		CountDownLatch releaseCreate = new CountDownLatch(1);
+		AtomicBoolean interruptHandled = new AtomicBoolean(false);
+
+		when(this.mockClient.audio()).thenReturn(audioService);
+		when(audioService.speech()).thenReturn(speechService);
+		when(speechService.create(any(SpeechCreateParams.class))).thenAnswer(invocation -> {
+			// Simulate cancellation racing with the initial HTTP call, before any
+			// response exists.
+			createStarted.countDown();
+			try {
+				releaseCreate.await(5, TimeUnit.SECONDS);
+				throw new IllegalStateException("Test did not interrupt the blocked create() call in time");
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				OpenAIIoException failure = new OpenAIIoException("Interrupted",
+						new InterruptedIOException("Interrupted while connecting"));
+				interruptHandled.set(true);
+				throw failure;
+			}
+		});
+
+		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().openAiClient(this.mockClient).build();
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt("Testing cancellation before any response arrives");
+
+		List<Throwable> droppedErrors = new CopyOnWriteArrayList<>();
+		AtomicBoolean errorReceived = new AtomicBoolean(false);
+		AtomicInteger nextCount = new AtomicInteger(0);
+
+		Hooks.onErrorDropped(droppedErrors::add);
+		try {
+			Disposable subscription = model.stream(prompt)
+				.subscribe(response -> nextCount.incrementAndGet(), error -> errorReceived.set(true));
+
+			assertThat(createStarted.await(5, TimeUnit.SECONDS)).isTrue();
+			subscription.dispose();
+
+			// Unlike testCancellationDuringReadCompletesWithoutError, no
+			// GenerateSubscription exists yet, so Operators.setOnce cancels it on
+			// arrival without ever calling request()/emitNextChunk - there's no
+			// terminal signal to wait on, only the mock's own interrupt handling.
+			Awaitility.await().atMost(Duration.ofSeconds(5)).untilTrue(interruptHandled);
+
+			// The rest is synchronous, in-process work with nothing left to await.
+			assertThat(nextCount.get()).isZero();
+			assertThat(errorReceived.get()).isFalse();
+			assertThat(droppedErrors).isEmpty();
+		}
+		finally {
+			Hooks.resetOnErrorDropped();
+		}
 	}
 
 	@Test

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
@@ -16,18 +16,37 @@
 
 package org.springframework.ai.openai.audio;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+
 import com.openai.client.OpenAIClient;
+import com.openai.core.http.Headers;
+import com.openai.core.http.HttpResponse;
+import com.openai.models.audio.speech.SpeechCreateParams;
+import com.openai.services.blocking.AudioService;
+import com.openai.services.blocking.audio.SpeechService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.ai.audio.tts.TextToSpeechOptions;
+import org.springframework.ai.audio.tts.TextToSpeechPrompt;
+import org.springframework.ai.audio.tts.TextToSpeechResponse;
 import org.springframework.ai.openai.OpenAiAudioSpeechModel;
 import org.springframework.ai.openai.OpenAiAudioSpeechOptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for OpenAiAudioSpeechModel.
@@ -161,6 +180,45 @@ class OpenAiAudioSpeechModelTests {
 		assertThat(options.getVoice()).isEqualTo("echo");
 		assertThat(options.getResponseFormat()).isEqualTo("opus");
 		assertThat(options.getSpeed()).isEqualTo(2.0);
+	}
+
+	@Test
+	void testStreamEmitsMultipleChunksInOrder() {
+		byte[] audioBytes = new byte[20_000];
+		new Random(42).nextBytes(audioBytes);
+
+		AudioService audioService = mock(AudioService.class);
+		SpeechService speechService = mock(SpeechService.class);
+		HttpResponse httpResponse = mock(HttpResponse.class);
+		Headers headers = mock(Headers.class);
+
+		when(this.mockClient.audio()).thenReturn(audioService);
+		when(audioService.speech()).thenReturn(speechService);
+		when(speechService.create(any(SpeechCreateParams.class))).thenReturn(httpResponse);
+		when(httpResponse.body()).thenReturn(new ByteArrayInputStream(audioBytes));
+		when(httpResponse.headers()).thenReturn(headers);
+		when(headers.values(anyString())).thenReturn(List.of());
+
+		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().openAiClient(this.mockClient).build();
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt("Testing streaming output");
+
+		List<TextToSpeechResponse> responses = model.stream(prompt).collectList().block(Duration.ofSeconds(5));
+
+		assertThat(responses).isNotNull();
+		// 20_000 bytes at an 8192-byte chunk size must be split across multiple chunks.
+		assertThat(responses.size()).isGreaterThan(1);
+
+		ByteArrayOutputStream reassembled = new ByteArrayOutputStream();
+		for (TextToSpeechResponse response : responses) {
+			reassembled.writeBytes(response.getResult().getOutput());
+		}
+		assertThat(reassembled.toByteArray()).isEqualTo(audioBytes);
+
+		ArgumentCaptor<SpeechCreateParams> paramsCaptor = ArgumentCaptor.forClass(SpeechCreateParams.class);
+		verify(speechService).create(paramsCaptor.capture());
+		assertThat(paramsCaptor.getValue().streamFormat()).contains(SpeechCreateParams.StreamFormat.AUDIO);
+
+		verify(httpResponse).close();
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech.adoc
@@ -216,6 +216,25 @@ public class TextToSpeechController {
 }
 ----
 
+[[streaming-consume-inputstream]]
+=== Consuming the Stream as a Blocking `InputStream`
+
+Some APIs only accept a `java.io.InputStream` rather than a reactive `Flux`.
+An audio-playback library or code that writes incrementally to disk with blocking I/O are typical examples.
+Bridging a `Flux<byte[]>` into an `InputStream` is straightforward, but it is worth being precise about what such a bridge actually guarantees.
+
+A well-behaved bridge should request one chunk at a time from the `Flux`, so it never buffers more than a single already-received chunk ahead of what the `InputStream` consumer has read.
+It should also cancel the underlying subscription when the `InputStream` is closed before reaching end-of-stream, so a consumer that stops early, for example aborting playback, releases the provider connection immediately instead of leaving it running until the response would otherwise have completed.
+A bridge built on `Flux#toIterable()` cannot offer that second property, since its iterator exposes no way to cancel the subscription.
+Bridging through a `reactor.core.publisher.BaseSubscriber` gives you both properties: request one element at a time from `hookOnNext`, and cancel from `close()` via `Subscriber.dispose()`.
+
+Pausing the `InputStream` consumer does propagate real backpressure to providers whose client uses HTTP/2, such as OpenAI's.
+The underlying transport, OkHttp, only sends the `WINDOW_UPDATE` frame that tells the server to send more data once application code actually reads the buffered bytes, so a stalled consumer eventually stops the server from sending further data on that connection.
+That effect is real but coarse-grained: it engages once a whole HTTP/2 flow-control window's worth of unread data has accumulated, commonly tens of kilobytes, not after a single unread chunk.
+It also only guarantees that the transport stops sending; whether a given provider's backend actually slows down generating audio once its send buffer fills, rather than continuing to buffer server-side, is provider-specific and not something a client-side bridge can control or verify.
+
+TIP: A complete, tested reference implementation, `FluxInputStream`, is available in `OpenAiAudioSpeechModelIT` in the `spring-ai-openai` module's test sources.
+
 === Configuration-Based Provider Selection
 
 Switch between providers using Spring profiles or properties:

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
@@ -207,6 +207,9 @@ Each element of the stream carries at most 8 KB of audio, the internal read-buff
 
 TIP: If you need to hand this stream to an API that only accepts a blocking `java.io.InputStream`, see xref:api/audio/speech.adoc#streaming-consume-inputstream[Consuming the Stream as a Blocking InputStream] for the practices that matter and a tested reference implementation.
 
+Each open stream pins a thread for its whole response duration, so `OpenAiAudioSpeechModel` runs streaming on a dedicated bounded-elastic scheduler rather than Reactor's shared `Schedulers.boundedElastic()`, keeping heavy speech-streaming load from starving unrelated blocking work elsewhere in the application.
+Override it with `OpenAiAudioSpeechModel.builder().streamScheduler(customScheduler)` to share a scheduler across components or to size the pool differently for expected concurrent-stream load.
+
 include::partial$openai/openai-http-client-customization.adoc[]
 
 == Migration Guide

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
@@ -203,6 +203,10 @@ Flux<TextToSpeechResponse> responseStream = openAiAudioSpeechModel.stream(speech
 Flux<byte[]> audioByteStream = openAiAudioSpeechModel.stream("Hello, world!");
 ----
 
+Each element of the stream carries at most 8 KB of audio, the internal read-buffer size `OpenAiAudioSpeechModel` uses when pulling bytes from the underlying HTTP response; chunks can be smaller than that, depending on how much data has arrived from OpenAI at the time of each read.
+
+TIP: If you need to hand this stream to an API that only accepts a blocking `java.io.InputStream`, see xref:api/audio/speech.adoc#streaming-consume-inputstream[Consuming the Stream as a Blocking InputStream] for the practices that matter and a tested reference implementation.
+
 include::partial$openai/openai-http-client-customization.adoc[]
 
 == Migration Guide


### PR DESCRIPTION
- The stream() used to buffer the full response and wrap it in a single Flux element.
- Now the request stream_format=audio and emit chunks as they arrive from the OpenAI SDK's InputStream instead.
- Tests and reference docs updated.
- Instructions how to bridge the Flux into binary input stream are provided along with demo IT.
