### PR TITLE
Preserve `$schema` in Typed Elicitation Requests

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/context/DefaultMcpAsyncRequestContext.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/context/DefaultMcpAsyncRequestContext.java
@@ -163,8 +163,6 @@ public final class DefaultMcpAsyncRequestContext implements McpAsyncRequestConte
 
 	private Map<String, Object> generateElicitSchema(Type type) {
 		Map<String, Object> schema = jsonHelper.fromJsonToMap(McpJsonSchemaGenerator.generateFromType(type));
-		// remove as elicitation schema does not support it
-		schema.remove("$schema");
 		return schema;
 	}
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/context/DefaultMcpSyncRequestContext.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/context/DefaultMcpSyncRequestContext.java
@@ -213,8 +213,6 @@ public final class DefaultMcpSyncRequestContext implements McpSyncRequestContext
 
 	private Map<String, Object> generateElicitSchema(Type type) {
 		Map<String, Object> schema = jsonHelper.fromJsonToMap(McpJsonSchemaGenerator.generateFromType(type));
-		// remove $schema as elicitation schema does not support it
-		schema.remove("$schema");
 		return schema;
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/context/DefaultMcpAsyncRequestContextTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/context/DefaultMcpAsyncRequestContextTests.java
@@ -180,6 +180,31 @@ public class DefaultMcpAsyncRequestContextTests {
 	}
 
 	@Test
+	public void testElicitationPreservesSchemaMetadata() {
+		ClientCapabilities capabilities = mock(ClientCapabilities.class);
+		ClientCapabilities.Elicitation elicitation = mock(ClientCapabilities.Elicitation.class);
+		when(capabilities.elicitation()).thenReturn(elicitation);
+		when(this.exchange.getClientCapabilities()).thenReturn(capabilities);
+
+		record Person(String name) {
+		}
+
+		ElicitResult expectedResult = mock(ElicitResult.class);
+		when(expectedResult.action()).thenReturn(ElicitResult.Action.ACCEPT);
+		when(expectedResult.content()).thenReturn(Map.of("name", "John"));
+		when(this.exchange.createElicitation(any(ElicitRequest.class))).thenReturn(Mono.just(expectedResult));
+
+		StepVerifier.create(this.context.elicit(Person.class)).expectNextCount(1).verifyComplete();
+
+		ArgumentCaptor<ElicitFormRequest> captor = ArgumentCaptor.forClass(ElicitFormRequest.class);
+		verify(this.exchange).createElicitation(captor.capture());
+
+		Map<String, Object> requestedSchema = captor.getValue().requestedSchema();
+		assertThat(requestedSchema).containsKeys("$schema", "type", "properties", "required");
+		assertThat(((Map<?, ?>) requestedSchema.get("properties")).containsKey("name")).isTrue();
+	}
+
+	@Test
 	public void testElicitationWithMetadata() {
 		ClientCapabilities capabilities = mock(ClientCapabilities.class);
 		ClientCapabilities.Elicitation elicitation = mock(ClientCapabilities.Elicitation.class);

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/context/DefaultMcpSyncRequestContextTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/context/DefaultMcpSyncRequestContextTests.java
@@ -225,6 +225,31 @@ public class DefaultMcpSyncRequestContextTests {
 	}
 
 	@Test
+	public void testElicitationPreservesSchemaMetadata() {
+		ClientCapabilities capabilities = mock(ClientCapabilities.class);
+		ClientCapabilities.Elicitation elicitation = mock(ClientCapabilities.Elicitation.class);
+		when(capabilities.elicitation()).thenReturn(elicitation);
+		when(this.exchange.getClientCapabilities()).thenReturn(capabilities);
+
+		record Person(String name) {
+		}
+
+		ElicitResult expectedResult = mock(ElicitResult.class);
+		when(expectedResult.action()).thenReturn(ElicitResult.Action.ACCEPT);
+		when(expectedResult.content()).thenReturn(Map.of("name", "John"));
+		when(this.exchange.createElicitation(any(ElicitRequest.class))).thenReturn(expectedResult);
+
+		this.context.elicit(Person.class);
+
+		ArgumentCaptor<ElicitFormRequest> captor = ArgumentCaptor.forClass(ElicitFormRequest.class);
+		verify(this.exchange).createElicitation(captor.capture());
+
+		Map<String, Object> requestedSchema = captor.getValue().requestedSchema();
+		assertThat(requestedSchema).containsKeys("$schema", "type", "properties", "required");
+		assertThat(((Map<?, ?>) requestedSchema.get("properties")).containsKey("name")).isTrue();
+	}
+
+	@Test
 	public void testElicitationWithTypeMessageAndMeta() {
 		ClientCapabilities capabilities = mock(ClientCapabilities.class);
 		ClientCapabilities.Elicitation elicitation = mock(ClientCapabilities.Elicitation.class);


### PR DESCRIPTION
## Summary

Typed MCP elicitation requests remove generated `$schema` metadata before
sending the request. MCP 2025-11-25 and later support `$schema` in
`requestedSchema`.

Preserve the generated metadata for both sync and async typed elicitation
requests.

## Testing

- `DefaultMcpAsyncRequestContextTests`
- `DefaultMcpSyncRequestContextTests`
- Full `mcp-annotations` test suite
- Spring Java Format and Checkstyle

Full repository builds were also attempted on Windows, but both this branch
and untouched `upstream/main` encounter CRLF-sensitive observation test
failures outside `mcp-annotations`. The Spring AI PR build runs on Ubuntu.

Fixes #6730