### PR TITLE
Validate thinkingLevel per Gemini model support

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -19,11 +19,14 @@ package org.springframework.ai.google.genai;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -141,6 +144,7 @@ import org.springframework.util.StringUtils;
  * @author Dan Dobrin
  * @author Thomas Vitale
  * @author Sebastien Deleuze
+ * @author Dimitar Proynov
  * @since 0.8.1
  * @see GoogleGenAiChatOptions
  * @see ToolCallingManager
@@ -867,48 +871,65 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	}
 
 	/**
-	 * Checks if the model name indicates a Gemini 3 Pro model.
-	 * @param modelName the model name to check
-	 * @return true if the model is a Gemini 3 Pro model
+	 * Per-model support matrix for {@code thinkingLevel} on the {@code generateContent}
+	 * API surface used by this client, keyed by exact model id (lower case). An empty set
+	 * means the model rejects {@code thinkingLevel} entirely (use
+	 * {@link GoogleGenAiChatOptions#getThinkingBudget() thinkingBudget} instead). Models
+	 * absent from this map are not validated client-side; gemini-2.5-pro thinking level
+	 * support is per account (API key) basis and cannot be validated here.
 	 */
-	private static boolean isGemini3ProModel(String modelName) {
-		if (modelName == null) {
-			return false;
-		}
-		String lower = modelName.toLowerCase(Locale.ROOT);
-		return lower.contains("gemini-3") && lower.contains("pro") && !lower.contains("flash");
-	}
+	private static final Map<String, Set<GoogleGenAiThinkingLevel>> THINKING_LEVEL_SUPPORT_BY_MODEL = Map.ofEntries(
+			Map.entry(ChatModel.GEMINI_2_5_FLASH.getValue(), EnumSet.noneOf(GoogleGenAiThinkingLevel.class)),
+			Map.entry(ChatModel.GEMINI_2_5_FLASH_LIGHT.getValue(), EnumSet.noneOf(GoogleGenAiThinkingLevel.class)),
+			Map.entry(ChatModel.GEMINI_3_0_PRO_PREVIEW.getValue(),
+					EnumSet.of(GoogleGenAiThinkingLevel.LOW, GoogleGenAiThinkingLevel.HIGH)),
+			Map.entry(ChatModel.GEMINI_3_1_PRO_PREVIEW.getValue(),
+					EnumSet.of(GoogleGenAiThinkingLevel.LOW, GoogleGenAiThinkingLevel.MEDIUM,
+							GoogleGenAiThinkingLevel.HIGH)),
+			Map.entry(ChatModel.GEMINI_3_FLASH_PREVIEW.getValue(),
+					EnumSet.of(GoogleGenAiThinkingLevel.MINIMAL, GoogleGenAiThinkingLevel.LOW,
+							GoogleGenAiThinkingLevel.MEDIUM, GoogleGenAiThinkingLevel.HIGH)),
+			Map.entry(ChatModel.GEMINI_3_5_FLASH.getValue(),
+					EnumSet.of(GoogleGenAiThinkingLevel.MINIMAL, GoogleGenAiThinkingLevel.LOW,
+							GoogleGenAiThinkingLevel.MEDIUM, GoogleGenAiThinkingLevel.HIGH)),
+			Map.entry(ChatModel.GEMINI_3_5_FLASH_LITE.getValue(),
+					EnumSet.of(GoogleGenAiThinkingLevel.MINIMAL, GoogleGenAiThinkingLevel.LOW,
+							GoogleGenAiThinkingLevel.MEDIUM, GoogleGenAiThinkingLevel.HIGH)),
+			Map.entry(ChatModel.GEMINI_3_6_FLASH.getValue(),
+					EnumSet.of(GoogleGenAiThinkingLevel.MINIMAL, GoogleGenAiThinkingLevel.LOW,
+							GoogleGenAiThinkingLevel.MEDIUM, GoogleGenAiThinkingLevel.HIGH)),
+			Map.entry(ChatModel.GEMINI_3_1_FLASH_LITE_IMAGE.getValue(),
+					EnumSet.of(GoogleGenAiThinkingLevel.MINIMAL, GoogleGenAiThinkingLevel.HIGH)));
 
 	/**
-	 * Checks if the model name indicates a Gemini 3 Flash model.
-	 * @param modelName the model name to check
-	 * @return true if the model is a Gemini 3 Flash model
-	 */
-	private static boolean isGemini3FlashModel(String modelName) {
-		if (modelName == null) {
-			return false;
-		}
-		String lower = modelName.toLowerCase(Locale.ROOT);
-		return lower.contains("gemini-3") && lower.contains("flash");
-	}
-
-	/**
-	 * Validates ThinkingLevel compatibility with the model. Gemini 3.1 Pro doesn't
-	 * support MINIMAL. Gemini 3 Flash supports all levels.
+	 * Validates that the requested {@code thinkingLevel} is supported by the target
+	 * model, using {@link #THINKING_LEVEL_SUPPORT_BY_MODEL}. Models that are not part of
+	 * that matrix are not validated here and are left to the API to accept or reject.
 	 * @param level the thinking level to validate
 	 * @param modelName the model name
 	 * @throws IllegalArgumentException if the level is not supported for the model
 	 */
 	private static void validateThinkingLevelForModel(GoogleGenAiThinkingLevel level, String modelName) {
-		if (level == null || level == GoogleGenAiThinkingLevel.THINKING_LEVEL_UNSPECIFIED) {
+		if (level == null || level == GoogleGenAiThinkingLevel.THINKING_LEVEL_UNSPECIFIED || modelName == null) {
 			return;
 		}
-		if (isGemini3ProModel(modelName)) {
-			if (level == GoogleGenAiThinkingLevel.MINIMAL) {
-				throw new IllegalArgumentException(
-						String.format("ThinkingLevel.%s is not supported for Gemini 3 Pro models. "
-								+ "Supported levels: LOW, MEDIUM, HIGH. Model: %s", level, modelName));
+		// Vertex AI style full resource names (e.g.
+		// "projects/{project}/locations/{location}/publishers/google/models/{model}")
+		// carry the model id as the last path segment.
+		String modelId = modelName.substring(modelName.lastIndexOf('/') + 1).toLowerCase(Locale.ROOT);
+		Set<GoogleGenAiThinkingLevel> supportedLevels = THINKING_LEVEL_SUPPORT_BY_MODEL.get(modelId);
+		if (supportedLevels == null) {
+			return;
+		}
+		if (!supportedLevels.contains(level)) {
+			if (supportedLevels.isEmpty()) {
+				throw new IllegalArgumentException(String.format(
+						"ThinkingLevel.%s is not supported for model '%s'. This model does not support thinkingLevel; use thinkingBudget instead.",
+						level, modelName));
 			}
+			throw new IllegalArgumentException(
+					String.format("ThinkingLevel.%s is not supported for model '%s'. Supported levels: %s.", level,
+							modelName, supportedLevels.stream().map(Enum::name).collect(Collectors.joining(", "))));
 		}
 	}
 
@@ -1163,11 +1184,21 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		@Deprecated
 		GEMINI_3_PRO_PREVIEW("gemini-3.1-pro-preview"),
 
+		GEMINI_3_0_PRO_PREVIEW("gemini-3-pro-preview"),
+
 		GEMINI_3_1_PRO_PREVIEW("gemini-3.1-pro-preview"),
+
+		GEMINI_3_FLASH_PREVIEW("gemini-3-flash-preview"),
 
 		GEMINI_3_1_FLASH_LITE("gemini-3.1-flash-lite"),
 
-		GEMINI_3_5_FLASH("gemini-3.5-flash");
+		GEMINI_3_1_FLASH_LITE_IMAGE("gemini-3.1-flash-lite-image"),
+
+		GEMINI_3_5_FLASH("gemini-3.5-flash"),
+
+		GEMINI_3_5_FLASH_LITE("gemini-3.5-flash-lite"),
+
+		GEMINI_3_6_FLASH("gemini-3.6-flash");
 
 		public final String value;
 

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/common/GoogleGenAiThinkingLevel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/common/GoogleGenAiThinkingLevel.java
@@ -21,8 +21,12 @@ package org.springframework.ai.google.genai.common;
  * the depth of reasoning the model applies during generation.
  *
  * <p>
- * <strong>Model Compatibility:</strong> This option is only supported by Gemini 3 Pro
- * models. For Gemini 2.5 series and earlier models, use
+ * <strong>Model Compatibility:</strong> Not every level is supported by every model, and
+ * not every model supports {@code thinkingLevel} at all. For example, {@code
+ * gemini-3-pro-preview} only supports {@link #LOW} and {@link #HIGH}, while {@code
+ * gemini-2.5-flash} and {@code gemini-2.5-flash-lite} don't support {@code
+ * thinkingLevel} at all on the {@code generateContent} API. Models that don't support
+ * {@code thinkingLevel}, use
  * {@link org.springframework.ai.google.genai.GoogleGenAiChatOptions#getThinkingBudget()
  * thinkingBudget} instead.
  *

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
@@ -322,7 +322,10 @@ public class CreateGeminiRequestTests {
 
 		// Override default thinkingLevel with prompt-specific value
 		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content",
-				GoogleGenAiChatOptions.builder().thinkingLevel(GoogleGenAiThinkingLevel.HIGH).build()));
+				GoogleGenAiChatOptions.builder()
+					.model("DEFAULT_MODEL")
+					.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+					.build()));
 
 		assertThat(request.config().thinkingConfig()).isPresent();
 		assertThat(request.config().thinkingConfig().get().thinkingLevel()).isPresent();
