### PR TITLE
Make MongoChatMemoryRepository.saveAll atomic

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
@@ -31,9 +31,13 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.Assert;
 
 /**
@@ -48,8 +52,18 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 
 	private final MongoTemplate mongoTemplate;
 
-	private MongoChatMemoryRepository(MongoTemplate mongoTemplate) {
+	private final TransactionTemplate transactionTemplate;
+
+	private MongoChatMemoryRepository(MongoTemplate mongoTemplate,
+			@Nullable PlatformTransactionManager transactionManager) {
+		Assert.notNull(mongoTemplate, "mongoTemplate cannot be null");
 		this.mongoTemplate = mongoTemplate;
+		if (transactionManager == null) {
+			MongoDatabaseFactory mongoDatabaseFactory = mongoTemplate.getMongoDatabaseFactory();
+			Assert.notNull(mongoDatabaseFactory, "mongoTemplate mongoDatabaseFactory cannot be null");
+			transactionManager = new MongoTransactionManager(mongoDatabaseFactory);
+		}
+		this.transactionTemplate = new TransactionTemplate(transactionManager);
 	}
 
 	@Override
@@ -76,13 +90,16 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 					"MongoChatMemoryRepository does not support tool call messages. Some messages were filtered out for conversation: "
 							+ conversationId);
 		}
-		deleteByConversationId(conversationId);
-		var conversations = persistableMessages.stream()
-			.map(message -> new Conversation(conversationId,
-					new Conversation.Message(message.getText(), message.getMessageType().name(), message.getMetadata()),
-					Instant.now()))
-			.toList();
-		this.mongoTemplate.insert(conversations, Conversation.class);
+		this.transactionTemplate.executeWithoutResult(status -> {
+			deleteByConversationId(conversationId);
+			var conversations = persistableMessages.stream()
+				.map(message -> new Conversation(conversationId,
+						new Conversation.Message(message.getText(), message.getMessageType().name(),
+								message.getMetadata()),
+						Instant.now()))
+				.toList();
+			this.mongoTemplate.insert(conversations, Conversation.class);
+		});
 	}
 
 	@Override
@@ -117,6 +134,8 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 
 		private @Nullable MongoTemplate mongoTemplate;
 
+		private @Nullable PlatformTransactionManager transactionManager;
+
 		private Builder() {
 		}
 
@@ -125,9 +144,23 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 			return this;
 		}
 
+		/**
+		 * Optionally provide a {@link PlatformTransactionManager} used to make
+		 * {@link #saveAll(String, List)} atomic. When omitted, a
+		 * {@link MongoTransactionManager} is created from the {@link MongoTemplate}'s
+		 * database factory (MongoDB multi-document transactions require a replica set).
+		 * @param transactionManager the transaction manager, or {@code null} to create a
+		 * default
+		 * @return this builder
+		 */
+		public Builder transactionManager(@Nullable PlatformTransactionManager transactionManager) {
+			this.transactionManager = transactionManager;
+			return this;
+		}
+
 		public MongoChatMemoryRepository build() {
 			Assert.state(this.mongoTemplate != null, "mongoTemplate must be provided");
-			return new MongoChatMemoryRepository(this.mongoTemplate);
+			return new MongoChatMemoryRepository(this.mongoTemplate, this.transactionManager);
 		}
 
 	}

--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/test/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/test/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepositoryIT.java
@@ -40,11 +40,17 @@ import org.springframework.boot.mongodb.autoconfigure.MongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 /**
  * Integration tests for {@link MongoChatMemoryRepository}.
@@ -185,6 +191,28 @@ public class MongoChatMemoryRepositoryIT {
 			.all();
 
 		assertThat(results.size()).isZero();
+	}
+
+	@Test
+	void shouldPreserveExistingMessagesWhenInsertFails() {
+		var conversationId = UUID.randomUUID().toString();
+		var existingMessages = List.<Message>of(new UserMessage("First message"),
+				new AssistantMessage("Second message"));
+
+		this.chatMemoryRepository.saveAll(conversationId, existingMessages);
+
+		var failingMongoTemplate = spy(this.mongoTemplate);
+		doThrow(new DataIntegrityViolationException("Insert failed")).when(failingMongoTemplate)
+			.insert(anyCollection(), eq(Conversation.class));
+
+		var failingRepository = MongoChatMemoryRepository.builder().mongoTemplate(failingMongoTemplate).build();
+
+		assertThatThrownBy(
+				() -> failingRepository.saveAll(conversationId, List.of(new UserMessage("Replacement message"))))
+			.isInstanceOf(DataIntegrityViolationException.class);
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results).isEqualTo(existingMessages);
 	}
 
 	@SpringBootConfiguration


### PR DESCRIPTION
## Problem

`MongoChatMemoryRepository.saveAll()` deletes existing conversation messages and then inserts the replacement list without a transaction. If the insert fails after the delete succeeds, the previous conversation history is lost.

`JdbcChatMemoryRepository` already runs the equivalent delete-and-insert flow inside a `TransactionTemplate`.

Fixes #6770

## Solution

- Run `saveAll` inside a `TransactionTemplate` backed by `MongoTransactionManager` (created from the `MongoTemplate` database factory by default).
- Allow an optional `PlatformTransactionManager` via the builder for advanced setups.
- Add an IT that spies `MongoTemplate.insert` to fail after delete and asserts the original messages are preserved.

Note: MongoDB multi-document transactions require a replica set. Testcontainers `MongoDBContainer` already starts as a single-node replica set.

## Test plan

- [x] `./mvnw -pl memory-repositories/spring-ai-model-chat-memory-repository-mongodb test -Dtest=MongoChatMemoryRepositoryIT`
- [x] Result: Tests run: 11, Failures: 0, Errors: 0, Skipped: 0 (includes `shouldPreserveExistingMessagesWhenInsertFails`)

---

I hereby agree to the terms of the Spring AI Contributor License / DCO (Signed-off-by on commit).