### PR TITLE
Close the resource stream in `TextReader`

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/reader/TextReader.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/reader/TextReader.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.reader;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -84,9 +85,9 @@ public class TextReader implements DocumentReader {
 
 	@Override
 	public List<Document> get() {
-		try {
+		try (InputStream inputStream = this.resource.getInputStream()) {
 
-			String document = StreamUtils.copyToString(this.resource.getInputStream(), this.charset);
+			String document = StreamUtils.copyToString(inputStream, this.charset);
 
 			// Inject source information as a metadata.
 			this.customMetadata.put(CHARSET_METADATA, this.charset.name());

--- a/spring-ai-commons/src/test/java/org/springframework/ai/reader/TextReaderTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/reader/TextReaderTests.java
@@ -18,9 +18,12 @@ package org.springframework.ai.reader;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -204,6 +207,27 @@ public class TextReaderTests {
 		assertThat(documents).hasSize(1);
 		assertThat(documents.get(0).getText()).isEqualTo("Content without extension");
 		assertThat(documents.get(0).getMetadata().get(TextReader.SOURCE_METADATA)).isEqualTo("no-extension-file");
+	}
+
+	@Test
+	void closesTheResourceInputStream() {
+		AtomicBoolean closed = new AtomicBoolean();
+		Resource resource = new ByteArrayResource("Test content".getBytes(StandardCharsets.UTF_8)) {
+			@Override
+			public InputStream getInputStream() throws IOException {
+				return new FilterInputStream(super.getInputStream()) {
+					@Override
+					public void close() throws IOException {
+						closed.set(true);
+						super.close();
+					}
+				};
+			}
+		};
+
+		new TextReader(resource).get();
+
+		assertThat(closed).isTrue();
 	}
 
 }


### PR DESCRIPTION
## Problem

`TextReader.get()` passes `resource.getInputStream()` directly into
`StreamUtils.copyToString(InputStream, Charset)`, whose javadoc states that it
"Leaves the stream open when done". Nothing else closes it, so the stream is
leaked on every call.

For a `ByteArrayResource` this is harmless, but `TextReader` is a public
`DocumentReader` normally pointed at files or URLs. An ETL pipeline reading a
directory holds one file descriptor per document until garbage collection.

`JsonReader` in the same package is not affected: Jackson's
`readTree(InputStream)` closes the source itself.

This looks like an oversight rather than a deliberate choice. The line reached
its current form in 161c4375, a 2,205-file module reshuffle, and the only later
change to `get()` was c1ee22da, which removed redundant metadata assignments
without touching resource handling.

## Solution

Read the resource inside a try-with-resources block.

## Testing

`TextReaderTests.closesTheResourceInputStream` wraps a resource so that
`close()` is observable. Reverting only the production change and keeping the
test makes it fail with:

    Expecting AtomicBoolean(false) to have value:
      true
    but did not.

and it passes with the fix in place.

    ./mvnw -Dmaven.build.cache.enabled=false -pl spring-ai-commons clean test

236 tests run, 0 failures, 0 errors, 0 skips. `spring-javaformat:apply` and
`checkstyle:check` ran as part of that build and reported no violations.

## Follow-up (not in this PR)

`ResourceCacheService` in `spring-ai-transformers` has the same pattern via
`StreamUtils.copyToByteArray(originalResource.getInputStream())`. I kept this
change to one module and can submit that separately — note that #6562 is
currently open against that file.

---

Contributed on behalf of [Goatshave](https://github.com/Goatshave).
