### PR TITLE
Fix PDF paragraph end page taken from a descendant or left at -1

### DIFF
--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
@@ -114,16 +114,16 @@ public class ParagraphManager {
 		while (current != null) {
 
 			int pageNumber = getPageNumber(current);
-			var nextSiblingNumber = getPageNumber(current.getNextSibling());
-			if (nextSiblingNumber < 0) {
-				nextSiblingNumber = getPageNumber(current.getLastChild());
+			var endPageNumber = getPageNumber(current.getNextSibling());
+			if (endPageNumber < 0) {
+				endPageNumber = parentParagraph.endPageNumber();
 			}
 
 			var paragraphPosition = (current.getDestination() instanceof PDPageXYZDestination)
 					? ((PDPageXYZDestination) current.getDestination()).getTop() : 0;
 
-			var currentParagraph = new Paragraph(parentParagraph, current.getTitle(), level, pageNumber,
-					nextSiblingNumber, paragraphPosition);
+			var currentParagraph = new Paragraph(parentParagraph, current.getTitle(), level, pageNumber, endPageNumber,
+					paragraphPosition);
 
 			parentParagraph.children().add(currentParagraph);
 

--- a/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
@@ -114,4 +114,24 @@ public class ParagraphPdfDocumentReaderTests {
 		assertThat(documents.get(1).getMetadata().get("title")).isEqualTo("Chapter 3");
 	}
 
+	@Test
+	void lastParagraphEndsOnTheLastPage() throws IOException {
+
+		int lastPage;
+		try (InputStream inputStream = new ClassPathResource("sample3.pdf").getInputStream();
+				PDDocument pdf = Loader.loadPDF(inputStream.readAllBytes())) {
+			lastPage = pdf.getNumberOfPages();
+		}
+
+		List<Document> documents = new ParagraphPdfDocumentReader("classpath:/sample3.pdf",
+				PdfDocumentReaderConfig.defaultConfig())
+			.get();
+
+		assertThat(documents).isNotEmpty();
+		assertThat(documents).extracting(document -> document.getMetadata().get("end_page_number"))
+			.allSatisfy(endPageNumber -> assertThat((Integer) endPageNumber).as("end_page_number must be a page number")
+				.isBetween(1, lastPage));
+		assertThat(documents.get(documents.size() - 1).getMetadata()).containsEntry("end_page_number", lastPage);
+	}
+
 }

--- a/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/config/ParagraphManagerTests.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/config/ParagraphManagerTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.reader.pdf.config;
+
+import java.io.IOException;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageXYZDestination;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.reader.pdf.config.ParagraphManager.Paragraph;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+/**
+ * Tests for {@link ParagraphManager}.
+ */
+class ParagraphManagerTests {
+
+	private static final int PAGE_COUNT = 8;
+
+	/**
+	 * A paragraph ends where the next item in reading order begins. For an item with no
+	 * following sibling that is the next item after its parent, and for the last item of
+	 * the document it is the last page.
+	 */
+	@Test
+	void endPageIsWhereTheNextItemInReadingOrderBegins() throws IOException {
+
+		try (PDDocument document = outlinedDocument()) {
+
+			var paragraphs = new ParagraphManager(document).flatten();
+
+			assertThat(paragraphs).extracting(Paragraph::title, Paragraph::endPageNumber)
+				.containsExactly(tuple("Chapter 1", 4), tuple("Section 1.1", 3), tuple("Section 1.2", 4),
+						tuple("Chapter 2", PAGE_COUNT), tuple("Section 2.1", 6), tuple("Section 2.2", PAGE_COUNT));
+		}
+	}
+
+	/**
+	 * Builds an eight page document outlined as two chapters of two sections each, so
+	 * that the last section of each chapter has neither a following sibling nor a child,
+	 * and the last chapter has no following sibling.
+	 */
+	private static PDDocument outlinedDocument() {
+
+		PDDocument document = new PDDocument();
+		for (int i = 0; i < PAGE_COUNT; i++) {
+			document.addPage(new PDPage());
+		}
+
+		PDDocumentOutline outline = new PDDocumentOutline();
+		document.getDocumentCatalog().setDocumentOutline(outline);
+
+		PDOutlineItem chapterOne = bookmark(document, "Chapter 1", 1);
+		chapterOne.addLast(bookmark(document, "Section 1.1", 2));
+		chapterOne.addLast(bookmark(document, "Section 1.2", 3));
+		outline.addLast(chapterOne);
+
+		PDOutlineItem chapterTwo = bookmark(document, "Chapter 2", 4);
+		chapterTwo.addLast(bookmark(document, "Section 2.1", 5));
+		chapterTwo.addLast(bookmark(document, "Section 2.2", 6));
+		outline.addLast(chapterTwo);
+
+		return document;
+	}
+
+	private static PDOutlineItem bookmark(PDDocument document, String title, int pageNumber) {
+
+		PDPageXYZDestination destination = new PDPageXYZDestination();
+		destination.setPage(document.getPage(pageNumber - 1));
+
+		PDOutlineItem bookmark = new PDOutlineItem();
+		bookmark.setTitle(title);
+		bookmark.setDestination(destination);
+		return bookmark;
+	}
+
+}


### PR DESCRIPTION
## Problem

`ParagraphManager` takes the end page of an outline item from its next sibling, and falls back to the item's own last child:

```java
var nextSiblingNumber = getPageNumber(current.getNextSibling());
if (nextSiblingNumber < 0) {
    nextSiblingNumber = getPageNumber(current.getLastChild());
}
```

Both branches go wrong for an item with no following sibling.

An item that also has no children reaches `getPageNumber(null)`, which returns `-1`, and `-1` is stored as the end page. That is not the final entry of the document alone: it is the last leaf of every branch, so an outline with chapters and sections hits it once per chapter.

An item that does have children takes the start page of one of its own descendants. A descendant begins inside the item, not after it, so the end page lands earlier than where the item actually ends.

`Paragraph` documents the field as the page where the paragraph ends, and the reference documentation describes `end_page_number` as the ending page number of the document. `ParagraphPdfDocumentReader` publishes the value unchanged and `FileDocumentWriter` renders it into document markers, so both values reach the output. Reading the module's own three page `sample3.pdf` produces `pages:[3,-1]` for the last chapter.

The same reader already refuses a page number below 1 at the other end of the range: `getTextBetweenParagraphs` logs an invalid start page and skips the paragraph, which drops the document. An end page of `-1` is published instead.

`-1` is not a sentinel that callers are meant to read. Nothing branches on it, and the root paragraph shows what the class means the field to hold. The root has no following sibling, and it is built as `new Paragraph(null, "root", -1, 1, document.getNumberOfPages(), 0)`, so an element with nothing after it already ends on the last page here. The local variable is named after the first of the two lookups rather than after the field it fills.

## Changes

An item ends where the next item in reading order begins. That is its following sibling, and for an item without one it is wherever its parent ends:

```java
var endPageNumber = getPageNumber(current.getNextSibling());
if (endPageNumber < 0) {
    endPageNumber = parentParagraph.endPageNumber();
}
```

The parent has already been resolved by the same rule when its children are processed, so this walks the ancestors without traversing them, and the chain terminates at the root paragraph, which is built with `document.getNumberOfPages()`. The last-child branch is removed rather than kept behind another fallback, since a descendant never marks where its ancestor ends.

Measured on an eight page document outlined as two chapters of two sections each:

```text
                before   after
Chapter 1          4       4
Section 1.1        3       3
Section 1.2       -1       4
Chapter 2          6       8
Section 2.1        6       6
Section 2.2       -1       8
```

`Chapter 2` is the behavior change beyond the negative values. It has no following sibling, so it previously ended at the start page of `Section 2.2` and now ends on the last page of the document.

`PagePdfDocumentReader` derives both page numbers from its page loop and writes `end_page_number` only when it differs from the start, so it does not share this defect.

## Testing

`ParagraphManagerTests.endPageIsWhereTheNextItemInReadingOrderBegins` builds the outline above and asserts the whole table. It fails without the change on the three entries listed, which is how the numbers above were measured.

`ParagraphPdfDocumentReaderTests.lastParagraphEndsOnTheLastPage` covers the reader path: every `end_page_number` from `sample3.pdf` falls between the first and last page, and the final paragraph ends on the last page. It fails without the change on the `-1`, and needs no new fixture.

```text
./mvnw -Dmaven.build.cache.enabled=false -pl document-readers/spring-ai-pdf-document-reader test
```

passes with 43 tests. `./mvnw -Dmaven.build.cache.enabled=false clean package -DskipITs` passes with no failures.
