### PR TITLE
Fix `JsoupDocumentReader` dropping relative link URLs

### DIFF
--- a/document-readers/spring-ai-jsoup-document-reader/src/main/java/org/springframework/ai/reader/jsoup/JsoupDocumentReader.java
+++ b/document-readers/spring-ai-jsoup-document-reader/src/main/java/org/springframework/ai/reader/jsoup/JsoupDocumentReader.java
@@ -69,7 +69,7 @@ public class JsoupDocumentReader implements DocumentReader {
 	@Override
 	public List<Document> get() {
 		try (InputStream inputStream = this.htmlResource.getInputStream()) {
-			org.jsoup.nodes.Document doc = Jsoup.parse(inputStream, this.config.charset, "");
+			org.jsoup.nodes.Document doc = Jsoup.parse(inputStream, this.config.charset, resolveBaseUri());
 
 			List<Document> documents = new ArrayList<>();
 
@@ -105,6 +105,22 @@ public class JsoupDocumentReader implements DocumentReader {
 		}
 		catch (IOException e) {
 			throw new RuntimeException("Failed to read HTML resource: " + this.htmlResource, e);
+		}
+	}
+
+	/**
+	 * Returns the base URI used to resolve relative links against, taken from the
+	 * resource itself. Resources that cannot be resolved to a URL, such as a
+	 * {@link org.springframework.core.io.ByteArrayResource}, have no base to resolve
+	 * against and keep an empty one.
+	 */
+	private String resolveBaseUri() {
+		try {
+			return this.htmlResource.getURL().toString();
+		}
+		catch (IOException ignored) {
+			// A resource without a URL has no base to resolve against.
+			return "";
 		}
 	}
 

--- a/document-readers/spring-ai-jsoup-document-reader/src/test/java/org/springframework/ai/reader/jsoup/JsoupDocumentReaderTests.java
+++ b/document-readers/spring-ai-jsoup-document-reader/src/test/java/org/springframework/ai/reader/jsoup/JsoupDocumentReaderTests.java
@@ -96,6 +96,21 @@ class JsoupDocumentReaderTests {
 	}
 
 	@Test
+	void testWithRelativeLinkUrls() {
+		JsoupDocumentReader reader = new JsoupDocumentReader(
+				new DefaultResourceLoader().getResource("classpath:/test-relative-links.html"),
+				JsoupDocumentReaderConfig.builder().includeLinkUrls(true).build());
+		List<Document> documents = reader.get();
+		assertThat(documents).hasSize(1);
+		Document document = documents.get(0);
+
+		List<String> linkUrls = (List<String>) document.getMetadata().get("linkUrls");
+		assertThat(linkUrls).contains("https://spring.io/");
+		assertThat(linkUrls).noneMatch(String::isEmpty);
+		assertThat(linkUrls).anySatisfy(url -> assertThat(url).endsWith("/guide.html"));
+	}
+
+	@Test
 	void testWithMetadataTags() {
 		JsoupDocumentReader reader = new JsoupDocumentReader(
 				new DefaultResourceLoader().getResource("classpath:/test.html"),

--- a/document-readers/spring-ai-jsoup-document-reader/src/test/resources/test-relative-links.html
+++ b/document-readers/spring-ai-jsoup-document-reader/src/test/resources/test-relative-links.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Relative Links</title>
+</head>
+<body>
+<a href="guide.html">Relative link</a>
+<a href="https://spring.io/">Absolute link</a>
+</body>
+</html>


### PR DESCRIPTION
## Problem

`JsoupDocumentReader` parses its resource with an empty base URI:

```java
org.jsoup.nodes.Document doc = Jsoup.parse(inputStream, this.config.charset, "");
```

Link extraction then asks jsoup for the absolute form of each `href`:

```java
List<String> linkUrls = links.stream().map(link -> link.attr("abs:href")).toList();
```

`abs:` resolves against the document base URI. With an empty base there is nothing to resolve against, so a relative link yields an empty string rather than a URL. Reading a page that contains `<a href="guide.html">` with `includeLinkUrls` enabled produces this metadata:

```text
linkUrls = ["", "https://spring.io/"]
```

The relative link is not shortened or left relative. It is gone, and nothing reports it.

Two places state the opposite behavior. The reference documentation, under the HTML (JSoup) reader in `etl-pipeline.adoc`:

> The base URI, for resolving relative links, will be extracted from URL resources.

And the module README, which lists as a feature:

> Extract a list of all absolute URLs of links (`<a href="...">`) within the document.

Commit 82b46d218 introduced the reader, that README line, and that documentation line together. The base URI has been empty since.

## Changes

Take the base URI from the resource:

```java
private String resolveBaseUri() {
    try {
        return this.htmlResource.getURL().toString();
    }
    catch (IOException ex) {
        return "";
    }
}
```

Resources that do not resolve to a URL, `ByteArrayResource` among them, keep the empty base and behave exactly as before. `TextReader` already treats a resource this way, catching `IOException` from `getURL()` when the resource has no URL to give.

Absolute links are unaffected, since jsoup returns those unchanged whatever the base is.

This is the only `Jsoup.parse` call in the repository, so no sibling reader carries the same omission.

## Testing

`testWithRelativeLinkUrls` reads a classpath resource holding one relative and one absolute link, then asserts that no entry in `linkUrls` is empty and that the relative link resolved against the resource. Without the change it fails on the empty entry:

```text
Expecting no elements of:
  ["", "https://spring.io/"]
to match given predicate but this element did:
  ""
```

The existing `ByteArrayResource` tests cover the no-URL path and still pass.

```text
./mvnw -pl document-readers/spring-ai-jsoup-document-reader test
```

passes with 12 tests, 1 skipped, the skip being the pre-existing test that needs an internet connection.
