### PR TITLE
Support generic output schemas in async MCP tool providers

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.annotation.provider.tool;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -127,12 +128,16 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 							&& !ReactiveUtils.isReactiveReturnTypeOfCallToolResult(mcpToolMethod)) {
 
 						ReactiveUtils.getReactiveReturnTypeArgument(mcpToolMethod).ifPresent(typeArgument -> {
-							Class<?> methodReturnType = typeArgument instanceof Class<?> ? (Class<?>) typeArgument
-									: null;
-							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
-									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
+							if (typeArgument instanceof Class<?> methodReturnType) {
+								if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+										&& !ClassUtils.isSimpleValueType(methodReturnType)) {
+									toolBuilder.outputSchema(this.getJsonMapper(),
+											McpJsonSchemaGenerator.generateFromClass(methodReturnType));
+								}
+							}
+							else if (typeArgument instanceof ParameterizedType) {
 								toolBuilder.outputSchema(this.getJsonMapper(),
-										McpJsonSchemaGenerator.generateFromClass((Class<?>) typeArgument));
+										McpJsonSchemaGenerator.generateFromType(typeArgument));
 							}
 						});
 					}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.annotation.provider.tool;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -132,10 +133,14 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 							&& !ReactiveUtils.isReactiveReturnTypeOfCallToolResult(mcpToolMethod)) {
 
 						ReactiveUtils.getReactiveReturnTypeArgument(mcpToolMethod).ifPresent(typeArgument -> {
-							Class<?> methodReturnType = typeArgument instanceof Class<?> ? (Class<?>) typeArgument
-									: null;
-							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
-									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
+							if (typeArgument instanceof Class<?> methodReturnType) {
+								if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+										&& !ClassUtils.isSimpleValueType(methodReturnType)) {
+									toolBuilder.outputSchema(this.getJsonMapper(),
+											McpJsonSchemaGenerator.generateFromClass(methodReturnType));
+								}
+							}
+							else if (typeArgument instanceof ParameterizedType) {
 								toolBuilder.outputSchema(this.getJsonMapper(),
 										McpJsonSchemaGenerator.generateFromType(typeArgument));
 							}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
@@ -918,6 +918,42 @@ public class AsyncMcpToolProviderTests {
 	}
 
 	@Test
+	void testToolWithStructuredListReturnType() {
+		record CustomResult(String message) {
+		}
+
+		class ListResponseTool {
+
+			@McpTool(name = "list-response", description = "Tool List response", generateOutputSchema = true)
+			public Mono<List<CustomResult>> listResponseTool(String input) {
+				return Mono.just(List.of(new CustomResult("Processed: " + input)));
+			}
+
+		}
+
+		AsyncMcpToolProvider provider = new AsyncMcpToolProvider(List.of(new ListResponseTool()));
+
+		List<AsyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		AsyncToolSpecification toolSpec = toolSpecs.get(0);
+		assertThat(toolSpec.tool().outputSchema()).containsEntry("type", "array").containsKey("items");
+		assertThat(toolSpec.tool().outputSchema().toString()).contains("message");
+
+		Mono<CallToolResult> result = toolSpec.callHandler()
+			.apply(mock(McpAsyncServerExchange.class),
+					CallToolRequest.builder("list-response").arguments(Map.of("input", "test")).build());
+
+		StepVerifier.create(result).assertNext(callToolResult -> {
+			assertThat(callToolResult.isError()).isFalse();
+			assertThat(callToolResult.structuredContent()).isInstanceOf(List.class);
+			assertThat((List<?>) callToolResult.structuredContent()).singleElement()
+				.isInstanceOfSatisfying(Map.class,
+						item -> assertThat(item).containsEntry("message", "Processed: test"));
+		}).verifyComplete();
+	}
+
+	@Test
 	void testToolWithFluxReturnType() {
 
 		record CustomResult(String message) {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
@@ -953,6 +953,42 @@ public class AsyncStatelessMcpToolProviderTests {
 	}
 
 	@Test
+	void testToolWithStructuredListReturnType() {
+		record CustomResult(String message) {
+		}
+
+		class ListResponseTool {
+
+			@McpTool(name = "list-response", description = "Tool List response", generateOutputSchema = true)
+			public Mono<List<CustomResult>> listResponseTool(String input) {
+				return Mono.just(List.of(new CustomResult("Processed: " + input)));
+			}
+
+		}
+
+		AsyncStatelessMcpToolProvider provider = new AsyncStatelessMcpToolProvider(List.of(new ListResponseTool()));
+
+		List<AsyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		AsyncToolSpecification toolSpec = toolSpecs.get(0);
+		assertThat(toolSpec.tool().outputSchema()).containsEntry("type", "array").containsKey("items");
+		assertThat(toolSpec.tool().outputSchema().toString()).contains("message");
+
+		Mono<CallToolResult> result = toolSpec.callHandler()
+			.apply(mock(McpTransportContext.class),
+					CallToolRequest.builder("list-response").arguments(Map.of("input", "test")).build());
+
+		StepVerifier.create(result).assertNext(callToolResult -> {
+			assertThat(callToolResult.isError()).isFalse();
+			assertThat(callToolResult.structuredContent()).isInstanceOf(List.class);
+			assertThat((List<?>) callToolResult.structuredContent()).singleElement()
+				.isInstanceOfSatisfying(Map.class,
+						item -> assertThat(item).containsEntry("message", "Processed: test"));
+		}).verifyComplete();
+	}
+
+	@Test
 	void testGetToolSpecificationsWithOutputSchemaGeneration() {
 		// Helper class for complex return type
 		class ComplexResult {


### PR DESCRIPTION
## Summary

Generate MCP output schemas for parameterized reactive return types in both stateful and stateless async tool providers.

When an `@McpTool(generateOutputSchema = true)` method returns a type such as `Mono<List<Result>>`, the reactive payload is a `ParameterizedType`. Both async providers converted non-`Class<?>` payloads to `null` before calling `ClassUtils`, causing tool registration to fail with `IllegalArgumentException: Class must not be null`.

This change:

- preserves the existing primitive and simple-value filtering for class payloads;
- generates schemas from `ParameterizedType` payloads;
- covers both stateful and stateless async providers;
- verifies the generated array schema and the structured tool result.

This supersedes and extends #5920 by covering both async provider variants and adding end-to-end structured-content assertions.

## Testing

- `./mvnw -Dmaven.build.cache.enabled=false -pl mcp/mcp-annotations -am test` (1,378 tests, 0 failures, 2 skipped)
- `./mvnw clean package` (169 reactor modules, BUILD SUCCESS)