@@ -422,7 +425,7 @@ public class CreateGeminiRequestTests {
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("MINIMAL")
 			.hasMessageContaining("not supported")
-			.hasMessageContaining("Gemini 3 Pro");
+			.hasMessageContaining("gemini-3.1-pro-preview");
 	}
 
 	@Test
@@ -561,6 +564,66 @@ public class CreateGeminiRequestTests {
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("MINIMAL")
 			.hasMessageContaining("not supported");
+	}
+
+	@Test
+	public void createRequestWithThinkingLevelOnGemini25FlashThrows() {
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("gemini-2.5-flash")
+			.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+		assertThatThrownBy(() -> client.createGeminiRequest(new Prompt("Test message content", options)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("HIGH")
+			.hasMessageContaining("not supported")
+			.hasMessageContaining("gemini-2.5-flash");
+	}
+
+	@Test
+	public void createRequestWithThinkingLevelOnGemini25FlashLiteThrows() {
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("gemini-2.5-flash-lite")
+			.thinkingLevel(GoogleGenAiThinkingLevel.LOW)
+			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+		assertThatThrownBy(() -> client.createGeminiRequest(new Prompt("Test message content", options)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("LOW")
+			.hasMessageContaining("not supported")
+			.hasMessageContaining("gemini-2.5-flash-lite");
+	}
+
+	@Test
+	public void createRequestWithThinkingLevelUnspecifiedOnGemini25FlashDoesNotThrow() {
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("gemini-2.5-flash")
+			.thinkingLevel(GoogleGenAiThinkingLevel.THINKING_LEVEL_UNSPECIFIED)
+			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
+
+		assertThat(request.config().thinkingConfig()).isPresent();
+	}
+
+	@Test
+	public void createRequestWithThinkingLevelOnGemini25ProDoesNotThrow() {
+		// gemini-2.5-pro's thinkingLevel support on generateContent could not be
+		// confirmed against the live API, so it is intentionally left unvalidated.
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("gemini-2.5-pro")
+			.thinkingLevel(GoogleGenAiThinkingLevel.MINIMAL)
+			.build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
+
+		assertThat(request.config().thinkingConfig()).isPresent();
+		assertThat(request.config().thinkingConfig().get().thinkingLevel()).isPresent();
+		assertThat(request.config().thinkingConfig().get().thinkingLevel().get().toString()).isEqualTo("MINIMAL");
 	}
 
 	@Test

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiThinkingLevelIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiThinkingLevelIT.java
@@ -34,14 +34,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Integration tests for ThinkingLevel validation with Gemini 3 models.
- *
- * <p>
- * Gemini 3 Pro only supports LOW and HIGH thinking levels. Gemini 3 Flash supports all
- * levels (MINIMAL, LOW, MEDIUM, HIGH).
+ * Gemini 3.1 Pro supports LOW, MEDIUM and HIGH thinking levels, but not MINIMAL. Gemini
+ * 3.5 Flash supports all levels (MINIMAL, LOW, MEDIUM, HIGH). Gemini 2.5 Flash and Flash
+ * Lite reject {@code thinkingLevel} entirely on the {@code generateContent} API. Gemini
+ * 2.5 Pro is intentionally not covered here: its behavior depends on the account used.
  *
  * @author Dan Dobrin
  * @author Sebastien Deleuze
+ * @author Dimitar Proynov
  */
 @EnabledIfEnvironmentVariable(named = "GOOGLE_API_KEY", matches = ".+")
 class GoogleGenAiThinkingLevelIT {
@@ -55,17 +55,16 @@ class GoogleGenAiThinkingLevelIT {
 	}
 
 	static Stream<Arguments> proModelUnsupportedLevels() {
-		return Stream.of(
-				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_3_1_PRO_PREVIEW.getValue(),
-						GoogleGenAiThinkingLevel.MINIMAL),
-				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_3_1_PRO_PREVIEW.getValue(),
-						GoogleGenAiThinkingLevel.MEDIUM));
+		return Stream.of(Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_3_1_PRO_PREVIEW.getValue(),
+				GoogleGenAiThinkingLevel.MINIMAL));
 	}
 
 	static Stream<Arguments> proModelSupportedLevels() {
 		return Stream.of(
 				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_3_1_PRO_PREVIEW.getValue(),
 						GoogleGenAiThinkingLevel.LOW),
+				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_3_1_PRO_PREVIEW.getValue(),
+						GoogleGenAiThinkingLevel.MEDIUM),
 				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_3_1_PRO_PREVIEW.getValue(),
 						GoogleGenAiThinkingLevel.HIGH));
 	}
