### PR TITLE
Add WaveSpeed AI image generation support

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-autoconfigure-model-wavespeed</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI WaveSpeed AI Auto Configuration</name>
+	<description>Spring AI WaveSpeed AI Auto Configuration</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<!-- Spring AI dependencies -->
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-wavespeed</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Spring AI auto configurations -->
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedConnectionProperties.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.wavespeed.autoconfigure;
+
+import java.time.Duration;
+
+import org.springframework.ai.wavespeed.api.WaveSpeedApi;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Connection properties for the WaveSpeed AI API.
+ *
+ * @author Zeyi Cheng
+ * @since 2.0.1
+ */
+@ConfigurationProperties(WaveSpeedConnectionProperties.CONFIG_PREFIX)
+public class WaveSpeedConnectionProperties extends WaveSpeedParentProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.wavespeed";
+
+	public static final String DEFAULT_BASE_URL = WaveSpeedApi.DEFAULT_BASE_URL;
+
+	/**
+	 * Interval between two prediction result polls.
+	 */
+	private Duration pollInterval = WaveSpeedApi.DEFAULT_POLL_INTERVAL;
+
+	/**
+	 * Maximum time to wait for a prediction to complete.
+	 */
+	private Duration timeout = WaveSpeedApi.DEFAULT_TIMEOUT;
+
+	public WaveSpeedConnectionProperties() {
+		super.setBaseUrl(DEFAULT_BASE_URL);
+	}
+
+	public Duration getPollInterval() {
+		return this.pollInterval;
+	}
+
+	public void setPollInterval(Duration pollInterval) {
+		this.pollInterval = pollInterval;
+	}
+
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedImageAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedImageAutoConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.wavespeed.autoconfigure;
+
+import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.wavespeed.WaveSpeedImageModel;
+import org.springframework.ai.wavespeed.api.WaveSpeedApi;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/**
+ * {@link AutoConfiguration Auto-configuration} for the WaveSpeed AI Image Model.
+ *
+ * @author Zeyi Cheng
+ * @since 2.0.1
+ */
+@AutoConfiguration
+@ConditionalOnClass(WaveSpeedApi.class)
+@ConditionalOnProperty(name = SpringAIModelProperties.IMAGE_MODEL, havingValue = SpringAIModels.WAVESPEED,
+		matchIfMissing = true)
+@EnableConfigurationProperties({ WaveSpeedConnectionProperties.class, WaveSpeedImageProperties.class })
+public class WaveSpeedImageAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public WaveSpeedApi waveSpeedApi(WaveSpeedConnectionProperties commonProperties,
+			WaveSpeedImageProperties imageProperties, ObjectProvider<RestClient.Builder> restClientBuilderProvider) {
+
+		String apiKey = StringUtils.hasText(imageProperties.getApiKey()) ? imageProperties.getApiKey()
+				: commonProperties.getApiKey();
+
+		String baseUrl = StringUtils.hasText(imageProperties.getBaseUrl()) ? imageProperties.getBaseUrl()
+				: commonProperties.getBaseUrl();
+
+		Assert.hasText(apiKey, "WaveSpeed API key must be set");
+		Assert.hasText(baseUrl, "WaveSpeed base URL must be set");
+
+		return new WaveSpeedApi(apiKey, baseUrl, restClientBuilderProvider.getIfAvailable(RestClient::builder),
+				commonProperties.getPollInterval(), commonProperties.getTimeout());
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public WaveSpeedImageModel waveSpeedImageModel(WaveSpeedApi waveSpeedApi,
+			WaveSpeedImageProperties imageProperties) {
+		return new WaveSpeedImageModel(waveSpeedApi, imageProperties.toOptions());
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedImageProperties.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.wavespeed.autoconfigure;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.wavespeed.api.WaveSpeedApi;
+import org.springframework.ai.wavespeed.api.WaveSpeedImageOptions;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the WaveSpeed AI image model.
+ *
+ * @author Zeyi Cheng
+ * @since 2.0.1
+ */
+@ConfigurationProperties(WaveSpeedImageProperties.CONFIG_PREFIX)
+public class WaveSpeedImageProperties extends WaveSpeedParentProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.wavespeed.image";
+
+	public static final String DEFAULT_IMAGE_MODEL = WaveSpeedApi.DEFAULT_IMAGE_MODEL;
+
+	/**
+	 * The model to use for image generation. The model is passed in the URL as a path
+	 * parameter.
+	 */
+	private String model = DEFAULT_IMAGE_MODEL;
+
+	/**
+	 * The size of the generated image as {width}*{height}, for example 1024*1024.
+	 */
+	private @Nullable String size;
+
+	/**
+	 * The width of the generated image, in pixels. Ignored when size is set.
+	 */
+	private @Nullable Integer width;
+
+	/**
+	 * The height of the generated image, in pixels. Ignored when size is set.
+	 */
+	private @Nullable Integer height;
+
+	/**
+	 * The random seed used for generation, or -1 for a random seed.
+	 */
+	private @Nullable Integer seed;
+
+	public String getModel() {
+		return this.model;
+	}
+
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+	public @Nullable String getSize() {
+		return this.size;
+	}
+
+	public void setSize(@Nullable String size) {
+		this.size = size;
+	}
+
+	public @Nullable Integer getWidth() {
+		return this.width;
+	}
+
+	public void setWidth(@Nullable Integer width) {
+		this.width = width;
+	}
+
+	public @Nullable Integer getHeight() {
+		return this.height;
+	}
+
+	public void setHeight(@Nullable Integer height) {
+		this.height = height;
+	}
+
+	public @Nullable Integer getSeed() {
+		return this.seed;
+	}
+
+	public void setSeed(@Nullable Integer seed) {
+		this.seed = seed;
+	}
+
+	public WaveSpeedImageOptions toOptions() {
+		return WaveSpeedImageOptions.builder()
+			.model(this.model)
+			.size(this.size)
+			.width(this.width)
+			.height(this.height)
+			.seed(this.seed)
+			.build();
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedParentProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedParentProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.wavespeed.autoconfigure;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Internal parent properties for the WaveSpeed AI properties.
+ *
+ * @author Zeyi Cheng
+ * @since 2.0.1
+ */
+class WaveSpeedParentProperties {
+
+	private @Nullable String apiKey;
+
+	private @Nullable String baseUrl;
+
+	public @Nullable String getApiKey() {
+		return this.apiKey;
+	}
+
+	public void setApiKey(@Nullable String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	public @Nullable String getBaseUrl() {
+		return this.baseUrl;
+	}
+
+	public void setBaseUrl(@Nullable String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/package-info.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/java/org/springframework/ai/model/wavespeed/autoconfigure/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.model.wavespeed.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.ai.model.wavespeed.autoconfigure.WaveSpeedImageAutoConfiguration

--- a/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/test/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedImagePropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-wavespeed/src/test/java/org/springframework/ai/model/wavespeed/autoconfigure/WaveSpeedImagePropertiesTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.wavespeed.autoconfigure;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.wavespeed.WaveSpeedImageModel;
+import org.springframework.ai.wavespeed.api.WaveSpeedApi;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WaveSpeedImageProperties} and {@link WaveSpeedConnectionProperties}.
+ *
+ * @author Zeyi Cheng
+ */
+class WaveSpeedImagePropertiesTests {
+
+	@Test
+	void imagePropertiesTest() {
+		new ApplicationContextRunner().withPropertyValues(
+		// @formatter:off
+				"spring.ai.wavespeed.api-key=API_KEY",
+				"spring.ai.wavespeed.base-url=ENDPOINT",
+				"spring.ai.wavespeed.poll-interval=2s",
+				"spring.ai.wavespeed.timeout=300s",
+				"spring.ai.wavespeed.image.model=MODEL_XYZ",
+				"spring.ai.wavespeed.image.size=1024*1024",
+				"spring.ai.wavespeed.image.seed=42"
+				)
+			// @formatter:on
+			.withConfiguration(AutoConfigurations.of(WaveSpeedImageAutoConfiguration.class))
+			.run(context -> {
+				var connectionProperties = context.getBean(WaveSpeedConnectionProperties.class);
+				var imageProperties = context.getBean(WaveSpeedImageProperties.class);
+
+				assertThat(connectionProperties.getApiKey()).isEqualTo("API_KEY");
+				assertThat(connectionProperties.getBaseUrl()).isEqualTo("ENDPOINT");
+				assertThat(connectionProperties.getPollInterval()).isEqualTo(Duration.ofSeconds(2));
+				assertThat(connectionProperties.getTimeout()).isEqualTo(Duration.ofSeconds(300));
+
+				assertThat(imageProperties.toOptions().getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(imageProperties.toOptions().getSize()).isEqualTo("1024*1024");
+				assertThat(imageProperties.toOptions().getSeed()).isEqualTo(42);
+			});
+	}
+
+	@Test
+	void imagePropertiesDefaultsTest() {
+		new ApplicationContextRunner().withPropertyValues("spring.ai.wavespeed.api-key=API_KEY")
+			.withConfiguration(AutoConfigurations.of(WaveSpeedImageAutoConfiguration.class))
+			.run(context -> {
+				var connectionProperties = context.getBean(WaveSpeedConnectionProperties.class);
+				var imageProperties = context.getBean(WaveSpeedImageProperties.class);
+
+				assertThat(connectionProperties.getBaseUrl()).isEqualTo(WaveSpeedApi.DEFAULT_BASE_URL);
+				assertThat(connectionProperties.getPollInterval()).isEqualTo(WaveSpeedApi.DEFAULT_POLL_INTERVAL);
+				assertThat(connectionProperties.getTimeout()).isEqualTo(WaveSpeedApi.DEFAULT_TIMEOUT);
+				assertThat(imageProperties.getModel()).isEqualTo(WaveSpeedApi.DEFAULT_IMAGE_MODEL);
+				assertThat(imageProperties.getSize()).isNull();
+				assertThat(imageProperties.getSeed()).isNull();
+			});
+	}
+
+	@Test
+	void imageActivation() {
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.ai.wavespeed.api-key=API_KEY", "spring.ai.model.image=none")
+			.withConfiguration(AutoConfigurations.of(WaveSpeedImageAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context.getBeansOfType(WaveSpeedImageProperties.class)).isEmpty();
+				assertThat(context.getBeansOfType(WaveSpeedImageModel.class)).isEmpty();
+			});
+
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.ai.wavespeed.api-key=API_KEY", "spring.ai.model.image=wavespeed")
+			.withConfiguration(AutoConfigurations.of(WaveSpeedImageAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context.getBeansOfType(WaveSpeedImageProperties.class)).isNotEmpty();
+				assertThat(context.getBeansOfType(WaveSpeedImageModel.class)).isNotEmpty();
+			});
+
+		new ApplicationContextRunner().withPropertyValues("spring.ai.wavespeed.api-key=API_KEY")
+			.withConfiguration(AutoConfigurations.of(WaveSpeedImageAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context.getBeansOfType(WaveSpeedImageProperties.class)).isNotEmpty();
+				assertThat(context.getBeansOfType(WaveSpeedImageModel.class)).isNotEmpty();
+			});
+	}
+
+}

--- a/models/spring-ai-wavespeed/pom.xml
+++ b/models/spring-ai-wavespeed/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-wavespeed</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Model - WaveSpeed AI</name>
+	<description>WaveSpeed AI models support</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<!-- production dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- Spring Framework -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/WaveSpeedImageModel.java
+++ b/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/WaveSpeedImageModel.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.wavespeed;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.image.Image;
+import org.springframework.ai.image.ImageGeneration;
+import org.springframework.ai.image.ImageMessage;
+import org.springframework.ai.image.ImageModel;
+import org.springframework.ai.image.ImageOptions;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.image.ImageResponseMetadata;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.wavespeed.api.WaveSpeedApi;
+import org.springframework.ai.wavespeed.api.WaveSpeedImageOptions;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * {@link ImageModel} implementation backed by the WaveSpeed AI image generation API.
+ *
+ * <p>
+ * The WaveSpeed API is asynchronous, so a call submits a prediction and polls until it
+ * completes, then returns the generated images as URLs.
+ *
+ * @author Zeyi Cheng
+ * @since 2.0.1
+ */
+public class WaveSpeedImageModel implements ImageModel {
+
+	private final WaveSpeedApi waveSpeedApi;
+
+	private final WaveSpeedImageOptions options;
+
+	public WaveSpeedImageModel(WaveSpeedApi waveSpeedApi) {
+		this(waveSpeedApi, WaveSpeedImageOptions.builder().build());
+	}
+
+	public WaveSpeedImageModel(WaveSpeedApi waveSpeedApi, WaveSpeedImageOptions options) {
+		Assert.notNull(waveSpeedApi, "'waveSpeedApi' must not be null");
+		Assert.notNull(options, "'options' must not be null");
+		this.waveSpeedApi = waveSpeedApi;
+		this.options = options;
+	}
+
+	public WaveSpeedImageOptions getOptions() {
+		return this.options;
+	}
+
+	@Override
+	public ImageResponse call(ImagePrompt imagePrompt) {
+		Assert.notNull(imagePrompt, "'imagePrompt' must not be null");
+		Assert.notEmpty(imagePrompt.getInstructions(), "'imagePrompt' must contain at least one message");
+
+		WaveSpeedImageOptions requestOptions = mergeOptions(imagePrompt.getOptions(), this.options);
+
+		String model = (requestOptions.getModel() != null) ? requestOptions.getModel()
+				: WaveSpeedApi.DEFAULT_IMAGE_MODEL;
+
+		String prompt = imagePrompt.getInstructions()
+			.stream()
+			.map(ImageMessage::getText)
+			.reduce((first, second) -> first + " " + second)
+			.orElseThrow();
+
+		WaveSpeedApi.GenerateImageRequest request = new WaveSpeedApi.GenerateImageRequest(prompt,
+				requestOptions.toSizeString(), requestOptions.getSeed());
+
+		WaveSpeedApi.Prediction prediction = this.waveSpeedApi.generateImage(model, request);
+
+		return convertResponse(prediction);
+	}
+
+	private ImageResponse convertResponse(WaveSpeedApi.Prediction prediction) {
+		List<String> outputs = prediction.outputs();
+		if (CollectionUtils.isEmpty(outputs)) {
+			return new ImageResponse(List.of(), new ImageResponseMetadata());
+		}
+		List<ImageGeneration> imageGenerations = outputs.stream()
+			.map(url -> new ImageGeneration(new Image(url, null)))
+			.toList();
+		return new ImageResponse(imageGenerations, new ImageResponseMetadata());
+	}
+
+	/**
+	 * Merge the runtime options passed via the prompt with the default options configured
+	 * via the constructor. Runtime options overwrite the default options.
+	 */
+	WaveSpeedImageOptions mergeOptions(@Nullable ImageOptions runtimeOptions, WaveSpeedImageOptions defaultOptions) {
+		if (runtimeOptions == null) {
+			return defaultOptions;
+		}
+		WaveSpeedImageOptions.Builder builder = WaveSpeedImageOptions.builder()
+			// Handle portable image options
+			.model(ModelOptionsUtils.mergeOption(runtimeOptions.getModel(), defaultOptions.getModel()))
+			.width(ModelOptionsUtils.mergeOption(runtimeOptions.getWidth(), defaultOptions.getWidth()))
+			.height(ModelOptionsUtils.mergeOption(runtimeOptions.getHeight(), defaultOptions.getHeight()))
+			// Always set the WaveSpeed-specific defaults
+			.size(defaultOptions.getSize())
+			.seed(defaultOptions.getSeed());
+		if (runtimeOptions instanceof WaveSpeedImageOptions waveSpeedOptions) {
+			// Handle WaveSpeed AI specific image options
+			builder.size(ModelOptionsUtils.mergeOption(waveSpeedOptions.getSize(), defaultOptions.getSize()))
+				.seed(ModelOptionsUtils.mergeOption(waveSpeedOptions.getSeed(), defaultOptions.getSeed()));
+		}
+		return builder.build();
+	}
+
+}

--- a/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/api/WaveSpeedApi.java
+++ b/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/api/WaveSpeedApi.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.wavespeed.api;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.retry.NonTransientAiException;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.retry.TransientAiException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Client for the WaveSpeed AI REST API.
+ *
+ * <p>
+ * The WaveSpeed API is asynchronous: submitting a generation request returns a prediction
+ * that is polled until it reaches a terminal status. See the
+ * <a href="https://wavespeed.ai/docs">WaveSpeed AI documentation</a> for more details.
+ *
+ * @author Zeyi Cheng
+ * @since 2.0.1
+ */
+public class WaveSpeedApi {
+
+	public static final String DEFAULT_BASE_URL = "https://api.wavespeed.ai";
+
+	public static final String DEFAULT_IMAGE_MODEL = "bytedance/seedream-v5.0-pro";
+
+	public static final Duration DEFAULT_POLL_INTERVAL = Duration.ofSeconds(1);
+
+	public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(600);
+
+	private static final String CLIENT_NAME_HEADER = "X-Client-Name";
+
+	private static final String CLIENT_NAME = "spring-ai-wavespeed";
+
+	private final RestClient restClient;
+
+	private final Duration pollInterval;
+
+	private final Duration timeout;
+
+	/**
+	 * Create a new WaveSpeed API client with default base URL, poll interval and timeout.
+	 * @param apiKey WaveSpeed API key
+	 */
+	public WaveSpeedApi(String apiKey) {
+		this(apiKey, DEFAULT_BASE_URL, RestClient.builder(), DEFAULT_POLL_INTERVAL, DEFAULT_TIMEOUT);
+	}
+
+	/**
+	 * Create a new WaveSpeed API client.
+	 * @param apiKey WaveSpeed API key
+	 * @param baseUrl API base URL
+	 * @param restClientBuilder RestClient builder
+	 * @param pollInterval interval between two prediction result polls
+	 * @param timeout maximum time to wait for a prediction to complete
+	 */
+	public WaveSpeedApi(String apiKey, String baseUrl, RestClient.Builder restClientBuilder, Duration pollInterval,
+			Duration timeout) {
+		Assert.hasText(apiKey, "'apiKey' must not be empty");
+		Assert.hasText(baseUrl, "'baseUrl' must not be empty");
+		Assert.notNull(restClientBuilder, "'restClientBuilder' must not be null");
+		Assert.notNull(pollInterval, "'pollInterval' must not be null");
+		Assert.notNull(timeout, "'timeout' must not be null");
+
+		this.pollInterval = pollInterval;
+		this.timeout = timeout;
+
+		Consumer<HttpHeaders> defaultHeaders = headers -> {
+			headers.setBearerAuth(apiKey);
+			headers.setContentType(MediaType.APPLICATION_JSON);
+			headers.set(CLIENT_NAME_HEADER, CLIENT_NAME);
+		};
+
+		this.restClient = restClientBuilder.clone()
+			.baseUrl(baseUrl)
+			.defaultHeaders(defaultHeaders)
+			.defaultStatusHandler(RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER)
+			.build();
+	}
+
+	/**
+	 * Submit an image generation request for the given model and wait for the resulting
+	 * prediction to reach a terminal status.
+	 * @param model the model identifier, for example {@code bytedance/seedream-v5.0-pro}
+	 * @param request the generation request
+	 * @return the completed prediction, with output image URLs
+	 */
+	public Prediction generateImage(String model, GenerateImageRequest request) {
+		Prediction prediction = submitGeneration(model, request);
+		return waitForPrediction(prediction.id());
+	}
+
+	/**
+	 * Submit an image generation request without waiting for its completion.
+	 * @param model the model identifier
+	 * @param request the generation request
+	 * @return the submitted prediction, typically with a {@code created} status
+	 */
+	public Prediction submitGeneration(String model, GenerateImageRequest request) {
+		Assert.hasText(model, "'model' must not be empty");
+		Assert.notNull(request, "'request' must not be null");
+		// WaveSpeed model identifiers contain slashes (for example
+		// "bytedance/seedream-v5.0-pro") that must remain path separators, so the
+		// model is concatenated instead of being expanded as a URI template variable.
+		PredictionResponse response = Objects.requireNonNull(
+				this.restClient.post().uri("/api/v3/" + model).body(request).retrieve().body(PredictionResponse.class),
+				"received a response without a body");
+		return unwrap(response);
+	}
+
+	/**
+	 * Fetch the current result of a prediction.
+	 * @param predictionId the prediction id
+	 * @return the prediction with its current status
+	 */
+	public Prediction getPrediction(String predictionId) {
+		Assert.hasText(predictionId, "'predictionId' must not be empty");
+		PredictionResponse response = Objects.requireNonNull(this.restClient.get()
+			.uri("/api/v3/predictions/{id}/result", predictionId)
+			.retrieve()
+			.body(PredictionResponse.class), "received a response without a body");
+		return unwrap(response);
+	}
+
+	/**
+	 * Poll a prediction until it reaches a terminal status or the configured timeout
+	 * elapses.
+	 * @param predictionId the prediction id
+	 * @return the completed prediction
+	 */
+	public Prediction waitForPrediction(String predictionId) {
+		long deadline = System.nanoTime() + this.timeout.toNanos();
+		while (true) {
+			Prediction prediction = getPrediction(predictionId);
+			if (Prediction.STATUS_COMPLETED.equals(prediction.status())) {
+				return prediction;
+			}
+			if (prediction.isTerminal()) {
+				throw new NonTransientAiException(
+						"WaveSpeed prediction %s ended with status '%s'%s".formatted(predictionId, prediction.status(),
+								(prediction.error() != null) ? ": " + prediction.error() : ""));
+			}
+			if (System.nanoTime() > deadline) {
+				throw new TransientAiException("WaveSpeed prediction %s still '%s' after %d seconds, giving up polling"
+					.formatted(predictionId, prediction.status(), this.timeout.toSeconds()));
+			}
+			try {
+				Thread.sleep(this.pollInterval.toMillis());
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new NonTransientAiException("Interrupted while waiting for WaveSpeed prediction " + predictionId);
+			}
+		}
+	}
+
+	private Prediction unwrap(PredictionResponse response) {
+		if (response.code() != null && response.code() != 200) {
+			throw new NonTransientAiException("WaveSpeed API returned code %d%s".formatted(response.code(),
+					(response.message() != null) ? ": " + response.message() : ""));
+		}
+		Prediction prediction = response.data();
+		if (prediction == null) {
+			throw new NonTransientAiException("WaveSpeed API returned a response without prediction data");
+		}
+		return prediction;
+	}
+
+	/**
+	 * An image generation request.
+	 *
+	 * @param prompt the text prompt describing the image to generate
+	 * @param size the image size as {@code {width}*{height}}, for example
+	 * {@code 1024*1024}
+	 * @param seed the random seed, or {@code -1} for a random seed
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record GenerateImageRequest(@JsonProperty(value = "prompt", required = true) String prompt,
+			@JsonProperty("size") @Nullable String size, @JsonProperty("seed") @Nullable Integer seed) {
+
+	}
+
+	/**
+	 * The envelope wrapping every WaveSpeed API response.
+	 *
+	 * @param code the API status code, {@code 200} on success
+	 * @param message the API status message
+	 * @param data the prediction payload
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record PredictionResponse(@JsonProperty("code") @Nullable Integer code,
+			@JsonProperty("message") @Nullable String message, @JsonProperty("data") @Nullable Prediction data) {
+
+	}
+
+	/**
+	 * A WaveSpeed prediction.
+	 *
+	 * @param id the prediction id
+	 * @param model the model that handles the prediction
+	 * @param status the prediction status, one of {@code created}, {@code processing},
+	 * {@code completed}, {@code failed}, {@code cancelled} or {@code timeout}
+	 * @param outputs the output image URLs, present once the prediction is completed
+	 * @param error the error message, present when the prediction failed
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Prediction(@JsonProperty(value = "id", required = true) String id,
+			@JsonProperty("model") @Nullable String model,
+			@JsonProperty(value = "status", required = true) String status,
+			@JsonProperty("outputs") @Nullable List<String> outputs, @JsonProperty("error") @Nullable String error) {
+
+		public static final String STATUS_COMPLETED = "completed";
+
+		private static final Set<String> TERMINAL_STATUSES = Set.of(STATUS_COMPLETED, "failed", "cancelled", "timeout");
+
+		/**
+		 * Return whether the prediction reached a terminal status.
+		 * @return {@code true} if the prediction is completed, failed, cancelled or timed
+		 * out
+		 */
+		public boolean isTerminal() {
+			return TERMINAL_STATUSES.contains(this.status);
+		}
+
+	}
+
+}

--- a/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/api/WaveSpeedImageOptions.java
+++ b/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/api/WaveSpeedImageOptions.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.wavespeed.api;
+
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.image.ImageOptions;
+
+/**
+ * {@link ImageOptions} implementation for the WaveSpeed AI image generation API.
+ *
+ * @author Zeyi Cheng
+ * @since 2.0.1
+ */
+public final class WaveSpeedImageOptions implements ImageOptions {
+
+	/**
+	 * The model to use for image generation, for example
+	 * {@code bytedance/seedream-v5.0-pro}. The model is passed in the URL as a path
+	 * parameter.
+	 */
+	private final @Nullable String model;
+
+	/**
+	 * The size of the generated image as {@code {width}*{height}}, for example
+	 * {@code 1024*1024}. Takes precedence over {@link #width} and {@link #height} when
+	 * both are set.
+	 */
+	private final @Nullable String size;
+
+	/**
+	 * The width of the generated image, in pixels. Combined with {@link #height} into a
+	 * {@code {width}*{height}} size when {@link #size} is not set.
+	 */
+	private final @Nullable Integer width;
+
+	/**
+	 * The height of the generated image, in pixels. Combined with {@link #width} into a
+	 * {@code {width}*{height}} size when {@link #size} is not set.
+	 */
+	private final @Nullable Integer height;
+
+	/**
+	 * The random seed used for generation, or {@code -1} for a random seed.
+	 */
+	private final @Nullable Integer seed;
+
+	private WaveSpeedImageOptions(Builder builder) {
+		this.model = builder.model;
+		this.size = builder.size;
+		this.width = builder.width;
+		this.height = builder.height;
+		this.seed = builder.seed;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public @Nullable String getModel() {
+		return this.model;
+	}
+
+	@Override
+	public @Nullable Integer getN() {
+		return null;
+	}
+
+	@Override
+	public @Nullable Integer getWidth() {
+		return this.width;
+	}
+
+	@Override
+	public @Nullable Integer getHeight() {
+		return this.height;
+	}
+
+	@Override
+	public @Nullable String getResponseFormat() {
+		return null;
+	}
+
+	@Override
+	public @Nullable String getStyle() {
+		return null;
+	}
+
+	public @Nullable String getSize() {
+		return this.size;
+	}
+
+	public @Nullable Integer getSeed() {
+		return this.seed;
+	}
+
+	/**
+	 * Compute the effective {@code {width}*{height}} size to send in the request:
+	 * {@link #size} when set, otherwise composed from {@link #width} and {@link #height}.
+	 * @return the effective size, or {@code null} to let the model use its default
+	 */
+	public @Nullable String toSizeString() {
+		if (this.size != null) {
+			return this.size;
+		}
+		if (this.width != null && this.height != null) {
+			return this.width + "*" + this.height;
+		}
+		return null;
+	}
+
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof WaveSpeedImageOptions other)) {
+			return false;
+		}
+		return Objects.equals(this.model, other.model) && Objects.equals(this.size, other.size)
+				&& Objects.equals(this.width, other.width) && Objects.equals(this.height, other.height)
+				&& Objects.equals(this.seed, other.seed);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.model, this.size, this.width, this.height, this.seed);
+	}
+
+	@Override
+	public String toString() {
+		return "WaveSpeedImageOptions{model='" + this.model + "', size='" + this.size + "', width=" + this.width
+				+ ", height=" + this.height + ", seed=" + this.seed + "}";
+	}
+
+	public static final class Builder {
+
+		private @Nullable String model;
+
+		private @Nullable String size;
+
+		private @Nullable Integer width;
+
+		private @Nullable Integer height;
+
+		private @Nullable Integer seed;
+
+		private Builder() {
+
+		}
+
+		public Builder model(@Nullable String model) {
+			this.model = model;
+			return this;
+		}
+
+		public Builder size(@Nullable String size) {
+			this.size = size;
+			return this;
+		}
+
+		public Builder width(@Nullable Integer width) {
+			this.width = width;
+			return this;
+		}
+
+		public Builder height(@Nullable Integer height) {
+			this.height = height;
+			return this;
+		}
+
+		public Builder seed(@Nullable Integer seed) {
+			this.seed = seed;
+			return this;
+		}
+
+		public WaveSpeedImageOptions build() {
+			return new WaveSpeedImageOptions(this);
+		}
+
+	}
+
+}

