### PR TITLE
Correct `ToolContext` parameter detection

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
@@ -147,7 +147,7 @@ public final class MethodToolCallback implements ToolCallback {
 	@SuppressWarnings("null")
 	private Object[] buildMethodArguments(Map<String, Object> toolInputArguments, @Nullable ToolContext toolContext) {
 		return Stream.of(this.toolMethod.getParameters()).map(parameter -> {
-			if (parameter.getType().isAssignableFrom(ToolContext.class)) {
+			if (ClassUtils.isAssignable(ToolContext.class, parameter.getType())) {
 				return toolContext;
 			}
 			Object rawArgument = toolInputArguments.get(parameter.getName());

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackGenericTypesTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackGenericTypesTest.java
@@ -173,6 +173,43 @@ class MethodToolCallbackGenericTypesTest {
 		assertThat(result).isEqualTo("1 entries processed {foo=bar}");
 	}
 
+	@Test
+	void testObjectType() throws Exception {
+		// Create a test object with a method that takes an Object
+		TestGenericClass testObject = new TestGenericClass();
+		Method method = TestGenericClass.class.getMethod("processObject", Object.class);
+
+		// Create a tool definition
+		ToolDefinition toolDefinition = DefaultToolDefinition.builder()
+			.name("processObject")
+			.description("Process an object")
+			.inputSchema("{}")
+			.build();
+
+		// Create a MethodToolCallback
+		MethodToolCallback callback = MethodToolCallback.builder()
+			.toolDefinition(toolDefinition)
+			.toolMethod(method)
+			.toolObject(testObject)
+			.build();
+
+		// Create a JSON input with an object value
+		String toolInput = """
+				{
+					"value": {
+						"name": "spring-ai",
+						"version": 2
+					}
+				}
+				""";
+
+		// Call the tool
+		String result = callback.call(toolInput);
+
+		// Verify the result
+		assertThat(result).isEqualTo("\"Object processed: {name=spring-ai, version=2}\"");
+	}
+
 	/**
 	 * Test class with methods that use generic types.
 	 */
@@ -193,6 +230,10 @@ class MethodToolCallbackGenericTypesTest {
 		public String processStringListInToolContext(ToolContext toolContext) {
 			Map<String, Object> context = toolContext.getContext();
 			return context.size() + " entries processed " + context;
+		}
+
+		public String processObject(Object value) {
+			return "Object processed: " + value;
 		}
 
 	}


### PR DESCRIPTION
## Problem

`MethodToolCallback` identifies `ToolContext` parameters using the following assignability check:

```java
parameter.getType().isAssignableFrom(ToolContext.class)
```

This condition also evaluates to `true` for an `Object` parameter, because a `ToolContext` instance can be assigned to `Object`.

As a result, when a tool method declares an `Object` parameter, the value supplied through the tool input is ignored and the `ToolContext` value is passed to the method instead.

For example, given a tool method such as:

```java
public String processObject(Object value)
```

the JSON value for `value` should be passed to the method. However, the current check incorrectly treats the parameter as a `ToolContext` parameter.

## Changes

* Correct the assignability check used to identify `ToolContext` parameters.
* Add a regression test verifying that an `Object` parameter is resolved from the tool input.
* Preserve the existing behavior for actual `ToolContext` parameters.

## Testing

Passed:

```text
./mvnw -pl spring-ai-model -am test
```

Also attempted:

```text
./mvnw -Dmaven.build.cache.enabled=false clean package
```

The full build did not complete because tests in the unrelated `spring-ai-transformers` module failed to load the DJL Hugging Face native tokenizer library on macOS x86_64:

```text
Failed to load Huggingface native library.
Unexpected flavor: cpu
```

## Checklist

* [x] Each commit includes a `Signed-off-by` line using `git commit -s`.
* [x] The changes have been rebased onto the latest `main` branch and the commits have been squashed.
* [x] A regression test has been added for the modified behavior.
* [x] The affected `spring-ai-model` module and its dependencies pass their tests.
* [ ] The complete `./mvnw clean package` build passes locally.
* [x] The changes were reviewed manually.
