### PR TITLE
Propagate @McpResource title to generated resources

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/resource/AsyncMcpResourceProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/resource/AsyncMcpResourceProvider.java
@@ -30,6 +30,7 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Mono;
@@ -89,11 +90,13 @@ public class AsyncMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
 
 					var mcpResource = McpSchema.Resource.builder(uri, name)
+						.title(Utils.hasText(title) ? title : null)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)
@@ -142,11 +145,13 @@ public class AsyncMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
 
 					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder(uri, name)
+						.title(Utils.hasText(title) ? title : null)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/resource/AsyncStatelessMcpResourceProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/resource/AsyncStatelessMcpResourceProvider.java
@@ -29,6 +29,7 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Mono;
@@ -89,11 +90,13 @@ public class AsyncStatelessMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
 
 					var mcpResource = McpSchema.Resource.builder(uri, name)
+						.title(Utils.hasText(title) ? title : null)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)
@@ -142,11 +145,13 @@ public class AsyncStatelessMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
 
 					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder(uri, name)
+						.title(Utils.hasText(title) ? title : null)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/resource/SyncMcpResourceProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/resource/SyncMcpResourceProvider.java
@@ -25,6 +25,7 @@ import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecificatio
 import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.Utils;
 
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.common.McpPredicates;
@@ -63,11 +64,13 @@ public class SyncMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
 
 					var mcpResource = McpSchema.Resource.builder(uri, name)
+						.title(Utils.hasText(title) ? title : null)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)
@@ -106,11 +109,13 @@ public class SyncMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
 
 					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder(uri, name)
+						.title(Utils.hasText(title) ? title : null)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/resource/SyncStatelessMcpResourceProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/resource/SyncStatelessMcpResourceProvider.java
@@ -29,6 +29,7 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.Utils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -88,11 +89,13 @@ public class SyncStatelessMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
 
 					var mcpResource = McpSchema.Resource.builder(uri, name)
+						.title(Utils.hasText(title) ? title : null)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)
@@ -141,11 +144,13 @@ public class SyncStatelessMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
 
 					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder(uri, name)
+						.title(Utils.hasText(title) ? title : null)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/resource/AsyncMcpResourceProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/resource/AsyncMcpResourceProviderTests.java
@@ -495,4 +495,61 @@ public class AsyncMcpResourceProviderTests {
 		}).verifyComplete();
 	}
 
+	@Test
+	void testResourceTitleIsPropagated() {
+		class TitledResource {
+
+			@McpResource(uri = "test://titled", name = "titled-resource", title = "My Resource Title",
+					description = "A titled resource")
+			public Mono<String> titledResource() {
+				return Mono.just("content");
+			}
+
+		}
+
+		List<AsyncResourceSpecification> resourceSpecs = new AsyncMcpResourceProvider(List.of(new TitledResource()))
+			.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isEqualTo("My Resource Title");
+	}
+
+	@Test
+	void testResourceTemplateTitleIsPropagated() {
+		class TitledResourceTemplate {
+
+			@McpResource(uri = "test://titled/{id}", name = "titled-template", title = "My Template Title",
+					description = "A titled resource template")
+			public Mono<String> titledTemplate(String id) {
+				return Mono.just("content");
+			}
+
+		}
+
+		List<AsyncResourceTemplateSpecification> templateSpecs = new AsyncMcpResourceProvider(
+				List.of(new TitledResourceTemplate()))
+			.getResourceTemplateSpecifications();
+
+		assertThat(templateSpecs).hasSize(1);
+		assertThat(templateSpecs.get(0).resourceTemplate().title()).isEqualTo("My Template Title");
+	}
+
+	@Test
+	void testResourceTitleIsAbsentWhenNotSet() {
+		class UntitledResource {
+
+			@McpResource(uri = "test://untitled", name = "untitled-resource", description = "No title")
+			public Mono<String> untitledResource() {
+				return Mono.just("content");
+			}
+
+		}
+
+		List<AsyncResourceSpecification> resourceSpecs = new AsyncMcpResourceProvider(List.of(new UntitledResource()))
+			.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isNull();
+	}
+
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/resource/AsyncStatelessMcpResourceProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/resource/AsyncStatelessMcpResourceProviderTests.java
@@ -496,4 +496,63 @@ public class AsyncStatelessMcpResourceProviderTests {
 		}).verifyComplete();
 	}
 
