### PR TITLE
Make `Neo4jChatMemoryRepository.saveAll` atomic

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/main/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/main/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepository.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.neo4j.driver.Session;
+import org.neo4j.driver.SimpleQueryRunner;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionContext;
 
@@ -124,12 +125,12 @@ public final class Neo4jChatMemoryRepository implements ChatMemoryRepository {
 
 	@Override
 	public void saveAll(String conversationId, List<Message> messages) {
-		// First delete existing messages for this conversation
-		deleteByConversationId(conversationId);
-
-		// Then add the new messages
+		// Replace the conversation in a single transaction. Deleting through a
+		// separate, already committed transaction loses the previous messages when
+		// the write that follows it fails.
 		try (Session s = this.config.getDriver().session()) {
 			s.executeWriteWithoutResult(tx -> {
+				deleteConversation(tx, conversationId);
 				for (Message m : messages) {
 					addMessageToTransaction(tx, conversationId, m);
 				}
@@ -139,6 +140,19 @@ public final class Neo4jChatMemoryRepository implements ChatMemoryRepository {
 
 	@Override
 	public void deleteByConversationId(String conversationId) {
+		try (Session s = this.config.getDriver().session()) {
+			try (Transaction t = s.beginTransaction()) {
+				deleteConversation(t, conversationId);
+				t.commit();
+			}
+		}
+	}
+
+	public Neo4jChatMemoryRepositoryConfig getConfig() {
+		return this.config;
+	}
+
+	private void deleteConversation(SimpleQueryRunner queryRunner, String conversationId) {
 		String deleteMessagesStatement = """
 				MATCH (s:$($sessionLabel) {id:$conversationId})-[r:HAS_MESSAGE]->(m:$($messageLabel))
 				OPTIONAL MATCH (m)-[:HAS_METADATA]->(metadata:$($metadataLabel))
@@ -158,17 +172,8 @@ public final class Neo4jChatMemoryRepository implements ChatMemoryRepository {
 				this.config.getMetadataLabel(), "mediaLabel", this.config.getMediaLabel(), "toolResponseLabel",
 				this.config.getToolResponseLabel(), "toolCallLabel", this.config.getToolCallLabel());
 
-		try (Session s = this.config.getDriver().session()) {
-			try (Transaction t = s.beginTransaction()) {
-				t.run(deleteMessagesStatement, params);
-				t.run(deleteConversationStatement, params);
-				t.commit();
-			}
-		}
-	}
-
-	public Neo4jChatMemoryRepositoryConfig getConfig() {
-		return this.config;
+		queryRunner.run(deleteMessagesStatement, params);
+		queryRunner.run(deleteConversationStatement, params);
 	}
 
 	private Message buildToolMessage(org.neo4j.driver.Record record) {

--- a/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryIT.java
@@ -429,6 +429,30 @@ class Neo4jChatMemoryRepositoryIT {
 			.hasMessageContaining("Unable to convert java.util.Optional");
 	}
 
+	@Test
+	void saveAllKeepsTheExistingConversationWhenAWriteFails() {
+		var conversationId = UUID.randomUUID().toString();
+
+		this.chatMemoryRepository.saveAll(conversationId,
+				List.of(new UserMessage("First message"), new AssistantMessage("Second message")));
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).hasSize(2);
+
+		// Optional-typed metadata cannot be serialized, so the replacement write
+		// fails on its second message. See
+		// saveAssistantMessageWithOptionalMetadataFails.
+		AssistantMessage unstorable = AssistantMessage.builder()
+			.content("Replacement that cannot be stored")
+			.properties(Map.of("refusal", Optional.of("I cannot answer that")))
+			.build();
+
+		assertThatThrownBy(() -> this.chatMemoryRepository.saveAll(conversationId,
+				List.of(new UserMessage("Replacement message"), unstorable)))
+			.isInstanceOf(org.neo4j.driver.exceptions.ClientException.class);
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).extracting(Message::getText)
+			.containsExactly("First message", "Second message");
+	}
+
 	private Message createMessageByType(String content, MessageType messageType) {
 		return switch (messageType) {
 			case ASSISTANT -> new AssistantMessage(content);


### PR DESCRIPTION
## Problem

`Neo4jChatMemoryRepository.saveAll()` replaces a conversation by calling
`deleteByConversationId()` first. That method opens its own session, runs the
two delete statements in a transaction and commits. Only then does `saveAll()`
open a second session to write the replacement messages.

If that write fails, the delete is already committed, so the conversation is
left with neither its previous messages nor the new ones.

`JdbcChatMemoryRepository` already runs the equivalent delete-and-insert flow
inside a `TransactionTemplate`. The same defect on the MongoDB repository is
tracked in #6770.

## Solution

Extract the delete statements into
`deleteConversation(SimpleQueryRunner, String)` and run them inside the same
write transaction as the inserts. `deleteByConversationId()` keeps its own
transaction and reuses that method, so its behaviour is unchanged.

Both statements are `MATCH ... DETACH DELETE`, and the inserts derive
`msg.idx` from a count taken inside the transaction, so the combined unit of
work stays safe under the driver's retry behaviour.

## Testing

`Neo4jChatMemoryRepositoryIT.saveAllKeepsTheExistingConversationWhenAWriteFails`
saves two messages, then attempts a replacement whose second message cannot be
serialized — the same `Optional`-typed metadata that the existing
`saveAssistantMessageWithOptionalMetadataFails` relies on.

Reverting only the production change and keeping the test shows the
conversation is wiped:

    Expecting actual:
      []
    to contain exactly (and in same order):
      ["First message", "Second message"]

With the fix the two original messages survive the failed write.

    ./mvnw -Dmaven.build.cache.enabled=false -Pintegration-tests \
      -pl memory-repositories/spring-ai-model-chat-memory-repository-neo4j verify

32 tests run, 0 failures, 0 errors, 0 skips. The downstream
`spring-ai-autoconfigure-model-chat-memory-repository-neo4j` module passes too
(3 tests). `spring-javaformat:apply` and `checkstyle:check` reported no
violations.

## Follow-up (not in this PR)

`deleteByConversationId()` is the only method here still using an unmanaged
transaction, so unlike the others it does not get the driver's retry behaviour
on transient failures. That is unrelated to atomicity, so I left it out — happy
to follow up separately if you would like it aligned with the rest of the class.

---

Contributed on behalf of [Goatshave](https://github.com/Goatshave).
