### PR TITLE
Fix unset OpenAI `StreamOptions` flags disabling streaming token usage

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -850,8 +850,12 @@ public final class OpenAiChatModel implements ChatModel {
 
 				var ops = requestOptions.getStreamOptions();
 
-				streamOptionsBuilder.includeObfuscation(ops.includeObfuscation() != null && ops.includeObfuscation());
-				streamOptionsBuilder.includeUsage(ops.includeUsage() != null && ops.includeUsage());
+				Boolean includeObfuscation = ops.includeObfuscation();
+				if (includeObfuscation != null) {
+					streamOptionsBuilder.includeObfuscation(includeObfuscation);
+				}
+				Boolean includeUsage = ops.includeUsage();
+				streamOptionsBuilder.includeUsage(includeUsage != null ? includeUsage : true);
 
 				if (!CollectionUtils.isEmpty(ops.additionalProperties())) {
 					Map<String, com.openai.core.JsonValue> nativeParams = ops.additionalProperties()

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -629,6 +629,61 @@ class OpenAiChatModelTests {
 	}
 
 	@Test
+	void streamOptionsWithoutIncludeUsageKeepsUsageReporting() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder()
+			.model("test-model")
+			.streamOptions(OpenAiChatOptions.StreamOptions.builder().includeObfuscation(true).build())
+			.build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), true);
+
+		assertThat(request.streamOptions()).isPresent();
+		assertThat(request.streamOptions().get().includeUsage()).contains(true);
+		assertThat(request.streamOptions().get().includeObfuscation()).contains(true);
+	}
+
+	@Test
+	void streamOptionsWithIncludeUsageDisabledIsHonored() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder()
+			.model("test-model")
+			.streamOptions(OpenAiChatOptions.StreamOptions.builder().includeUsage(false).build())
+			.build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), true);
+
+		assertThat(request.streamOptions()).isPresent();
+		assertThat(request.streamOptions().get().includeUsage()).contains(false);
+	}
+
+	@Test
+	void streamOptionsWithoutIncludeObfuscationLeavesItUnset() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder()
+			.model("test-model")
+			.streamOptions(OpenAiChatOptions.StreamOptions.builder().includeUsage(true).build())
+			.build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), true);
+
+		assertThat(request.streamOptions()).isPresent();
+		assertThat(request.streamOptions().get().includeObfuscation()).isEmpty();
+	}
+
+	@Test
 	void reasoningContentFromReasoningContentProperty() {
 		ChatService chatService = mock(ChatService.class);
 		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);


### PR DESCRIPTION

`OpenAiChatModel#createRequest` coerces both `StreamOptions` flags with `value != null && value`, so a flag the caller never set is forwarded as an explicit `false` instead of being omitted from the request.

A streaming request built without `StreamOptions` defaults to `include_usage=true`, so setting any unrelated stream option silently turns token usage reporting off: with only `spring.ai.openai.chat.stream-options.include-obfuscation` configured, streaming responses come back without usage metadata. The same coercion sends `include_obfuscation=false` instead of leaving that flag to the API default.

Both flags are now forwarded only when explicitly set, and usage remains enabled by default for streaming requests.

## Testing

Three unit tests in `OpenAiChatModelTests` assert the built `ChatCompletionCreateParams`. Two fail on main (`include_usage` is `false`; `include_obfuscation` is present as `false`) and pass with the fix; the third guards that an explicit `includeUsage(false)` is still honored. They build the request directly, so no credentials or network access are required.

`./mvnw -pl models/spring-ai-openai clean test` — 215/215 green.