+	@Test
+	void testResourceTitleIsPropagated() {
+		class TitledResource {
+
+			@McpResource(uri = "test://titled", name = "titled-resource", title = "My Resource Title",
+					description = "A titled resource")
+			public Mono<String> titledResource() {
+				return Mono.just("content");
+			}
+
+		}
+
+		List<AsyncResourceSpecification> resourceSpecs = new AsyncStatelessMcpResourceProvider(
+				List.of(new TitledResource()))
+			.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isEqualTo("My Resource Title");
+	}
+
+	@Test
+	void testResourceTemplateTitleIsPropagated() {
+		class TitledResourceTemplate {
+
+			@McpResource(uri = "test://titled/{id}", name = "titled-template", title = "My Template Title",
+					description = "A titled resource template")
+			public Mono<String> titledTemplate(String id) {
+				return Mono.just("content");
+			}
+
+		}
+
+		List<AsyncResourceTemplateSpecification> templateSpecs = new AsyncStatelessMcpResourceProvider(
+				List.of(new TitledResourceTemplate()))
+			.getResourceTemplateSpecifications();
+
+		assertThat(templateSpecs).hasSize(1);
+		assertThat(templateSpecs.get(0).resourceTemplate().title()).isEqualTo("My Template Title");
+	}
+
+	@Test
+	void testResourceTitleIsAbsentWhenNotSet() {
+		class UntitledResource {
+
+			@McpResource(uri = "test://untitled", name = "untitled-resource", description = "No title")
+			public Mono<String> untitledResource() {
+				return Mono.just("content");
+			}
+
+		}
+
+		List<AsyncResourceSpecification> resourceSpecs = new AsyncStatelessMcpResourceProvider(
+				List.of(new UntitledResource()))
+			.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isNull();
+	}
+
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/resource/SyncMcpResourceProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/resource/SyncMcpResourceProviderTests.java
@@ -531,6 +531,63 @@ public class SyncMcpResourceProviderTests {
 		assertThat(((TextResourceContents) content).text()).isEqualTo("No parameters needed");
 	}
 
