### PR TITLE
Make jtokkit optional in spring-ai-commons

### DIFF
--- a/spring-ai-commons/pom.xml
+++ b/spring-ai-commons/pom.xml
@@ -59,6 +59,7 @@
 			<groupId>com.knuddels</groupId>
 			<artifactId>jtokkit</artifactId>
 			<version>${jtokkit.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/spring-ai-model/pom.xml
+++ b/spring-ai-model/pom.xml
@@ -20,6 +20,13 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 
+		<!-- Required by TokenCountBatchingStrategy; optional in spring-ai-commons. -->
+		<dependency>
+			<groupId>com.knuddels</groupId>
+			<artifactId>jtokkit</artifactId>
+			<version>${jtokkit.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-template-st</artifactId>


### PR DESCRIPTION
Closes #6778.

Marks jtokkit optional at the broad spring-ai-commons boundary and adds an explicit dependency to spring-ai-model, which directly uses it in TokenCountBatchingStrategy. spring-ai-client-chat already declares jtokkit directly.

This preserves tokenizer behavior for the modules that require it while letting unrelated consumers such as MCP-only servers omit the roughly 3.1 MiB tokenizer JAR.

Validation:
- affected reactor package build on OpenJDK 26
- spring-ai-commons and spring-ai-model test reactor: 834 tests, 0 failures/errors