### PR TITLE
Fix formatted heading extraction in `MarkdownDocumentReader`

### DIFF
--- a/document-readers/spring-ai-markdown-document-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/spring-ai-markdown-document-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -165,7 +165,24 @@ public class MarkdownDocumentReader implements DocumentReader {
 		@Override
 		public void visit(Heading heading) {
 			buildAndFlush();
-			super.visit(heading);
+			this.currentDocumentBuilder.metadata("category", "header_%d".formatted(heading.getLevel()))
+				.metadata("title", extractHeadingTitle(heading));
+		}
+
+		private static String extractHeadingTitle(Heading heading) {
+			StringBuilder title = new StringBuilder();
+			heading.accept(new AbstractVisitor() {
+				@Override
+				public void visit(Text text) {
+					title.append(text.getLiteral());
+				}
+
+				@Override
+				public void visit(Code code) {
+					title.append(code.getLiteral());
+				}
+			});
+			return title.toString();
 		}
 
 		@Override
@@ -230,14 +247,7 @@ public class MarkdownDocumentReader implements DocumentReader {
 
 		@Override
 		public void visit(Text text) {
-			if (text.getParent() instanceof Heading heading) {
-				this.currentDocumentBuilder.metadata("category", "header_%d".formatted(heading.getLevel()))
-					.metadata("title", text.getLiteral());
-			}
-			else {
-				this.currentParagraphs.add(text.getLiteral());
-			}
-
+			this.currentParagraphs.add(text.getLiteral());
 			super.visit(text);
 		}
 

--- a/document-readers/spring-ai-markdown-document-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/spring-ai-markdown-document-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -104,6 +104,19 @@ class MarkdownDocumentReaderTest {
 	}
 
 	@Test
+	void testFormattedHeading() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/formatted-heading.md");
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).satisfiesExactly(document -> {
+			assertThat(document.getMetadata()).containsEntry("category", "header_1")
+				.containsEntry("title", "Spring AI Guide ChatClient");
+			assertThat(document.getText()).isEqualTo("Body text.");
+		});
+	}
+
+	@Test
 	void testDocumentDividedViaHorizontalRules() {
 		MarkdownDocumentReaderConfig config = MarkdownDocumentReaderConfig.builder()
 			.withHorizontalRuleCreateDocument(true)

--- a/document-readers/spring-ai-markdown-document-reader/src/test/resources/formatted-heading.md
+++ b/document-readers/spring-ai-markdown-document-reader/src/test/resources/formatted-heading.md
@@ -1,0 +1,3 @@
+# Spring **AI** [Guide](https://spring.io) `ChatClient`
+
+Body text.


### PR DESCRIPTION
## Problem

`MarkdownDocumentReader` only used text whose direct parent was a heading. Text inside emphasis, links, or inline code was left out of the title and then added to the document body.

For example:

```markdown
# Spring **AI** [Guide](https://spring.io) `ChatClient`

Body text.
```

The title should be `Spring AI Guide ChatClient`, and the document body should only contain `Body text.`

## Change

Read the title from the heading subtree and keep that subtree out of the body visitor. The regression test covers strong text, a link, and inline code in the same heading.

## Testing

- `./mvnw -Dmaven.build.cache.enabled=false -pl document-readers/spring-ai-markdown-document-reader -am clean package`

I also ran `./mvnw clean package`. It reached `models/spring-ai-bedrock-converse` and stopped at `URLValidatorTest.unknownHostThrowsSecurityException` because the local DNS resolves `.invalid` hosts to `198.18.0.179`.