--- a/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/api/package-info.java
+++ b/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/api/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.wavespeed.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/package-info.java
+++ b/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.wavespeed;
+
+import org.jspecify.annotations.NullMarked;

--- a/models/spring-ai-wavespeed/src/test/java/org/springframework/ai/wavespeed/WaveSpeedImageModelTests.java
+++ b/models/spring-ai-wavespeed/src/test/java/org/springframework/ai/wavespeed/WaveSpeedImageModelTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.wavespeed;
+
+import java.time.Duration;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.retry.NonTransientAiException;
+import org.springframework.ai.wavespeed.api.WaveSpeedApi;
+import org.springframework.ai.wavespeed.api.WaveSpeedImageOptions;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link WaveSpeedImageModel} using a mock WaveSpeed API server.
+ *
+ * @author Zeyi Cheng
+ */
+class WaveSpeedImageModelTests {
+
+	private MockWebServer server;
+
+	private WaveSpeedImageModel imageModel;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		this.server = new MockWebServer();
+		this.server.start();
+		WaveSpeedApi api = new WaveSpeedApi("test-api-key", this.server.url("/").toString(), RestClient.builder(),
+				Duration.ofMillis(10), Duration.ofSeconds(5));
+		this.imageModel = new WaveSpeedImageModel(api,
+				WaveSpeedImageOptions.builder().model("bytedance/seedream-v5.0-pro").build());
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		this.server.shutdown();
+	}
+
+	@Test
+	void callReturnsImageUrlAfterPolling() throws Exception {
+		this.server.enqueue(jsonResponse("""
+				{"code":200,"message":"success","data":{"id":"pred-123","status":"created"}}"""));
+		this.server.enqueue(jsonResponse("""
+				{"code":200,"message":"success","data":{"id":"pred-123","status":"processing"}}"""));
+		this.server.enqueue(jsonResponse("""
+				{"code":200,"message":"success","data":{"id":"pred-123","status":"completed",
+				"outputs":["https://example.org/image.png"]}}"""));
+
+		ImageResponse response = this.imageModel.call(new ImagePrompt("A sunrise over snowy mountains"));
+
+		assertThat(response.getResults()).hasSize(1);
+		assertThat(response.getResult().getOutput().getUrl()).isEqualTo("https://example.org/image.png");
+
+		RecordedRequest submitRequest = this.server.takeRequest();
+		assertThat(submitRequest.getPath()).isEqualTo("/api/v3/bytedance/seedream-v5.0-pro");
+		assertThat(submitRequest.getHeader("Authorization")).isEqualTo("Bearer test-api-key");
+		assertThat(submitRequest.getHeader("X-Client-Name")).isEqualTo("spring-ai-wavespeed");
+		assertThat(submitRequest.getBody().readUtf8()).contains("A sunrise over snowy mountains");
+
+		RecordedRequest pollRequest = this.server.takeRequest();
+		assertThat(pollRequest.getPath()).isEqualTo("/api/v3/predictions/pred-123/result");
+	}
+
+	@Test
+	void callSendsSizeAndSeed() throws Exception {
+		this.server.enqueue(jsonResponse("""
+				{"code":200,"message":"success","data":{"id":"pred-456","status":"completed",
+				"outputs":["https://example.org/other.png"]}}"""));
+		this.server.enqueue(jsonResponse("""
+				{"code":200,"message":"success","data":{"id":"pred-456","status":"completed",
+				"outputs":["https://example.org/other.png"]}}"""));
+
+		WaveSpeedImageOptions runtimeOptions = WaveSpeedImageOptions.builder().size("2048*2048").seed(42).build();
+		this.imageModel.call(new ImagePrompt("A red bicycle", runtimeOptions));
+
+		RecordedRequest submitRequest = this.server.takeRequest();
+		String body = submitRequest.getBody().readUtf8();
+		assertThat(body).contains("\"size\":\"2048*2048\"");
+		assertThat(body).contains("\"seed\":42");
+	}
+
+	@Test
+	void callThrowsOnFailedPrediction() {
+		this.server.enqueue(jsonResponse("""
+				{"code":200,"message":"success","data":{"id":"pred-789","status":"created"}}"""));
+		this.server.enqueue(jsonResponse("""
+				{"code":200,"message":"success","data":{"id":"pred-789","status":"failed","error":"NSFW content"}}"""));
+
+		assertThatThrownBy(() -> this.imageModel.call(new ImagePrompt("A test prompt")))
+			.isInstanceOf(NonTransientAiException.class)
+			.hasMessageContaining("failed")
+			.hasMessageContaining("NSFW content");
+	}
+
+	@Test
+	void callThrowsOnErrorEnvelope() {
+		this.server.enqueue(jsonResponse("""
+				{"code":401,"message":"invalid api key"}"""));
+
+		assertThatThrownBy(() -> this.imageModel.call(new ImagePrompt("A test prompt")))
+			.isInstanceOf(NonTransientAiException.class)
+			.hasMessageContaining("invalid api key");
+	}
+
+	private static MockResponse jsonResponse(String body) {
+		return new MockResponse().setHeader("Content-Type", "application/json").setBody(body);
+	}
+
+}

