### PR TITLE
Add FIM (fill-in-the-middle) completion support for DeepSeek

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatProperties.java
@@ -76,6 +76,10 @@ public class DeepSeekChatProperties extends DeepSeekParentProperties {
 
 	private @Nullable ReasoningEffort reasoningEffort;
 
+	private @Nullable Boolean echo;
+
+	private @Nullable String suffix;
+
 	public boolean isEnabled() {
 		return this.enabled;
 	}
@@ -196,6 +200,22 @@ public class DeepSeekChatProperties extends DeepSeekParentProperties {
 		this.reasoningEffort = reasoningEffort;
 	}
 
+	public @Nullable Boolean getEcho() {
+		return this.echo;
+	}
+
+	public void setEcho(@Nullable Boolean echo) {
+		this.echo = echo;
+	}
+
+	public @Nullable String getSuffix() {
+		return this.suffix;
+	}
+
+	public void setSuffix(@Nullable String suffix) {
+		this.suffix = suffix;
+	}
+
 	public DeepSeekChatOptions toOptions() {
 		return DeepSeekChatOptions.builder()
 			.model(this.model)
@@ -210,6 +230,8 @@ public class DeepSeekChatProperties extends DeepSeekParentProperties {
 			.topLogprobs(this.topLogprobs)
 			.thinking(this.thinking)
 			.reasoningEffort(this.reasoningEffort)
+			.echo(this.echo)
+			.suffix(this.suffix)
 			.build();
 	}
 
@@ -345,6 +367,26 @@ public class DeepSeekChatProperties extends DeepSeekParentProperties {
 
 		public void setReasoningEffort(@Nullable ReasoningEffort reasoningEffort) {
 			DeepSeekChatProperties.this.setReasoningEffort(reasoningEffort);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.echo")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getEcho() {
+			return DeepSeekChatProperties.this.getEcho();
+		}
+
+		public void setEcho(@Nullable Boolean echo) {
+			DeepSeekChatProperties.this.setEcho(echo);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.suffix")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getSuffix() {
+			return DeepSeekChatProperties.this.getSuffix();
+		}
+
+		public void setSuffix(@Nullable String suffix) {
+			DeepSeekChatProperties.this.setSuffix(suffix);
 		}
 
 	}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/test/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/test/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekPropertiesTests.java
@@ -119,7 +119,9 @@ public class DeepSeekPropertiesTests {
 				"spring.ai.deepseek.chat.top-p=0.56",
 				"spring.ai.deepseek.chat.user=userXYZ",
 				"spring.ai.deepseek.chat.thinking.type=disabled",
-				"spring.ai.deepseek.chat.reasoning-effort=max"
+				"spring.ai.deepseek.chat.reasoning-effort=max",
+				"spring.ai.deepseek.chat.echo=true",
+				"spring.ai.deepseek.chat.suffix=return x"
 				)
 			// @formatter:on
 			.withConfiguration(AutoConfigurations.of(DeepSeekChatAutoConfiguration.class,
@@ -141,6 +143,13 @@ public class DeepSeekPropertiesTests {
 				assertThat(chatProperties.getTopP()).isEqualTo(0.56);
 				assertThat(chatProperties.getThinking()).isEqualTo(Thinking.DISABLED);
 				assertThat(chatProperties.getReasoningEffort()).isEqualTo(ReasoningEffort.MAX);
+
+				assertThat(chatProperties.getEcho()).isTrue();
+				assertThat(chatProperties.getSuffix()).isEqualTo("return x");
+
+				var chatOptions = chatProperties.toOptions();
+				assertThat(chatOptions.getEcho()).isTrue();
+				assertThat(chatOptions.getSuffix()).isEqualTo("return x");
 			});
 	}
 

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -437,6 +437,12 @@ public class DeepSeekChatModel implements ChatModel {
 		if (options.getReasoningEffort() != null) {
 			requestBuilder.reasoningEffort(options.getReasoningEffort());
 		}
+		if (options.getEcho() != null) {
+			requestBuilder.echo(options.getEcho());
+		}
+		if (options.getSuffix() != null) {
+			requestBuilder.suffix(options.getSuffix());
+		}
 
 		// Add the tool definitions to the request's tools parameter.
 		List<ToolDefinition> toolDefinitions = this.toolCallingManager.resolveToolDefinitions(options);

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
@@ -143,6 +143,16 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 	private final @Nullable ReasoningEffort reasoningEffort;
 
 	/**
+	 * Echo back the prompt in addition to the completion.
+	 */
+	private final @Nullable Boolean echo;
+
+	/**
+	 * The suffix that comes after a completion of inserted text.
+	 */
+	private final @Nullable String suffix;
+
+	/**
 	 * Tool Function Callbacks to register with the ChatModel.
 	 * For Prompt Options the toolCallbacks are automatically enabled for the duration of the prompt execution.
 	 * For Default Options the toolCallbacks are registered but disabled by default. Use the enableFunctions to set the functions
@@ -158,7 +168,8 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 			@Nullable List<String> stop, @Nullable Double temperature, @Nullable Double topP,
 			@Nullable Boolean logprobs, @Nullable Integer topLogprobs, @Nullable List<DeepSeekApi.FunctionTool> tools,
 			@Nullable Object toolChoice, @Nullable Thinking thinking, @Nullable ReasoningEffort reasoningEffort,
-			@Nullable List<ToolCallback> toolCallbacks, @Nullable Map<String, Object> toolContext) {
+			@Nullable Boolean echo, @Nullable String suffix, @Nullable List<ToolCallback> toolCallbacks,
+			@Nullable Map<String, Object> toolContext) {
 		this.model = model != null ? model : DeepSeekApi.DEFAULT_CHAT_MODEL.getValue();
 		this.frequencyPenalty = frequencyPenalty;
 		this.maxTokens = maxTokens;
@@ -173,6 +184,8 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 		this.toolChoice = toolChoice;
 		this.thinking = thinking;
 		this.reasoningEffort = reasoningEffort;
+		this.echo = echo;
+		this.suffix = suffix;
 		this.toolCallbacks = toolCallbacks != null ? List.copyOf(toolCallbacks) : null;
 		this.toolContext = toolContext != null ? Map.copyOf(toolContext) : null;
 	}
@@ -253,6 +266,14 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 		return this.topLogprobs;
 	}
 
+	public @Nullable Boolean getEcho() {
+		return this.echo;
+	}
+
+	public @Nullable String getSuffix() {
+		return this.suffix;
+	}
+
 	@Override
 	public @Nullable Integer getTopK() {
 		return null;
@@ -285,14 +306,17 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 			.tools(this.tools)
 			.toolChoice(this.toolChoice)
 			.thinking(this.thinking)
-			.reasoningEffort(this.reasoningEffort);
+			.reasoningEffort(this.reasoningEffort)
+			.echo(this.echo)
+			.suffix(this.suffix);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.model, this.frequencyPenalty, this.logprobs, this.topLogprobs, this.maxTokens,
 				this.presencePenalty, this.responseFormat, this.stop, this.temperature, this.topP, this.tools,
-				this.toolChoice, this.thinking, this.reasoningEffort, this.toolCallbacks, this.toolContext);
+				this.toolChoice, this.thinking, this.reasoningEffort, this.echo, this.suffix, this.toolCallbacks,
+				this.toolContext);
 	}
 
 	@Override
@@ -312,8 +336,8 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.temperature, other.temperature) && Objects.equals(this.topP, other.topP)
 				&& Objects.equals(this.tools, other.tools) && Objects.equals(this.toolChoice, other.toolChoice)
 				&& Objects.equals(this.thinking, other.thinking)
-				&& Objects.equals(this.reasoningEffort, other.reasoningEffort)
-				&& Objects.equals(this.toolCallbacks, other.toolCallbacks)
+				&& Objects.equals(this.reasoningEffort, other.reasoningEffort) && Objects.equals(this.echo, other.echo)
+				&& Objects.equals(this.suffix, other.suffix) && Objects.equals(this.toolCallbacks, other.toolCallbacks)
 				&& Objects.equals(this.toolContext, other.toolContext);
 	}
 
@@ -346,6 +370,10 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 		protected @Nullable Thinking thinking;
 
 		protected @Nullable ReasoningEffort reasoningEffort;
+
+		protected @Nullable Boolean echo;
+
+		protected @Nullable String suffix;
 
 		public B model(DeepSeekApi.@Nullable ChatModel deepseekAiChatModel) {
 			if (deepseekAiChatModel == null) {
@@ -416,6 +444,16 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 			return self();
 		}
 
+		public B echo(@Nullable Boolean echo) {
+			this.echo = echo;
+			return self();
+		}
+
+		public B suffix(@Nullable String suffix) {
+			this.suffix = suffix;
+			return self();
+		}
+
 		public B combineWith(ChatOptions.Builder<?> other) {
 			super.combineWith(other);
 			if (other instanceof AbstractBuilder<?> that) {
@@ -447,6 +485,12 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 				if (that.reasoningEffort != null) {
 					this.reasoningEffort = that.reasoningEffort;
 				}
+				if (that.echo != null) {
+					this.echo = that.echo;
+				}
+				if (that.suffix != null) {
+					this.suffix = that.suffix;
+				}
 			}
 			return self();
 		}
@@ -455,8 +499,8 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 		public DeepSeekChatOptions build() {
 			return new DeepSeekChatOptions(this.model, this.frequencyPenalty, this.maxTokens, this.presencePenalty,
 					this.responseFormat, this.stopSequences, this.temperature, this.topP, this.logprobs,
-					this.topLogprobs, this.tools, this.toolChoice, this.thinking, this.reasoningEffort,
-					this.toolCallbacks, this.toolContext);
+					this.topLogprobs, this.tools, this.toolChoice, this.thinking, this.reasoningEffort, this.echo,
+					this.suffix, this.toolCallbacks, this.toolContext);
 		}
 
 	}

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekApi.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekApi.java
@@ -42,6 +42,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -218,7 +219,7 @@ public class DeepSeekApi {
 			.map(ChatCompletionMessage::prefix)
 			.filter(Objects::nonNull)
 			.anyMatch(prefix -> prefix);
-		String endpointPrefix = isPrefix ? this.betaPrefixPath : "";
+		String endpointPrefix = isPrefix || StringUtils.hasText(request.suffix) ? this.betaPrefixPath : "";
 		return endpointPrefix + this.completionsPath;
 	}
 
@@ -517,7 +518,9 @@ public class DeepSeekApi {
 			@JsonProperty("tools") @Nullable List<FunctionTool> tools,
 			@JsonProperty("tool_choice") @Nullable Object toolChoice,
 			@JsonProperty("thinking") @Nullable Thinking thinking,
-			@JsonProperty("reasoning_effort") @Nullable ReasoningEffort reasoningEffort) {
+			@JsonProperty("reasoning_effort") @Nullable ReasoningEffort reasoningEffort,
+			@JsonProperty("echo") @Nullable Boolean echo,
+			@JsonProperty("suffix") @Nullable String suffix) {
 
 		/**
 		 * Create a new {@link ChatCompletionRequest} builder.
@@ -537,7 +540,7 @@ public class DeepSeekApi {
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, Boolean stream) {
 			this(messages, null, null, null, null, null,
 					null, stream, null, null, null, null, null,
-					null, null, null);
+					null, null, null, null, null);
 		}
 
 		/**
@@ -550,7 +553,7 @@ public class DeepSeekApi {
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, Double temperature) {
 			this(messages, model, null,
 		null, null, null, null,  false,  temperature, null,
-			null, null, null, null, null, null);
+			null, null, null, null, null, null, null, null);
 		}
 
 		/**
@@ -565,7 +568,7 @@ public class DeepSeekApi {
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, Double temperature, boolean stream) {
 			this(messages, model, null,
 					null, null, null, null,  stream,  temperature, null,
-				null, null, null, null, null, null);
+				null, null, null, null, null, null, null, null);
 		}
 
 		/**
@@ -682,6 +685,10 @@ public class DeepSeekApi {
 			private @Nullable ReasoningEffort reasoningEffort;
 
 			private @Nullable Thinking thinking;
+
+			private @Nullable Boolean echo;
+
+			private @Nullable String suffix;
 
 			/**
 			 * Set the messages comprising the conversation so far.
@@ -844,6 +851,26 @@ public class DeepSeekApi {
 			}
 
 			/**
+			 * Set whether to echo the prompt.
+			 * @param echo whether to echo the prompt.
+			 * @return this builder.
+			 */
+			public Builder echo(@Nullable Boolean echo) {
+				this.echo = echo;
+				return this;
+			}
+
+			/**
+			 * Set the suffix.
+			 * @param suffix the suffix.
+			 * @return this builder.
+			 */
+			public Builder suffix(@Nullable String suffix) {
+				this.suffix = suffix;
+				return this;
+			}
+
+			/**
 			 * Build the {@link ChatCompletionRequest}.
 			 * @return a new {@link ChatCompletionRequest}.
 			 */
@@ -852,7 +879,7 @@ public class DeepSeekApi {
 				return new ChatCompletionRequest(this.messages, this.model, this.frequencyPenalty, this.maxTokens,
 						this.presencePenalty, this.responseFormat, this.stop, this.stream, this.temperature, this.topP,
 						this.logprobs, this.topLogprobs, this.tools, this.toolChoice, this.thinking,
-						this.reasoningEffort);
+						this.reasoningEffort, this.echo, this.suffix);
 			}
 
 		}

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatOptionsTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatOptionsTests.java
@@ -18,12 +18,16 @@ package org.springframework.ai.deepseek;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.deepseek.DeepSeekChatOptions.Builder;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
+import org.springframework.ai.deepseek.api.MockWeatherService;
+import org.springframework.ai.deepseek.api.ResponseFormat;
 import org.springframework.ai.test.options.AbstractChatOptionsTests;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link DeepSeekChatOptions}.
  *
  * @author Geng Rong
