### PR TITLE
Prepare Redis replacements before clearing history

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepository.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -105,43 +104,55 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 		Assert.notNull(conversationId, "Conversation ID must not be null");
 		Assert.notNull(messages, "Messages must not be null");
 
+		List<PreparedMessage> preparedMessages = prepareMessages(conversationId, messages);
+		writeMessages(preparedMessages);
+	}
+
+	private List<PreparedMessage> prepareMessages(String conversationId, List<Message> messages) {
 		if (messages.isEmpty()) {
-			return;
+			return Collections.emptyList();
 		}
 
 		if (logger.isDebugEnabled()) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("Adding " + messages.size() + " messages to conversation: " + conversationId);
-			}
+			logger.debug("Adding " + messages.size() + " messages to conversation: " + conversationId);
 		}
 
 		// Atomically reserve a contiguous block of timestamps, one per message, so
 		// that concurrent add() calls for the same conversation never claim the same
 		// slot.
 		long nextTimestamp = reserveTimestampsForConversation(conversationId, messages.size());
-		final AtomicLong timestampSequence = new AtomicLong(nextTimestamp);
+		List<PreparedMessage> preparedMessages = new ArrayList<>(messages.size());
+
+		for (Message message : messages) {
+			long timestamp = nextTimestamp++;
+			String key = createKey(conversationId, timestamp);
+
+			Map<String, Object> documentMap = createMessageDocument(conversationId, message);
+			// Ensure the timestamp in the document matches the key timestamp for
+			// consistency
+			documentMap.put("timestamp", timestamp);
+
+			preparedMessages.add(new PreparedMessage(key, gson.toJson(documentMap)));
+		}
+
+		return preparedMessages;
+	}
+
+	private void writeMessages(List<PreparedMessage> messages) {
+		if (messages.isEmpty()) {
+			return;
+		}
 
 		try (Pipeline pipeline = this.jedisClient.pipelined()) {
-			for (Message message : messages) {
-				long timestamp = timestampSequence.getAndIncrement();
-				String key = createKey(conversationId, timestamp);
-
-				Map<String, Object> documentMap = createMessageDocument(conversationId, message);
-				// Ensure the timestamp in the document matches the key timestamp for
-				// consistency
-				documentMap.put("timestamp", timestamp);
-
-				String json = gson.toJson(documentMap);
-
+			for (PreparedMessage message : messages) {
 				if (logger.isDebugEnabled()) {
-					logger.debug("Storing batch message with key: " + key + ", type: " + message.getMessageType()
-							+ ", content: " + message.getText());
+					logger.debug("Storing batch message with key: " + message.key());
 				}
 
-				pipeline.jsonSet(key, ROOT_PATH, json);
+				pipeline.jsonSet(message.key(), ROOT_PATH, message.json());
 
 				if (this.config.getTimeToLiveSeconds() != -1) {
-					pipeline.expire(key, this.config.getTimeToLiveSeconds());
+					pipeline.expire(message.key(), this.config.getTimeToLiveSeconds());
 				}
 			}
 			pipeline.sync();
@@ -589,11 +600,14 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 
 	@Override
 	public void saveAll(String conversationId, List<Message> messages) {
-		// First clear any existing messages for this conversation
-		clear(conversationId);
+		Assert.notNull(conversationId, "Conversation ID must not be null");
+		Assert.notNull(messages, "Messages must not be null");
 
-		// Then add all the new messages
-		add(conversationId, messages);
+		// Prepare every replacement before deleting the existing conversation so that
+		// validation or serialization failures cannot erase its history.
+		List<PreparedMessage> preparedMessages = prepareMessages(conversationId, messages);
+		clear(conversationId);
+		writeMessages(preparedMessages);
 	}
 
 	@Override
@@ -1124,6 +1138,9 @@ public final class RedisChatMemoryRepository implements ChatMemoryRepository, Ad
 			return new RedisChatMemoryRepository(config);
 		}
 
+	}
+
+	private record PreparedMessage(String key, String json) {
 	}
 
 }

