### PR TITLE
Fix OpenAI `connection-pool-metrics-enabled` being ignored

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtil.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtil.java
@@ -64,6 +64,9 @@ public final class OpenAiAutoConfigurationUtil {
 
 		resolved.setGitHubModels(modelProperties.isGitHubModels() || commonProperties.isGitHubModels());
 
+		resolved.setConnectionPoolMetricsEnabled(
+				modelProperties.isConnectionPoolMetricsEnabled() || commonProperties.isConnectionPoolMetricsEnabled());
+
 		resolved.setMaxRetries(modelProperties.getMaxRetries() != OpenAiCommonProperties.DEFAULT_MAX_RETRIES
 				? modelProperties.getMaxRetries() : commonProperties.getMaxRetries());
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtilTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtilTests.java
@@ -86,6 +86,38 @@ public class OpenAiAutoConfigurationUtilTests {
 		assertThat(resolved.getApiKey()).isNull();
 	}
 
+	@Test
+	void commonConnectionPoolMetricsEnabledUsedWhenModelUsesDefault() {
+		var common = new OpenAiCommonProperties();
+		common.setConnectionPoolMetricsEnabled(true);
+		var model = new OpenAiCommonProperties();
+
+		var resolved = OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model);
+
+		assertThat(resolved.isConnectionPoolMetricsEnabled()).isTrue();
+	}
+
+	@Test
+	void modelConnectionPoolMetricsEnabledUsedWhenCommonUsesDefault() {
+		var common = new OpenAiCommonProperties();
+		var model = new OpenAiCommonProperties();
+		model.setConnectionPoolMetricsEnabled(true);
+
+		var resolved = OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model);
+
+		assertThat(resolved.isConnectionPoolMetricsEnabled()).isTrue();
+	}
+
+	@Test
+	void connectionPoolMetricsDisabledWhenNeitherLevelEnablesIt() {
+		var common = new OpenAiCommonProperties();
+		var model = new OpenAiCommonProperties();
+
+		var resolved = OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model);
+
+		assertThat(resolved.isConnectionPoolMetricsEnabled()).isFalse();
+	}
+
 	private static OpenAiCommonProperties properties(String apiKey) {
 		var props = new OpenAiCommonProperties();
 		props.setApiKey(apiKey);

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatPropertiesTests.java
@@ -18,6 +18,8 @@ package org.springframework.ai.model.openai.autoconfigure;
 
 import java.util.List;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -169,6 +171,36 @@ public class OpenAiChatPropertiesTests {
 				assertThat(options.getExtraBody()).containsEntry("key1", "value1");
 				assertThat(options.getExtraBody()).containsEntry("key2", "123");
 				assertThat(options.getExtraBody()).containsKey("nested");
+			});
+	}
+
+	@Test
+	public void connectionPoolMetricsEnabled() {
+
+		this.contextRunner
+			.withPropertyValues("spring.ai.openai.api-key=abc123",
+					"spring.ai.openai.connection-pool-metrics-enabled=true")
+			.withBean(SimpleMeterRegistry.class)
+			.withConfiguration(
+					AutoConfigurations.of(OpenAiChatAutoConfiguration.class, ToolCallingAutoConfiguration.class))
+			.run(context -> {
+				var meterRegistry = context.getBean(MeterRegistry.class);
+
+				assertThat(meterRegistry.find("okhttp.pool.connection.count").gauges()).isNotEmpty();
+			});
+	}
+
+	@Test
+	public void connectionPoolMetricsDisabledByDefault() {
+
+		this.contextRunner.withPropertyValues("spring.ai.openai.api-key=abc123")
+			.withBean(SimpleMeterRegistry.class)
+			.withConfiguration(
+					AutoConfigurations.of(OpenAiChatAutoConfiguration.class, ToolCallingAutoConfiguration.class))
+			.run(context -> {
+				var meterRegistry = context.getBean(MeterRegistry.class);
+
+				assertThat(meterRegistry.find("okhttp.pool.connection.count").gauges()).isEmpty();
 			});
 	}
 


### PR DESCRIPTION
## Problem

`OpenAiAutoConfigurationUtil.resolveCommonProperties` builds the `ResolvedConnectionProperties` instance that every OpenAI model auto-configuration reads. It resolves each connection property from the model-level or the common-level properties, but there is no branch for `connectionPoolMetricsEnabled`, so the resolved value stays at its `false` default whatever the user configures.

All six OpenAI auto-configurations (chat, embedding, image, moderation, audio speech, audio transcription) pick their meter registry from that resolved value:

```java
MeterRegistry meterRegistryToUse = commonProperties.isConnectionPoolMetricsEnabled()
        ? meterRegistry.getIfAvailable() : null;
```

The parameter is named `commonProperties`, but each caller passes `resolvedProperties` into it. So all six pass `null` to the OpenAI clients, and `SpringAiOpenAiHttpClient` binds `OkHttpConnectionPoolMetrics` only when the registry is non-null.

The opt-in that `openai-chat.adoc` tells users to set therefore does nothing:

```properties
spring.ai.openai.chat.connection-pool-metrics-enabled=true
```

Neither does `spring.ai.openai.connection-pool-metrics-enabled`, the row listed in the property table of all six OpenAI reference pages. Auto-configuration never registers an `okhttp.pool.*` gauge.

Commit 386df9cc46 added the property and the six consumers but did not touch `OpenAiAutoConfigurationUtil`.

## Changes

Resolve `connectionPoolMetricsEnabled` next to the sibling booleans, with the resolution they already use:

```java
resolved.setConnectionPoolMetricsEnabled(
        modelProperties.isConnectionPoolMetricsEnabled() || commonProperties.isConnectionPoolMetricsEnabled());
```

For a primitive boolean defaulting to `false`, that OR is the same rule the other properties follow: take the model value unless it is the default, otherwise take the common value. Both documented keys start working, and the property stays opt-in.

It does not let a model-level `false` override a common-level `true`. Distinguishing "explicitly false" from "not set" needs a nullable `Boolean`, and `isMicrosoftFoundry` and `isGitHubModels` do not do that either.

I checked the rest of the resolver rather than this field alone. Comparing every setter on `AbstractOpenAiProperties` against the ones `resolveCommonProperties` assigns, `connectionPoolMetricsEnabled` was the only property left unresolved.

## Testing

`OpenAiChatPropertiesTests.connectionPoolMetricsEnabled` starts the chat auto-configuration with `spring.ai.openai.connection-pool-metrics-enabled=true` and a `SimpleMeterRegistry`, then asserts that `okhttp.pool.connection.count` gauges are registered. Without the change it fails with `Expecting actual not to be empty`, since no gauge is bound. `connectionPoolMetricsDisabledByDefault` pins the opt-in default.

`OpenAiAutoConfigurationUtilTests` adds three resolver cases: enabled at the common level only, enabled at the model level only, and enabled at neither. The first two fail without the change.

```text
./mvnw -Dmaven.build.cache.enabled=false -pl auto-configurations/models/spring-ai-autoconfigure-model-openai test
```

passes with 29 tests. `starters/spring-ai-starter-model-openai` and `auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai`, the modules that depend on it, pass with 12 tests.

`./mvnw -Dmaven.build.cache.enabled=false clean package -DskipITs` also passes, with 5662 tests and no failures.
