### PR TITLE
Normalize advisor observation contextual names

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConvention.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConvention.java
@@ -26,6 +26,7 @@ import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.observation.conventions.SpringAiKind;
 import org.springframework.ai.util.ParsingUtils;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Default implementation of the {@link AdvisorObservationConvention}.
@@ -55,7 +56,8 @@ public class DefaultAdvisorObservationConvention implements AdvisorObservationCo
 	@Override
 	public String getContextualName(AdvisorObservationContext context) {
 		Assert.notNull(context, "context cannot be null");
-		return ParsingUtils.reConcatenateCamelCase(context.getAdvisorName(), "_")
+		String advisorName = StringUtils.trimAllWhitespace(context.getAdvisorName());
+		return ParsingUtils.reConcatenateCamelCase(advisorName, "_")
 			.replace("_around_advisor", "")
 			.replace("_advisor", "");
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
@@ -64,6 +64,25 @@ class DefaultAdvisorObservationConventionTests {
 	}
 
 	@Test
+	void contextualNameNormalizesWhitespaceForStructuredOutputValidationAdvisor() {
+		AdvisorObservationContext observationContext = AdvisorObservationContext.builder()
+			.chatClientRequest(ChatClientRequest.builder().prompt(new Prompt("Hello")).build())
+			.advisorName("Structured Output Validation Advisor")
+			.build();
+		assertThat(this.observationConvention.getContextualName(observationContext))
+			.isEqualTo("structured_output_validation");
+	}
+
+	@Test
+	void contextualNameStripsAroundAdvisorSuffix() {
+		AdvisorObservationContext observationContext = AdvisorObservationContext.builder()
+			.chatClientRequest(ChatClientRequest.builder().prompt(new Prompt("Hello")).build())
+			.advisorName("MyAroundAdvisor")
+			.build();
+		assertThat(this.observationConvention.getContextualName(observationContext)).isEqualTo("my");
+	}
+
+	@Test
 	void supportsAdvisorObservationContext() {
 		AdvisorObservationContext observationContext = AdvisorObservationContext.builder()
 			.chatClientRequest(ChatClientRequest.builder().prompt(new Prompt("Hello")).build())

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
@@ -55,6 +55,15 @@ class DefaultAdvisorObservationConventionTests {
 	}
 
 	@Test
+	void contextualNameNormalizesWhitespaceInAdvisorName() {
+		AdvisorObservationContext observationContext = AdvisorObservationContext.builder()
+			.chatClientRequest(ChatClientRequest.builder().prompt(new Prompt("Hello")).build())
+			.advisorName("Tool Calling Advisor")
+			.build();
+		assertThat(this.observationConvention.getContextualName(observationContext)).isEqualTo("tool_calling");
+	}
+
+	@Test
 	void supportsAdvisorObservationContext() {
 		AdvisorObservationContext observationContext = AdvisorObservationContext.builder()
 			.chatClientRequest(ChatClientRequest.builder().prompt(new Prompt("Hello")).build())


### PR DESCRIPTION
## Summary
- Strip whitespace from advisor names in `DefaultAdvisorObservationConvention.getContextualName()` before camel-case concatenation
- Prevents stray spaces in span names such as `tool _calling ` for `Tool Calling Advisor`
- Adds a focused unit test covering the `Tool Calling Advisor` case

Fixes #6750

## Test plan
- [x] `./mvnw -pl spring-ai-client-chat -am -Dtest=DefaultAdvisorObservationConventionTests -Dsurefire.failIfNoSpecifiedTests=false test`
- [ ] Verify OTLP / Tempo span name is `tool_calling` with tool callbacks enabled