### PR TITLE
Default OpenAI tool-calling strict mode to false

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -981,9 +981,9 @@ public final class OpenAiChatModel implements ChatModel {
 			FunctionParameters.Builder parametersBuilder = FunctionParameters.builder();
 			// Defaults to false: OpenAI's strict mode requires every schema property to
 			// appear in "required" (optionality is expressed via nullable types, not
-			// omission), which JsonSchemaGenerator does not produce. Callers that know
-			// their tool schemas are strict-mode compatible can opt in explicitly via
-			// OpenAiChatOptions#strict.
+			// omission), which JsonSchemaGenerator does not produce by default. When a
+			// caller opts in via OpenAiChatOptions#strict, applyStrictModeRequirements
+			// below rewrites the schema to satisfy that contract.
 			Boolean strictMode = false;
 			if (requestOptions != null && requestOptions.getStrict() != null) {
 				strictMode = requestOptions.getStrict();
@@ -996,6 +996,10 @@ public final class OpenAiChatModel implements ChatModel {
 				try {
 					@SuppressWarnings("unchecked")
 					Map<String, Object> schemaMap = objectMapper.readValue(toolDefinition.inputSchema(), Map.class);
+
+					if (Boolean.TRUE.equals(strictMode)) {
+						applyStrictModeRequirements(schemaMap);
+					}
 
 					// Add each property from the schema to the parameters
 					schemaMap
@@ -1015,6 +1019,101 @@ public final class OpenAiChatModel implements ChatModel {
 			return ChatCompletionTool
 				.ofFunction(ChatCompletionFunctionTool.builder().function(functionDefinition).build());
 		}).toList();
+	}
+
+	/**
+	 * A JSON Schema fragment representing exactly the {@code null} type, used as the
+	 * extra {@code anyOf} branch when widening a {@code $ref}/{@code anyOf}-based
+	 * property to accept {@code null}.
+	 */
+	private static final Map<String, Object> NULL_TYPE_SCHEMA = Map.of("type", "null");
+
+	/**
+	 * Rewrites an object schema in place to satisfy OpenAI's strict function-calling
+	 * mode: every property must be listed in "required", with optionality expressed via a
+	 * nullable type rather than omission from "required". {@link JsonSchemaGenerator}
+	 * produces conventional JSON Schema instead - it omits
+	 * {@code @ToolParam(required = false)} properties from "required" - so this widens
+	 * the type of each such property to also accept {@code null} and backfills "required"
+	 * with every property key. Recurses into nested object/array-item schemas and
+	 * {@code $defs} definitions so their own optional properties are fixed up too.
+	 */
+	@SuppressWarnings("unchecked")
+	private static void applyStrictModeRequirements(Map<String, Object> schema) {
+		if (schema.get("$defs") instanceof Map<?, ?> defs) {
+			for (Object definition : defs.values()) {
+				if (definition instanceof Map<?, ?> definitionSchema) {
+					applyStrictModeRequirements((Map<String, Object>) definitionSchema);
+				}
+			}
+		}
+
+		if (!(schema.get("properties") instanceof Map<?, ?> properties) || properties.isEmpty()) {
+			return;
+		}
+
+		List<?> alreadyRequired = schema.get("required") instanceof List<?> required ? required : List.of();
+
+		for (Object propertySchemaValue : properties.values()) {
+			if (!(propertySchemaValue instanceof Map<?, ?> propertySchema)) {
+				continue;
+			}
+			applyStrictModeRequirements((Map<String, Object>) propertySchema);
+			if (propertySchema.get("items") instanceof Map<?, ?> itemsSchema) {
+				applyStrictModeRequirements((Map<String, Object>) itemsSchema);
+			}
+		}
+
+		for (Map.Entry<?, ?> property : properties.entrySet()) {
+			if (alreadyRequired.contains(property.getKey())
+					|| !(property.getValue() instanceof Map<?, ?> propertySchema)) {
+				continue;
+			}
+			widenToNullable((Map<String, Object>) propertySchema);
+		}
+
+		schema.put("required", new ArrayList<>(properties.keySet()));
+	}
+
+	/**
+	 * Widens a property schema's "type" to also accept {@code null}. Properties defined
+	 * purely via {@code $ref} or {@code anyOf} (no "type" key of their own - typically a
+	 * complex object parameter) are instead wrapped in an {@code anyOf} alongside a null
+	 * branch, since there is no "type" value to widen directly.
+	 */
+	private static void widenToNullable(Map<String, Object> propertySchema) {
+		Object type = propertySchema.get("type");
+		if (type instanceof String typeName) {
+			if (!"null".equals(typeName)) {
+				propertySchema.put("type", new ArrayList<>(List.of(typeName, "null")));
+			}
+			return;
+		}
+		if (type instanceof List<?> typeList) {
+			if (!typeList.contains("null")) {
+				List<Object> widened = new ArrayList<>(typeList);
+				widened.add("null");
+				propertySchema.put("type", widened);
+			}
+			return;
+		}
+		if (propertySchema.get("anyOf") instanceof List<?> anyOf) {
+			if (!anyOf.contains(NULL_TYPE_SCHEMA)) {
+				List<Object> widened = new ArrayList<>(anyOf);
+				widened.add(NULL_TYPE_SCHEMA);
+				propertySchema.put("anyOf", widened);
+			}
+			return;
+		}
+		if (propertySchema.containsKey("$ref")) {
+			Map<String, Object> refBranch = new LinkedHashMap<>(propertySchema);
+			Object description = refBranch.remove("description");
+			propertySchema.clear();
+			if (description != null) {
+				propertySchema.put("description", description);
+			}
+			propertySchema.put("anyOf", new ArrayList<>(List.of(refBranch, NULL_TYPE_SCHEMA)));
+		}
 	}
 
 	private String getReasoningContent(ChatCompletion.Choice choice) {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -979,7 +979,12 @@ public final class OpenAiChatModel implements ChatModel {
 			@Nullable OpenAiChatOptions requestOptions) {
 		return toolDefinitions.stream().map(toolDefinition -> {
 			FunctionParameters.Builder parametersBuilder = FunctionParameters.builder();
-			Boolean strictMode = true;
+			// Defaults to false: OpenAI's strict mode requires every schema property to
+			// appear in "required" (optionality is expressed via nullable types, not
+			// omission), which JsonSchemaGenerator does not produce. Callers that know
+			// their tool schemas are strict-mode compatible can opt in explicitly via
+			// OpenAiChatOptions#strict.
+			Boolean strictMode = false;
 			if (requestOptions != null && requestOptions.getStrict() != null) {
 				strictMode = requestOptions.getStrict();
 			}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -1208,7 +1208,7 @@ class OpenAiChatModelTests {
 	}
 
 	@Test
-	void toolStrictIsEmittedAtFunctionLevel() {
+	void toolStrictDefaultsToFalseWhenUnset() {
 		ToolCallingManager mockToolCallingManager = mock(ToolCallingManager.class);
 
 		ToolDefinition toolDefinition = ToolDefinition.builder()
@@ -1220,7 +1220,10 @@ class OpenAiChatModelTests {
 		when(mockToolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of(toolDefinition));
 
 		// Model options with model set, relying on the fallback default logic of
-		// strict(true)
+		// strict(false) - JsonSchemaGenerator omits optional properties from
+		// "required" instead of the nullable-type pattern OpenAI's strict mode expects,
+		// so defaulting to strict(true) would reject any tool with an optional
+		// parameter.
 		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gpt-4.1").build();
 		OpenAiChatModel chatModel = OpenAiChatModel.builder()
 			.openAiClient(this.openAiClient)
@@ -1239,10 +1242,45 @@ class OpenAiChatModelTests {
 		ChatCompletionFunctionTool functionTool = tools.get(0).function().orElseThrow();
 		FunctionDefinition functionDef = functionTool.function();
 
-		assertThat(functionDef.strict()).contains(true);
+		assertThat(functionDef.strict()).contains(false);
 
 		FunctionParameters parameters = functionDef.parameters().orElseThrow();
 		assertThat(parameters._additionalProperties()).doesNotContainKey("strict");
+	}
+
+	@Test
+	void toolStrictTrueOverrideAtRequestLevel() {
+		ToolCallingManager mockToolCallingManager = mock(ToolCallingManager.class);
+
+		ToolDefinition toolDefinition = ToolDefinition.builder()
+			.name("get_weather")
+			.description("Get weather")
+			.inputSchema("{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}}}")
+			.build();
+
+		when(mockToolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of(toolDefinition));
+
+		// Model configured with strict(false) by default (implicitly, nothing set)
+		OpenAiChatOptions modelOptions = OpenAiChatOptions.builder().model("gpt-4.1").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(modelOptions)
+			.toolCallingManager(mockToolCallingManager)
+			.build();
+
+		// Prompt requests strict(true) override
+		OpenAiChatOptions requestOptions = OpenAiChatOptions.builder().strict(true).build();
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", requestOptions), false);
+
+		var tools = request.tools().orElseThrow();
+		assertThat(tools).hasSize(1);
+
+		ChatCompletionFunctionTool functionTool = tools.get(0).function().orElseThrow();
+		FunctionDefinition functionDef = functionTool.function();
+
+		// Verify that prompt-level option overrides the false default
+		assertThat(functionDef.strict()).contains(true);
 	}
 
 	@Test

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -1284,6 +1284,49 @@ class OpenAiChatModelTests {
 	}
 
 	@Test
+	void toolStrictTrueWidensOptionalPropertiesToNullableAndBackfillsRequired() {
+		ToolCallingManager mockToolCallingManager = mock(ToolCallingManager.class);
+
+		// "unit" is optional (absent from "required"), matching what
+		// JsonSchemaGenerator produces for a @ToolParam(required = false) parameter.
+		ToolDefinition toolDefinition = ToolDefinition.builder()
+			.name("get_weather")
+			.description("Get weather")
+			.inputSchema(
+					"{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"},\"unit\":{\"type\":\"string\"}},\"required\":[\"location\"]}")
+			.build();
+
+		when(mockToolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of(toolDefinition));
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gpt-4.1").strict(true).build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.toolCallingManager(mockToolCallingManager)
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), false);
+
+		FunctionDefinition functionDef = request.tools().orElseThrow().get(0).function().orElseThrow().function();
+		assertThat(functionDef.strict()).contains(true);
+
+		Map<String, JsonValue> additionalProperties = functionDef.parameters().orElseThrow()._additionalProperties();
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> properties = additionalProperties.get("properties").convert(Map.class);
+		@SuppressWarnings("unchecked")
+		Map<String, Object> unitSchema = (Map<String, Object>) properties.get("unit");
+		// OpenAI strict mode requires every property in "required"; optionality is
+		// expressed by widening the type to also accept null instead.
+		assertThat(unitSchema.get("type")).isEqualTo(List.of("string", "null"));
+
+		@SuppressWarnings("unchecked")
+		List<String> required = additionalProperties.get("required").convert(List.class);
+		assertThat(required).containsExactlyInAnyOrder("location", "unit");
+	}
+
+	@Test
 	void toolStrictFalseOverrideAtRequestLevel() {
 		ToolCallingManager mockToolCallingManager = mock(ToolCallingManager.class);
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -71,6 +71,7 @@ import org.springframework.ai.openai.OpenAiTestConfiguration;
 import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -738,6 +739,32 @@ public class OpenAiChatModelIT {
 			.hasMessageContaining("Unknown parameter");
 	}
 
+	@Test
+	void toolWithOptionalParameterSucceedsUnderStrictMode() {
+		// OpenAiChatOptions#strict(true) requires every schema property to be listed
+		// in "required", with optionality expressed via a nullable type instead of
+		// omission - see OpenAiChatModel#applyStrictModeRequirements(). GreetingTools
+		// has one optional parameter ("title"), which previously made OpenAI reject
+		// the tool outright before the model ever got a chance to call it.
+		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder().build();
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder()
+			.toolCallbacks(ToolCallbacks.from(new GreetingTools()))
+			.strict(true)
+			.build();
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("Greet Alice")), options);
+		ChatResponse response = this.chatModel.call(prompt);
+
+		while (response.hasToolCalls()) {
+			ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, response);
+			prompt = new Prompt(toolExecutionResult.conversationHistory(), options);
+			response = this.chatModel.call(prompt);
+		}
+
+		assertThat(response.getResult().getOutput().getText()).contains("Alice");
+	}
+
 	record ActorsFilmsRecord(String actor, List<String> movies) {
 
 	}
@@ -747,6 +774,16 @@ public class OpenAiChatModelIT {
 		@Tool(description = "Multiply the two numbers")
 		double multiply(double a, double b) {
 			return a * b;
+		}
+
+	}
+
+	static class GreetingTools {
+
+		@Tool(description = "Builds a greeting for a person")
+		String greet(String name,
+				@ToolParam(required = false, description = "Optional title, e.g. Dr., Mr.") String title) {
+			return (title != null ? title + " " : "") + name;
 		}
 
 	}


### PR DESCRIPTION
Tool schemas defaulted to strict:true whenever unset, but JsonSchemaGenerator omits optional parameters from required instead of the nullable-type pattern OpenAI's strict mode requires. Any tool with an optional parameter was rejected by OpenAI with a 400 error by default.

- Default to false, matching what the generator actually produces and matching the [official OpenAI API Spec defaults](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create#(resource)%20%24shared%20%3E%20(model)%20response_format_json_schema%20%3E%20(schema)%20%3E%20(property)%20json_schema%20%3E%20(property)%20strict). Callers can still opt in via OpenAiChatOptions#strict. - Renamed toolStrictIsEmittedAtFunctionLevel to toolStrictDefaultsToFalseWhenUnset and added toolStrictTrueOverrideAtRequestLevel for the other override direction.