### PR TITLE
GH-6602: Align OkHttp dependency on okhttp-jvm 5.3.2

### DIFF
--- a/models/spring-ai-anthropic/pom.xml
+++ b/models/spring-ai-anthropic/pom.xml
@@ -34,7 +34,7 @@
 
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp</artifactId>
+			<artifactId>okhttp-jvm</artifactId>
 			<version>${okhttp3.version}</version>
 		</dependency>
 

--- a/models/spring-ai-openai/pom.xml
+++ b/models/spring-ai-openai/pom.xml
@@ -32,7 +32,7 @@
 
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp</artifactId>
+			<artifactId>okhttp-jvm</artifactId>
 			<version>${okhttp3.version}</version>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
 		<jsonschema.version>5.0.0</jsonschema.version>
 		<jtokkit.version>1.1.0</jtokkit.version>
 		<lucene.version>9.12.3</lucene.version>
-		<okhttp3.version>4.12.0</okhttp3.version>
+		<okhttp3.version>5.3.2</okhttp3.version>
 		<ST4.version>4.3.4</ST4.version>
 		<swagger-annotations.version>2.2.38</swagger-annotations.version>
 

--- a/vector-stores/spring-ai-typesense-store/pom.xml
+++ b/vector-stores/spring-ai-typesense-store/pom.xml
@@ -20,7 +20,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>com.squareup.okhttp3</groupId>
-				<artifactId>okhttp</artifactId>
+				<artifactId>okhttp-jvm</artifactId>
 				<version>${okhttp3.version}</version>
 			</dependency>
 		</dependencies>
@@ -37,6 +37,12 @@
 			<groupId>org.typesense</groupId>
 			<artifactId>typesense-java</artifactId>
 			<version>${typesense.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.squareup.okhttp3</groupId>
+					<artifactId>okhttp</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- TESTING -->


### PR DESCRIPTION
Fixes #6602

## Problem

Spring AI currently depends on `com.squareup.okhttp3:okhttp:4.12.0`.

With Spring Boot 4's OpenTelemetry starter, applications can receive `com.squareup.okhttp3:okhttp-jvm:5.3.2`. Since Maven treats `okhttp` and `okhttp-jvm` as different artifacts, both JARs can exist on the classpath and introduce duplicate `okhttp3.*` classes.

Additionally, using `okhttp:5.x` directly would not solve this because the OkHttp 5 root artifact is only a Kotlin Multiplatform metadata artifact; the JVM implementation is published as `okhttp-jvm`.

## Solution

Aligned Spring AI's OkHttp dependency usage with the OkHttp 5 JVM artifact:

- Updated `okhttp3.version` from `4.12.0` to `5.3.2`
- Migrated `spring-ai-openai` from `okhttp` to `okhttp-jvm`
- Migrated `spring-ai-anthropic` from `okhttp` to `okhttp-jvm`
- Updated Typesense dependency management to use `okhttp-jvm`
- Excluded the transitive `okhttp:4.x` dependency from `typesense-java` to prevent duplicate classes

## Verification

Confirmed Maven dependency resolution contains only:

com.squareup.okhttp3:okhttp-jvm:5.3.2


Verified affected modules:

- `spring-ai-openai`
- `spring-ai-anthropic`
- `spring-ai-typesense-store`
- `spring-ai-test`

All tests passed.

No Java source changes were required.