### PR TITLE
Ignore empty OpenAI stream tool calls in messages

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1299,25 +1299,28 @@ public final class OpenAiChatModel implements ChatModel {
 					// so they are readable on the message, as in the non-streaming path.
 					.putAllAdditionalProperties(cccc.delta()._additionalProperties());
 				cccc.delta().toolCalls().ifPresent(ccctcs -> {
-					msgBuilder.toolCalls(ccctcs.stream().map(tc -> {
+					List<ChatCompletionMessageToolCall> toolCalls = ccctcs.stream().flatMap(tc -> {
+						if (tc.function().isEmpty() || tc.id().filter(StringUtils::hasText).isEmpty()) {
+							return Stream.empty();
+						}
 						ChatCompletionMessageFunctionToolCall.Builder toolCallBuilder = ChatCompletionMessageFunctionToolCall
 							.builder();
-						Function function = tc.function()
-							.orElseThrow(() -> new IllegalStateException("Tool call function is missing"));
-						String id = tc.id()
-							.filter(StringUtils::hasText)
-							.orElseThrow(() -> new IllegalStateException("Tool call id is missing"));
-						String name = function.name()
-							.filter(StringUtils::hasText)
-							.orElseThrow(() -> new IllegalStateException("Tool call function name is missing"));
+						Function function = tc.function().get();
+						Optional<String> name = function.name().filter(StringUtils::hasText);
+						if (name.isEmpty()) {
+							return Stream.empty();
+						}
 						toolCallBuilder.putAllAdditionalProperties(tc._additionalProperties());
-						toolCallBuilder.id(id);
+						toolCallBuilder.id(tc.id().get());
 						toolCallBuilder.function(ChatCompletionMessageFunctionToolCall.Function.builder()
-							.name(name)
+							.name(name.get())
 							.arguments(function.arguments().orElse(""))
 							.build());
-						return ChatCompletionMessageToolCall.ofFunction(toolCallBuilder.build());
-					}).toList());
+						return Stream.of(ChatCompletionMessageToolCall.ofFunction(toolCallBuilder.build()));
+					}).toList();
+					if (!toolCalls.isEmpty()) {
+						msgBuilder.toolCalls(toolCalls);
+					}
 				});
 				choiceBuilder.message(msgBuilder.build());
 				return choiceBuilder.build();

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -904,6 +904,22 @@ class OpenAiChatModelTests {
 	}
 
 	@Test
+	void streamingTextIgnoresEmptyToolCalls() {
+		List<ChatCompletionChunk> chunks = List.of(
+				streamingChunk(delta -> delta.role(ChatCompletionChunk.Choice.Delta.Role.ASSISTANT)
+					.content("Hel")
+					.toolCalls(List.of()), null),
+				streamingChunk(delta -> delta.content("lo").toolCalls(List.of()), null),
+				streamingChunk(delta -> delta.content("!").toolCalls(List.of()),
+						ChatCompletionChunk.Choice.FinishReason.STOP));
+
+		AssistantMessage aggregated = aggregateStreaming(chunks);
+
+		assertThat(aggregated.getText()).isEqualTo("Hello!");
+		assertThat(aggregated.getToolCalls()).isEmpty();
+	}
+
+	@Test
 	void streamingReasoningContentAccumulatesAcrossIntermediateResponses() {
 		List<ChatCompletionChunk> chunks = List.of(
 				streamingChunk(delta -> delta.role(ChatCompletionChunk.Choice.Delta.Role.ASSISTANT)


### PR DESCRIPTION
Follow-up to #6504.

We hit this with a local vLLM OpenAI-compatible endpoint while streaming from a DeepSeek-style model. The same flow worked against NVIDIA's OpenAI-compatible endpoint, but the local vLLM stream can emit normal text deltas with `tool_calls: []` and can also leave an incomplete streamed tool-call object in the reconstructed chunk.

After #6504, `ChunkMerger.hasToolCall` no longer treats an empty `tool_calls` list as an active tool call. However, the stream path still converts chunk deltas back into `ChatCompletion` messages in `chunkToChatCompletion`. In that conversion, every present tool call was mapped with required `id`, `function`, and `function.name` fields. With the vLLM response shape, that path can still fail during stream aggregation with:

```text
java.lang.IllegalStateException: Tool call function name is missing
    at org.springframework.ai.openai.OpenAiChatModel$ChunkMerger.lambda$chunkToChatCompletion...
```

This change keeps empty or incomplete streamed tool calls out of the reconstructed assistant message. Only tool calls with a non-empty id, function, and function name are mapped to `ChatCompletionMessageToolCall`. Empty `tool_calls: []` text deltas are treated the same as missing tool calls.

Validation:
- `./mvnw.cmd -pl models/spring-ai-openai -Dtest=OpenAiChatModelTests -Dspring-javaformat.skip=true -Dcheckstyle.skip=true test`
- `./mvnw.cmd -pl models/spring-ai-openai -am -DskipTests -DskipITs -Dspring-javaformat.skip=true -Dcheckstyle.skip=true install`