### PR TITLE
Fix RedisChatMemoryRepository clear()

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepository.java
@@ -363,13 +363,20 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 		// Use QueryBuilders to create a tag field query
 		QueryNode queryNode = QueryBuilders.intersect("conversation_id",
 				Values.tags(RediSearchUtil.escape(conversationId)));
-		Query query = new Query(queryNode.toString());
-		SearchResult result = this.jedisClient.ftSearch(this.config.getIndexName(), query);
 
-		try (Pipeline pipeline = this.jedisClient.pipelined()) {
-			result.getDocuments().forEach(doc -> pipeline.del(doc.getId()));
-			pipeline.sync();
+		// FT.SEARCH defaults to LIMIT 0 10, so page through the matching documents,
+		// deleting each batch, until none remain.
+		SearchResult result;
+		do {
+			Query query = new Query(queryNode.toString());
+			result = this.jedisClient.ftSearch(this.config.getIndexName(), query);
+
+			try (Pipeline pipeline = this.jedisClient.pipelined()) {
+				result.getDocuments().forEach(doc -> pipeline.del(doc.getId()));
+				pipeline.sync();
+			}
 		}
+		while (!result.getDocuments().isEmpty());
 	}
 
 	private void initializeSchema() {

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepositoryIT.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.chat.memory.repository.redis;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.redis.testcontainers.RedisContainer;
@@ -173,6 +174,30 @@ class RedisChatMemoryRepositoryIT {
 			this.chatMemoryRepository.deleteByConversationId("test-conversation");
 
 			// Verify conversation is gone
+			assertThat(this.chatMemoryRepository.findByConversationId("test-conversation")).isEmpty();
+			assertThat(this.chatMemoryRepository.findConversationIds()).doesNotContain("test-conversation");
+		});
+	}
+
+	@Test
+	void shouldDeleteConversationWithMoreThanTenMessages() {
+		this.contextRunner.run(context -> {
+			// FT.SEARCH defaults to LIMIT 0 10, so use more than 10 messages to
+			// verify clear() pages through all matching documents instead of only
+			// deleting the first page.
+			List<Message> messages = new ArrayList<>();
+			for (int i = 0; i < 15; i++) {
+				messages.add(new UserMessage("Message " + i));
+			}
+			this.chatMemoryRepository.saveAll("test-conversation", messages);
+
+			// Verify initial state
+			assertThat(this.chatMemoryRepository.findByConversationId("test-conversation")).hasSize(15);
+
+			// Delete the conversation
+			this.chatMemoryRepository.deleteByConversationId("test-conversation");
+
+			// Verify every message was removed, not just the first 10
 			assertThat(this.chatMemoryRepository.findByConversationId("test-conversation")).isEmpty();
 			assertThat(this.chatMemoryRepository.findConversationIds()).doesNotContain("test-conversation");
 		});


### PR DESCRIPTION
The default limit in ftSearch was 10, so any conversations with more than 10 messages had leftovers after clear(...) was called.

Remove all documents matching the conversationId in a loop until ftSearch returns an empty set.

Built and ran ITs
