### PR TITLE
Add `GovernanceAdvisor` for PII scanning and session token budget tracking

### DIFF
--- a/advisors/spring-ai-governance-advisor/pom.xml
+++ b/advisors/spring-ai-governance-advisor/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-governance-advisor</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Governance Advisor</name>
+	<description>A governance advisor for Spring AI that provides PII scanning, session cost
+		budget tracking, and structured audit records.</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/BudgetExceededException.java
+++ b/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/BudgetExceededException.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+/**
+ * Thrown when a session exceeds the token budget configured in
+ * {@link SessionCostTracker}.
+ *
+ * @author Spring AI Contributors
+ * @since 2.0.0
+ */
+public class BudgetExceededException extends RuntimeException {
+
+	private final String sessionId;
+
+	private final long tokenLimit;
+
+	private final long currentTokenCount;
+
+	/**
+	 * Creates a new exception indicating that {@code sessionId} has exceeded its budget.
+	 * @param sessionId the identifier of the session that exceeded the budget
+	 * @param tokenLimit the maximum token count allowed per session
+	 * @param currentTokenCount the token count accumulated so far in the session
+	 */
+	public BudgetExceededException(String sessionId, long tokenLimit, long currentTokenCount) {
+		super(String.format("Session '%s' has exceeded its token budget (limit=%d, current=%d).", sessionId, tokenLimit,
+				currentTokenCount));
+		this.sessionId = sessionId;
+		this.tokenLimit = tokenLimit;
+		this.currentTokenCount = currentTokenCount;
+	}
+
+	/**
+	 * Returns the identifier of the session that exceeded the budget.
+	 */
+	public String getSessionId() {
+		return this.sessionId;
+	}
+
+	/**
+	 * Returns the token limit configured for the session.
+	 */
+	public long getTokenLimit() {
+		return this.tokenLimit;
+	}
+
+	/**
+	 * Returns the token count accumulated in the session at the time of the exception.
+	 */
+	public long getCurrentTokenCount() {
+		return this.currentTokenCount;
+	}
+
+}

