### PR TITLE
Fix `OpenAiChatModel` discarding streamed content on tool call turns

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -124,6 +124,7 @@ import org.springframework.util.StringUtils;
  * @author Eric Bottard
  * @author Taewoong Kim
  * @author Jewoo Shin
+ * @author Subhash Polisetti
  */
 public final class OpenAiChatModel implements ChatModel {
 
@@ -1208,6 +1209,12 @@ public final class OpenAiChatModel implements ChatModel {
 			}).orElse(List.of());
 
 			Delta.Builder deltaBuilder = left.toBuilder().toolCalls(tcs);
+			right.content()
+				.filter(StringUtils::hasLength)
+				.ifPresent(rightFragment -> deltaBuilder.content(left.content().orElse("") + rightFragment));
+			right.refusal()
+				.filter(StringUtils::hasLength)
+				.ifPresent(rightFragment -> deltaBuilder.refusal(left.refusal().orElse("") + rightFragment));
 			// Concatenate reasoning fragments (e.g. DeepSeek "reasoning_content") so
 			// they survive the tool-call chunk merge instead of keeping only the first
 			// chunk's value.

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
@@ -34,11 +34,13 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Unit tests for {@link OpenAiChatModel.ChunkMerger}, covering the merging of streamed
- * tool call deltas by their {@code index} field. OpenAI omits {@code id} and
- * {@code function.name} on continuation deltas, while some OpenAI-compatible providers
- * (e.g. DeepSeek) send them as empty strings instead.
+ * tool call deltas by their {@code index} field and of the assistant text carried by the
+ * same chunks. OpenAI omits {@code id} and {@code function.name} on continuation deltas,
+ * while some OpenAI-compatible providers (e.g. DeepSeek) send them as empty strings
+ * instead.
  *
  * @author Jewoo Shin
+ * @author Subhash Polisetti
  */
 class OpenAiChatModelChunkMergerTests {
 
@@ -116,6 +118,32 @@ class OpenAiChatModelChunkMergerTests {
 	}
 
 	@Test
+	void mergeContentDeltasAcrossToolCallChunks() {
+		ChatCompletionChunk merged = OpenAiChatModel.ChunkMerger
+			.mergeChunks(List.of(contentChunk("I'll check ", toolCallDelta(0, "call_1", "get_weather", "{\"city\": ")),
+					contentChunk("that now.", toolCallDelta(0, null, null, "\"London\"}")), finishChunk()));
+
+		assertThat(merged.choices().get(0).delta().content()).contains("I'll check that now.");
+		List<ToolCall> toolCalls = merged.choices().get(0).delta().toolCalls().orElseThrow();
+		assertThat(toolCalls.get(0).function().orElseThrow().arguments()).contains("{\"city\": \"London\"}");
+
+		ChatCompletion completion = OpenAiChatModel.ChunkMerger.chunkToChatCompletion(merged);
+		assertThat(completion.choices().get(0).message().content()).contains("I'll check that now.");
+	}
+
+	@Test
+	void mergeRefusalDeltasAcrossToolCallChunks() {
+		ChatCompletionChunk merged = OpenAiChatModel.ChunkMerger
+			.mergeChunks(List.of(refusalChunk("I cannot ", toolCallDelta(0, "call_1", "get_weather", "{\"city\": ")),
+					refusalChunk("help with that.", toolCallDelta(0, null, null, "\"London\"}")), finishChunk()));
+
+		assertThat(merged.choices().get(0).delta().refusal()).contains("I cannot help with that.");
+
+		ChatCompletion completion = OpenAiChatModel.ChunkMerger.chunkToChatCompletion(merged);
+		assertThat(completion.choices().get(0).message().refusal()).contains("I cannot help with that.");
+	}
+
+	@Test
 	void chunkToChatCompletionRequiresToolCallId() {
 		ChatCompletionChunk chunk = chunk(FinishReason.TOOL_CALLS,
 				toolCallDelta(0, null, "get_weather", "{\"city\":\"Seoul\"}"));
@@ -172,7 +200,19 @@ class OpenAiChatModelChunkMergerTests {
 	}
 
 	private static ChatCompletionChunk chunk(@Nullable FinishReason finishReason, ToolCall... toolCalls) {
-		Delta.Builder delta = Delta.builder();
+		return chunk(Delta.builder(), finishReason, toolCalls);
+	}
+
+	private static ChatCompletionChunk contentChunk(String content, ToolCall... toolCalls) {
+		return chunk(Delta.builder().content(content), null, toolCalls);
+	}
+
+	private static ChatCompletionChunk refusalChunk(String refusal, ToolCall... toolCalls) {
+		return chunk(Delta.builder().refusal(refusal), null, toolCalls);
+	}
+
+	private static ChatCompletionChunk chunk(Delta.Builder delta, @Nullable FinishReason finishReason,
+			ToolCall... toolCalls) {
 		if (toolCalls.length > 0) {
 			delta.toolCalls(List.of(toolCalls));
 		}


### PR DESCRIPTION
`OpenAiChatModel` buffers streamed chunks from the first tool call delta until `finish_reason=tool_calls`, then collapses them with `ChunkMerger#mergeDeltas`. That merge seeds its builder from the left delta and merges only the tool calls and the reasoning fragments, so assistant text and refusal text carried by any later chunk in the buffered sequence are silently dropped — only the first chunk's values survive.

The merged delta backs the `ChatCompletionMessage` that the `AssistantMessage` is built from, so this is not confined to streamed display: the aggregated response can differ from what the provider generated. A model that emits text around its tool call, split across two chunks as "I'll check " and "that now.", keeps only the first fragment.

Both fields are now concatenated across the buffered chunks, the same way reasoning fragments already are.

## Testing

Two unit tests in `OpenAiChatModelChunkMergerTests` merge a two-chunk tool call sequence and assert both the merged delta and the resulting `ChatCompletion` message, which is the value that reaches `AssistantMessage`. Both fail on main (`Optional[I'll check ]` rather than `Optional[I'll check that now.]`) and pass with the fix. They build the chunks directly, so no credentials or network access are required.

`./mvnw -pl models/spring-ai-openai clean test` — 214/214 green.