+ * @author guan xu
  */
 class DeepSeekChatOptionsTests extends AbstractChatOptionsTests<DeepSeekChatOptions, Builder> {
 
@@ -78,5 +83,151 @@ class DeepSeekChatOptionsTests extends AbstractChatOptionsTests<DeepSeekChatOpti
 	void cloneHandlesNullToolsList() {
 		assertThat(DeepSeekChatOptions.builder().clone().build().getTools()).isNull();
 	}
+
+	@Test
+	void testGetters() {
+		DeepSeekChatOptions options = fullyPopulatedBuilder().build();
+
+		assertThat(options.getModel()).isEqualTo("deepseek-chat");
+		assertThat(options.getFrequencyPenalty()).isEqualTo(0.5);
+		assertThat(options.getMaxTokens()).isEqualTo(128);
+		assertThat(options.getPresencePenalty()).isEqualTo(0.3);
+		assertThat(options.getResponseFormat())
+			.isEqualTo(ResponseFormat.builder().type(ResponseFormat.Type.JSON_OBJECT).build());
+		assertThat(options.getStop()).containsExactly("foo", "bar");
+		assertThat(options.getStopSequences()).containsExactly("foo", "bar");
+		assertThat(options.getTemperature()).isEqualTo(0.2);
+		assertThat(options.getTopP()).isEqualTo(0.9);
+		assertThat(options.getLogprobs()).isTrue();
+		assertThat(options.getTopLogprobs()).isEqualTo(5);
+		assertThat(options.getEcho()).isTrue();
+		assertThat(options.getSuffix()).isEqualTo("return result");
+		assertThat(options.getTools()).hasSize(1);
+		assertThat(options.getToolChoice()).isEqualTo("auto");
+		assertThat(options.getToolCallbacks()).hasSize(1);
+		assertThat(options.getToolContext()).containsEntry("locale", "en-US");
+		assertThat(options.getTopK()).isNull();
+	}
+
+	@Test
+	void testMutate() {
+		DeepSeekChatOptions options = fullyPopulatedBuilder().build();
+		DeepSeekChatOptions mutated = options.mutate().build();
+
+		assertThat(mutated).isEqualTo(options);
+		assertThat(mutated).isNotSameAs(options);
+		assertThat(mutated.getModel()).isEqualTo(options.getModel());
+		assertThat(mutated.getFrequencyPenalty()).isEqualTo(options.getFrequencyPenalty());
+		assertThat(mutated.getMaxTokens()).isEqualTo(options.getMaxTokens());
+		assertThat(mutated.getPresencePenalty()).isEqualTo(options.getPresencePenalty());
+		assertThat(mutated.getResponseFormat()).isEqualTo(options.getResponseFormat());
+		assertThat(mutated.getStop()).isEqualTo(options.getStop());
+		assertThat(mutated.getTemperature()).isEqualTo(options.getTemperature());
+		assertThat(mutated.getTopP()).isEqualTo(options.getTopP());
+		assertThat(mutated.getLogprobs()).isEqualTo(options.getLogprobs());
+		assertThat(mutated.getTopLogprobs()).isEqualTo(options.getTopLogprobs());
+		assertThat(mutated.getEcho()).isEqualTo(options.getEcho());
+		assertThat(mutated.getSuffix()).isEqualTo(options.getSuffix());
+		assertThat(mutated.getTools()).isEqualTo(options.getTools());
+		assertThat(mutated.getToolChoice()).isEqualTo(options.getToolChoice());
+		assertThat(mutated.getToolCallbacks()).isEqualTo(options.getToolCallbacks());
+		assertThat(mutated.getToolContext()).isEqualTo(options.getToolContext());
+	}
+
+	@Test
+	void combineWithOverridesScalars() {
+		DeepSeekChatOptions base = fullyPopulatedBuilder().build();
+		DeepSeekChatOptions override = DeepSeekChatOptions.builder()
+			.model("deepseek-reasoner")
+			.frequencyPenalty(1.0)
+			.maxTokens(256)
+			.presencePenalty(0.8)
+			.responseFormat(ResponseFormat.builder().type(ResponseFormat.Type.TEXT).build())
+			.stop(List.of("baz"))
+			.temperature(0.9)
+			.topP(0.1)
+			.logprobs(false)
+			.topLogprobs(2)
+			.echo(false)
+			.suffix("other suffix")
+			.toolChoice("none")
+			.build();
+
+		DeepSeekChatOptions merged = base.mutate().combineWith(override.mutate()).build();
+
+		assertThat(merged.getModel()).isEqualTo("deepseek-reasoner");
+		assertThat(merged.getFrequencyPenalty()).isEqualTo(1.0);
+		assertThat(merged.getMaxTokens()).isEqualTo(256);
+		assertThat(merged.getPresencePenalty()).isEqualTo(0.8);
+		assertThat(merged.getResponseFormat())
+			.isEqualTo(ResponseFormat.builder().type(ResponseFormat.Type.TEXT).build());
+		assertThat(merged.getTemperature()).isEqualTo(0.9);
+		assertThat(merged.getTopP()).isEqualTo(0.1);
+		assertThat(merged.getLogprobs()).isFalse();
+		assertThat(merged.getTopLogprobs()).isEqualTo(2);
+		assertThat(merged.getEcho()).isFalse();
+		assertThat(merged.getSuffix()).isEqualTo("other suffix");
+		assertThat(merged.getToolChoice()).isEqualTo("none");
+		assertThat(merged.getStop()).containsExactly("foo", "bar", "baz");
+	}
+
+	@Test
+	void combineWithKeepsBaseValuesWhenOverrideIsNull() {
+		DeepSeekChatOptions base = fullyPopulatedBuilder().build();
+		DeepSeekChatOptions override = DeepSeekChatOptions.builder().build();
+
+		DeepSeekChatOptions merged = base.mutate().combineWith(override.mutate()).build();
+
+		assertThat(merged.getFrequencyPenalty()).isEqualTo(0.5);
+		assertThat(merged.getMaxTokens()).isEqualTo(128);
+		assertThat(merged.getPresencePenalty()).isEqualTo(0.3);
+		assertThat(merged.getTemperature()).isEqualTo(0.2);
+		assertThat(merged.getTopP()).isEqualTo(0.9);
+		assertThat(merged.getLogprobs()).isTrue();
+		assertThat(merged.getTopLogprobs()).isEqualTo(5);
+		assertThat(merged.getEcho()).isTrue();
+		assertThat(merged.getSuffix()).isEqualTo("return result");
+		assertThat(merged.getResponseFormat())
+			.isEqualTo(ResponseFormat.builder().type(ResponseFormat.Type.JSON_OBJECT).build());
+		assertThat(merged.getToolChoice()).isEqualTo("auto");
+	}
+
+	@Test
+	void testEqualsAndHashCode() {
+		DeepSeekChatOptions a = fullyPopulatedBuilder().build();
+		DeepSeekChatOptions b = fullyPopulatedBuilder().build();
+
+		assertThat(a).isEqualTo(b);
+		assertThat(a.hashCode()).isEqualTo(b.hashCode());
+	}
+
+	private Builder fullyPopulatedBuilder() {
+		return DeepSeekChatOptions.builder()
+			.model("deepseek-chat")
+			.frequencyPenalty(0.5)
+			.maxTokens(128)
+			.presencePenalty(0.3)
+			.responseFormat(ResponseFormat.builder().type(ResponseFormat.Type.JSON_OBJECT).build())
+			.stop(List.of("foo", "bar"))
+			.temperature(0.2)
+			.topP(0.9)
+			.logprobs(true)
+			.topLogprobs(5)
+			.echo(true)
+			.suffix("return result")
+			.tools(List.of(FUNCTION_TOOL))
+			.toolChoice("auto")
+			.toolCallbacks(List.of(WEATHER_TOOL_CALLBACK))
+			.toolContext(Map.of("locale", "en-US"));
+	}
+
+	private static final DeepSeekApi.FunctionTool FUNCTION_TOOL = new DeepSeekApi.FunctionTool(
+			DeepSeekApi.FunctionTool.Type.FUNCTION, new DeepSeekApi.FunctionTool.Function("function", "desc", "{}"));
+
+	private static final FunctionToolCallback<MockWeatherService.Request, MockWeatherService.Response> WEATHER_TOOL_CALLBACK = FunctionToolCallback
+		.builder("getCurrentWeather", new MockWeatherService())
+		.description("Get the weather in location")
+		.inputType(MockWeatherService.Request.class)
+		.build();
 
 }

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelIT.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelIT.java
@@ -309,7 +309,26 @@ class DeepSeekChatModelIT {
 		assertThat(deepSeekAssistantMessage.getText()).isNotEmpty();
 	}
 
