### PR TITLE
Guard `GoogleGenAiEmbeddingConnectionAutoConfiguration` with the model enablement property

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfiguration.java
@@ -22,9 +22,12 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.genai.Client;
 
 import org.springframework.ai.google.genai.embedding.GoogleGenAiEmbeddingConnectionDetails;
+import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.model.SpringAIModels;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.util.Assert;
@@ -40,6 +43,8 @@ import org.springframework.util.StringUtils;
  */
 @AutoConfiguration
 @ConditionalOnClass({ Client.class, GoogleGenAiEmbeddingConnectionDetails.class })
+@ConditionalOnProperty(name = SpringAIModelProperties.TEXT_EMBEDDING_MODEL, havingValue = SpringAIModels.GOOGLE_GEN_AI,
+		matchIfMissing = true)
 @EnableConfigurationProperties(GoogleGenAiEmbeddingConnectionProperties.class)
 public class GoogleGenAiEmbeddingConnectionAutoConfiguration {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiEmbeddingConnectionAutoConfigurationTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.embedding;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.google.genai.embedding.GoogleGenAiEmbeddingConnectionDetails;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link GoogleGenAiEmbeddingConnectionAutoConfiguration}.
+ *
+ * @author Hoyong Eom
+ */
+class GoogleGenAiEmbeddingConnectionAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(GoogleGenAiEmbeddingConnectionAutoConfiguration.class));
+
+	@Test
+	void connectionDetailsCreatedWhenTextEmbeddingModelIsGoogleGenAi() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.google.genai.embedding.api-key=test-key",
+					"spring.ai.model.embedding.text=google-genai")
+			.run(context -> assertThat(context).hasSingleBean(GoogleGenAiEmbeddingConnectionDetails.class));
+	}
+
+	@Test
+	void connectionDetailsCreatedByDefault() {
+		this.contextRunner.withPropertyValues("spring.ai.google.genai.embedding.api-key=test-key")
+			.run(context -> assertThat(context).hasSingleBean(GoogleGenAiEmbeddingConnectionDetails.class));
+	}
+
+	@Test
+	void connectionDetailsNotCreatedWhenTextEmbeddingModelIsNone() {
+		this.contextRunner.withPropertyValues("spring.ai.model.embedding.text=none")
+			.run(context -> assertThat(context).doesNotHaveBean(GoogleGenAiEmbeddingConnectionDetails.class));
+	}
+
+	@Test
+	void connectionDetailsNotCreatedWhenAnotherTextEmbeddingModelIsSelected() {
+		this.contextRunner.withPropertyValues("spring.ai.model.embedding.text=openai")
+			.run(context -> assertThat(context).doesNotHaveBean(GoogleGenAiEmbeddingConnectionDetails.class));
+	}
+
+	/**
+	 * Without the property condition the auto-configuration runs unconditionally, and the
+	 * unconfigured connection falls back to Vertex AI mode, failing the context with
+	 * "Google GenAI project-id must be set!". Applications that do not use Google GenAI
+	 * embeddings must still start.
+	 */
+	@Test
+	void contextStartsWhenNothingIsConfiguredAndAnotherModelIsSelected() {
+		this.contextRunner.withPropertyValues("spring.ai.model.embedding.text=none").run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context).doesNotHaveBean(GoogleGenAiEmbeddingConnectionDetails.class);
+		});
+	}
+
+}


### PR DESCRIPTION
`GoogleGenAiEmbeddingConnectionAutoConfiguration` is not guarded by the
model enablement property, so it is applied whenever the artifact is on
the classpath. When nothing is configured it falls back to Vertex AI mode
and fails the context:

```
java.lang.IllegalArgumentException: Google GenAI project-id must be set!
```

This means adding `spring-ai-starter-model-google-genai-embedding` breaks
startup for applications that do not use Google GenAI embeddings, and
`spring.ai.model.embedding.text=none` does not help because the condition
is never evaluated.

## Reproduce

1. Add `spring-ai-starter-model-google-genai-embedding`.
2. Set `spring.ai.model.embedding.text=none` (or leave everything unset).
3. Start the application.

## Relation to previous reports

The same symptom was reported in #6130 and closed as a duplicate of
#6171, which removed the embedding artifact from the chat starter. That
resolves the reported case, where the artifact was pulled in
unintentionally.

It does not cover this one. Here the embedding starter is added on
purpose, because the application does use Google GenAI embeddings in some
environments and selects another provider in others. Since the artifact
is wanted on the classpath, dependency removal is not an option and the
missing condition is the only thing left.

This is exactly what was pointed out in #6130:

> There is `@ConditionalOnProperty` annotation on
> `GoogleGenAiTextEmbeddingAutoConfiguration`, so it should disable it,
> but not on `GoogleGenAiEmbeddingConnectionAutoConfiguration`, which is
> not ideal because it can't be disabled like this for now.

Unlike #6156, which gated the auto-configuration on the presence of
credentials, this reuses the existing model enablement property so that
the connection and the model it feeds share one switch.

See #6130
See #6171

## Inconsistency

The sibling auto-configurations in the same module are guarded, the
connection one is not:

| Auto-configuration | Property condition |
| --- | --- |
| `GoogleGenAiChatAutoConfiguration` | `spring.ai.model.chat` |
| `GoogleGenAiTextEmbeddingAutoConfiguration` | `spring.ai.model.embedding.text` |
| `GoogleGenAiImageAutoConfiguration` | `spring.ai.model.image` |
| `GoogleGenAiEmbeddingConnectionAutoConfiguration` | none |

## Change

Applies the same condition already used by
`GoogleGenAiTextEmbeddingAutoConfiguration`, so the connection and the
model it feeds share a single switch. `matchIfMissing = true` keeps the
current default-on behaviour, so applications that configure nothing are
unaffected.

Adds `GoogleGenAiEmbeddingConnectionAutoConfigurationTests` covering
explicit enable, default enable, `none`, another provider, and that the
context starts when nothing is configured.

## Note

`GoogleGenAiImageConnectionAutoConfiguration` has the same missing
condition. I left it out because its bean method does not fail fast the
same way and I could not confirm a broken startup for it. Happy to
extend this PR if you would like both aligned.

This may also be a small piece of the broader auto-configuration
activation discussion raised in #6130 and #5989.
