### PR TITLE
Fix `DeepSeekChatModel` rejecting assistant messages without content

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -73,6 +73,7 @@ import org.springframework.util.CollectionUtils;
  * @author Thomas Vitale
  * @author Sebastien Deleuze
  * @author guan xu
+ * @author Subhash Polisetti
  */
 public class DeepSeekChatModel implements ChatModel {
 
@@ -366,7 +367,6 @@ public class DeepSeekChatModel implements ChatModel {
 					}
 				}
 				String text = assistantMessage.getText();
-				Assert.state(text != null, "text must not be null");
 				return List.of(new ChatCompletionMessage(text, ChatCompletionMessage.Role.ASSISTANT, null, null,
 						toolCalls, isPrefixAssistantMessage, reasoningContent));
 			}

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Geng Rong
  * @author guan xu
+ * @author Subhash Polisetti
  */
 public class DeepSeekChatCompletionRequestTests {
 
@@ -216,6 +217,30 @@ public class DeepSeekChatCompletionRequestTests {
 		var request = client.createRequest(prompt, false);
 
 		assertThat(request.reasoningEffort()).isNull();
+	}
+
+	@Test
+	public void createRequestWithAssistantToolCallWithoutContent() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		var toolCall = new AssistantMessage.ToolCall("call_1", "function", "getCurrentWeather",
+				"{\"location\":\"Paris\"}");
+		AssistantMessage assistantMessage = AssistantMessage.builder().toolCalls(List.of(toolCall)).build();
+
+		var prompt = new Prompt(List.of(assistantMessage),
+				DeepSeekChatOptions.builder().model("deepseek-chat").build());
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(1);
+		ChatCompletionMessage message = request.messages().get(0);
+		assertThat(message.role()).isEqualTo(ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(message.content()).isNull();
+		assertThat(message.toolCalls()).hasSize(1);
+		ChatCompletionMessage.ToolCall requestToolCall = message.toolCalls().get(0);
+		assertThat(requestToolCall.id()).isEqualTo("call_1");
+		assertThat(requestToolCall.function().name()).isEqualTo("getCurrentWeather");
+		assertThat(requestToolCall.function().arguments()).isEqualTo("{\"location\":\"Paris\"}");
 	}
 
 }

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatModelToolCallTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatModelToolCallTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.deepseek;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.deepseek.api.DeepSeekApi;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletion;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletion.Choice;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionFinishReason;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionMessage;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionMessage.ChatCompletionFunction;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionMessage.Role;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionMessage.ToolCall;
+import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionRequest;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for {@link DeepSeekChatModel} tool calling.
+ *
+ * @author Subhash Polisetti
+ */
+@ExtendWith(MockitoExtension.class)
+public class DeepSeekChatModelToolCallTests {
+
+	private @Mock DeepSeekApi deepSeekApi;
+
+	@Test
+	public void toolCallConversationContinuesWhenApiReturnsNullContent() {
+		var function = new ChatCompletionFunction("getCurrentWeather", "{\"location\":\"Paris\"}");
+		var apiMessage = new ChatCompletionMessage(null, Role.ASSISTANT, null, null,
+				List.of(new ToolCall("call_1", "function", function)), null, null);
+		var completion = new ChatCompletion("chatcmpl-1",
+				List.of(new Choice(ChatCompletionFinishReason.TOOL_CALLS, 0, apiMessage, null)), 1L, "deepseek-chat",
+				null, "chat.completion", null);
+		given(this.deepSeekApi.chatCompletionEntity(isA(ChatCompletionRequest.class)))
+			.willReturn(ResponseEntity.ok(completion));
+
+		var toolCallback = FunctionToolCallback.builder("getCurrentWeather", (Map<String, Object> request) -> "sunny")
+			.inputType(Map.class)
+			.description("Get the current weather")
+			.build();
+		var options = DeepSeekChatOptions.builder().model("deepseek-chat").toolCallbacks(List.of(toolCallback)).build();
+		var prompt = new Prompt(List.of(new UserMessage("What is the weather in Paris?")), options);
+		var chatModel = DeepSeekChatModel.builder().deepSeekApi(this.deepSeekApi).build();
+
+		ChatResponse response = chatModel.call(prompt);
+
+		AssistantMessage assistantMessage = response.getResult().getOutput();
+		assertThat(assistantMessage.getText()).isNull();
+		assertThat(assistantMessage.getToolCalls()).hasSize(1);
+		assertThat(assistantMessage.getToolCalls().get(0).name()).isEqualTo("getCurrentWeather");
+
+		ToolExecutionResult toolExecutionResult = ToolCallingManager.builder()
+			.build()
+			.executeToolCalls(prompt, response);
+		var followUpRequest = chatModel.createRequest(new Prompt(toolExecutionResult.conversationHistory(), options),
+				false);
+
+		assertThat(followUpRequest.messages()).hasSize(3);
+		ChatCompletionMessage assistantParam = followUpRequest.messages().get(1);
+		assertThat(assistantParam.role()).isEqualTo(Role.ASSISTANT);
+		assertThat(assistantParam.content()).isNull();
+		assertThat(assistantParam.toolCalls()).hasSize(1);
+		assertThat(assistantParam.toolCalls().get(0).id()).isEqualTo("call_1");
+		ChatCompletionMessage toolParam = followUpRequest.messages().get(2);
+		assertThat(toolParam.role()).isEqualTo(Role.TOOL);
+		assertThat(toolParam.toolCallId()).isEqualTo("call_1");
+		assertThat(toolParam.content()).contains("sunny");
+	}
+
+}


### PR DESCRIPTION
`createRequest` rejects an assistant message with a null text, but that is the normal
shape of a tool call turn: DeepSeek sends no content alongside `tool_calls`, and
`ChatCompletionMessage#content` is documented as null in that case. Replaying such a
message after tool execution, as `ToolCallingManager` does, fails with
`IllegalStateException: text must not be null`, so a blocking tool calling conversation
cannot complete. Streaming is unaffected because `MessageAggregator` rebuilds the
content from a `StringBuilder`.

Dropping the assertion forwards the null unchanged. `ChatCompletionMessage` is
`@JsonInclude(NON_NULL)`, so content is omitted from the request rather than sent as
null, which is what `MistralAiChatModel` and `OllamaChatModel` already do. #5568 fixed
the same regression on the response side.

Both tests are offline: one builds the request directly, the other drives a tool call
round trip against a mocked `DeepSeekApi`.

See #5568