+	@Test
+	void suffixCompletionTest() {
+		// DeepSeek FIM (fill-in-the-middle) completion API usage:
+		// prompt="def fib(a):"
+		// suffix=" return fib(a-1) + fib(a-2)"
+		String promptContent = "def fib(a):";
+		String suffix = "    return fib(a-1) + fib(a-2)";
+		Prompt prompt = Prompt.builder()
+			.messages(UserMessage.builder().text(promptContent).build())
+			.chatOptions(DeepSeekChatOptions.builder().echo(true).suffix(suffix).maxTokens(128).build())
+			.build();
+		ChatResponse response = this.chatModel.call(prompt);
+
+		String output = response.getResult().getOutput().getText();
+		assertThat(output).isNotEmpty();
+		assertThat(output).contains(promptContent);
+	}
+
 	record ActorsFilmsRecord(String actor, List<String> movies) {
+
 	}
 
 }


### PR DESCRIPTION
# Summary

  This change adds support for DeepSeek's beta FIM (fill-in-the-middle) parameters — echo and suffix — across the DeepSeek model integration. With suffix set, callers can ask the
  model to complete text that bridges a given prompt and a trailing suffix, and echo=true instructs the API to echo the prompt back alongside the completion.

# Referer
[FIM completion API Guide](https://api-docs.deepseek.com/guides/fim_completion)
[FIM completion API](https://api-docs.deepseek.com/api/create-completion/)

# Verify
```sh
./mvnw -am -pl spring-ai-model -Dit.test=org.springframework.ai.deepseek.chat.DeepSeekChatModelIT#suffixCompletionTest -Dfailsafe.failIfNoSpecifiedTests=false -Dmaven.build.cache.enabled=false verify
```
<img width="2830" height="738" alt="image" src="https://github.com/user-attachments/assets/a6cd2307-0023-41e3-bd74-a9746f923010" />