--- a/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/GovernanceAdvisor.java
+++ b/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/GovernanceAdvisor.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Scheduler;
+
+import org.springframework.ai.chat.client.ChatClientMessageAggregator;
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.util.Assert;
+
+/**
+ * A governance advisor that intercepts every {@link ChatClientRequest} and applies
+ * configurable policy checks before forwarding the request to the rest of the advisor
+ * chain.
+ *
+ * <p>
+ * <strong>Checks performed (in order):</strong>
+ * <ol>
+ * <li><em>Session budget</em> — verifies that the session has not exceeded its token
+ * budget (requires a non-{@code null} session ID in the request context under
+ * {@value #DEFAULT_SESSION_ID_CONTEXT_KEY}).</li>
+ * <li><em>PII scan</em> — inspects the full prompt text for personally identifiable
+ * information using {@link PiiScanner}.</li>
+ * </ol>
+ *
+ * <p>
+ * Each check produces a {@link GovernanceDecision} that is forwarded to all registered
+ * {@link #auditListeners}. The behaviour when a violation is detected is controlled by
+ * {@link GovernanceMode}:
+ * <ul>
+ * <li>{@link GovernanceMode#OBSERVE} — log only; the request continues.</li>
+ * <li>{@link GovernanceMode#MONITOR} — log + emit audit event; the request
+ * continues.</li>
+ * <li>{@link GovernanceMode#ENFORCE} — throw {@link GovernanceViolationException}; the
+ * request is blocked.</li>
+ * </ul>
+ *
+ * <p>
+ * After a successful model call the advisor records the response token usage against the
+ * session via {@link SessionCostTracker#recordUsage}.
+ *
+ * @author Spring AI Contributors
+ * @since 2.0.0
+ * @see GovernanceMode
+ * @see GovernanceDecision
+ * @see PiiScanner
+ * @see SessionCostTracker
+ */
+public final class GovernanceAdvisor implements CallAdvisor, StreamAdvisor {
+
+	private static final Log logger = LogFactory.getLog(GovernanceAdvisor.class);
+
+	/**
+	 * Default key used to look up the session / conversation identifier from the request
+	 * context.
+	 */
+	public static final String DEFAULT_SESSION_ID_CONTEXT_KEY = "conversationId";
+
+	/**
+	 * Context key under which the latest {@link GovernanceDecision} is stored in the
+	 * response context so downstream code can inspect it.
+	 */
+	public static final String GOVERNANCE_DECISION_CONTEXT_KEY = GovernanceDecision.class.getName();
+
+	private static final int DEFAULT_ORDER = 0;
+
+	private final GovernanceMode mode;
+
+	private final PiiScanner piiScanner;
+
+	private final boolean piiEnabled;
+
+	private final SessionCostTracker costTracker;
+
+	private final boolean budgetEnabled;
+
+	private final String sessionIdContextKey;
+
+	private final List<Consumer<GovernanceDecision>> auditListeners;
+
+	private final int order;
+
+	private final Scheduler scheduler;
+
+	// -------------------------------------------------------------------------
+	// Constructor (package-private — use Builder)
+	// -------------------------------------------------------------------------
+
+	private GovernanceAdvisor(GovernanceMode mode, PiiScanner piiScanner, boolean piiEnabled,
+			SessionCostTracker costTracker, boolean budgetEnabled, String sessionIdContextKey,
+			List<Consumer<GovernanceDecision>> auditListeners, int order, Scheduler scheduler) {
+		this.mode = mode;
+		this.piiScanner = piiScanner;
+		this.piiEnabled = piiEnabled;
+		this.costTracker = costTracker;
+		this.budgetEnabled = budgetEnabled;
+		this.sessionIdContextKey = sessionIdContextKey;
+		this.auditListeners = List.copyOf(auditListeners);
+		this.order = order;
+		this.scheduler = scheduler;
+	}
+
+	// -------------------------------------------------------------------------
+	// Advisor identity
+	// -------------------------------------------------------------------------
+
+	@Override
+	public String getName() {
+		return this.getClass().getSimpleName();
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	// -------------------------------------------------------------------------
+	// CallAdvisor
+	// -------------------------------------------------------------------------
+
+	@Override
+	public ChatClientResponse adviseCall(ChatClientRequest chatClientRequest, CallAdvisorChain callAdvisorChain) {
+		GovernanceDecision decision = evaluate(chatClientRequest);
+		if (decision.isDenied() && this.mode == GovernanceMode.ENFORCE) {
+			throw new GovernanceViolationException(decision);
+		}
+
+		ChatClientResponse response = callAdvisorChain.nextCall(chatClientRequest);
+
+		// Record token usage for the session after a successful call.
+		recordUsageIfPresent(chatClientRequest, response.chatResponse());
+
+		return response.mutate().context(GOVERNANCE_DECISION_CONTEXT_KEY, decision).build();
+	}
+
+	// -------------------------------------------------------------------------
+	// StreamAdvisor
+	// -------------------------------------------------------------------------
+
+	@Override
+	public Flux<ChatClientResponse> adviseStream(ChatClientRequest chatClientRequest,
+			StreamAdvisorChain streamAdvisorChain) {
+
+		GovernanceDecision decision = evaluate(chatClientRequest);
+		if (decision.isDenied() && this.mode == GovernanceMode.ENFORCE) {
+			return Flux.error(new GovernanceViolationException(decision));
+		}
+
+		Flux<ChatClientResponse> responseFlux = streamAdvisorChain.nextStream(chatClientRequest);
+
+		// Aggregate to record usage after the stream completes.
+		return new ChatClientMessageAggregator()
+			.aggregateChatClientResponse(responseFlux,
+					aggregated -> recordUsageIfPresent(chatClientRequest, aggregated.chatResponse()))
+			.map(r -> r.mutate().context(GOVERNANCE_DECISION_CONTEXT_KEY, decision).build());
+	}
+
+	// -------------------------------------------------------------------------
+	// Evaluation logic
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Runs all enabled governance checks against {@code request} and returns a
+	 * {@link GovernanceDecision}. Also notifies audit listeners and logs accordingly.
+	 */
+	private GovernanceDecision evaluate(ChatClientRequest request) {
+		long start = System.currentTimeMillis();
+		String correlationId = UUID.randomUUID().toString();
+
+		// 1. Budget check
+		if (this.budgetEnabled && this.costTracker.hasLimit()) {
+			String sessionId = resolveSessionId(request);
+			if (sessionId != null) {
+				try {
+					this.costTracker.checkBudget(sessionId);
+				}
+				catch (BudgetExceededException ex) {
+					return makeDecision(correlationId, GovernanceDecision.ACTION_DENY,
+							"Token budget exceeded for session '" + sessionId + "'", 1.0, start);
+				}
+			}
+		}
+
+		// 2. PII scan
+		if (this.piiEnabled) {
+			String promptText = request.prompt().getContents();
+			String piiType = this.piiScanner.firstMatchDescription(promptText);
+			if (piiType != null) {
+				return makeDecision(correlationId, GovernanceDecision.ACTION_DENY,
+						"PII detected in prompt (" + piiType + ")", 0.9, start);
+			}
+		}
+
+		// All checks passed
+		return makeDecision(correlationId, GovernanceDecision.ACTION_ALLOW, "All governance checks passed", 0.0, start);
+	}
+
+	private GovernanceDecision makeDecision(String correlationId, String action, String reason, double riskScore,
+			long startMs) {
+		long elapsed = System.currentTimeMillis() - startMs;
+		GovernanceDecision decision = new GovernanceDecision(correlationId, action, reason, riskScore, elapsed);
+
+		notifyAuditListeners(decision);
+		logDecision(decision);
+
+		return decision;
+	}
+
+	private void notifyAuditListeners(GovernanceDecision decision) {
+		for (Consumer<GovernanceDecision> listener : this.auditListeners) {
+			try {
+				listener.accept(decision);
+			}
+			catch (Exception ex) {
+				logger.warn("Audit listener threw an exception for decision " + decision.correlationId(), ex);
+			}
+		}
+	}
+
+	private void logDecision(GovernanceDecision decision) {
+		if (decision.isDenied()) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("Governance [" + this.mode + "] DENY — " + decision.reason() + " (correlationId="
+						+ decision.correlationId() + ", riskScore=" + decision.riskScore() + ")");
+			}
+		}
+		else {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Governance [" + this.mode + "] ALLOW — " + decision.reason() + " (correlationId="
+						+ decision.correlationId() + ")");
+			}
+		}
+	}
+
+	private void recordUsageIfPresent(ChatClientRequest request, @Nullable ChatResponse chatResponse) {
+		if (!this.budgetEnabled || chatResponse == null) {
+			return;
+		}
+		String sessionId = resolveSessionId(request);
+		if (sessionId != null) {
+			this.costTracker.recordUsage(sessionId, chatResponse);
+		}
+	}
+
+	private @Nullable String resolveSessionId(ChatClientRequest request) {
+		Object value = request.context().get(this.sessionIdContextKey);
+		return value != null ? value.toString() : null;
+	}
+
+	// -------------------------------------------------------------------------
+	// Builder
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns a new {@link Builder} with sensible defaults: {@link GovernanceMode#ENFORCE
+	 * ENFORCE} mode, PII scanning enabled, no token budget.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for {@link GovernanceAdvisor}.
+	 */
+	public static final class Builder {
+
+		private GovernanceMode mode = GovernanceMode.ENFORCE;
+
+		private PiiScanner piiScanner = PiiScanner.builder().build();
+
+		private boolean piiEnabled = true;
+
+		private SessionCostTracker costTracker = new SessionCostTracker();
+
+		private boolean budgetEnabled = true;
+
+		private String sessionIdContextKey = DEFAULT_SESSION_ID_CONTEXT_KEY;
+
+		private final List<Consumer<GovernanceDecision>> auditListeners = new ArrayList<>();
+
+		private int order = DEFAULT_ORDER;
+
+		private Scheduler scheduler = BaseAdvisor.DEFAULT_SCHEDULER;
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets the governance mode (default: {@link GovernanceMode#ENFORCE}).
+		 */
+		public Builder mode(GovernanceMode mode) {
+			Assert.notNull(mode, "mode must not be null");
+			this.mode = mode;
+			return this;
+		}
+
+		/**
+		 * Replaces the default {@link PiiScanner} with a custom one.
+		 */
+		public Builder piiScanner(PiiScanner piiScanner) {
+			Assert.notNull(piiScanner, "piiScanner must not be null");
+			this.piiScanner = piiScanner;
+			return this;
+		}
+
+		/**
+		 * Enables or disables PII scanning (default: {@code true}).
+		 */
+		public Builder piiEnabled(boolean piiEnabled) {
+			this.piiEnabled = piiEnabled;
+			return this;
+		}
+
+		/**
+		 * Replaces the default {@link SessionCostTracker} with a custom one.
+		 */
+		public Builder costTracker(SessionCostTracker costTracker) {
+			Assert.notNull(costTracker, "costTracker must not be null");
+			this.costTracker = costTracker;
+			return this;
+		}
+
+		/**
+		 * Enables or disables budget enforcement (default: {@code true}).
+		 * <p>
+		 * When disabled the {@link SessionCostTracker} is never consulted even if a token
+		 * limit is configured.
+		 */
+		public Builder budgetEnabled(boolean budgetEnabled) {
+			this.budgetEnabled = budgetEnabled;
+			return this;
+		}
+
+		/**
+		 * Sets the context key used to look up the session identifier (default:
+		 * {@value #DEFAULT_SESSION_ID_CONTEXT_KEY}).
+		 */
+		public Builder sessionIdContextKey(String sessionIdContextKey) {
+			Assert.hasText(sessionIdContextKey, "sessionIdContextKey must not be blank");
+			this.sessionIdContextKey = sessionIdContextKey;
+			return this;
+		}
+
+		/**
+		 * Adds an audit listener that is called with every {@link GovernanceDecision}
+		 * produced.
+		 */
+		public Builder auditListener(Consumer<GovernanceDecision> listener) {
+			Assert.notNull(listener, "listener must not be null");
+			this.auditListeners.add(listener);
+			return this;
+		}
+
+		/**
+		 * Sets the advisor order (default: {@code 0}).
+		 */
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		/**
+		 * Sets the {@link Scheduler} used for stream processing (default:
+		 * {@link BaseAdvisor#DEFAULT_SCHEDULER}).
+		 */
+		public Builder scheduler(Scheduler scheduler) {
+			Assert.notNull(scheduler, "scheduler must not be null");
+			this.scheduler = scheduler;
+			return this;
+		}
+
+		/**
+		 * Builds the {@link GovernanceAdvisor}.
+		 */
+		public GovernanceAdvisor build() {
+			return new GovernanceAdvisor(this.mode, this.piiScanner, this.piiEnabled, this.costTracker,
+					this.budgetEnabled, this.sessionIdContextKey, this.auditListeners, this.order, this.scheduler);
+		}
+
+	}
+
+}

--- a/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/GovernanceDecision.java
+++ b/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/GovernanceDecision.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+import org.springframework.util.Assert;
+
+/**
+ * Immutable audit record produced by the {@link GovernanceAdvisor} for every evaluated
+ * request.
+ *
+ * <p>
+ * A {@code GovernanceDecision} carries:
+ * <ul>
+ * <li>a {@code correlationId} that can be used to link this decision to the originating
+ * {@link org.springframework.ai.chat.client.ChatClientRequest} via its context;</li>
+ * <li>the {@code action} taken — one of {@code "ALLOW"} or {@code "DENY"};</li>
+ * <li>a human-readable {@code reason} describing why the action was taken;</li>
+ * <li>a {@code riskScore} in the range {@code [0.0, 1.0]} indicating the severity of any
+ * detected violation (0.0 means no risk);</li>
+ * <li>the {@code evaluationTimeMs} in milliseconds it took to reach the decision.</li>
+ * </ul>
+ *
+ * @param correlationId opaque identifier linking this decision to a request; never
+ * {@code null}
+ * @param action either {@code "ALLOW"} or {@code "DENY"}; never {@code null}
+ * @param reason human-readable description of the decision; never {@code null}
+ * @param riskScore detected risk level in {@code [0.0, 1.0]}
+ * @param evaluationTimeMs time taken to produce this decision in milliseconds
+ * @author Spring AI Contributors
+ * @since 2.0.0
+ */
+public record GovernanceDecision(String correlationId, String action, String reason, double riskScore,
+		long evaluationTimeMs) {
+
+	/**
+	 * Action constant for a request that passed all governance checks.
+	 */
+	public static final String ACTION_ALLOW = "ALLOW";
+
+	/**
+	 * Action constant for a request that was blocked by a governance check.
+	 */
+	public static final String ACTION_DENY = "DENY";
+
+	public GovernanceDecision {
+		Assert.hasText(correlationId, "correlationId must not be blank");
+		Assert.hasText(action, "action must not be blank");
+		Assert.hasText(reason, "reason must not be blank");
+		Assert.isTrue(riskScore >= 0.0 && riskScore <= 1.0, "riskScore must be in [0.0, 1.0]");
+		Assert.isTrue(evaluationTimeMs >= 0, "evaluationTimeMs must be non-negative");
+	}
+
+	/**
+	 * Returns {@code true} when the request was allowed.
+	 */
+	public boolean isAllowed() {
+		return ACTION_ALLOW.equals(this.action);
+	}
+
+	/**
+	 * Returns {@code true} when the request was denied.
+	 */
+	public boolean isDenied() {
+		return ACTION_DENY.equals(this.action);
+	}
+
+}

--- a/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/GovernanceMode.java
+++ b/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/GovernanceMode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+/**
+ * Controls how the {@link GovernanceAdvisor} reacts to a detected policy violation.
+ *
+ * <ul>
+ * <li>{@link #OBSERVE} — the advisor only logs violations; the request proceeds
+ * normally.</li>
+ * <li>{@link #MONITOR} — the advisor logs violations and records metrics; the request
+ * still proceeds.</li>
+ * <li>{@link #ENFORCE} — the advisor blocks the request and throws a
+ * {@link GovernanceViolationException} on any detected violation.</li>
+ * </ul>
+ *
+ * @author Spring AI Contributors
+ * @since 2.0.0
+ */
+public enum GovernanceMode {
+
+	/**
+	 * Passive observation: violations are logged but never block the request.
+	 */
+	OBSERVE,
+
+	/**
+	 * Active monitoring: violations are logged and recorded; the request still proceeds.
+	 */
+	MONITOR,
+
+	/**
+	 * Strict enforcement: any violation immediately blocks the request with a
+	 * {@link GovernanceViolationException}.
+	 */
+	ENFORCE
+
+}

--- a/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/GovernanceViolationException.java
+++ b/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/GovernanceViolationException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+/**
+ * Thrown by the {@link GovernanceAdvisor} when it operates in
+ * {@link GovernanceMode#ENFORCE} mode and a policy violation is detected.
+ *
+ * <p>
+ * The exception always carries the {@link GovernanceDecision} that triggered it, so
+ * callers can inspect the violation details (correlation id, reason, risk score, etc.)
+ * without having to re-evaluate the request.
+ *
+ * @author Spring AI Contributors
+ * @since 2.0.0
+ */
+public class GovernanceViolationException extends RuntimeException {
+
+	private final GovernanceDecision decision;
+
+	/**
+	 * Creates a new exception for the given {@code decision}.
+	 * @param decision the {@link GovernanceDecision} that caused the violation; must not
+	 * be {@code null}
+	 */
+	public GovernanceViolationException(GovernanceDecision decision) {
+		super("Governance violation [" + decision.action() + "]: " + decision.reason());
+		this.decision = decision;
+	}
+
+	/**
+	 * Returns the {@link GovernanceDecision} that triggered this exception.
+	 * @return the decision; never {@code null}
+	 */
+	public GovernanceDecision getDecision() {
+		return this.decision;
+	}
+
+}

--- a/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/PiiScanner.java
+++ b/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/PiiScanner.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * Scans text for common personally identifiable information (PII) patterns.
+ *
+ * <p>
+ * The default scanner recognises:
+ * <ul>
+ * <li>US Social Security Numbers — e.g. {@code 123-45-6789}</li>
+ * <li>Credit / debit card numbers — groups of 4 digits separated by spaces or dashes,
+ * e.g. {@code 4111 1111 1111 1111}</li>
+ * <li>E-mail addresses</li>
+ * <li>Bearer / API tokens in common header formats — e.g.
+ * {@code Authorization: Bearer eyJ…}</li>
+ * </ul>
+ *
+ * <p>
+ * Additional patterns can be supplied via {@link Builder#extraPatterns(List)}. Built-in
+ * checks can be disabled individually through the builder.
+ *
+ * <p>
+ * This scanner performs regex-based heuristics and is intended as a <em>first line of
+ * defence</em>, not a complete PII detection solution. It does not handle obfuscated
+ * input (homoglyphs, zero-width characters, etc.).
+ *
+ * @author Spring AI Contributors
+ * @since 2.0.0
+ */
+public final class PiiScanner {
+
+	// -------------------------------------------------------------------------
+	// Built-in patterns
+	// -------------------------------------------------------------------------
+
+	/** US Social Security Number: 3-2-4 digit groups separated by hyphens. */
+	static final Pattern SSN_PATTERN = Pattern.compile("\\b\\d{3}-\\d{2}-\\d{4}\\b");
+
+	/**
+	 * Credit / debit card: four groups of four digits with space or hyphen separators, or
+	 * a continuous 16-digit string.
+	 */
+	static final Pattern CREDIT_CARD_PATTERN = Pattern.compile("\\b(?:\\d{4}[- ]){3}\\d{4}\\b|\\b\\d{16}\\b");
+
+	/** E-mail address. */
+	static final Pattern EMAIL_PATTERN = Pattern.compile("\\b[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}\\b");
+
+	/** API key / Bearer token appearing in a header-style context. */
+	static final Pattern API_KEY_PATTERN = Pattern
+		.compile("(?i)\\b(?:Authorization\\s*:\\s*Bearer\\s+|api[_\\-]?key\\s*[=:]\\s*)[A-Za-z0-9\\-._~+/]{16,}");
+
+	// -------------------------------------------------------------------------
+	// Fields
+	// -------------------------------------------------------------------------
+
+	private final boolean ssnEnabled;
+
+	private final boolean creditCardEnabled;
+
+	private final boolean emailEnabled;
+
+	private final boolean apiKeyEnabled;
+
+	private final List<Pattern> extraPatterns;
+
+	// -------------------------------------------------------------------------
+	// Constructor (package-private, use Builder)
+	// -------------------------------------------------------------------------
+
+	private PiiScanner(boolean ssnEnabled, boolean creditCardEnabled, boolean emailEnabled, boolean apiKeyEnabled,
+			List<Pattern> extraPatterns) {
+		this.ssnEnabled = ssnEnabled;
+		this.creditCardEnabled = creditCardEnabled;
+		this.emailEnabled = emailEnabled;
+		this.apiKeyEnabled = apiKeyEnabled;
+		this.extraPatterns = List.copyOf(extraPatterns);
+	}
+
+	// -------------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns {@code true} when any enabled PII pattern matches inside {@code text}.
+	 * @param text the text to inspect; may be {@code null} (returns {@code false})
+	 */
+	public boolean containsPii(@Nullable String text) {
+		if (text == null || text.isBlank()) {
+			return false;
+		}
+		return (this.ssnEnabled && SSN_PATTERN.matcher(text).find())
+				|| (this.creditCardEnabled && CREDIT_CARD_PATTERN.matcher(text).find())
+				|| (this.emailEnabled && EMAIL_PATTERN.matcher(text).find())
+				|| (this.apiKeyEnabled && API_KEY_PATTERN.matcher(text).find())
+				|| this.extraPatterns.stream().anyMatch(p -> p.matcher(text).find());
+	}
+
+	/**
+	 * Returns a human-readable description of the first PII type detected in
+	 * {@code text}, or {@code null} when nothing is detected.
+	 * @param text the text to inspect; may be {@code null}
+	 * @return a description like {@code "SSN"}, {@code "credit card"}, {@code "email"},
+	 * {@code "API key/token"}, or {@code "custom pattern"}, or {@code null}
+	 */
+	public @Nullable String firstMatchDescription(@Nullable String text) {
+		if (text == null || text.isBlank()) {
+			return null;
+		}
+		if (this.ssnEnabled && SSN_PATTERN.matcher(text).find()) {
+			return "SSN";
+		}
+		if (this.creditCardEnabled && CREDIT_CARD_PATTERN.matcher(text).find()) {
+			return "credit card";
+		}
+		if (this.emailEnabled && EMAIL_PATTERN.matcher(text).find()) {
+			return "email";
+		}
+		if (this.apiKeyEnabled && API_KEY_PATTERN.matcher(text).find()) {
+			return "API key/token";
+		}
+		if (this.extraPatterns.stream().anyMatch(p -> p.matcher(text).find())) {
+			return "custom pattern";
+		}
+		return null;
+	}
+
+	// -------------------------------------------------------------------------
+	// Builder
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns a new {@link Builder} with all built-in checks enabled.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for {@link PiiScanner}.
+	 */
+	public static final class Builder {
+
+		private boolean ssnEnabled = true;
+
+		private boolean creditCardEnabled = true;
+
+		private boolean emailEnabled = true;
+
+		private boolean apiKeyEnabled = true;
+
+		private final List<Pattern> extraPatterns = new ArrayList<>();
+
+		private Builder() {
+		}
+
+		/**
+		 * Enables or disables SSN detection (default: {@code true}).
+		 */
+		public Builder ssnEnabled(boolean ssnEnabled) {
+			this.ssnEnabled = ssnEnabled;
+			return this;
+		}
+
+		/**
+		 * Enables or disables credit/debit card detection (default: {@code true}).
+		 */
+		public Builder creditCardEnabled(boolean creditCardEnabled) {
+			this.creditCardEnabled = creditCardEnabled;
+			return this;
+		}
+
+		/**
+		 * Enables or disables e-mail detection (default: {@code true}).
+		 */
+		public Builder emailEnabled(boolean emailEnabled) {
+			this.emailEnabled = emailEnabled;
+			return this;
+		}
+
+		/**
+		 * Enables or disables API key / Bearer token detection (default: {@code true}).
+		 */
+		public Builder apiKeyEnabled(boolean apiKeyEnabled) {
+			this.apiKeyEnabled = apiKeyEnabled;
+			return this;
+		}
+
+		/**
+		 * Appends additional compiled {@link Pattern}s to scan for. All patterns are
+		 * always applied after the built-in ones.
+		 * @param patterns the extra patterns; must not be {@code null}
+		 */
+		public Builder extraPatterns(List<Pattern> patterns) {
+			Assert.notNull(patterns, "patterns must not be null");
+			this.extraPatterns.addAll(patterns);
+			return this;
+		}
+
+		/**
+		 * Builds the {@link PiiScanner}.
+		 */
+		public PiiScanner build() {
+			return new PiiScanner(this.ssnEnabled, this.creditCardEnabled, this.emailEnabled, this.apiKeyEnabled,
+					this.extraPatterns);
+		}
+
+	}
+
+}

--- a/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/SessionCostTracker.java
+++ b/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/SessionCostTracker.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.util.Assert;
+
+/**
+ * Tracks token consumption per session and enforces an optional per-session token budget.
+ *
+ * <p>
+ * Token counts are incremented by calling {@link #recordUsage(String, ChatResponse)}
+ * after every model response. The total consumed tokens for a session can be retrieved
+ * with {@link #getTokenCount(String)}. Sessions can be cleared with
+ * {@link #clearSession(String)}.
+ *
+ * <p>
+ * When a {@code tokenLimit} greater than zero is configured, a call to
+ * {@link #checkBudget(String)} throws {@link BudgetExceededException} if the accumulated
+ * token count for that session has reached or exceeded the limit.
+ *
+ * @author Spring AI Contributors
+ * @since 2.0.0
+ */
+public final class SessionCostTracker {
+
+	private static final Log logger = LogFactory.getLog(SessionCostTracker.class);
+
+	/**
+	 * Sentinel value meaning "no budget limit is enforced".
+	 */
+	public static final long UNLIMITED = 0L;
+
+	private final long tokenLimit;
+
+	private final ConcurrentHashMap<String, LongAdder> sessionTokens = new ConcurrentHashMap<>();
+
+	/**
+	 * Creates a tracker with no token limit.
+	 */
+	public SessionCostTracker() {
+		this(UNLIMITED);
+	}
+
+	/**
+	 * Creates a tracker with the given per-session token limit.
+	 * @param tokenLimit maximum tokens allowed per session; use {@link #UNLIMITED} (or
+	 * any value {@code <= 0}) to disable enforcement
+	 */
+	public SessionCostTracker(long tokenLimit) {
+		this.tokenLimit = tokenLimit;
+	}
+
+	// -------------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Records token usage reported in {@code chatResponse} for {@code sessionId}.
+	 * <p>
+	 * If the response contains no usage metadata the call is a no-op.
+	 * @param sessionId the session to charge; must not be {@code null}
+	 * @param chatResponse the response from the model; may be {@code null}
+	 */
+	public void recordUsage(String sessionId, ChatResponse chatResponse) {
+		Assert.hasText(sessionId, "sessionId must not be blank");
+		if (chatResponse == null || chatResponse.getMetadata() == null) {
+			return;
+		}
+		Usage usage = chatResponse.getMetadata().getUsage();
+		if (usage == null) {
+			return;
+		}
+		long tokens = safeTokenCount(usage);
+		if (tokens > 0) {
+			this.sessionTokens.computeIfAbsent(sessionId, id -> new LongAdder()).add(tokens);
+			if (logger.isDebugEnabled()) {
+				logger.debug("Session '" + sessionId + "' consumed " + tokens + " tokens (total: "
+						+ this.sessionTokens.get(sessionId).sum() + ")");
+			}
+		}
+	}
+
+	/**
+	 * Returns the total number of tokens consumed by {@code sessionId} so far.
+	 * @param sessionId the session identifier; must not be {@code null}
+	 * @return token count; {@code 0} if no usage has been recorded
+	 */
+	public long getTokenCount(String sessionId) {
+		Assert.hasText(sessionId, "sessionId must not be blank");
+		LongAdder adder = this.sessionTokens.get(sessionId);
+		return adder != null ? adder.sum() : 0L;
+	}
+
+	/**
+	 * Checks whether {@code sessionId} has exceeded its token budget and throws
+	 * {@link BudgetExceededException} if it has.
+	 * <p>
+	 * When {@link #tokenLimit} is {@link #UNLIMITED} this is always a no-op.
+	 * @param sessionId the session to check; must not be {@code null}
+	 * @throws BudgetExceededException when the session token count &ge; the configured
+	 * limit
+	 */
+	public void checkBudget(String sessionId) {
+		Assert.hasText(sessionId, "sessionId must not be blank");
+		if (this.tokenLimit <= UNLIMITED) {
+			return;
+		}
+		long current = getTokenCount(sessionId);
+		if (current >= this.tokenLimit) {
+			throw new BudgetExceededException(sessionId, this.tokenLimit, current);
+		}
+	}
+
+	/**
+	 * Removes all recorded token usage for {@code sessionId}.
+	 * @param sessionId the session to clear; must not be {@code null}
+	 */
+	public void clearSession(String sessionId) {
+		Assert.hasText(sessionId, "sessionId must not be blank");
+		this.sessionTokens.remove(sessionId);
+	}
+
+	/**
+	 * Returns whether a token limit is configured.
+	 */
+	public boolean hasLimit() {
+		return this.tokenLimit > UNLIMITED;
+	}
+
+	/**
+	 * Returns the configured token limit, or {@link #UNLIMITED} if none is set.
+	 */
+	public long getTokenLimit() {
+		return this.tokenLimit;
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private static long safeTokenCount(Usage usage) {
+		// Prefer total tokens; fall back to prompt + completion sum when total is absent.
+		try {
+			Integer total = usage.getTotalTokens();
+			if (total != null && total > 0) {
+				return total.longValue();
+			}
+			long prompt = usage.getPromptTokens() != null ? usage.getPromptTokens().longValue() : 0L;
+			long completion = usage.getCompletionTokens() != null ? usage.getCompletionTokens().longValue() : 0L;
+			return prompt + completion;
+		}
+		catch (UnsupportedOperationException ex) {
+			return 0L;
+		}
+	}
+
+}

--- a/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/package-info.java
+++ b/advisors/spring-ai-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Governance advisor for Spring AI providing PII scanning, session token budget tracking,
+ * and structured audit records.
+ */
+@NullMarked
+package org.springframework.ai.chat.client.advisor.governance;
+
+import org.jspecify.annotations.NullMarked;

--- a/advisors/spring-ai-governance-advisor/src/test/java/org/springframework/ai/chat/client/advisor/governance/GovernanceAdvisorTests.java
+++ b/advisors/spring-ai-governance-advisor/src/test/java/org/springframework/ai/chat/client/advisor/governance/GovernanceAdvisorTests.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link GovernanceAdvisor}.
+ *
+ * @author Spring AI Contributors
+ */
+@ExtendWith(MockitoExtension.class)
+class GovernanceAdvisorTests {
+
+	@Mock
+	private ChatModel chatModel;
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private static ChatResponse okResponse() {
+		return ChatResponse.builder().generations(List.of(new Generation(new AssistantMessage("ok")))).build();
+	}
+
+	private ChatClient chatClientWith(GovernanceAdvisor advisor) {
+		given(this.chatModel.getOptions()).willReturn(ChatOptions.builder().build());
+		return ChatClient.builder(this.chatModel).defaultAdvisors(advisor).build();
+	}
+
+	// -------------------------------------------------------------------------
+	// ENFORCE — PII detection
+	// -------------------------------------------------------------------------
+
+	@Test
+	void blocksPiiInEnforceMode() {
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder().mode(GovernanceMode.ENFORCE).build();
+		ChatClient client = chatClientWith(advisor);
+
+		assertThatThrownBy(() -> client.prompt().user("My SSN is 123-45-6789").call().chatResponse())
+			.isInstanceOf(GovernanceViolationException.class)
+			.satisfies(ex -> {
+				GovernanceDecision d = ((GovernanceViolationException) ex).getDecision();
+				assertThat(d.action()).isEqualTo(GovernanceDecision.ACTION_DENY);
+				assertThat(d.reason()).containsIgnoringCase("PII");
+				assertThat(d.riskScore()).isGreaterThan(0.0);
+			});
+
+		verify(this.chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void allowsCleanPromptInEnforceMode() {
+		given(this.chatModel.call(any(Prompt.class))).willReturn(okResponse());
+
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder().mode(GovernanceMode.ENFORCE).build();
+		ChatClient client = chatClientWith(advisor);
+
+		ChatResponse response = client.prompt()
+			.user("Explain Spring Boot security best practices")
+			.call()
+			.chatResponse();
+
+		assertThat(response).isNotNull();
+	}
+
+	// -------------------------------------------------------------------------
+	// OBSERVE — PII passes through
+	// -------------------------------------------------------------------------
+
+	@Test
+	void piiPassesThroughInObserveMode() {
+		given(this.chatModel.call(any(Prompt.class))).willReturn(okResponse());
+
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder().mode(GovernanceMode.OBSERVE).build();
+		ChatClient client = chatClientWith(advisor);
+
+		// Should NOT throw in OBSERVE mode
+		ChatResponse response = client.prompt().user("My SSN is 123-45-6789").call().chatResponse();
+
+		assertThat(response).isNotNull();
+		verify(this.chatModel).call(any(Prompt.class));
+	}
+
+	// -------------------------------------------------------------------------
+	// MONITOR — PII passes through
+	// -------------------------------------------------------------------------
+
+	@Test
+	void piiPassesThroughInMonitorMode() {
+		given(this.chatModel.call(any(Prompt.class))).willReturn(okResponse());
+
+		List<GovernanceDecision> audit = new ArrayList<>();
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder()
+			.mode(GovernanceMode.MONITOR)
+			.auditListener(audit::add)
+			.build();
+		ChatClient client = chatClientWith(advisor);
+
+		client.prompt().user("My SSN is 123-45-6789").call().chatResponse();
+
+		assertThat(audit).hasSize(1);
+		assertThat(audit.get(0).action()).isEqualTo(GovernanceDecision.ACTION_DENY);
+	}
+
+	// -------------------------------------------------------------------------
+	// Budget enforcement
+	// -------------------------------------------------------------------------
+
+	@Test
+	void blocksBudgetExceededInEnforceMode() {
+		SessionCostTracker tracker = new SessionCostTracker(10L);
+		// Pre-seed the session to already be at the limit.
+		tracker.recordUsage("session-1", buildResponse(10L));
+
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder()
+			.mode(GovernanceMode.ENFORCE)
+			.costTracker(tracker)
+			.piiEnabled(false)
+			.build();
+		ChatClient client = chatClientWith(advisor);
+
+		assertThatThrownBy(() -> client.prompt()
+			.user("What is 1 + 1?")
+			.advisors(a -> a.param(GovernanceAdvisor.DEFAULT_SESSION_ID_CONTEXT_KEY, "session-1"))
+			.call()
+			.chatResponse()).isInstanceOf(GovernanceViolationException.class).satisfies(ex -> {
+				GovernanceDecision d = ((GovernanceViolationException) ex).getDecision();
+				assertThat(d.action()).isEqualTo(GovernanceDecision.ACTION_DENY);
+				assertThat(d.reason()).containsIgnoringCase("budget");
+			});
+
+		verify(this.chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void allowsRequestWithinBudget() {
+		given(this.chatModel.call(any(Prompt.class))).willReturn(okResponse());
+
+		SessionCostTracker tracker = new SessionCostTracker(1000L);
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder()
+			.mode(GovernanceMode.ENFORCE)
+			.costTracker(tracker)
+			.piiEnabled(false)
+			.build();
+		ChatClient client = chatClientWith(advisor);
+
+		ChatResponse response = client.prompt()
+			.user("What is 1 + 1?")
+			.advisors(a -> a.param(GovernanceAdvisor.DEFAULT_SESSION_ID_CONTEXT_KEY, "session-2"))
+			.call()
+			.chatResponse();
+
+		assertThat(response).isNotNull();
+	}
+
+	// -------------------------------------------------------------------------
+	// Audit listener
+	// -------------------------------------------------------------------------
+
+	@Test
+	void auditListenerReceivesAllowDecision() {
+		given(this.chatModel.call(any(Prompt.class))).willReturn(okResponse());
+
+		List<GovernanceDecision> decisions = new ArrayList<>();
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder()
+			.mode(GovernanceMode.ENFORCE)
+			.auditListener(decisions::add)
+			.build();
+		ChatClient client = chatClientWith(advisor);
+
+		client.prompt().user("Explain Spring Boot").call().chatResponse();
+
+		assertThat(decisions).hasSize(1);
+		assertThat(decisions.get(0).isAllowed()).isTrue();
+		assertThat(decisions.get(0).correlationId()).isNotBlank();
+		assertThat(decisions.get(0).evaluationTimeMs()).isGreaterThanOrEqualTo(0L);
+	}
+
+	@Test
+	void auditListenerReceivesDenyDecision() {
+		List<GovernanceDecision> decisions = new ArrayList<>();
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder()
+			.mode(GovernanceMode.ENFORCE)
+			.auditListener(decisions::add)
+			.build();
+		ChatClient client = chatClientWith(advisor);
+
+		assertThatThrownBy(() -> client.prompt().user("My SSN is 123-45-6789").call().chatResponse());
+
+		assertThat(decisions).hasSize(1);
+		assertThat(decisions.get(0).isDenied()).isTrue();
+		assertThat(decisions.get(0).riskScore()).isGreaterThan(0.0);
+	}
+
+	// -------------------------------------------------------------------------
+	// Governance decision in response context
+	// -------------------------------------------------------------------------
+
+	@Test
+	void governanceDecisionStoredInResponseContext() {
+		given(this.chatModel.call(any(Prompt.class))).willReturn(okResponse());
+
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder().mode(GovernanceMode.ENFORCE).build();
+		given(this.chatModel.getOptions()).willReturn(ChatOptions.builder().build());
+
+		ChatClient client = ChatClient.builder(this.chatModel).defaultAdvisors(advisor).build();
+
+		// Use the lower-level API to inspect the context map.
+		var response = client.prompt().user("Hello").call().chatClientResponse();
+		assertThat(response).isNotNull();
+		assertThat(response.context()).containsKey(GovernanceAdvisor.GOVERNANCE_DECISION_CONTEXT_KEY);
+
+		GovernanceDecision d = (GovernanceDecision) response.context()
+			.get(GovernanceAdvisor.GOVERNANCE_DECISION_CONTEXT_KEY);
+		assertThat(d).isNotNull();
+		assertThat(d.isAllowed()).isTrue();
+	}
+
+	// -------------------------------------------------------------------------
+	// PII disabled
+	// -------------------------------------------------------------------------
+
+	@Test
+	void piiCheckCanBeDisabled() {
+		given(this.chatModel.call(any(Prompt.class))).willReturn(okResponse());
+
+		GovernanceAdvisor advisor = GovernanceAdvisor.builder().mode(GovernanceMode.ENFORCE).piiEnabled(false).build();
+		ChatClient client = chatClientWith(advisor);
+
+		// SSN present but PII check is off — should not throw
+		ChatResponse response = client.prompt().user("My SSN is 123-45-6789").call().chatResponse();
+
+		assertThat(response).isNotNull();
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private static ChatResponse buildResponse(long totalTokens) {
+		int total = (int) totalTokens;
+		int half = total / 2;
+		return ChatResponse.builder()
+			.generations(List.of(new Generation(new AssistantMessage("ok"))))
+			.metadata(org.springframework.ai.chat.metadata.ChatResponseMetadata.builder()
+				.usage(new org.springframework.ai.chat.metadata.DefaultUsage(half, half, total))
+				.build())
+			.build();
+	}
+
+}

--- a/advisors/spring-ai-governance-advisor/src/test/java/org/springframework/ai/chat/client/advisor/governance/PiiScannerTests.java
+++ b/advisors/spring-ai-governance-advisor/src/test/java/org/springframework/ai/chat/client/advisor/governance/PiiScannerTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PiiScanner}.
+ *
+ * @author Spring AI Contributors
+ */
+class PiiScannerTests {
+
+	private final PiiScanner scanner = PiiScanner.builder().build();
+
+	// -------------------------------------------------------------------------
+	// SSN
+	// -------------------------------------------------------------------------
+
+	@Test
+	void detectsSsn() {
+		assertThat(this.scanner.containsPii("My SSN is 123-45-6789")).isTrue();
+	}
+
+	@Test
+	void detectsSsnDescription() {
+		assertThat(this.scanner.firstMatchDescription("SSN 123-45-6789")).isEqualTo("SSN");
+	}
+
+	@Test
+	void doesNotFlagNonSsn() {
+		// Phone-like pattern that does not match the SSN regex
+		assertThat(this.scanner.containsPii("Call me on 800-123-4567")).isFalse();
+	}
+
+	// -------------------------------------------------------------------------
+	// Credit card
+	// -------------------------------------------------------------------------
+
+	@Test
+	void detectsCreditCardWithSpaces() {
+		assertThat(this.scanner.containsPii("Card: 4111 1111 1111 1111")).isTrue();
+	}
+
+	@Test
+	void detectsCreditCardWithDashes() {
+		assertThat(this.scanner.containsPii("Card: 4111-1111-1111-1111")).isTrue();
+	}
+
+	@Test
+	void detectsCreditCardContinuous() {
+		assertThat(this.scanner.containsPii("pay with 4111111111111111 now")).isTrue();
+	}
+
+	// -------------------------------------------------------------------------
+	// E-mail
+	// -------------------------------------------------------------------------
+
+	@Test
+	void detectsEmail() {
+		assertThat(this.scanner.containsPii("Contact user@example.com for details")).isTrue();
+	}
+
+	@Test
+	void detectsEmailDescription() {
+		assertThat(this.scanner.firstMatchDescription("email: alice@example.org")).isEqualTo("email");
+	}
+
+	// -------------------------------------------------------------------------
+	// API key / Bearer token
+	// -------------------------------------------------------------------------
+
+	@Test
+	void detectsBearerToken() {
+		assertThat(this.scanner.containsPii("Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")).isTrue();
+	}
+
+	@Test
+	void detectsApiKeyAssignment() {
+		assertThat(this.scanner.containsPii("api_key=sk-abcdefghijklmnopqrstuvwxyz0123456789")).isTrue();
+	}
+
+	// -------------------------------------------------------------------------
+	// Clean prompts
+	// -------------------------------------------------------------------------
+
+	@Test
+	void allowsCleanPrompt() {
+		assertThat(this.scanner.containsPii("Explain Spring Boot security best practices")).isFalse();
+	}
+
+	@Test
+	void nullTextIsClean() {
+		assertThat(this.scanner.containsPii(null)).isFalse();
+	}
+
+	@Test
+	void blankTextIsClean() {
+		assertThat(this.scanner.containsPii("   ")).isFalse();
+	}
+
+	@Test
+	void firstMatchDescriptionNullForCleanText() {
+		assertThat(this.scanner.firstMatchDescription("hello world")).isNull();
+	}
+
+	// -------------------------------------------------------------------------
+	// Disabling built-in checks
+	// -------------------------------------------------------------------------
+
+	@Test
+	void ssnCheckCanBeDisabled() {
+		PiiScanner noSsn = PiiScanner.builder().ssnEnabled(false).build();
+		assertThat(noSsn.containsPii("SSN 123-45-6789")).isFalse();
+	}
+
+	@Test
+	void emailCheckCanBeDisabled() {
+		PiiScanner noEmail = PiiScanner.builder().emailEnabled(false).build();
+		assertThat(noEmail.containsPii("user@example.com")).isFalse();
+	}
+
+	// -------------------------------------------------------------------------
+	// Extra patterns
+	// -------------------------------------------------------------------------
+
+	@Test
+	void customPatternIsApplied() {
+		PiiScanner custom = PiiScanner.builder()
+			.ssnEnabled(false)
+			.creditCardEnabled(false)
+			.emailEnabled(false)
+			.apiKeyEnabled(false)
+			.extraPatterns(List.of(Pattern.compile("SECRET_WORD")))
+			.build();
+		assertThat(custom.containsPii("do not share SECRET_WORD with anyone")).isTrue();
+		assertThat(custom.firstMatchDescription("SECRET_WORD found")).isEqualTo("custom pattern");
+	}
+
+}

--- a/advisors/spring-ai-governance-advisor/src/test/java/org/springframework/ai/chat/client/advisor/governance/SessionCostTrackerTests.java
+++ b/advisors/spring-ai-governance-advisor/src/test/java/org/springframework/ai/chat/client/advisor/governance/SessionCostTrackerTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link SessionCostTracker}.
+ *
+ * @author Spring AI Contributors
+ */
+class SessionCostTrackerTests {
+
+	// -------------------------------------------------------------------------
+	// No limit
+	// -------------------------------------------------------------------------
+
+	@Test
+	void noLimitNeverThrows() {
+		SessionCostTracker tracker = new SessionCostTracker();
+		tracker.recordUsage("s1", buildResponse(1_000_000L));
+		// Should not throw
+		tracker.checkBudget("s1");
+		assertThat(tracker.hasLimit()).isFalse();
+	}
+
+	@Test
+	void tokenCountAccumulatesAcrossResponses() {
+		SessionCostTracker tracker = new SessionCostTracker();
+		tracker.recordUsage("s1", buildResponse(100L));
+		tracker.recordUsage("s1", buildResponse(50L));
+		assertThat(tracker.getTokenCount("s1")).isEqualTo(150L);
+	}
+
+	@Test
+	void separateSessionsTrackedIndependently() {
+		SessionCostTracker tracker = new SessionCostTracker();
+		tracker.recordUsage("s1", buildResponse(200L));
+		tracker.recordUsage("s2", buildResponse(300L));
+		assertThat(tracker.getTokenCount("s1")).isEqualTo(200L);
+		assertThat(tracker.getTokenCount("s2")).isEqualTo(300L);
+	}
+
+	@Test
+	void zeroCountForUnknownSession() {
+		SessionCostTracker tracker = new SessionCostTracker();
+		assertThat(tracker.getTokenCount("unknown")).isZero();
+	}
+
+	// -------------------------------------------------------------------------
+	// With limit
+	// -------------------------------------------------------------------------
+
+	@Test
+	void budgetNotExceededBelowLimit() {
+		SessionCostTracker tracker = new SessionCostTracker(500L);
+		tracker.recordUsage("s1", buildResponse(499L));
+		// Should not throw
+		tracker.checkBudget("s1");
+	}
+
+	@Test
+	void budgetExceededAtLimit() {
+		SessionCostTracker tracker = new SessionCostTracker(500L);
+		tracker.recordUsage("s1", buildResponse(500L));
+		assertThatThrownBy(() -> tracker.checkBudget("s1")).isInstanceOf(BudgetExceededException.class)
+			.hasMessageContaining("s1")
+			.satisfies(ex -> {
+				BudgetExceededException bex = (BudgetExceededException) ex;
+				assertThat(bex.getSessionId()).isEqualTo("s1");
+				assertThat(bex.getTokenLimit()).isEqualTo(500L);
+				assertThat(bex.getCurrentTokenCount()).isEqualTo(500L);
+			});
+	}
+
+	@Test
+	void budgetExceededAboveLimit() {
+		SessionCostTracker tracker = new SessionCostTracker(100L);
+		tracker.recordUsage("s1", buildResponse(50L));
+		tracker.recordUsage("s1", buildResponse(60L));
+		assertThatThrownBy(() -> tracker.checkBudget("s1")).isInstanceOf(BudgetExceededException.class);
+	}
+
+	// -------------------------------------------------------------------------
+	// Clear session
+	// -------------------------------------------------------------------------
+
+	@Test
+	void clearSessionResetsCount() {
+		SessionCostTracker tracker = new SessionCostTracker(100L);
+		tracker.recordUsage("s1", buildResponse(90L));
+		tracker.clearSession("s1");
+		assertThat(tracker.getTokenCount("s1")).isZero();
+		// Should not throw after reset
+		tracker.checkBudget("s1");
+	}
+
+	// -------------------------------------------------------------------------
+	// Null / missing response
+	// -------------------------------------------------------------------------
+
+	@Test
+	void nullResponseIsIgnored() {
+		SessionCostTracker tracker = new SessionCostTracker(100L);
+		tracker.recordUsage("s1", null);
+		assertThat(tracker.getTokenCount("s1")).isZero();
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private static ChatResponse buildResponse(long totalTokens) {
+		int total = (int) totalTokens;
+		int half = total / 2;
+		return ChatResponse.builder()
+			.generations(
+					java.util.List.of(new Generation(new org.springframework.ai.chat.messages.AssistantMessage("ok"))))
+			.metadata(org.springframework.ai.chat.metadata.ChatResponseMetadata.builder()
+				.usage(new DefaultUsage(half, half, total))
+				.build())
+			.build();
+	}
+
+}

--- a/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/pom.xml
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-autoconfigure-governance-advisor</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Governance Advisor Auto Configuration</name>
+	<description>Spring Boot auto-configuration for the Spring AI Governance Advisor.</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-governance-advisor</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-test-autoconfigure</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/autoconfigure/GovernanceAdvisorAutoConfiguration.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/autoconfigure/GovernanceAdvisorAutoConfiguration.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance.autoconfigure;
+
+import org.springframework.ai.chat.client.advisor.governance.GovernanceAdvisor;
+import org.springframework.ai.chat.client.advisor.governance.PiiScanner;
+import org.springframework.ai.chat.client.advisor.governance.SessionCostTracker;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link GovernanceAdvisor}.
+ *
+ * <p>
+ * Activated when {@code spring.ai.advisor.governance.enabled=true} is set and
+ * {@link GovernanceAdvisor} is on the classpath. All advisor components — the
+ * {@link PiiScanner}, the {@link SessionCostTracker}, and the {@link GovernanceAdvisor}
+ * itself — are registered as beans and can be individually replaced by declaring beans of
+ * the same type in the application context.
+ *
+ * @author Spring AI Contributors
+ * @since 2.0.0
+ */
+@AutoConfiguration
+@ConditionalOnClass(GovernanceAdvisor.class)
+@EnableConfigurationProperties(GovernanceAdvisorProperties.class)
+@ConditionalOnProperty(prefix = GovernanceAdvisorProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")
+public class GovernanceAdvisorAutoConfiguration {
+
+	/**
+	 * Registers the {@link PiiScanner} bean.
+	 * <p>
+	 * Skipped when the application already declares a {@link PiiScanner} bean.
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	PiiScanner piiScanner(GovernanceAdvisorProperties properties) {
+		GovernanceAdvisorProperties.Pii pii = properties.getPii();
+		return PiiScanner.builder()
+			.ssnEnabled(pii.isSsnEnabled())
+			.creditCardEnabled(pii.isCreditCardEnabled())
+			.emailEnabled(pii.isEmailEnabled())
+			.apiKeyEnabled(pii.isApiKeyEnabled())
+			.build();
+	}
+
+	/**
+	 * Registers the {@link SessionCostTracker} bean.
+	 * <p>
+	 * Skipped when the application already declares a {@link SessionCostTracker} bean.
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	SessionCostTracker sessionCostTracker(GovernanceAdvisorProperties properties) {
+		return new SessionCostTracker(properties.getBudget().getTokenLimit());
+	}
+
+	/**
+	 * Registers the {@link GovernanceAdvisor} bean.
+	 * <p>
+	 * Skipped when the application already declares a {@link GovernanceAdvisor} bean.
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	GovernanceAdvisor governanceAdvisor(GovernanceAdvisorProperties properties, PiiScanner piiScanner,
+			SessionCostTracker sessionCostTracker) {
+		return GovernanceAdvisor.builder()
+			.mode(properties.getMode())
+			.piiScanner(piiScanner)
+			.piiEnabled(properties.getPii().isEnabled())
+			.costTracker(sessionCostTracker)
+			.budgetEnabled(properties.getBudget().isEnabled())
+			.sessionIdContextKey(properties.getSessionIdContextKey())
+			.order(properties.getAdvisorOrder())
+			.build();
+	}
+
+}

--- a/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/autoconfigure/GovernanceAdvisorProperties.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/autoconfigure/GovernanceAdvisorProperties.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance.autoconfigure;
+
+import org.springframework.ai.chat.client.advisor.governance.GovernanceAdvisor;
+import org.springframework.ai.chat.client.advisor.governance.GovernanceMode;
+import org.springframework.ai.chat.client.advisor.governance.SessionCostTracker;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for {@link GovernanceAdvisorAutoConfiguration}.
+ *
+ * <p>
+ * All properties share the prefix {@code spring.ai.advisor.governance}.
+ *
+ * <p>
+ * Example {@code application.yml}: <pre>{@code
+ * spring:
+ *   ai:
+ *     advisor:
+ *       governance:
+ *         enabled: true
+ *         mode: enforce
+ *         pii:
+ *           enabled: true
+ *         budget:
+ *           enabled: true
+ *           token-limit: 10000
+ * }</pre>
+ *
+ * @author Spring AI Contributors
+ * @since 2.0.0
+ */
+@ConfigurationProperties(GovernanceAdvisorProperties.CONFIG_PREFIX)
+public class GovernanceAdvisorProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.advisor.governance";
+
+	/**
+	 * Whether to register the {@link GovernanceAdvisor} bean automatically.
+	 */
+	private boolean enabled = false;
+
+	/**
+	 * Governance enforcement mode. One of {@code observe}, {@code monitor}, or
+	 * {@code enforce} (default: {@code enforce}).
+	 */
+	private GovernanceMode mode = GovernanceMode.ENFORCE;
+
+	/**
+	 * Advisor order in the advisor chain (default: {@code 0}).
+	 */
+	private int advisorOrder = 0;
+
+	/**
+	 * Key in the request context that holds the session / conversation identifier used
+	 * for budget tracking. Defaults to
+	 * {@value GovernanceAdvisor#DEFAULT_SESSION_ID_CONTEXT_KEY}.
+	 */
+	private String sessionIdContextKey = GovernanceAdvisor.DEFAULT_SESSION_ID_CONTEXT_KEY;
+
+	private final Pii pii = new Pii();
+
+	private final Budget budget = new Budget();
+
+	// -------------------------------------------------------------------------
+	// Getters / setters
+	// -------------------------------------------------------------------------
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public GovernanceMode getMode() {
+		return this.mode;
+	}
+
+	public void setMode(GovernanceMode mode) {
+		this.mode = mode;
+	}
+
+	public int getAdvisorOrder() {
+		return this.advisorOrder;
+	}
+
+	public void setAdvisorOrder(int advisorOrder) {
+		this.advisorOrder = advisorOrder;
+	}
+
+	public String getSessionIdContextKey() {
+		return this.sessionIdContextKey;
+	}
+
+	public void setSessionIdContextKey(String sessionIdContextKey) {
+		this.sessionIdContextKey = sessionIdContextKey;
+	}
+
+	public Pii getPii() {
+		return this.pii;
+	}
+
+	public Budget getBudget() {
+		return this.budget;
+	}
+
+	// -------------------------------------------------------------------------
+	// Nested property classes
+	// -------------------------------------------------------------------------
+
+	/**
+	 * PII-scanning sub-properties.
+	 */
+	public static class Pii {
+
+		/**
+		 * Whether PII scanning is enabled (default: {@code true}).
+		 */
+		private boolean enabled = true;
+
+		/**
+		 * Whether to scan for US Social Security Numbers (default: {@code true}).
+		 */
+		private boolean ssnEnabled = true;
+
+		/**
+		 * Whether to scan for credit/debit card numbers (default: {@code true}).
+		 */
+		private boolean creditCardEnabled = true;
+
+		/**
+		 * Whether to scan for e-mail addresses (default: {@code true}).
+		 */
+		private boolean emailEnabled = true;
+
+		/**
+		 * Whether to scan for API keys and Bearer tokens (default: {@code true}).
+		 */
+		private boolean apiKeyEnabled = true;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public boolean isSsnEnabled() {
+			return this.ssnEnabled;
+		}
+
+		public void setSsnEnabled(boolean ssnEnabled) {
+			this.ssnEnabled = ssnEnabled;
+		}
+
+		public boolean isCreditCardEnabled() {
+			return this.creditCardEnabled;
+		}
+
+		public void setCreditCardEnabled(boolean creditCardEnabled) {
+			this.creditCardEnabled = creditCardEnabled;
+		}
+
+		public boolean isEmailEnabled() {
+			return this.emailEnabled;
+		}
+
+		public void setEmailEnabled(boolean emailEnabled) {
+			this.emailEnabled = emailEnabled;
+		}
+
+		public boolean isApiKeyEnabled() {
+			return this.apiKeyEnabled;
+		}
+
+		public void setApiKeyEnabled(boolean apiKeyEnabled) {
+			this.apiKeyEnabled = apiKeyEnabled;
+		}
+
+	}
+
+	/**
+	 * Session token budget sub-properties.
+	 */
+	public static class Budget {
+
+		/**
+		 * Whether budget tracking and enforcement is enabled (default: {@code true}).
+		 */
+		private boolean enabled = true;
+
+		/**
+		 * Maximum number of tokens allowed per session. A value of
+		 * {@link SessionCostTracker#UNLIMITED} (zero or negative) means no limit is
+		 * enforced (default: no limit).
+		 */
+		private long tokenLimit = SessionCostTracker.UNLIMITED;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public long getTokenLimit() {
+			return this.tokenLimit;
+		}
+
+		public void setTokenLimit(long tokenLimit) {
+			this.tokenLimit = tokenLimit;
+		}
+
+	}
+
+}

--- a/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/autoconfigure/package-info.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/main/java/org/springframework/ai/chat/client/advisor/governance/autoconfigure/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Spring Boot auto-configuration for the Spring AI Governance Advisor.
+ */
+@NullMarked
+package org.springframework.ai.chat.client.advisor.governance.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.ai.chat.client.advisor.governance.autoconfigure.GovernanceAdvisorAutoConfiguration

--- a/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/test/java/org/springframework/ai/chat/client/advisor/governance/autoconfigure/GovernanceAdvisorAutoConfigurationTests.java
+++ b/auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor/src/test/java/org/springframework/ai/chat/client/advisor/governance/autoconfigure/GovernanceAdvisorAutoConfigurationTests.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.governance.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.advisor.governance.GovernanceAdvisor;
+import org.springframework.ai.chat.client.advisor.governance.GovernanceMode;
+import org.springframework.ai.chat.client.advisor.governance.PiiScanner;
+import org.springframework.ai.chat.client.advisor.governance.SessionCostTracker;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link GovernanceAdvisorAutoConfiguration}.
+ *
+ * @author Spring AI Contributors
+ */
+class GovernanceAdvisorAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(GovernanceAdvisorAutoConfiguration.class));
+
+	// -------------------------------------------------------------------------
+	// Disabled by default
+	// -------------------------------------------------------------------------
+
+	@Test
+	void noBeansWhenDisabled() {
+		this.contextRunner.run(ctx -> {
+			assertThat(ctx).doesNotHaveBean(GovernanceAdvisor.class);
+			assertThat(ctx).doesNotHaveBean(PiiScanner.class);
+			assertThat(ctx).doesNotHaveBean(SessionCostTracker.class);
+		});
+	}
+
+	// -------------------------------------------------------------------------
+	// Enabled with defaults
+	// -------------------------------------------------------------------------
+
+	@Test
+	void registersBeansWhenEnabled() {
+		this.contextRunner.withPropertyValues("spring.ai.advisor.governance.enabled=true").run(ctx -> {
+			assertThat(ctx).hasSingleBean(GovernanceAdvisor.class);
+			assertThat(ctx).hasSingleBean(PiiScanner.class);
+			assertThat(ctx).hasSingleBean(SessionCostTracker.class);
+		});
+	}
+
+	// -------------------------------------------------------------------------
+	// Mode configuration
+	// -------------------------------------------------------------------------
+
+	@Test
+	void defaultModeIsEnforce() {
+		this.contextRunner.withPropertyValues("spring.ai.advisor.governance.enabled=true").run(ctx -> {
+			GovernanceAdvisorProperties props = ctx.getBean(GovernanceAdvisorProperties.class);
+			assertThat(props.getMode()).isEqualTo(GovernanceMode.ENFORCE);
+		});
+	}
+
+	@Test
+	void modeCanBeSetToObserve() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.advisor.governance.enabled=true",
+					"spring.ai.advisor.governance.mode=observe")
+			.run(ctx -> {
+				GovernanceAdvisorProperties props = ctx.getBean(GovernanceAdvisorProperties.class);
+				assertThat(props.getMode()).isEqualTo(GovernanceMode.OBSERVE);
+			});
+	}
+
+	@Test
+	void modeCanBeSetToMonitor() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.advisor.governance.enabled=true",
+					"spring.ai.advisor.governance.mode=monitor")
+			.run(ctx -> {
+				GovernanceAdvisorProperties props = ctx.getBean(GovernanceAdvisorProperties.class);
+				assertThat(props.getMode()).isEqualTo(GovernanceMode.MONITOR);
+			});
+	}
+
+	// -------------------------------------------------------------------------
+	// PII configuration
+	// -------------------------------------------------------------------------
+
+	@Test
+	void piiEnabledByDefault() {
+		this.contextRunner.withPropertyValues("spring.ai.advisor.governance.enabled=true").run(ctx -> {
+			GovernanceAdvisorProperties props = ctx.getBean(GovernanceAdvisorProperties.class);
+			assertThat(props.getPii().isEnabled()).isTrue();
+		});
+	}
+
+	@Test
+	void piiCanBeDisabled() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.advisor.governance.enabled=true",
+					"spring.ai.advisor.governance.pii.enabled=false")
+			.run(ctx -> {
+				GovernanceAdvisorProperties props = ctx.getBean(GovernanceAdvisorProperties.class);
+				assertThat(props.getPii().isEnabled()).isFalse();
+			});
+	}
+
+	// -------------------------------------------------------------------------
+	// Budget configuration
+	// -------------------------------------------------------------------------
+
+	@Test
+	void budgetTokenLimitDefaultIsUnlimited() {
+		this.contextRunner.withPropertyValues("spring.ai.advisor.governance.enabled=true").run(ctx -> {
+			SessionCostTracker tracker = ctx.getBean(SessionCostTracker.class);
+			assertThat(tracker.hasLimit()).isFalse();
+		});
+	}
+
+	@Test
+	void budgetTokenLimitIsApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.advisor.governance.enabled=true",
+					"spring.ai.advisor.governance.budget.token-limit=5000")
+			.run(ctx -> {
+				SessionCostTracker tracker = ctx.getBean(SessionCostTracker.class);
+				assertThat(tracker.hasLimit()).isTrue();
+				assertThat(tracker.getTokenLimit()).isEqualTo(5000L);
+			});
+	}
+
+	// -------------------------------------------------------------------------
+	// @ConditionalOnMissingBean — user-defined beans take precedence
+	// -------------------------------------------------------------------------
+
+	@Test
+	void userDefinedGovernanceAdvisorTakesPrecedence() {
+		this.contextRunner.withPropertyValues("spring.ai.advisor.governance.enabled=true")
+			.withUserConfiguration(CustomGovernanceAdvisorConfig.class)
+			.run(ctx -> {
+				assertThat(ctx).hasSingleBean(GovernanceAdvisor.class);
+				GovernanceAdvisor advisor = ctx.getBean(GovernanceAdvisor.class);
+				assertThat(advisor).isSameAs(ctx.getBean("customAdvisor"));
+			});
+	}
+
+	@Test
+	void userDefinedPiiScannerTakesPrecedence() {
+		this.contextRunner.withPropertyValues("spring.ai.advisor.governance.enabled=true")
+			.withUserConfiguration(CustomPiiScannerConfig.class)
+			.run(ctx -> assertThat(ctx).hasSingleBean(PiiScanner.class));
+	}
+
+	@Test
+	void userDefinedCostTrackerTakesPrecedence() {
+		this.contextRunner.withPropertyValues("spring.ai.advisor.governance.enabled=true")
+			.withUserConfiguration(CustomCostTrackerConfig.class)
+			.run(ctx -> {
+				assertThat(ctx).hasSingleBean(SessionCostTracker.class);
+				SessionCostTracker tracker = ctx.getBean(SessionCostTracker.class);
+				assertThat(tracker.getTokenLimit()).isEqualTo(9999L);
+			});
+	}
+
+	// -------------------------------------------------------------------------
+	// Helper configurations
+	// -------------------------------------------------------------------------
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomGovernanceAdvisorConfig {
+
+		@Bean("customAdvisor")
+		GovernanceAdvisor governanceAdvisor() {
+			return GovernanceAdvisor.builder().mode(GovernanceMode.OBSERVE).build();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomPiiScannerConfig {
+
+		@Bean
+		PiiScanner piiScanner() {
+			return PiiScanner.builder().emailEnabled(false).build();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomCostTrackerConfig {
+
+		@Bean
+		SessionCostTracker sessionCostTracker() {
+			return new SessionCostTracker(9999L);
+		}
+
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,11 @@
 		<module>spring-ai-tool-search-tool</module>
 		<module>spring-ai-vector-store</module>
 
+		<module>advisors/spring-ai-governance-advisor</module>
 		<module>advisors/spring-ai-tool-search-advisor</module>
 		<module>advisors/spring-ai-vector-store-advisor</module>
 
+		<module>auto-configurations/advisors/spring-ai-autoconfigure-governance-advisor</module>
 		<module>auto-configurations/advisors/spring-ai-autoconfigure-tool-search-advisor</module>
 
 		<module>auto-configurations/common/spring-ai-autoconfigure-retry</module>


### PR DESCRIPTION
Adds a governance advisor that intercepts ChatClientRequest before it reaches 
the model and enforces configurable policies.

## What's included

- `GovernanceAdvisor` — implements CallAdvisor + StreamAdvisor
- `GovernanceMode` — OBSERVE (log only), MONITOR (log + audit), ENFORCE (block)
- `GovernanceDecision` — immutable audit record per request
- `PiiScanner` — regex detection of SSN, credit card, email, API keys/Bearer tokens
- `SessionCostTracker` — per-session token budget with configurable limit
- Spring Boot auto-configuration under `spring.ai.advisor.governance.*`, disabled by default
- 48 tests, 0 failures

## Scope

This is a Phase 1 implementation focused on the Spring AI integration layer.
PII detection uses regex heuristics (same approach as SafeGuardAdvisor).
Budget tracking is token-count based. Dollar-cost mapping and ML-based 
PII detection are left for follow-up.

Closes #6683 