--- a/models/spring-ai-wavespeed/src/test/java/org/springframework/ai/wavespeed/WaveSpeedImageOptionsTests.java
+++ b/models/spring-ai-wavespeed/src/test/java/org/springframework/ai/wavespeed/WaveSpeedImageOptionsTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.wavespeed;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.image.ImageOptions;
+import org.springframework.ai.image.ImageOptionsBuilder;
+import org.springframework.ai.wavespeed.api.WaveSpeedApi;
+import org.springframework.ai.wavespeed.api.WaveSpeedImageOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link WaveSpeedImageOptions}.
+ *
+ * @author Zeyi Cheng
+ */
+class WaveSpeedImageOptionsTests {
+
+	@Test
+	void shouldPreferRuntimeOptionsOverDefaultOptions() {
+		WaveSpeedImageModel imageModel = new WaveSpeedImageModel(mock(WaveSpeedApi.class));
+
+		WaveSpeedImageOptions defaultOptions = WaveSpeedImageOptions.builder()
+			.model("default-model")
+			.size("1024*1024")
+			.seed(1234)
+			.build();
+
+		WaveSpeedImageOptions runtimeOptions = WaveSpeedImageOptions.builder()
+			.model("runtime-model")
+			.size("2048*2048")
+			.seed(5678)
+			.build();
+
+		WaveSpeedImageOptions merged = imageModel.mergeOptions(runtimeOptions, defaultOptions);
+
+		assertThat(merged.getModel()).isEqualTo("runtime-model");
+		assertThat(merged.getSize()).isEqualTo("2048*2048");
+		assertThat(merged.getSeed()).isEqualTo(5678);
+	}
+
+	@Test
+	void shouldFallBackToDefaultOptionsWhenRuntimeOptionsAreEmpty() {
+		WaveSpeedImageModel imageModel = new WaveSpeedImageModel(mock(WaveSpeedApi.class));
+
+		WaveSpeedImageOptions defaultOptions = WaveSpeedImageOptions.builder()
+			.model("default-model")
+			.size("1024*1024")
+			.seed(1234)
+			.build();
+
+		WaveSpeedImageOptions merged = imageModel.mergeOptions(WaveSpeedImageOptions.builder().build(), defaultOptions);
+
+		assertThat(merged.getModel()).isEqualTo("default-model");
+		assertThat(merged.getSize()).isEqualTo("1024*1024");
+		assertThat(merged.getSeed()).isEqualTo(1234);
+	}
+
+	@Test
+	void shouldMergePortableImageOptions() {
+		WaveSpeedImageModel imageModel = new WaveSpeedImageModel(mock(WaveSpeedApi.class));
+
+		WaveSpeedImageOptions defaultOptions = WaveSpeedImageOptions.builder().model("default-model").build();
+
+		ImageOptions runtimeOptions = ImageOptionsBuilder.builder().width(1280).height(720).build();
+
+		WaveSpeedImageOptions merged = imageModel.mergeOptions(runtimeOptions, defaultOptions);
+
+		assertThat(merged.getModel()).isEqualTo("default-model");
+		assertThat(merged.getWidth()).isEqualTo(1280);
+		assertThat(merged.getHeight()).isEqualTo(720);
+		assertThat(merged.toSizeString()).isEqualTo("1280*720");
+	}
+
+	@Test
+	void sizeShouldTakePrecedenceOverWidthAndHeight() {
+		WaveSpeedImageOptions options = WaveSpeedImageOptions.builder()
+			.size("1024*1024")
+			.width(512)
+			.height(512)
+			.build();
+
+		assertThat(options.toSizeString()).isEqualTo("1024*1024");
+	}
+
+	@Test
+	void sizeStringShouldBeNullWhenNotConfigured() {
+		assertThat(WaveSpeedImageOptions.builder().build().toSizeString()).isNull();
+		assertThat(WaveSpeedImageOptions.builder().width(512).build().toSizeString()).isNull();
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-stability-ai</module>
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-transformers</module>
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai</module>
+		<module>auto-configurations/models/spring-ai-autoconfigure-model-wavespeed</module>
 		<module>auto-configurations/models/tool/spring-ai-autoconfigure-model-tool</module>
 
 		<module>auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure</module>
@@ -123,6 +124,7 @@
 		<module>models/spring-ai-stability-ai</module>
 		<module>models/spring-ai-transformers</module>
 		<module>models/spring-ai-vertex-ai-embedding</module>
+		<module>models/spring-ai-wavespeed</module>
 
 		<module>starters/spring-ai-starter-mcp-client</module>
 		<module>starters/spring-ai-starter-mcp-client-webflux</module>
@@ -151,6 +153,7 @@
 		<module>starters/spring-ai-starter-model-stability-ai</module>
 		<module>starters/spring-ai-starter-model-transformers</module>
 		<module>starters/spring-ai-starter-model-vertex-ai-embedding</module>
+		<module>starters/spring-ai-starter-model-wavespeed</module>
 
 		<module>starters/spring-ai-starter-tool-search-advisor</module>
 

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -314,6 +314,12 @@
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-wavespeed</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-transformers</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -664,6 +670,12 @@
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-autoconfigure-model-wavespeed</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-transformers</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -993,6 +1005,12 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-stability-ai</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-starter-model-wavespeed</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -53,6 +53,7 @@
 **** xref:api/image/openai-image.adoc[OpenAI]
 **** xref:api/image/stabilityai-image.adoc[Stability]
 **** xref:api/image/google-genai-image.adoc[Google GenAI]
+**** xref:api/image/wavespeed-image.adoc[WaveSpeed AI]
 
 *** xref:api/audio.adoc[Audio Models]
 **** xref:api/audio/transcriptions.adoc[]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/wavespeed-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/wavespeed-image.adoc
@@ -1,0 +1,162 @@
+= WaveSpeed AI Image Generation
+
+Spring AI supports the https://wavespeed.ai[WaveSpeed AI] image generation models, such as ByteDance Seedream.
+
+The WaveSpeed API is asynchronous: submitting a generation request creates a prediction that is polled until it reaches a terminal status, then the generated images are returned as URLs.
+
+== Prerequisites
+
+You will need to create an API key with WaveSpeed AI to access their models.
+Create an account at https://wavespeed.ai[wavespeed.ai] and generate an API key on the dashboard.
+
+The Spring AI project defines a configuration property named `spring.ai.wavespeed.api-key` that you should set to the value of the API key obtained from WaveSpeed AI.
+
+You can set this configuration property in your `application.properties` file:
+
+[source,properties]
+----
+spring.ai.wavespeed.api-key=<your-wavespeed-api-key>
+----
+
+For enhanced security when handling sensitive information like API keys, you can use Spring Expression Language (SpEL) to reference a custom environment variable:
+
+[source,yaml]
+----
+# In application.yml
+spring:
+  ai:
+    wavespeed:
+      api-key: ${WAVESPEED_API_KEY}
+----
+
+[source,bash]
+----
+# In your environment or .env file
+export WAVESPEED_API_KEY=<your-wavespeed-api-key>
+----
+
+== Auto-configuration
+
+Spring AI provides Spring Boot auto-configuration for the WaveSpeed AI image generation client.
+To enable it add the following dependency to your project's Maven `pom.xml` file:
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-model-wavespeed</artifactId>
+</dependency>
+----
+
+or to your Gradle `build.gradle` build file.
+
+[source,groovy]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-starter-model-wavespeed'
+}
+----
+
+TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
+
+=== Image Generation Properties
+
+The prefix `spring.ai.wavespeed` is used as the property prefix that lets you connect to WaveSpeed AI.
+
+[cols="3,5,1"]
+|====
+| Property | Description | Default
+
+| spring.ai.wavespeed.base-url      | The URL to connect to | `+https://api.wavespeed.ai+`
+| spring.ai.wavespeed.api-key       | The API key           |  -
+| spring.ai.wavespeed.poll-interval | The interval between two prediction result polls | 1s
+| spring.ai.wavespeed.timeout       | The maximum time to wait for a prediction to complete | 600s
+|====
+
+[NOTE]
+====
+Enabling and disabling of the image auto-configurations are now configured via top level properties with the prefix `spring.ai.model.image`.
+
+To enable, spring.ai.model.image=wavespeed (It is enabled by default)
+
+To disable, spring.ai.model.image=none (or any value which doesn't match wavespeed)
+
+This change is done to allow configuration of multiple models.
+====
+
+The prefix `spring.ai.wavespeed.image` is the property prefix that lets you configure the `ImageModel` implementation for WaveSpeed AI.
+
+[cols="3,5,2"]
+|====
+| Property | Description | Default
+
+| spring.ai.wavespeed.image.base-url | Optionally overrides `spring.ai.wavespeed.base-url` to provide a specific URL | -
+| spring.ai.wavespeed.image.api-key  | Optionally overrides `spring.ai.wavespeed.api-key` to provide a specific API key | -
+| spring.ai.wavespeed.image.model    | The model to use for image generation. The model is passed in the URL as a path parameter. | `bytedance/seedream-v5.0-pro`
+| spring.ai.wavespeed.image.size     | The size of the generated image as `{width}*{height}`, for example `1024*1024`. Takes precedence over width and height. | -
+| spring.ai.wavespeed.image.width    | The width of the generated image, in pixels. Used together with height when size is not set. | -
+| spring.ai.wavespeed.image.height   | The height of the generated image, in pixels. Used together with width when size is not set. | -
+| spring.ai.wavespeed.image.seed     | The random seed used for generation, or -1 for a random seed. | -
+|====
+
+== Runtime Options [[image-options]]
+
+The https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-wavespeed/src/main/java/org/springframework/ai/wavespeed/api/WaveSpeedImageOptions.java[WaveSpeedImageOptions] provides the model configuration, such as the model to use, the size and the seed.
+
+On start-up, the default options can be configured with the `WaveSpeedImageModel(WaveSpeedApi, WaveSpeedImageOptions)` constructor or the `spring.ai.wavespeed.image.*` properties.
+
+At run-time you can override the default options by adding new, request specific, options to the `ImagePrompt` call.
+For example to override the WaveSpeed AI specific options such as the size and the model:
+
+[source,java]
+----
+ImageResponse response = imageModel.call(
+        new ImagePrompt("A light cream colored mini golden doodle",
+        WaveSpeedImageOptions.builder()
+                .model("bytedance/seedream-v5.0-pro")
+                .size("2048*2048")
+                .seed(42)
+                .build()));
+
+String imageUrl = response.getResult().getOutput().getUrl();
+----
+
+== Manual Configuration
+
+Add the `spring-ai-wavespeed` dependency to your project's Maven `pom.xml` file:
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-wavespeed</artifactId>
+</dependency>
+----
+
+or to your Gradle `build.gradle` build file.
+
+[source,groovy]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-wavespeed'
+}
+----
+
+TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
+
+Next, create a `WaveSpeedImageModel`:
+
+[source,java]
+----
+WaveSpeedApi waveSpeedApi = new WaveSpeedApi(System.getenv("WAVESPEED_API_KEY"));
+
+ImageModel imageModel = new WaveSpeedImageModel(waveSpeedApi,
+        WaveSpeedImageOptions.builder()
+                .model("bytedance/seedream-v5.0-pro")
+                .size("1024*1024")
+                .build());
+
+ImageResponse response = imageModel.call(new ImagePrompt("A light cream colored mini golden doodle"));
+
+String imageUrl = response.getResult().getOutput().getUrl();
+----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/imageclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/imageclient.adoc
@@ -162,3 +162,4 @@ public class ImageGeneration implements ModelResult<Image> {
 * xref:api/image/openai-image.adoc[OpenAI Image Generation]
 * xref:api/image/stabilityai-image.adoc[StabilityAI Image Generation]
 * xref:api/image/google-genai-image.adoc[Google GenAI Image Generation]
+* xref:api/image/wavespeed-image.adoc[WaveSpeed AI Image Generation]

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModels.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModels.java
@@ -56,4 +56,6 @@ public final class SpringAIModels {
 
 	public static final String ELEVEN_LABS = "elevenlabs";
 
+	public static final String WAVESPEED = "wavespeed";
+
 }

--- a/starters/spring-ai-starter-model-wavespeed/pom.xml
+++ b/starters/spring-ai-starter-model-wavespeed/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-starter-model-wavespeed</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Starter - WaveSpeed AI</name>
+	<description>Spring AI WaveSpeed AI Spring Boot Starter</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-wavespeed</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-wavespeed</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+	</dependencies>
+
+</project>


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc

---

## Context and motivation

This PR adds an `ImageModel` implementation for [WaveSpeed AI](https://wavespeed.ai), an image and video generation platform serving models such as ByteDance Seedream, FLUX and Qwen-Image. I am the founder of WaveSpeed AI, so this is an official provider contribution, and we are happy to maintain it going forward.

The WaveSpeed API is asynchronous (submit a prediction, poll `/api/v3/predictions/{id}/result` until a terminal status), which is a slightly different shape from the existing image providers, so the API client encapsulates the polling with a configurable poll interval (default 1s) and timeout (default 600s).

## What's included

Mirrors the structure of the existing Stability AI image provider:

* `models/spring-ai-wavespeed`: `WaveSpeedApi` (RestClient-based), `WaveSpeedImageModel`, `WaveSpeedImageOptions`
* `auto-configurations/models/spring-ai-autoconfigure-model-wavespeed`: auto-configuration with `spring.ai.wavespeed.*` properties, activated via `spring.ai.model.image=wavespeed`
* `starters/spring-ai-starter-model-wavespeed`
* BOM entries, `SpringAIModels.WAVESPEED` constant, Antora reference documentation page, nav and image model index entries
* Unit tests: options merging, property binding/activation, and `MockWebServer`-based tests covering submit + poll, request headers/body, failed predictions and error envelopes (no live API calls)

`./mvnw install -pl models/spring-ai-wavespeed,auto-configurations/models/spring-ai-autoconfigure-model-wavespeed,starters/spring-ai-starter-model-wavespeed -am` passes locally (tests, checkstyle and spring-javaformat).

## Disclosure

This contribution was developed with the help of an AI coding agent (Claude Code) and has been reviewed by the WaveSpeed team, which remains accountable for its quality, per the contributing guidelines.
