### PR TITLE
Fix WebFluxSseClientTransport SSE parsing when event type is omitted

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransport.java
@@ -50,6 +50,7 @@ import reactor.util.retry.Retry.RetrySignal;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
@@ -262,13 +263,21 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 					s.error(new RuntimeException("Failed to handle SSE endpoint event"));
 				}
 			}
-			else if (MESSAGE_EVENT_TYPE.equals(event.event())) {
-				try {
-					JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, event.data());
-					s.next(message);
+			else if (isMessageEvent(event.event())) {
+				String data = event.data();
+				if (data == null || data.isEmpty()) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Ignoring SSE message event with empty data: " + event);
+					}
 				}
-				catch (IOException ioException) {
-					s.error(ioException);
+				else {
+					try {
+						JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, data);
+						s.next(message);
+					}
+					catch (IOException ioException) {
+						s.error(ioException);
+					}
 				}
 			}
 			else {
@@ -281,6 +290,11 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 
 		// The connection is established once the server sends the endpoint event
 		return this.messageEndpointSink.asMono().then();
+	}
+
+	private static boolean isMessageEvent(@Nullable String eventType) {
+		// Per SSE semantics, missing/blank event type defaults to "message".
+		return !StringUtils.hasText(eventType) || MESSAGE_EVENT_TYPE.equals(eventType);
 	}
 
 	/**

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransportIT.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransportIT.java
@@ -356,6 +356,34 @@ class WebFluxSseClientTransportIT {
 	}
 
 	@Test
+	void testDataOnlySseMessage() throws InterruptedException {
+		CopyOnWriteArrayList<McpSchema.JSONRPCMessage> receivedMessages = new CopyOnWriteArrayList<>();
+		TestSseClientTransport localTransport = new TestSseClientTransport(this.webClientBuilder,
+				McpJsonMapperUtils.JSON_MAPPER, this.sseMessageEndpointValidator);
+
+		localTransport.connect(flux -> flux.doOnNext(receivedMessages::add)).block();
+
+		// Simulate receiving a message without an "event" field, which defaults to
+		// "message"
+		localTransport.simulateDataOnlyEvent("""
+				{
+					"jsonrpc": "2.0",
+					"id": "test-id",
+					"result": {"status": "success"}
+				}
+				""");
+
+		// Wait briefly for the event to be processed
+		Thread.sleep(200);
+
+		assertThat(receivedMessages).hasSize(1);
+		assertThat(receivedMessages.get(0)).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		assertThat(((McpSchema.JSONRPCResponse) receivedMessages.get(0)).id()).isEqualTo("test-id");
+
+		localTransport.closeGracefully().block();
+	}
+
+	@Test
 	void testMessageEndpointValidation() throws InvalidSseMessageEndpointException {
 		var uriCaptor = ArgumentCaptor.forClass(URI.class);
 		verify(this.sseMessageEndpointValidator).validate(uriCaptor.capture(),
@@ -433,6 +461,11 @@ class WebFluxSseClientTransportIT {
 
 		public void simulateMessageEvent(String jsonMessage) {
 			this.events.tryEmitNext(ServerSentEvent.<String>builder().event("message").data(jsonMessage).build());
+			this.inboundMessageCount.incrementAndGet();
+		}
+
+		public void simulateDataOnlyEvent(String jsonMessage) {
+			this.events.tryEmitNext(ServerSentEvent.<String>builder().data(jsonMessage).build());
 			this.inboundMessageCount.incrementAndGet();
 		}
 


### PR DESCRIPTION
Per SSE semantics, missing or blank event types should default to 'message'. This matches the fix already done in WebClientStreamableHttpTransport.