### PR TITLE
Add image model usage metrics

### DIFF
--- a/auto-configurations/models/image/observation/spring-ai-autoconfigure-model-image-observation/src/main/java/org/springframework/ai/model/image/observation/autoconfigure/ImageObservationAutoConfiguration.java
+++ b/auto-configurations/models/image/observation/spring-ai-autoconfigure-model-image-observation/src/main/java/org/springframework/ai/model/image/observation/autoconfigure/ImageObservationAutoConfiguration.java
@@ -16,14 +16,17 @@
 
 package org.springframework.ai.model.image.observation.autoconfigure;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.tracing.Tracer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.ai.image.ImageModel;
+import org.springframework.ai.image.observation.ImageModelMeterObservationHandler;
 import org.springframework.ai.image.observation.ImageModelObservationContext;
 import org.springframework.ai.image.observation.ImageModelPromptContentObservationHandler;
 import org.springframework.ai.observation.TracingAwareLoggingObservationHandler;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -41,7 +44,10 @@ import org.springframework.context.annotation.Configuration;
  * @author Jonatan Ivanov
  * @since 1.0.0
  */
-@AutoConfiguration
+// afterName: CompositeMeterRegistryAutoConfiguration declares a MeterRegistry bean that
+// some beans here are conditional on
+@AutoConfiguration(
+		afterName = "org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration")
 @ConditionalOnClass(ImageModel.class)
 @EnableConfigurationProperties(ImageObservationProperties.class)
 public class ImageObservationAutoConfiguration {
@@ -51,6 +57,13 @@ public class ImageObservationAutoConfiguration {
 	private static void logPromptContentWarning() {
 		logger.warn(
 				"You have enabled logging out the image prompt content with the risk of exposing sensitive or private information. Please, be careful!");
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean(MeterRegistry.class)
+	ImageModelMeterObservationHandler imageModelMeterObservationHandler(ObjectProvider<MeterRegistry> meterRegistry) {
+		return new ImageModelMeterObservationHandler(meterRegistry.getObject());
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/auto-configurations/models/image/observation/spring-ai-autoconfigure-model-image-observation/src/test/java/org/springframework/ai/model/image/observation/autoconfigure/ImageObservationAutoConfigurationTests.java
+++ b/auto-configurations/models/image/observation/spring-ai-autoconfigure-model-image-observation/src/test/java/org/springframework/ai/model/image/observation/autoconfigure/ImageObservationAutoConfigurationTests.java
@@ -16,10 +16,12 @@
 
 package org.springframework.ai.model.image.observation.autoconfigure;
 
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.tracing.Tracer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.springframework.ai.image.observation.ImageModelMeterObservationHandler;
 import org.springframework.ai.image.observation.ImageModelObservationContext;
 import org.springframework.ai.image.observation.ImageModelPromptContentObservationHandler;
 import org.springframework.ai.observation.TracingAwareLoggingObservationHandler;
@@ -45,6 +47,29 @@ class ImageObservationAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(ImageObservationAutoConfiguration.class));
+
+	@Test
+	void meterObservationHandlerEnabled() {
+		this.contextRunner.withBean(CompositeMeterRegistry.class)
+			.run(context -> assertThat(context).hasSingleBean(ImageModelMeterObservationHandler.class));
+	}
+
+	@Test
+	void meterObservationHandlerDisabled() {
+		this.contextRunner.run(context -> assertThat(context).doesNotHaveBean(ImageModelMeterObservationHandler.class));
+	}
+
+	@Test
+	void meterObservationHandlerBacksOff() {
+		var customHandler = new ImageModelMeterObservationHandler(new CompositeMeterRegistry());
+		this.contextRunner.withBean(CompositeMeterRegistry.class)
+			.withBean("customImageModelMeterObservationHandler", ImageModelMeterObservationHandler.class,
+					() -> customHandler)
+			.run(context -> {
+				assertThat(context).hasSingleBean(ImageModelMeterObservationHandler.class);
+				assertThat(context.getBean(ImageModelMeterObservationHandler.class)).isSameAs(customHandler);
+			});
+	}
 
 	@Test
 	void imageModelPromptContentHandlerNoTracer() {

--- a/spring-ai-model/src/main/java/org/springframework/ai/image/observation/ImageModelMeterObservationHandler.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/image/observation/ImageModelMeterObservationHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.image.observation;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+
+import org.springframework.ai.model.observation.ModelUsageMetricsGenerator;
+
+/**
+ * Handler for generating metrics from image model observations.
+ *
+ * @author ZYZ666-RGB
+ * @since 2.0.1
+ */
+public class ImageModelMeterObservationHandler implements ObservationHandler<ImageModelObservationContext> {
+
+	private final MeterRegistry meterRegistry;
+
+	public ImageModelMeterObservationHandler(MeterRegistry meterRegistry) {
+		this.meterRegistry = meterRegistry;
+	}
+
+	@Override
+	public void onStop(ImageModelObservationContext context) {
+		if (context.getResponse() != null && context.getResponse().getMetadata() != null
+				&& context.getResponse().getMetadata().getUsage() != null) {
+			ModelUsageMetricsGenerator.generate(context.getResponse().getMetadata().getUsage(), context,
+					this.meterRegistry);
+		}
+	}
+
+	@Override
+	public boolean supportsContext(Observation.Context context) {
+		return context instanceof ImageModelObservationContext;
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/image/observation/ImageModelMeterObservationHandlerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/image/observation/ImageModelMeterObservationHandlerTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.image.observation;
+
+import java.util.List;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.image.ImageOptionsBuilder;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.image.ImageResponseMetadata;
+import org.springframework.ai.observation.conventions.AiObservationMetricAttributes;
+import org.springframework.ai.observation.conventions.AiObservationMetricNames;
+import org.springframework.ai.observation.conventions.AiOperationType;
+import org.springframework.ai.observation.conventions.AiTokenType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.ai.image.observation.ImageModelObservationDocumentation.LowCardinalityKeyNames;
+
+/**
+ * Unit tests for {@link ImageModelMeterObservationHandler}.
+ *
+ * @author ZYZ666-RGB
+ */
+class ImageModelMeterObservationHandlerTests {
+
+	private MeterRegistry meterRegistry;
+
+	private ObservationRegistry observationRegistry;
+
+	@BeforeEach
+	void setUp() {
+		this.meterRegistry = new SimpleMeterRegistry();
+		this.observationRegistry = ObservationRegistry.create();
+		this.observationRegistry.observationConfig()
+			.observationHandler(new ImageModelMeterObservationHandler(this.meterRegistry));
+	}
+
+	@Test
+	void shouldCreateUsageMetersDuringAnObservation() {
+		var observationContext = generateObservationContext();
+		var observation = Observation
+			.createNotStarted(new DefaultImageModelObservationConvention(), () -> observationContext,
+					this.observationRegistry)
+			.start();
+
+		observationContext
+			.setResponse(new ImageResponse(List.of(), new ImageResponseMetadata(42L, new DefaultUsage(100, 20, 120))));
+
+		observation.stop();
+
+		assertThat(this.meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value()).meters()).hasSize(3);
+		assertThat(this.meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value())
+			.tag(LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(), AiOperationType.IMAGE.value())
+			.tag(LowCardinalityKeyNames.AI_PROVIDER.asString(), "superprovider")
+			.tag(LowCardinalityKeyNames.REQUEST_MODEL.asString(), "image-model")
+			.meters()).hasSize(3);
+		assertThat(this.meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value())
+			.tag(AiObservationMetricAttributes.TOKEN_TYPE.value(), AiTokenType.INPUT.value())
+			.counter()
+			.count()).isEqualTo(100);
+		assertThat(this.meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value())
+			.tag(AiObservationMetricAttributes.TOKEN_TYPE.value(), AiTokenType.OUTPUT.value())
+			.counter()
+			.count()).isEqualTo(20);
+		assertThat(this.meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value())
+			.tag(AiObservationMetricAttributes.TOKEN_TYPE.value(), AiTokenType.TOTAL.value())
+			.counter()
+			.count()).isEqualTo(120);
+	}
+
+	@Test
+	void shouldHandleNullUsageGracefully() {
+		var observationContext = generateObservationContext();
+		var observation = Observation
+			.createNotStarted(new DefaultImageModelObservationConvention(), () -> observationContext,
+					this.observationRegistry)
+			.start();
+
+		observationContext.setResponse(new ImageResponse(List.of(), new ImageResponseMetadata(42L, null)));
+
+		observation.stop();
+
+		assertThat(this.meterRegistry.getMeters())
+			.noneMatch(meter -> meter.getId().getName().equals(AiObservationMetricNames.TOKEN_USAGE.value()));
+	}
+
+	@Test
+	void shouldHandleObservationWithoutResponse() {
+		var observationContext = generateObservationContext();
+		var observation = Observation
+			.createNotStarted(new DefaultImageModelObservationConvention(), () -> observationContext,
+					this.observationRegistry)
+			.start();
+
+		observation.stop();
+
+		assertThat(this.meterRegistry.getMeters())
+			.noneMatch(meter -> meter.getId().getName().equals(AiObservationMetricNames.TOKEN_USAGE.value()));
+	}
+
+	private ImageModelObservationContext generateObservationContext() {
+		return ImageModelObservationContext.builder()
+			.imagePrompt(new ImagePrompt("hello", ImageOptionsBuilder.builder().model("image-model").build()))
+			.provider("superprovider")
+			.build();
+	}
+
+}


### PR DESCRIPTION
﻿## Summary

- add an image model observation handler that publishes `gen_ai.client.token.usage` counters
- register the handler when a `MeterRegistry` is available and back off when a custom handler exists
- add focused tests for metric values and tags, missing responses, null usage, and auto-configuration behavior

## Motivation

`ImageResponseMetadata` exposes token usage, but image model observations currently have no meter observation handler. As a result, token usage from image generation is not recorded in Micrometer metrics.

This change aligns image model observability with the existing chat and embedding model behavior.

Fixes #6799.

## Testing

- `.\mvnw.cmd -pl spring-ai-model "-Dtest=ImageModelMeterObservationHandlerTests" test` — 3 tests passed
- `.\mvnw.cmd -pl auto-configurations/models/image/observation/spring-ai-autoconfigure-model-image-observation -am "-Dtest=ImageObservationAutoConfigurationTests" "-Dsurefire.failIfNoSpecifiedTests=false" test` — 12 tests passed
- `.\mvnw.cmd clean package` — image-related modules passed; the overall Windows build stopped in unrelated, whitespace-sensitive `spring-ai-rag` prompt assertions
