### PR TITLE
Fix group precedence in `TypesenseFilterExpressionConverter`

### DIFF
--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseFilterExpressionConverter.java
@@ -54,9 +54,13 @@ public class TypesenseFilterExpressionConverter extends AbstractFilterExpression
 	}
 
 	@Override
-	protected void doGroup(Filter.Group group, StringBuilder context) {
-		this.convertOperand(new Filter.Expression(Filter.ExpressionType.AND, group.content(), group.content()),
-				context); // trick
+	protected void doStartGroup(Filter.Group group, StringBuilder context) {
+		context.append("(");
+	}
+
+	@Override
+	protected void doEndGroup(Filter.Group group, StringBuilder context) {
+		context.append(")");
 	}
 
 	@Override

--- a/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/typesense/TypesenseFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/typesense/TypesenseFilterExpressionConverterTests.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.vectorstore.filter.Filter.Expression;
+import org.springframework.ai.vectorstore.filter.Filter.Group;
 import org.springframework.ai.vectorstore.filter.Filter.Key;
 import org.springframework.ai.vectorstore.filter.Filter.Value;
 import org.springframework.ai.vectorstore.filter.FilterExpressionConverter;
@@ -103,6 +104,17 @@ class TypesenseFilterExpressionConverterTests {
 			.convertExpression(new Expression(OR, new Expression(EQ, new Key("country"), new Value("BG")),
 					new Expression(EQ, new Key("country"), new Value("NL"))));
 		assertThat(vectorExpr).isEqualTo("metadata.country: \"BG\" || metadata.country: \"NL\"");
+	}
+
+	@Test
+	void testGroupAsRightOperand() {
+		// city == "Sofia" AND (year >= 2020 OR country == "BG")
+		String vectorExpr = this.converter
+			.convertExpression(new Expression(AND, new Expression(EQ, new Key("city"), new Value("Sofia")),
+					new Group(new Expression(OR, new Expression(GTE, new Key("year"), new Value(2020)),
+							new Expression(EQ, new Key("country"), new Value("BG"))))));
+		assertThat(vectorExpr).isEqualTo(
+				"metadata.city: \"Sofia\" && (metadata.year: >= 2020 || metadata.country: \"BG\")");
 	}
 
 	@Test


### PR DESCRIPTION
The `doGroup` override in `TypesenseFilterExpressionConverter` converts a parenthesized filter group into `content && content`, duplicating the group body and dropping the parentheses that express grouping.

Because Typesense evaluates `&&` and `||` with equal precedence from left to right, a filter such as
```text
city == "Sofia" AND (year >= 2020 OR country == "BG")
```

is currently emitted as

```text
metadata.city: "Sofia" && metadata.year: >= 2020 || metadata.country: "BG" && metadata.year: >= 2020 || metadata.country: "BG"
```

This allows documents with country == "BG" to match regardless of the city condition.

Replace the doGroup override with the conventional doStartGroup and doEndGroup hooks that wrap the group content in parentheses.

## Testing

Added testGroupAsRightOperand covering a grouped OR expression used as the right-hand operand of an AND.
The expected filter preserves the original grouping:

```text
metadata.city: "Sofia" && (metadata.year: >= 2020 || metadata.country: "BG")
```