--- a/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/chat/memory/repository/redis/RedisChatMemoryRepositoryIT.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.chat.memory.repository.redis;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,12 +31,16 @@ import redis.clients.jedis.RedisClient;
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Integration tests for RedisChatMemoryRepository implementation of ChatMemoryRepository
@@ -226,6 +231,91 @@ class RedisChatMemoryRepositoryIT {
 			assertThat(storedMessages).hasSize(7);
 			assertThat(storedMessages.stream().map(Message::getText).toList()).containsExactly("first-1", "first-2",
 					"first-3", "second-1", "second-2", "second-3", "second-4");
+		});
+	}
+
+	@Test
+	void shouldPreserveExistingMessagesWhenReplacementPreparationFails() {
+		this.contextRunner.run(context -> {
+			String conversationId = "test-conversation";
+			this.chatMemoryRepository.saveAll(conversationId,
+					List.of(new UserMessage("First message"), new AssistantMessage("Second message")));
+			assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).hasSize(2);
+
+			Message failingMessage = mock(Message.class);
+			when(failingMessage.getMessageType()).thenReturn(MessageType.USER);
+			when(failingMessage.getText()).thenThrow(new IllegalStateException("Message preparation failed"));
+
+			assertThatThrownBy(() -> this.chatMemoryRepository.saveAll(conversationId,
+					List.of(new UserMessage("Replacement message"), failingMessage)))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("Message preparation failed");
+
+			assertThat(this.chatMemoryRepository.findByConversationId(conversationId)
+				.stream()
+				.map(Message::getText)
+				.toList()).containsExactly("First message", "Second message");
+		});
+	}
+
+	@Test
+	void shouldPreserveExistingMessagesWhenReplacementMessagesAreNull() {
+		this.contextRunner.run(context -> {
+			String conversationId = "test-conversation";
+			this.chatMemoryRepository.saveAll(conversationId,
+					List.of(new UserMessage("First message"), new AssistantMessage("Second message")));
+			assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).hasSize(2);
+
+			assertThatThrownBy(() -> this.chatMemoryRepository.saveAll(conversationId, null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Messages must not be null");
+
+			assertThat(this.chatMemoryRepository.findByConversationId(conversationId)
+				.stream()
+				.map(Message::getText)
+				.toList()).containsExactly("First message", "Second message");
+		});
+	}
+
+	@Test
+	void shouldApplyTimeToLiveToReplacementMessages() {
+		this.contextRunner.run(context -> {
+			RedisChatMemoryRepository ttlRepository = RedisChatMemoryRepository.builder()
+				.jedisClient(this.jedisClient)
+				.indexName("test-save-all-ttl-" + RedisChatMemoryConfig.DEFAULT_INDEX_NAME)
+				.keyPrefix("save-all-ttl:")
+				.timeToLive(Duration.ofSeconds(1))
+				.build();
+
+			String conversationId = "ttl-test-conversation";
+			ttlRepository.saveAll(conversationId, List.of(new UserMessage("Original message")));
+			assertThat(ttlRepository.findByConversationId(conversationId).stream().map(Message::getText).toList())
+				.containsExactly("Original message");
+
+			ttlRepository.saveAll(conversationId,
+					List.of(new UserMessage("First replacement"), new AssistantMessage("Second replacement")));
+
+			assertThat(ttlRepository.findByConversationId(conversationId).stream().map(Message::getText).toList())
+				.containsExactly("First replacement", "Second replacement");
+
+			Thread.sleep(1500);
+
+			assertThat(ttlRepository.findByConversationId(conversationId)).isEmpty();
+		});
+	}
+
+	@Test
+	void shouldClearExistingMessagesWhenReplacementIsEmpty() {
+		this.contextRunner.run(context -> {
+			String conversationId = "test-conversation";
+			this.chatMemoryRepository.saveAll(conversationId,
+					List.of(new UserMessage("First message"), new AssistantMessage("Second message")));
+			assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).hasSize(2);
+
+			this.chatMemoryRepository.saveAll(conversationId, List.of());
+
+			assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEmpty();
+			assertThat(this.chatMemoryRepository.findConversationIds()).doesNotContain(conversationId);
 		});
 	}
 


### PR DESCRIPTION
## Summary

`RedisChatMemoryRepository.saveAll()` previously cleared a conversation before validating and preparing its replacement messages. If a message accessor or JSON serialization failed, the original history was already gone, and any earlier replacement entries could become visible.

This change:

- validates `conversationId` and the replacement list before clearing;
- prepares every final Redis key and JSON payload before the destructive operation;
- reuses the preparation/writer helpers from batch `add()` while preserving timestamp reservation, pipelined writes, and per-message TTL;
- preserves empty-list replacement semantics (the conversation is still cleared);
- adds regression coverage for preparation failure, a null replacement list, an empty replacement list, and replacement-message TTL.

If validation or client-side preparation fails, the existing history now remains unchanged. This intentionally does **not** claim rollback after Redis operations begin or linearizability for concurrent operations/RediSearch visibility.

Fixes #6808

## Reproduction

Against unchanged `main` at `c988e72ab7282bcc352b2155e8cb27ff4b5e0fda`, the new preparation-failure regression failed deterministically: after a valid replacement followed by a `Message` whose `getText()` throws, Redis contained `"Replacement message"` instead of the original `"First message"`, `"Second message"` history.

Baseline result: 1 test run, 1 failure, 0 errors, 0 skipped.

## Validation

All Redis integration tests ran through Testcontainers using the rootless Podman socket (`redis/redis-stack:latest` and `redis/redis-stack-server:latest`) with Java 17 and Maven 3.9.9.

- Focused `RedisChatMemoryRepositoryIT`: **11 tests, 0 failures, 0 errors, 0 skipped**
- Complete Redis repository integration suite: **61 tests, 0 failures, 0 errors, 0 skipped**
- Reactor unit-test prerequisites: **834 tests, 0 failures, 0 errors, 0 skipped**
- Spring Java Format validation: passed
- Configured Checkstyle validation: **0 violations**
- `git diff --check`: passed

One pre-existing StringTemplate test outside the Redis integration aggregate was skipped during the reactor build; all Redis integration tests ran without skips.