+	@Test
+	void testResourceTitleIsPropagated() {
+		class TitledResource {
+
+			@McpResource(uri = "test://titled", name = "titled-resource", title = "My Resource Title",
+					description = "A titled resource")
+			public String titledResource() {
+				return "content";
+			}
+
+		}
+
+		List<SyncResourceSpecification> resourceSpecs = new SyncMcpResourceProvider(List.of(new TitledResource()))
+			.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isEqualTo("My Resource Title");
+	}
+
+	@Test
+	void testResourceTemplateTitleIsPropagated() {
+		class TitledResourceTemplate {
+
+			@McpResource(uri = "test://titled/{id}", name = "titled-template", title = "My Template Title",
+					description = "A titled resource template")
+			public String titledTemplate(String id) {
+				return "content";
+			}
+
+		}
+
+		List<SyncResourceTemplateSpecification> templateSpecs = new SyncMcpResourceProvider(
+				List.of(new TitledResourceTemplate()))
+			.getResourceTemplateSpecifications();
+
+		assertThat(templateSpecs).hasSize(1);
+		assertThat(templateSpecs.get(0).resourceTemplate().title()).isEqualTo("My Template Title");
+	}
+
+	@Test
+	void testResourceTitleIsAbsentWhenNotSet() {
+		class UntitledResource {
+
+			@McpResource(uri = "test://untitled", name = "untitled-resource", description = "No title")
+			public String untitledResource() {
+				return "content";
+			}
+
+		}
+
+		List<SyncResourceSpecification> resourceSpecs = new SyncMcpResourceProvider(List.of(new UntitledResource()))
+			.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isNull();
+	}
+
 	public static class ResourceMetaProvider implements MetaProvider {
 
 		@Override

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/resource/SyncStatelessMcpResourceProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/resource/SyncStatelessMcpResourceProviderTests.java
@@ -458,4 +458,63 @@ public class SyncStatelessMcpResourceProviderTests {
 		assertThat(((TextResourceContents) content).text()).isEqualTo("Resource for URI: request://resource");
 	}
 
+	@Test
+	void testResourceTitleIsPropagated() {
+		class TitledResource {
+
+			@McpResource(uri = "test://titled", name = "titled-resource", title = "My Resource Title",
+					description = "A titled resource")
+			public String titledResource() {
+				return "content";
+			}
+
+		}
+
+		List<SyncResourceSpecification> resourceSpecs = new SyncStatelessMcpResourceProvider(
+				List.of(new TitledResource()))
+			.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isEqualTo("My Resource Title");
+	}
+
+	@Test
+	void testResourceTemplateTitleIsPropagated() {
+		class TitledResourceTemplate {
+
+			@McpResource(uri = "test://titled/{id}", name = "titled-template", title = "My Template Title",
+					description = "A titled resource template")
+			public String titledTemplate(String id) {
+				return "content";
+			}
+
+		}
+
+		List<SyncResourceTemplateSpecification> templateSpecs = new SyncStatelessMcpResourceProvider(
+				List.of(new TitledResourceTemplate()))
+			.getResourceTemplateSpecifications();
+
+		assertThat(templateSpecs).hasSize(1);
+		assertThat(templateSpecs.get(0).resourceTemplate().title()).isEqualTo("My Template Title");
+	}
+
+	@Test
+	void testResourceTitleIsAbsentWhenNotSet() {
+		class UntitledResource {
+
+			@McpResource(uri = "test://untitled", name = "untitled-resource", description = "No title")
+			public String untitledResource() {
+				return "content";
+			}
+
+		}
+
+		List<SyncResourceSpecification> resourceSpecs = new SyncStatelessMcpResourceProvider(
+				List.of(new UntitledResource()))
+			.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isNull();
+	}
+
 }


### PR DESCRIPTION
Fixes #6786

**Background** — `@McpResource(title = "...")` never reached the client. MCP clients then fall back to `name`, which defaults to the Java method name, so a server author who sets a title sees no effect and no error.

**Cause** — The four resource providers build `McpSchema.Resource` / `ResourceTemplate` without ever reading `McpResource#title`:

```java
var mcpResource = McpSchema.Resource.builder(uri, name)
    .description(description)
    .mimeType(mimeType)
    .meta(meta)
    .build();               // no .title(...)
```

These are the runtime path — `SyncMcpAnnotationProviders` and `AsyncMcpAnnotationProviders` delegate to them. `ResourceAdapter#asResource` does set the title, but nothing in production calls that adapter. `@McpTool` and `@McpPrompt` both propagate their title, so resources were the only family dropping it.

**Fix** — Set the title in all four providers, for both the resource and the resource-template paths (8 sites). It is applied only when it has text, so resources without a title keep serializing exactly as before rather than gaining an empty `title: ""`.

I deliberately kept this narrow. Routing the providers through `ResourceAdapter` would fix #6749 at the same time, but that pulls in the `lastModified` design question raised there which has no maintainer answer yet. Happy to do it that way instead if you prefer — just say so.

**Validation**

Added three tests to each of the four provider test classes: title propagated on a resource, title propagated on a resource template, and title absent when unset.

Verified they actually catch the bug by reverting the main-code change and re-running — 8 failures, 2 per provider:

```
expected: "My Resource Title"
 but was: null
```

With the fix applied:

```
$ ./mvnw -pl mcp/mcp-annotations -am -Dtest='*ResourceProviderTests' test
Tests run: 21, Failures: 0, Errors: 0, Skipped: 0 -- SyncMcpResourceProviderTests
Tests run: 19, Failures: 0, Errors: 0, Skipped: 0 -- AsyncMcpResourceProviderTests
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0 -- SyncStatelessMcpResourceProviderTests
Tests run: 19, Failures: 0, Errors: 0, Skipped: 0 -- AsyncStatelessMcpResourceProviderTests
Tests run: 77, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Checkstyle passes. The commit is signed off per the DCO.
