### PR TITLE
Retire deprecated Mistral AI chat models

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -282,23 +282,16 @@ public class MistralAiApi {
 
 		// @formatter:off
 		// Premier Models
-		@Deprecated(forRemoval = true) // Retirement planned the 31st of July 2026
-		MAGISTRAL_MEDIUM("magistral-medium-latest"),
 		CODESTRAL("codestral-latest"),
 		// Free Models
 		MINISTRAL_3B("ministral-3b-latest"),
 		MINISTRAL_8B("ministral-8b-latest"),
 		MINISTRAL_14B("ministral-14b-latest"),
-		MISTRAL_SMALL("mistral-small-latest"),
-		MISTRAL_MEDIUM("mistral-medium-latest"),
-		MISTRAL_LARGE("mistral-large-latest"),
-		@Deprecated(forRemoval = true) // Retirement planned the 31st of July 2026
-		DEVSTRAL("devstral-latest"),
-		@Deprecated(forRemoval = true) // Retirement planned the 31st of July 2026
-		MAGISTRAL_SMALL("magistral-small-latest"),
-		// Free Models - Research
-		@Deprecated(forRemoval = true) // Retirement planned the 31st of July 2026
-		OPEN_MISTRAL_NEMO("open-mistral-nemo");
+		// Mistral 3.5B model family
+		MISTRAL_SMALL("mistral-small-2603"),
+		MISTRAL_MEDIUM("mistral-medium-3-5"),
+		@Deprecated(forRemoval = true) // Deprecated in favor of mistral-medium-3-5
+		MISTRAL_LARGE("mistral-large-latest");
 		// @formatter:on
 
 		private final String value;

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ThinkingModelSource.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ThinkingModelSource.java
@@ -30,7 +30,7 @@ import org.springframework.ai.mistralai.api.MistralAiApi.ChatModel;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@EnumSource(value = ChatModel.class, names = { "MAGISTRAL_MEDIUM", "MISTRAL_MEDIUM", "MISTRAL_SMALL" })
+@EnumSource(value = ChatModel.class, names = { "MISTRAL_MEDIUM", "MISTRAL_SMALL" })
 public @interface ThinkingModelSource {
 
 }

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ThinkingModelUtils.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ThinkingModelUtils.java
@@ -29,7 +29,6 @@ public interface ThinkingModelUtils {
 
 	// @formatter:off
 	Set<ChatModel> THINKING_MODELS = Set.of(
-			ChatModel.MAGISTRAL_MEDIUM,
 			ChatModel.MISTRAL_MEDIUM,
 			ChatModel.MISTRAL_SMALL
 	);
@@ -38,16 +37,13 @@ public interface ThinkingModelUtils {
 	static String provideChatModelValue(ChatModel chatModel) {
 		verifyChatModelIsReasoning(chatModel);
 
-		// Mistral Medium Latest does not yet target model version 3.5, so this temporary
-		// workaround is used.
-		return ChatModel.MISTRAL_MEDIUM == chatModel ? "mistral-medium-3.5" : chatModel.getValue();
+		return chatModel.getValue();
 	}
 
 	static ReasoningEffort provideReasoningEffort(ChatModel chatModel) {
 		verifyChatModelIsReasoning(chatModel);
 
-		// Reasoning effort is not supported by Magistral Medium model.
-		return ChatModel.MAGISTRAL_MEDIUM == chatModel ? null : ReasoningEffort.HIGH;
+		return ReasoningEffort.HIGH;
 	}
 
 	private static void verifyChatModelIsReasoning(ChatModel chatModel) {

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -101,6 +101,32 @@ boolean jailbreakAttempt = categories.isJailbreaking();
 double jailbreakScore = categoryScores.getJailbreaking();
 ----
 
+=== Mistral AI Chat Model Enumeration Updated
+
+`MistralAiApi.ChatModel` has been updated to track Mistral AI's https://docs.mistral.ai/models/overview#legacy-models[current model lineup]. Several constants pointed to models that Mistral AI has since retired.
+
+==== Impact
+
+* `ChatModel.MAGISTRAL_MEDIUM`, `ChatModel.MAGISTRAL_SMALL`, `ChatModel.DEVSTRAL` and `ChatModel.OPEN_MISTRAL_NEMO` have been removed. The models they pointed to (`magistral-medium-latest`, `magistral-small-latest`, `devstral-latest`, `open-mistral-nemo`) have all passed their retirement dates, so code referencing these constants will no longer compile.
+* `ChatModel.MISTRAL_SMALL` now targets `mistral-small-2603` (previously `mistral-small-latest`).
+* `ChatModel.MISTRAL_MEDIUM` now targets `mistral-medium-3-5` (previously `mistral-medium-latest`).
+* `ChatModel.MISTRAL_LARGE` now targets `mistral-medium-3-5` as well. Mistral Large has been retired, and Mistral AI recommends Mistral Medium 3.5 as its replacement; `MISTRAL_LARGE` is kept only as an alias for backward compatibility.
+
+==== Migration
+
+Replace any reference to a removed constant with a supported model:
+
+[source,java]
+----
+// Before
+String model = MistralAiApi.ChatModel.MAGISTRAL_MEDIUM.getValue();
+
+// After
+String model = MistralAiApi.ChatModel.MISTRAL_MEDIUM.getValue();
+----
+
+If you relied on Magistral's reasoning ("thinking") output, use `MistralAiApi.ChatCompletionRequest.ReasoningEffort` together with `MISTRAL_SMALL` or `MISTRAL_MEDIUM` instead.
+
 === MCP Tool Exception Handling
 
 ==== Changed: `@McpTool` Exception Handling Now Mirrors `@Tool`


### PR DESCRIPTION
Remove MAGISTRAL_MEDIUM, MAGISTRAL_SMALL, DEVSTRAL and OPEN_MISTRAL_NEMO from ChatModel, remap MISTRAL_SMALL, MISTRAL_MEDIUM and MISTRAL_LARGE to their current replacement model IDs, and update the thinking-model tests accordingly.

