### PR TITLE
Fix ToolCallingAdvisor streaming loop dropping doBeforeStream mutations

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -289,8 +289,18 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
 
+			// Use the options doBeforeStream() produced on finalRequest - not the
+			// pre-doBeforeStream toolCallingChatOptions captured above - so that tool
+			// callbacks/context a subclass hook injects for this iteration (e.g. a
+			// dynamically resolved tool that only exists on the mutated options, not via
+			// any globally registered ToolCallbackResolver) are visible when the tool
+			// calls in the model's response are actually executed below.
+			ToolCallingChatOptions processedOptions = (ToolCallingChatOptions) finalRequest.prompt().getOptions();
+			Assert.notNull(processedOptions,
+					"redundant check that should never fail (doBeforeStream must not change the options type away from ToolCallingChatOptions), but here to help NullAway");
+
 			return streamWithToolCallResponses(responseFlux, finalRequest, fullTurnHistory, streamAdvisorChain,
-					originalRequest, toolCallingChatOptions, usageAccumulator);
+					originalRequest, processedOptions, usageAccumulator);
 		});
 	}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -157,6 +157,13 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			// Next Call
 			processedChatClientRequest = this.doBeforeCall(processedChatClientRequest, callAdvisorChain);
 
+			// Re-read the options doBeforeCall() may have mutated (e.g. a subclass
+			// injecting per-iteration tool callbacks) so executeToolCalls() below sees
+			// what was actually sent to the model, not the pre-doBeforeCall snapshot.
+			toolCallingChatOptions = (ToolCallingChatOptions) processedChatClientRequest.prompt().getOptions();
+			Assert.notNull(toolCallingChatOptions,
+					"redundant check that should never fail (doBeforeCall must not change the options type away from ToolCallingChatOptions), but here to help NullAway");
+
 			chatClientResponse = callAdvisorChain.copy(this).nextCall(processedChatClientRequest);
 
 			chatClientResponse = this.doAfterCall(chatClientResponse, callAdvisorChain);
@@ -289,12 +296,9 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 			Flux<ChatClientResponse> responseFlux = chainCopy.nextStream(processedRequest);
 
-			// Use the options doBeforeStream() produced on finalRequest - not the
-			// pre-doBeforeStream toolCallingChatOptions captured above - so that tool
-			// callbacks/context a subclass hook injects for this iteration (e.g. a
-			// dynamically resolved tool that only exists on the mutated options, not via
-			// any globally registered ToolCallbackResolver) are visible when the tool
-			// calls in the model's response are actually executed below.
+			// Re-read the options doBeforeStream() may have mutated (e.g. a subclass
+			// injecting per-iteration tool callbacks) so executeToolCalls() below sees
+			// what was actually sent to the model, not the pre-doBeforeStream snapshot.
 			ToolCallingChatOptions processedOptions = (ToolCallingChatOptions) finalRequest.prompt().getOptions();
 			Assert.notNull(processedOptions,
 					"redundant check that should never fail (doBeforeStream must not change the options type away from ToolCallingChatOptions), but here to help NullAway");

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -56,6 +56,8 @@ import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
 import org.springframework.ai.model.tool.ToolExecutionResult;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1322,6 +1324,62 @@ public class ToolCallingAdvisorTests {
 		assertThat(advisor.getOrder()).isEqualTo(customOrder);
 	}
 