@@ -78,6 +77,24 @@ class GoogleGenAiThinkingLevelIT {
 				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_3_5_FLASH.getValue(),
 						GoogleGenAiThinkingLevel.MEDIUM),
 				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_3_5_FLASH.getValue(),
+						GoogleGenAiThinkingLevel.HIGH));
+	}
+
+	static Stream<Arguments> gemini25FlashRejectsThinkingLevel() {
+		return Stream.of(
+				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue(),
+						GoogleGenAiThinkingLevel.MINIMAL),
+				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue(), GoogleGenAiThinkingLevel.LOW),
+				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue(),
+						GoogleGenAiThinkingLevel.MEDIUM),
+				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH.getValue(), GoogleGenAiThinkingLevel.HIGH),
+				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH_LIGHT.getValue(),
+						GoogleGenAiThinkingLevel.MINIMAL),
+				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH_LIGHT.getValue(),
+						GoogleGenAiThinkingLevel.LOW),
+				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH_LIGHT.getValue(),
+						GoogleGenAiThinkingLevel.MEDIUM),
+				Arguments.of(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH_LIGHT.getValue(),
 						GoogleGenAiThinkingLevel.HIGH));
 	}
 
@@ -95,7 +112,7 @@ class GoogleGenAiThinkingLevelIT {
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining(level.name())
 			.hasMessageContaining("not supported")
-			.hasMessageContaining("Gemini 3 Pro");
+			.hasMessageContaining(modelName);
 	}
 
 	@ParameterizedTest
