### PR TITLE
docs: fix OpenAI Transcriptions page title

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
@@ -1,4 +1,5 @@
 = OpenAI Transcriptions
+:page-title: OpenAI Transcriptions
 
 Spring AI supports https://platform.openai.com/docs/api-reference/audio/createTranscription[OpenAI's Transcription model].
 


### PR DESCRIPTION
## Summary
- Add the page title metadata for the OpenAI Transcriptions reference page.
- Ensure the generated page no longer renders with an untitled browser title.

Fixes #6691

## Testing
- AsciiDoc metadata-only change; reviewed the diff.