+	@Test
+	void streamToolExecutionSeesOptionsMutatedByDoBeforeStreamHook() {
+		// Subclasses (e.g. ToolSearchToolCallingAdvisor) use the doBeforeStream hook to
+		// inject per-iteration tool callbacks into the ToolCallingChatOptions - for
+		// example a synthetic "search for more tools" callback that isn't a globally
+		// resolvable bean. internalStream() captures `toolCallingChatOptions` from the
+		// incoming request *before* calling doBeforeStream, and
+		// streamWithToolCallResponses
+		// / handleToolCallRecursion go on to execute tool calls against that stale,
+		// pre-mutation options object instead of the one on the mutated request that was
+		// actually sent to the model. When the model calls the advisor-injected tool, the
+		// stale options don't contain it, so DefaultToolCallingManager falls through to
+		// the ToolCallbackResolver - which has no way to resolve a callback that only
+		// ever
+		// existed on the per-iteration mutated options - and resolution fails.
+		ToolCallback injectedCallback = mock(ToolCallback.class, Mockito.withSettings().strictness(Strictness.LENIENT));
+		when(injectedCallback.getToolDefinition())
+			.thenReturn(ToolDefinition.builder().name("injectedTool").description("").inputSchema("{}").build());
+
+		MutatingToolCallingAdvisor advisor = new MutatingToolCallingAdvisor(this.toolCallingManager, injectedCallback);
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+		ChatClientResponse finalResponse = createMockResponse(false);
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			return Flux.just(callCount[0] == 1 ? responseWithToolCall : finalResponse);
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		advisor.adviseStream(request, realChain).collectList().block();
+
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		verify(this.toolCallingManager).executeToolCalls(promptCaptor.capture(), any(ChatResponse.class));
+
+		ToolCallingChatOptions executedOptions = (ToolCallingChatOptions) promptCaptor.getValue().getOptions();
+		// Fails today: executedOptions.getToolCallbacks() does not contain
+		// injectedCallback, because executeToolCalls was invoked with the options
+		// captured before doBeforeStream ran, not the mutated options doBeforeStream
+		// produced.
+		assertThat(executedOptions.getToolCallbacks()).contains(injectedCallback);
+	}
+
 	// Helper methods
 
 	private ChatClientRequest createMockRequestWithSystemMessage() {
@@ -1557,6 +1615,36 @@ public class ToolCallingAdvisorTests {
 				return new TestableToolCallingAdvisor(getToolCallingManager(), getAdvisorOrder(), null);
 			}
 
+		}
+
+	}
+
+	/**
+	 * Test subclass mimicking how {@code ToolSearchToolCallingAdvisor} uses the
+	 * doBeforeStream hook to inject a per-iteration tool callback into the
+	 * ToolCallingChatOptions on the mutated request.
+	 */
+	private static class MutatingToolCallingAdvisor extends ToolCallingAdvisor {
+
+		private final ToolCallback injectedCallback;
+
+		MutatingToolCallingAdvisor(ToolCallingManager toolCallingManager, ToolCallback injectedCallback) {
+			super(toolCallingManager, DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER, DEFAULT_ORDER, true);
+			this.injectedCallback = injectedCallback;
+		}
+
+		@Override
+		protected ChatClientRequest doBeforeStream(ChatClientRequest chatClientRequest,
+				StreamAdvisorChain streamAdvisorChain) {
+			ToolCallingChatOptions options = (ToolCallingChatOptions) chatClientRequest.prompt().getOptions();
+			List<ToolCallback> callbacks = options.getToolCallbacks() != null
+					? new ArrayList<>(options.getToolCallbacks()) : new ArrayList<>();
+			callbacks.add(this.injectedCallback);
+			ToolCallingChatOptions mutatedOptions = options.mutate().toolCallbacks(callbacks).build();
+			return ChatClientRequest.builder()
+				.prompt(chatClientRequest.prompt().mutate().chatOptions(mutatedOptions).build())
+				.context(chatClientRequest.context())
+				.build();
 		}
 
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -1326,19 +1326,11 @@ public class ToolCallingAdvisorTests {
 
 	@Test
 	void streamToolExecutionSeesOptionsMutatedByDoBeforeStreamHook() {
-		// Subclasses (e.g. ToolSearchToolCallingAdvisor) use the doBeforeStream hook to
-		// inject per-iteration tool callbacks into the ToolCallingChatOptions - for
-		// example a synthetic "search for more tools" callback that isn't a globally
-		// resolvable bean. internalStream() captures `toolCallingChatOptions` from the
-		// incoming request *before* calling doBeforeStream, and
-		// streamWithToolCallResponses
-		// / handleToolCallRecursion go on to execute tool calls against that stale,
-		// pre-mutation options object instead of the one on the mutated request that was
-		// actually sent to the model. When the model calls the advisor-injected tool, the
-		// stale options don't contain it, so DefaultToolCallingManager falls through to
-		// the ToolCallbackResolver - which has no way to resolve a callback that only
-		// ever
-		// existed on the per-iteration mutated options - and resolution fails.
+		// Regression guard: a subclass (e.g. ToolSearchToolCallingAdvisor) may inject
+		// per-iteration tool callbacks into ToolCallingChatOptions from its
+		// doBeforeStream hook. executeToolCalls() must see that mutated options, not
+		// the pre-doBeforeStream snapshot - otherwise the injected tool can't be
+		// resolved when the model calls it.
 		ToolCallback injectedCallback = mock(ToolCallback.class, Mockito.withSettings().strictness(Strictness.LENIENT));
 		when(injectedCallback.getToolDefinition())
 			.thenReturn(ToolDefinition.builder().name("injectedTool").description("").inputSchema("{}").build());
@@ -1373,10 +1365,48 @@ public class ToolCallingAdvisorTests {
 		verify(this.toolCallingManager).executeToolCalls(promptCaptor.capture(), any(ChatResponse.class));
 
 		ToolCallingChatOptions executedOptions = (ToolCallingChatOptions) promptCaptor.getValue().getOptions();
-		// Fails today: executedOptions.getToolCallbacks() does not contain
-		// injectedCallback, because executeToolCalls was invoked with the options
-		// captured before doBeforeStream ran, not the mutated options doBeforeStream
-		// produced.
+		assertThat(executedOptions.getToolCallbacks()).contains(injectedCallback);
+	}
+
+	@Test
+	void callToolExecutionSeesOptionsMutatedByDoBeforeCallHook() {
+		// Non-streaming counterpart of
+		// streamToolExecutionSeesOptionsMutatedByDoBeforeStreamHook:
+		// the same options-mutation-visibility guarantee must hold for adviseCall().
+		ToolCallback injectedCallback = mock(ToolCallback.class, Mockito.withSettings().strictness(Strictness.LENIENT));
+		when(injectedCallback.getToolDefinition())
+			.thenReturn(ToolDefinition.builder().name("injectedTool").description("").inputSchema("{}").build());
+
+		MutatingToolCallingAdvisor advisor = new MutatingToolCallingAdvisor(this.toolCallingManager, injectedCallback);
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+		ChatClientResponse finalResponse = createMockResponse(false);
+
+		int[] callCount = { 0 };
+		TerminalCallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? responseWithToolCall : finalResponse;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		advisor.adviseCall(request, realChain);
+
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		verify(this.toolCallingManager).executeToolCalls(promptCaptor.capture(), any(ChatResponse.class));
+
+		ToolCallingChatOptions executedOptions = (ToolCallingChatOptions) promptCaptor.getValue().getOptions();
 		assertThat(executedOptions.getToolCallbacks()).contains(injectedCallback);
 	}
 
@@ -1621,7 +1651,7 @@ public class ToolCallingAdvisorTests {
 
 	/**
 	 * Test subclass mimicking how {@code ToolSearchToolCallingAdvisor} uses the
-	 * doBeforeStream hook to inject a per-iteration tool callback into the
+	 * doBeforeCall/doBeforeStream hooks to inject a per-iteration tool callback into the
 	 * ToolCallingChatOptions on the mutated request.
 	 */
 	private static class MutatingToolCallingAdvisor extends ToolCallingAdvisor {
@@ -1636,6 +1666,16 @@ public class ToolCallingAdvisorTests {
 		@Override
 		protected ChatClientRequest doBeforeStream(ChatClientRequest chatClientRequest,
 				StreamAdvisorChain streamAdvisorChain) {
+			return injectCallback(chatClientRequest);
+		}
+
+		@Override
+		protected ChatClientRequest doBeforeCall(ChatClientRequest chatClientRequest,
+				CallAdvisorChain callAdvisorChain) {
+			return injectCallback(chatClientRequest);
+		}
+
+		private ChatClientRequest injectCallback(ChatClientRequest chatClientRequest) {
 			ToolCallingChatOptions options = (ToolCallingChatOptions) chatClientRequest.prompt().getOptions();
 			List<ToolCallback> callbacks = options.getToolCallbacks() != null
 					? new ArrayList<>(options.getToolCallbacks()) : new ArrayList<>();


### PR DESCRIPTION
internalStream() captured `toolCallingChatOptions` from the incoming request before calling the doBeforeStream() hook, then threaded that stale, pre-mutation reference all the way through
streamWithToolCallResponses() and handleToolCallRecursion() into the actual toolCallingManager.executeToolCalls(...) call - on every round of the streaming tool-calling loop, not just the first. Any ToolCallingChatOptions mutation a subclass hook applied in doBeforeStream() (extra tool callbacks, toolContext entries) was therefore invisible at tool-execution time, even though that same mutated options object was what actually got sent to the chat model.

This silently breaks ToolSearchToolCallingAdvisor: its prepareIteration() (invoked from its doBeforeStream() override) injects a synthetic toolSearchTool ToolCallback into the options for the current iteration so the model can search the indexed tool set. Because that mutation never reached executeToolCalls(), the model's call to toolSearchTool couldn't be resolved from the (stale) options and fell through to the configured ToolCallbackResolver - which has no way to resolve a callback that only ever existed on the per-iteration mutated options, since it isn't a registered bean. The resolver's "unavailable" fallback response is plain text, not the JSON tool-name array extractToolNameReferences() expects, so it throws a StreamReadException and the whole streamed chat response fails with an Aggregation Error whenever the model decides to call toolSearchTool.

Fix: derive the options passed into streamWithToolCallResponses() from finalRequest (the request as mutated by doBeforeStream()) instead of the pre-mutation snapshot, so tool execution and the model call agree on what tools/context are available for each iteration.

Added streamToolExecutionSeesOptionsMutatedByDoBeforeStreamHook to ToolCallingAdvisorTests, which reproduces the bug with a minimal doBeforeStream-mutating subclass (independent of the tool-search-advisor module) and asserts the Prompt passed to executeToolCalls carries the callback injected by the hook.

Signed-off-by: kezhenxu94 <kezhenxu94@apache.org>