@@ -130,6 +147,23 @@ class GoogleGenAiThinkingLevelIT {
 		assertThat(response).isNotNull();
 		assertThat(response.getResult()).isNotNull();
 		assertThat(response.getResult().getOutput().getText()).isNotBlank();
+	}
+
+	@ParameterizedTest
+	@MethodSource("gemini25FlashRejectsThinkingLevel")
+	void testGemini25FlashRejectsThinkingLevel(String modelName, GoogleGenAiThinkingLevel level) {
+		var chatModel = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.options(GoogleGenAiChatOptions.builder().model(modelName).thinkingLevel(level).build())
+			.toolCallingManager(ToolCallingManager.builder().build())
+			.observationRegistry(ObservationRegistry.NOOP)
+			.build();
+
+		assertThatThrownBy(() -> chatModel.call(new Prompt("What is 2+2?")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining(level.name())
+			.hasMessageContaining("not supported")
+			.hasMessageContaining(modelName);
 	}
 
 }


### PR DESCRIPTION
The previous validateThinkingLevelForModel only rejected MINIMAL on Gemini 3 Pro models, matched via a fragile substring heuristic. It missed every other model-specific constraint documented by Google and verified against the live API.

Replace it with an exact-match support matrix keyed by model id, backed by new `GoogleGenAiChatModel.ChatModel` constants (GEMINI_3_0_PRO_PREVIEW, GEMINI_3_FLASH_PREVIEW,
GEMINI_3_1_FLASH_LITE_IMAGE, GEMINI_3_5_FLASH_LITE, GEMINI_3_6_FLASH) instead of raw string literals. Model ids are normalized from full Vertex AI resource paths before lookup, preserving support for values like "projects/.../models/gemini-3-pro-preview".

Live API testing showed `gemini-2.5-flash` and
`gemini-2.5-flash-lite` reject `thinkingLevel` entirely on the generateContent API, contradicting the public docs (which describe the newer Interactions API instead); `gemini-2.5-pro` is intentionally left unvalidated since its behavior could not be confirmed against the live API. Models absent from the matrix are left to the API to accept or reject.

Update the GoogleGenAiThinkingLevel javadoc to reflect the real per-model constraints, and extend CreateGeminiRequestTests and GoogleGenAiThinkingLevelIT to cover the new cases.

mvn clean install - passed
GoogleGenAi ITs - passed