### PR TITLE
Fix `OpenAiAudioTranscriptionModel` leaking the stream on cancellation

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.MultipartField;
+import com.openai.core.http.AsyncStreamResponse;
 import com.openai.models.audio.AudioResponseFormat;
 import com.openai.models.audio.transcriptions.Transcription;
 import com.openai.models.audio.transcriptions.TranscriptionCreateParams;
@@ -154,19 +155,20 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 			logger.trace("OpenAiAudioTranscriptionModel stream with model: " + mergedOptions.getModel());
 		}
 
-		Flux<TranscriptionStreamEvent> chunks = Flux.create(sink -> this.openAiClientAsync.audio()
-			.transcriptions()
-			.createStreaming(params)
-			.subscribe(sink::next)
-			.onCompleteFuture()
-			.whenComplete((unused, throwable) -> {
+		Flux<TranscriptionStreamEvent> chunks = Flux.create(sink -> {
+			AsyncStreamResponse<TranscriptionStreamEvent> response = this.openAiClientAsync.audio()
+				.transcriptions()
+				.createStreaming(params);
+			sink.onDispose(response::close);
+			response.subscribe(sink::next).onCompleteFuture().whenComplete((unused, throwable) -> {
 				if (throwable != null) {
 					sink.error(throwable);
 				}
 				else {
 					sink.complete();
 				}
-			}));
+			});
+		});
 
 		return chunks.map(event -> {
 			String text = extractStreamEventText(event);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
@@ -43,6 +44,7 @@ import com.openai.services.blocking.AudioService;
 import com.openai.services.blocking.audio.TranscriptionService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import reactor.core.Disposable;
 
 import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
 import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
@@ -745,6 +747,46 @@ class OpenAiAudioTranscriptionModelTests {
 		assertThat(chunks).isNotNull();
 		String text = String.join("", chunks);
 		assertThat(text).isEqualTo("Hello, streamed transcription result");
+	}
+
+	@Test
+	void streamClosesResponseWhenSubscriptionIsCancelled() {
+		AtomicBoolean closed = new AtomicBoolean();
+		AsyncStreamResponse<TranscriptionStreamEvent> openResponse = new AsyncStreamResponse<>() {
+			@Override
+			public AsyncStreamResponse<TranscriptionStreamEvent> subscribe(
+					AsyncStreamResponse.Handler<? super TranscriptionStreamEvent> handler) {
+				return this;
+			}
+
+			@Override
+			public AsyncStreamResponse<TranscriptionStreamEvent> subscribe(
+					AsyncStreamResponse.Handler<? super TranscriptionStreamEvent> handler, Executor executor) {
+				return this;
+			}
+
+			@Override
+			public CompletableFuture<Void> onCompleteFuture() {
+				return new CompletableFuture<>();
+			}
+
+			@Override
+			public void close() {
+				closed.set(true);
+			}
+		};
+
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"));
+
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(mock(OpenAIClient.class))
+			.openAiClientAsync(createMockAsyncClient(openResponse))
+			.build();
+
+		Disposable subscription = model.stream(prompt).subscribe();
+		subscription.dispose();
+
+		assertThat(closed).isTrue();
 	}
 
 	private OpenAIClient createMockClient(TranscriptionCreateResponse mockResponse) {


### PR DESCRIPTION
`OpenAiAudioTranscriptionModel.stream()` creates the SDK `AsyncStreamResponse` inside `Flux.create`
but discards the handle. Cancelling the returned `Flux` then stops the downstream signals without
closing the SDK stream, so the underlying HTTP response stays open until the server sends EOF or the
request times out.

Retain the response and close it from `FluxSink#onDispose`, releasing it on cancellation, error, or
completion. Same defect as #6654 on the chat path, here on the transcription path.

## Testing

Added `streamClosesResponseWhenSubscriptionIsCancelled`, which fails without the fix (the discarded
response is never closed) and passes with it; existing transcription streaming tests are unaffected.
It needs no credentials  a mock async client returns an open `AsyncStreamResponse`, the subscription
is disposed, and the response is asserted closed.

`./mvnw -pl models/spring-ai-openai clean test` passes (203 tests).