### PR TITLE
Fix scheduler for calling chat models streaming

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ChatModelStreamAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ChatModelStreamAdvisor.java
@@ -55,7 +55,7 @@ public final class ChatModelStreamAdvisor implements StreamAdvisor {
 				.chatResponse(chatResponse)
 				.context(Map.copyOf(chatClientRequest.context()))
 				.build())
-			.publishOn(Schedulers.boundedElastic()); // TODO add option to disable
+			.subscribeOn(Schedulers.boundedElastic()); // TODO add option to disable
 	}
 
 	@Override


### PR DESCRIPTION
Replace `publishOn` with `subscribeOn` for calling a chat model in the streaming flow.

`publishOn` affects the flow downstream of where it is defined, which doesn't make that much sense in this context because it's forwarding from I/O call, not producing an I/O call.

At least for the Google GenAI chat models, OkHttp is used in a blocking call. With `publishOn` this ends up blocking the original thread (e.g. a Spring Boot worker thread) and only AFTER the I/O call switching to the boundedElastic pool. It makes a lot more sense to run the OkHttp blocking call on the boundedElastic scheduler instead to free up the worker thread.

If needed, you could release that afterwards but there's not a lot of value in that.