### PR TITLE
Fix NoSuchElementException for safety-blocked candidates in GoogleGenAiChatModel

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -595,8 +595,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		}
 		else {
 			List<Generation> generations = candidate.content()
-				.get()
-				.parts()
+				.flatMap(Content::parts)
 				.orElse(List.of())
 				.stream()
 				.filter(part -> part.toolCall().isEmpty() && part.toolResponse().isEmpty())

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelExtendedUsageTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelExtendedUsageTests.java
@@ -21,6 +21,7 @@ import java.util.List;
 import com.google.genai.Client;
 import com.google.genai.types.Candidate;
 import com.google.genai.types.Content;
+import com.google.genai.types.FinishReason;
 import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
 import com.google.genai.types.MediaModality;
@@ -440,6 +441,36 @@ public class GoogleGenAiChatModelExtendedUsageTests {
 		assertThat(genAiUsage.getTotalTokens()).isEqualTo(0);
 		assertThat(genAiUsage.getThoughtsTokenCount()).isNull();
 		assertThat(genAiUsage.getCachedContentTokenCount()).isNull();
+	}
+
+	@Test
+	void testSafetyBlockedCandidateWithoutContent() {
+		// Safety-blocked candidates may have no content at all (absent Optional).
+		// Verify that responseCandidateToGeneration does not throw NoSuchElementException
+		// and returns a valid empty generation instead.
+		Candidate blockedCandidate = Candidate.builder()
+			.index(0)
+			.finishReason(new FinishReason(FinishReason.Known.SAFETY))
+			// intentionally no .content(...) — content() Optional is absent
+			.build();
+
+		GenerateContentResponse mockResponse = GenerateContentResponse.builder()
+			.candidates(List.of(blockedCandidate))
+			.modelVersion("gemini-2.5-flash")
+			.build();
+
+		this.chatModel.setMockGenerateContentResponse(mockResponse);
+
+		UserMessage userMessage = new UserMessage("Test safety-blocked response");
+		Prompt prompt = new Prompt(List.of(userMessage));
+
+		// Must not throw NoSuchElementException
+		ChatResponse response = this.chatModel.call(prompt);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).hasSize(1);
+		assertThat(response.getResult().getOutput().getText()).isEmpty();
+		assertThat(response.getMetadata().getModel()).isEqualTo("gemini-2.5-flash");
 	}
 
 }


### PR DESCRIPTION
## Summary

`GoogleGenAiChatModel.responseCandidateToGeneration` calls `candidate.content().get()` without checking whether `content()` is present. When a response candidate is blocked by safety filters, the candidate carries a `finishReason` (e.g. `SAFETY`) but **no `content`** — an empty `Optional`. In the non-function-call path this throws `NoSuchElementException: No value present`, failing the whole `call()` even though the API responded successfully.

This is the same class of bug reported in #6665 for `modelVersion().get()`, but on a different accessor that is not covered by #6681.

## Changes

- Replace the chained `candidate.content().get().parts()` with `candidate.content().flatMap(Content::parts)` in the non-function-call branch, so an absent `content` falls back to an empty parts list (which then yields a single empty generation via the existing fallback).
- Add regression test `testSafetyBlockedCandidateWithoutContent` that feeds a candidate with `finishReason=SAFETY` and no `content`, asserting the call returns a valid `ChatResponse` instead of throwing.

## Testing

Unit test added. Note: I was unable to run `./mvnw` locally because the build enforces JDK 17.0.19+ (`-XDaddTypeAnnotationsToSymbol`) and my environment has 17.0.12. Please verify in CI.

Fixes #6665
