### PR TITLE
Find @McpTool methods on AOP-proxied beans

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AbstractMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AbstractMcpToolProvider.java
@@ -24,6 +24,7 @@ import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.util.Assert;
 
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.aop.support.AopUtils;
 
 /**
  * @author Christian Tzolov
@@ -43,7 +44,10 @@ public abstract class AbstractMcpToolProvider {
 	}
 
 	protected Method[] doGetClassMethods(Object bean) {
-		return bean.getClass().getDeclaredMethods();
+		// Resolve to the target class so @McpTool methods are still found when the
+		// bean is wrapped in a Spring AOP proxy (JDK dynamic proxy or CGLIB).
+		Class<?> targetClass = AopUtils.isAopProxy(bean) ? AopUtils.getTargetClass(bean) : bean.getClass();
+		return targetClass.getDeclaredMethods();
 	}
 
 	protected McpTool doGetMcpToolAnnotation(Method method) {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
@@ -36,6 +36,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.context.MetaProvider;
+import org.springframework.aop.framework.ProxyFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -916,6 +917,30 @@ public class SyncMcpToolProviderTests {
 
 		// The input schema should be minimal when only CallToolRequest is present
 		assertThat(toolSpec.tool().inputSchema()).isNotNull();
+	}
+
+	@Test // gh-4405
+	void testGetToolSpecificationsWithAopProxiedBean() {
+		AopProxiedTool target = new AopProxiedTool();
+		ProxyFactory proxyFactory = new ProxyFactory(target);
+		Object proxy = proxyFactory.getProxy();
+
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(proxy));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		assertThat(toolSpecs.get(0).tool().name()).isEqualTo("proxied-tool");
+		assertThat(toolSpecs.get(0).tool().description()).isEqualTo("Tool declared on an AOP-proxied bean");
+	}
+
+	public static class AopProxiedTool {
+
+		@McpTool(name = "proxied-tool", description = "Tool declared on an AOP-proxied bean")
+		public String proxiedTool(String input) {
+			return "Proxied: " + input;
+		}
+
 	}
 
 	public static class UiMetaProvider implements MetaProvider {


### PR DESCRIPTION
## Summary

`AbstractMcpToolProvider` scans annotated methods using `bean.getClass().getDeclaredMethods()`.

When the bean is wrapped in a Spring AOP proxy, `bean.getClass()` returns the proxy class rather than the original target class. In the case of a CGLIB proxy, the overridden target method does not retain the `@McpTool` annotation, causing the tool to be silently skipped during registration.

This change resolves the bean to its AOP target class before scanning for annotated methods.

## Why

This mirrors the existing behavior in `AnnotationProviderUtil.beanMethods()`, which is already used by the Spring-facing annotation providers such as:

* `SyncMcpAnnotationProviders`
* `AsyncMcpAnnotationProviders`

The lower-level tool providers under `provider.tool` did not apply the same AOP-aware lookup.

Since all four tool provider variants — sync/async and stateless/stateful — inherit from `AbstractMcpToolProvider`, the fix can be applied in one place.

## Testing

Added a test that wraps a bean containing an `@McpTool` method with a real Spring `ProxyFactory` proxy and verifies that the tool is still discovered.

* Current `main`: **0 tools found**
* With this change: **tool is discovered successfully**

## Scope

This PR is intentionally limited to tool providers, matching the reported issue.

The resource, prompt, complete, and progress providers currently use the same proxy-unaware pattern and may require similar treatment in a follow-up.

  
Fixes #4405