### PR TITLE
fix: preserve tool schema property order in Bedrock Converse conversion

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
@@ -19,6 +19,7 @@ package org.springframework.ai.bedrock.converse.api;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -100,7 +101,8 @@ public final class ConverseApiUtils {
 	private static Document convertMapToDocument(Map<String, Object> value) {
 		Map<String, Document> attr = value.entrySet()
 			.stream()
-			.collect(Collectors.toMap(e -> e.getKey(), e -> convertObjectToDocument(e.getValue())));
+			.collect(Collectors.toMap(Map.Entry::getKey, e -> convertObjectToDocument(e.getValue()), (a, b) -> a,
+					LinkedHashMap::new));
 
 		return Document.fromMap(attr);
 	}

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse.api;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.core.document.Document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConverseApiUtils}.
+ *
+ * @author Mrxiao03
+ */
+class ConverseApiUtilsTests {
+
+	@Test
+	void convertObjectToDocumentPreservesMapIterationOrder() {
+		Map<String, Object> nested = new LinkedHashMap<>();
+		nested.put("alpha", 1);
+		nested.put("beta", 2);
+
+		Map<String, Object> value = new LinkedHashMap<>();
+		value.put("first", nested);
+		value.put("second", "value");
+		value.put("third", true);
+
+		Document document = ConverseApiUtils.convertObjectToDocument(value);
+
+		assertThat(document.asMap().keySet()).containsExactly("first", "second", "third");
+		assertThat(document.asMap().get("first").asMap().keySet()).containsExactly("alpha", "beta");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Preserve map insertion order when converting nested schema maps to Bedrock Document values.
- Add regression coverage for ordered map conversion.

Fixes #6696

## Testing
- Compiled the updated Bedrock Converse utility and regression test locally with javac.