### PR TITLE
Return a single Generation on ToolCallLimitExceededException

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -175,13 +175,12 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 						.executeToolCalls(new Prompt(fullTurnHistory, toolCallingChatOptions), chatResponse);
 				}
 				catch (ToolCallLimitExceededException ex) {
-					// A configured tool call limit was hit. Return whatever was
-					// executed so far directly to the application client instead of
-					// looping back to the LLM.
+					// Return the breach as a single generation - directly to the
+					// application client instead of looping back to the LLM.
 					chatClientResponse = chatClientResponse.mutate()
 						.chatResponse(ChatResponse.builder()
 							.from(chatResponse)
-							.generations(ToolExecutionResult.buildGenerations(ex.getPartialToolExecutionResult()))
+							.generations(List.of(ex.buildGeneration()))
 							.build())
 						.build();
 					break;
@@ -191,17 +190,14 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 				if (toolExecutionResult.returnDirect()) {
 
-					// Return tool execution result directly to the application client.
+					// Return tool execution result directly to the application client
+					// instead of returning it to the LLM.
 					chatClientResponse = chatClientResponse.mutate()
 						.chatResponse(ChatResponse.builder()
 							.from(chatResponse)
 							.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
 							.build())
 						.build();
-
-					// Interrupt the tool calling loop and return the tool execution
-					// result directly to the client application instead of returning
-					// it to the LLM.
 					break;
 				}
 
@@ -355,13 +351,15 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 						chatResponse);
 			}
 			catch (ToolCallLimitExceededException ex) {
-				// A configured tool call limit was hit. Return whatever was executed
-				// so far directly to the application client instead of looping back
-				// to the LLM.
+				// A configured tool call limit was hit. Return the breach as a single
+				// generation - rather than mixing it with any successful calls from
+				// the same batch as if they were equally valid alternative answers -
+				// directly to the application client instead of looping back to the
+				// LLM.
 				ChatClientResponse limitResponse = finalAggregatedResponse.mutate()
 					.chatResponse(ChatResponse.builder()
 						.from(chatResponse)
-						.generations(ToolExecutionResult.buildGenerations(ex.getPartialToolExecutionResult()))
+						.generations(List.of(ex.buildGeneration()))
 						.build())
 					.build();
 				return Flux.just(usageAccumulator.applyAccumulatedUsage(limitResponse));

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -1151,10 +1151,16 @@ public class ToolCallingAdvisorTests {
 			.pushAll(List.of(advisor, terminalAdvisor))
 			.build();
 
-		ToolResponseMessage.ToolResponse partialToolResponse = new ToolResponseMessage.ToolResponse("tool-1",
-				"testTool", "partial result");
+		// Simulates a parallel tool-call batch where the first call to "testTool"
+		// already succeeded before the second call breached the limit.
+		// DefaultToolCallingManager always appends the synthesized breach response
+		// last.
+		ToolResponseMessage.ToolResponse successfulToolResponse = new ToolResponseMessage.ToolResponse("tool-1",
+				"testTool", "successful result");
+		ToolResponseMessage.ToolResponse breachToolResponse = new ToolResponseMessage.ToolResponse("tool-2", "testTool",
+				"Tool call limit (1) exceeded for tool 'testTool'.");
 		ToolResponseMessage partialToolResponseMessage = ToolResponseMessage.builder()
-			.responses(List.of(partialToolResponse))
+			.responses(List.of(successfulToolResponse, breachToolResponse))
 			.build();
 		List<Message> partialHistory = List.of(new UserMessage("test"), AssistantMessage.builder().content("").build(),
 				partialToolResponseMessage);
@@ -1169,13 +1175,19 @@ public class ToolCallingAdvisorTests {
 		// looping back to the LLM.
 		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
 
-		// The partial tool execution result carried by the exception is returned to
-		// the client instead of the exception propagating.
+		// A single generation is returned to the client - carrying the breach message,
+		// not one of the successful calls from the same batch, so the limit is never
+		// mistaken for one of several equally valid answers. The successful call is
+		// preserved in metadata instead of being discarded or emitted as a sibling
+		// generation.
 		assertThat(result.chatResponse()).isNotNull();
 		assertThat(result.chatResponse().getResults()).hasSize(1);
-		assertThat(result.chatResponse().getResults().get(0).getOutput().getText()).isEqualTo("partial result");
-		assertThat(result.chatResponse().getResults().get(0).getMetadata().getFinishReason())
-			.isEqualTo(ToolExecutionResult.FINISH_REASON);
+		Generation generation = result.chatResponse().getResults().get(0);
+		assertThat(generation.getOutput().getText()).isEqualTo(breachToolResponse.responseData());
+		assertThat(generation.getMetadata().getFinishReason()).isEqualTo(ToolCallLimitExceededException.FINISH_REASON);
+		assertThat(generation.getMetadata().<List<ToolResponseMessage
+				.ToolResponse>>get(ToolCallLimitExceededException.METADATA_PARTIAL_TOOL_RESPONSES))
+			.containsExactly(successfulToolResponse);
 	}
 
 	@Test
@@ -1192,10 +1204,16 @@ public class ToolCallingAdvisorTests {
 			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
 			.build();
 
-		ToolResponseMessage.ToolResponse partialToolResponse = new ToolResponseMessage.ToolResponse("tool-1",
-				"testTool", "partial result");
+		// Simulates a parallel tool-call batch where the first call to "testTool"
+		// already succeeded before the second call breached the limit.
+		// DefaultToolCallingManager always appends the synthesized breach response
+		// last.
+		ToolResponseMessage.ToolResponse successfulToolResponse = new ToolResponseMessage.ToolResponse("tool-1",
+				"testTool", "successful result");
+		ToolResponseMessage.ToolResponse breachToolResponse = new ToolResponseMessage.ToolResponse("tool-2", "testTool",
+				"Tool call limit (1) exceeded for tool 'testTool'.");
 		ToolResponseMessage partialToolResponseMessage = ToolResponseMessage.builder()
-			.responses(List.of(partialToolResponse))
+			.responses(List.of(successfulToolResponse, breachToolResponse))
 			.build();
 		List<Message> partialHistory = List.of(new UserMessage("test"), AssistantMessage.builder().content("").build(),
 				partialToolResponseMessage);
@@ -1210,14 +1228,18 @@ public class ToolCallingAdvisorTests {
 		// looping back to the LLM.
 		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
 
-		// Intermediate tool call response is filtered out; only the partial result
-		// carried by the exception is emitted.
+		// Intermediate tool call response is filtered out; only the single breach
+		// generation carried by the exception is emitted, with the successful call
+		// preserved in metadata rather than as a sibling generation.
 		assertThat(results).isNotNull().hasSize(1);
 		assertThat(results.get(0).chatResponse()).isNotNull();
 		assertThat(results.get(0).chatResponse().getResults()).hasSize(1);
-		assertThat(results.get(0).chatResponse().getResults().get(0).getOutput().getText()).isEqualTo("partial result");
-		assertThat(results.get(0).chatResponse().getResults().get(0).getMetadata().getFinishReason())
-			.isEqualTo(ToolExecutionResult.FINISH_REASON);
+		Generation generation = results.get(0).chatResponse().getResults().get(0);
+		assertThat(generation.getOutput().getText()).isEqualTo(breachToolResponse.responseData());
+		assertThat(generation.getMetadata().getFinishReason()).isEqualTo(ToolCallLimitExceededException.FINISH_REASON);
+		assertThat(generation.getMetadata().<List<ToolResponseMessage
+				.ToolResponse>>get(ToolCallLimitExceededException.METADATA_PARTIAL_TOOL_RESPONSES))
+			.containsExactly(successfulToolResponse);
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -846,7 +846,7 @@ Counts are scoped to the current turn only: only `ToolResponseMessage` entries f
 
 ==== Behavior When a Limit Is Exceeded
 
-`DefaultToolCallingManager` throws `ToolCallLimitExceededException`, carrying the tool name (`null` for a total-limit breach), the limit that was hit, and the partial `ToolExecutionResult` already executed in the current batch, so no completed work is discarded. `ToolCallingAdvisor` catches it and returns that partial result as the final response, the same "break the loop" path used for `returnDirect`.
+`DefaultToolCallingManager` throws `ToolCallLimitExceededException`, carrying the tool name (`null` for a total-limit breach), the limit that was hit, and the partial `ToolExecutionResult` already executed in the current batch, so no completed work is discarded. `ToolCallingAdvisor` catches it and returns the breach as the final response - a single `Generation` (via `ex.buildGeneration()`), never one generation per tool call, so a successful call earlier in a parallel batch can't hide the breach from callers reading only the first result. Its finish reason is `ToolCallLimitExceededException.FINISH_REASON`, and any tool calls that did succeed earlier in the batch are preserved under the `METADATA_PARTIAL_TOOL_RESPONSES` metadata key instead of being discarded.
 
 With `onLimitExceeded(ToolCallLimitBehavior.RETURN_ERROR_RESPONSE)`, the manager instead skips the call and synthesizes an error `ToolResponse` — the same mechanism used for `ToolExecutionException` — so the model is told the limit was reached and the conversation continues instead of terminating. This is also the option to reach for if you call `ToolCallingManager.executeToolCalls(...)` directly instead of going through `ToolCallingAdvisor`.
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallLimitExceededException.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallLimitExceededException.java
@@ -16,7 +16,15 @@
 
 package org.springframework.ai.model.tool;
 
+import java.util.List;
+
 import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.model.Generation;
 
 /**
  * Thrown by {@link DefaultToolCallingManager} when a configured tool call limit is
@@ -30,6 +38,23 @@ import org.jspecify.annotations.Nullable;
  * @since 2.0.1
  */
 public class ToolCallLimitExceededException extends RuntimeException {
+
+	/**
+	 * {@link Generation#getMetadata()} finish reason set on the {@link Generation} built
+	 * by {@link #buildGeneration()}, distinguishing a forcibly aborted turn from a
+	 * regular {@link ToolExecutionResult#FINISH_REASON returnDirect} completion.
+	 */
+	public static final String FINISH_REASON = "toolCallLimitExceeded";
+
+	/**
+	 * {@link ChatGenerationMetadata} key under which the
+	 * {@link ToolResponseMessage.ToolResponse}s that completed successfully in the
+	 * current batch before the limit was hit are attached to the {@link Generation} built
+	 * by {@link #buildGeneration()}. Keeping them in metadata - rather than as separate,
+	 * sibling {@link Generation}s - avoids mixing successful tool output with the error
+	 * message as if they were equally valid alternative answers.
+	 */
+	public static final String METADATA_PARTIAL_TOOL_RESPONSES = "partialToolResponses";
 
 	private final @Nullable String toolName;
 
@@ -79,6 +104,37 @@ public class ToolCallLimitExceededException extends RuntimeException {
 	 */
 	public ToolExecutionResult getPartialToolExecutionResult() {
 		return this.partialToolExecutionResult;
+	}
+
+	/**
+	 * Builds a single {@link Generation} representing this exception, so that a limit
+	 * breach is never mistaken for one of several equally valid answers.
+	 * <p>
+	 * The {@link Generation}'s output is the breach message synthesized by
+	 * {@link DefaultToolCallingManager} for the call that exceeded the limit. Any tool
+	 * responses that completed successfully earlier in the same batch are attached under
+	 * {@value #METADATA_PARTIAL_TOOL_RESPONSES} instead of being emitted as separate,
+	 * sibling generations, so completed work isn't discarded but also isn't confused with
+	 * the error itself.
+	 */
+	public Generation buildGeneration() {
+		String breachMessage = getMessage();
+		List<ToolResponseMessage.ToolResponse> partialResponses = List.of();
+
+		List<Message> history = this.partialToolExecutionResult.conversationHistory();
+		if (!history.isEmpty() && history.get(history.size() - 1) instanceof ToolResponseMessage toolResponseMessage) {
+			List<ToolResponseMessage.ToolResponse> responses = toolResponseMessage.getResponses();
+			if (!responses.isEmpty()) {
+				breachMessage = responses.get(responses.size() - 1).responseData();
+				partialResponses = responses.subList(0, responses.size() - 1);
+			}
+		}
+
+		ChatGenerationMetadata metadata = ChatGenerationMetadata.builder()
+			.finishReason(FINISH_REASON)
+			.metadata(METADATA_PARTIAL_TOOL_RESPONSES, partialResponses)
+			.build();
+		return new Generation(new AssistantMessage(breachMessage), metadata);
 	}
 
 }

--- a/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallingAdvisorIT.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallingAdvisorIT.java
@@ -30,6 +30,7 @@ import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
@@ -274,20 +275,23 @@ public abstract class AbstractToolCallingAdvisorIT {
 				.maxCallsPerTool("getCurrentWeather", 1)
 				.build();
 
-			String response = ChatClient.create(getChatModel())
+			ChatResponse response = Objects.requireNonNull(ChatClient.create(getChatModel())
 				.prompt()
 				.advisors(ToolCallingAdvisor.builder().toolCallingManager(limitedManager).build())
-				.system("You MUST call getCurrentWeather separately and sequentially for each city, "
-						+ "one tool call per city, never batching multiple cities into one call.")
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
 				.tools(createWeatherToolCallback())
 				.call()
-				.content();
+				.chatResponse());
 
 			// Only the first call to getCurrentWeather is allowed; the rest are
 			// rejected with the message DefaultToolCallingManager synthesizes when a
-			// configured limit is exceeded.
-			assertThat(response).contains("limit");
+			// configured limit is exceeded. Regardless of whether the model calls the
+			// tool sequentially or batches all three into one parallel round, the
+			// breach is always returned as the sole generation - never mixed in with a
+			// successful call from the same batch as if they were equally valid
+			// alternative answers.
+			assertThat(response.getResults()).hasSize(1);
+			assertThat(response.getResults().get(0).getOutput().getText()).contains("limit");
 		}
 
 		@Test
@@ -299,8 +303,6 @@ public abstract class AbstractToolCallingAdvisorIT {
 			Flux<String> response = ChatClient.create(getChatModel())
 				.prompt()
 				.advisors(ToolCallingAdvisor.builder().toolCallingManager(limitedManager).build())
-				.system("You MUST call getCurrentWeather separately and sequentially for each city, "
-						+ "one tool call per city, never batching multiple cities into one call.")
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
 				.tools(createWeatherToolCallback())
 				.stream()


### PR DESCRIPTION
- Converting the partial ToolExecutionResult via buildGenerations() created one Generation per tool response.
- Add ToolCallLimitExceededException.buildGeneration(): a single Generation carrying the breach message, a new distinct FINISH_REASON, and any earlier-succeeded calls preserved as metadata.
- Update tests & docs