### PR TITLE
Fix JSON round trip for URI-backed media

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/content/Media.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/content/Media.java
@@ -19,7 +19,12 @@ package org.springframework.ai.content;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Base64;
+import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.io.Resource;
@@ -146,11 +151,23 @@ public class Media {
 	}
 
 	/**
-	 * Create a new Media instance.
+	 * Create a Media instance from deserialized JSON values.
+	 * <p>
+	 * Jackson uses this property-based creator when reading media back from JSON, so we
+	 * accept the serialized shape directly instead of requiring a dedicated DTO. The data
+	 * is normalized to its string form, and shapes the builder never allows are rejected
+	 * explicitly.
 	 * @param mimeType the media MIME type
 	 * @param data the media data
 	 * @param id the media id
+	 * @param name the media name
 	 */
+	@JsonCreator
+	private Media(@JsonProperty("mimeType") Object mimeType, @JsonProperty("data") Object data,
+			@JsonProperty("id") @Nullable String id, @JsonProperty("name") @Nullable String name) {
+		this(toMimeType(mimeType), toData(data), id, name);
+	}
+
 	private Media(MimeType mimeType, Object data, @Nullable String id, @Nullable String name) {
 		Assert.notNull(mimeType, "MimeType must not be null");
 		Assert.notNull(data, "Data must not be null");
@@ -162,6 +179,83 @@ public class Media {
 
 	private static String generateDefaultName(MimeType mimeType) {
 		return NAME_PREFIX + mimeType.getSubtype() + "-" + java.util.UUID.randomUUID();
+	}
+
+	/**
+	 * Convert the Jackson materialized MIME type value back to a {@link MimeType}.
+	 * <p>
+	 * Jackson may provide either a {@link MimeType} instance, a raw string, or a nested
+	 * map representation depending on the serializer/deserializer pair in use.
+	 * @param mimeType the serialized MIME type value
+	 * @return the normalized {@link MimeType} instance
+	 */
+	private static MimeType toMimeType(Object mimeType) {
+		Assert.notNull(mimeType, "MimeType must not be null");
+		// Jackson may materialize MimeType as either the real type, a simple string, or a
+		// nested object map depending on the active serializer/deserializer pair.
+		if (mimeType instanceof MimeType) {
+			return (MimeType) mimeType;
+		}
+		if (mimeType instanceof String) {
+			return MimeType.valueOf((String) mimeType);
+		}
+		if (mimeType instanceof Map) {
+			return MimeType.valueOf(toMimeTypeString((Map<?, ?>) mimeType));
+		}
+		throw new IllegalArgumentException("Unsupported MimeType value: " + mimeType.getClass().getName());
+	}
+
+	/**
+	 * Reconstruct the canonical MIME type string from Jackson's map representation.
+	 * <p>
+	 * This keeps the parsing logic in one place so the creator can normalize
+	 * object-shaped MIME type values before delegating to
+	 * {@link MimeType#valueOf(String)}.
+	 * @param mimeType the Jackson map representation of a MIME type
+	 * @return the canonical MIME type string
+	 */
+	private static String toMimeTypeString(Map<?, ?> mimeType) {
+		Object type = mimeType.get("type");
+		Object subtype = mimeType.get("subtype");
+		Assert.state(type instanceof String && !((String) type).trim().isEmpty(), "MimeType type must not be blank");
+		Assert.state(subtype instanceof String && !((String) subtype).trim().isEmpty(),
+				"MimeType subtype must not be blank");
+
+		// Rebuild the canonical MIME type string so MimeType.valueOf(...) can parse it.
+		StringBuilder value = new StringBuilder((String) type).append('/').append((String) subtype);
+		Object parameters = mimeType.get("parameters");
+		if (parameters instanceof Map) {
+			for (Map.Entry<?, ?> entry : ((Map<?, ?>) parameters).entrySet()) {
+				value.append(';').append(entry.getKey()).append('=').append(entry.getValue());
+			}
+		}
+		return value.toString();
+	}
+
+	/**
+	 * Normalize the Jackson materialized data value to the canonical string form that a
+	 * JSON round-trip produces from the builder's supported shapes ({@code String},
+	 * {@code byte[]}, {@link URL}, {@link URI}), and reject shapes the builder never
+	 * allows (e.g. objects, arrays, numbers) with a clear exception.
+	 * @param data the Jackson materialized data value
+	 * @return the normalized media data, as a {@code String}
+	 */
+	private static Object toData(Object data) {
+		Assert.notNull(data, "Data must not be null");
+		if (data instanceof String text) {
+			return text;
+		}
+		if (data instanceof byte[] bytes) {
+			return Base64.getEncoder().encodeToString(bytes);
+		}
+		if (data instanceof URL url) {
+			return url.toString();
+		}
+		if (data instanceof URI uri) {
+			return uri.toString();
+		}
+		throw new IllegalArgumentException(
+				"Unsupported data type for deserialized Media: " + data.getClass().getName());
 	}
 
 	/**
@@ -185,6 +279,7 @@ public class Media {
 	 * Get the media data as a byte array
 	 * @return the media data as a byte array
 	 */
+	@JsonIgnore
 	public byte[] getDataAsByteArray() {
 		if (this.data instanceof byte[]) {
 			return (byte[]) this.data;

--- a/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.exc.ValueInstantiationException;
 import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.content.Media;
@@ -29,6 +31,7 @@ import org.springframework.ai.util.JacksonUtils;
 import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DocumentTests {
@@ -479,6 +482,76 @@ public class DocumentTests {
 
 		assertThat(deserialized.getText()).isEqualTo(specialText);
 		assertThat(deserialized).isEqualTo(original);
+	}
+
+	/**
+	 * Regression test for GitHub issue 6834: URI-backed media must serialize without
+	 * Jackson treating the derived byte-array accessor as a bean property.
+	 */
+	@Test
+	void roundTripUriBackedMediaDocument() throws Exception {
+		JsonMapper mapper = JacksonUtils.getDefaultJsonMapper();
+		Media originalMedia = Media.builder()
+			.mimeType(MimeTypeUtils.IMAGE_PNG)
+			.data(URI.create("https://www.wikimedia.org/static/images/wmf-logo-2x.png"))
+			.name("image")
+			.build();
+		Document original = Document.builder().id("media-doc").media(originalMedia).build();
+
+		String json = mapper.writeValueAsString(original);
+		Document deserialized = mapper.readValue(json, Document.class);
+
+		JsonNode mediaNode = mapper.readTree(json).get("media");
+		assertThat(mediaNode.get("data").asText()).isEqualTo("https://www.wikimedia.org/static/images/wmf-logo-2x.png");
+		assertThat(mediaNode.has("dataAsByteArray")).isFalse();
+		assertThat(deserialized.getId()).isEqualTo("media-doc");
+		assertThat(deserialized.getMedia()).isNotNull();
+		assertThat(deserialized.getMedia().getMimeType()).isEqualTo(MimeTypeUtils.IMAGE_PNG);
+		assertThat(deserialized.getMedia().getData())
+			.isEqualTo("https://www.wikimedia.org/static/images/wmf-logo-2x.png");
+		assertThat(deserialized.getMedia().getName()).isEqualTo("image");
+	}
+
+	/**
+	 * Round-trip for a document whose media data is a {@code byte[]}. Jackson serializes
+	 * the data as a base64 string, so the data comes back as a {@link String} (not a
+	 * {@code byte[]}), while the {@code dataAsByteArray} accessor is excluded from the
+	 * JSON (see issue 6834).
+	 */
+	@Test
+	void roundTripByteArrayBackedMediaDocument() throws Exception {
+		JsonMapper mapper = JacksonUtils.getDefaultJsonMapper();
+		Media originalMedia = Media.builder()
+			.mimeType(MimeTypeUtils.IMAGE_PNG)
+			.data(new byte[] { 1, 2, 3 })
+			.name("bytes")
+			.build();
+		Document original = Document.builder().id("media-bytes").media(originalMedia).build();
+
+		String json = mapper.writeValueAsString(original);
+		Document deserialized = mapper.readValue(json, Document.class);
+
+		JsonNode mediaNode = mapper.readTree(json).get("media");
+		assertThat(mediaNode.get("data").asText()).isEqualTo("AQID");
+		assertThat(mediaNode.has("dataAsByteArray")).isFalse();
+		assertThat(deserialized.getMedia().getData()).isEqualTo("AQID");
+	}
+
+	/**
+	 * Deserialization must reject JSON whose media data is not one of the shapes the
+	 * builder allows (e.g. an object), instead of silently creating a {@link Media}
+	 * instance the builder could never produce.
+	 */
+	@Test
+	void deserializationRejectsObjectMediaData() throws Exception {
+		JsonMapper mapper = JacksonUtils.getDefaultJsonMapper();
+		String json = "{\"id\":\"media-reject\",\"text\":null,\"media\":{\"mimeType\":{\"type\":\"image\","
+				+ "\"subtype\":\"png\",\"parameters\":{}},\"data\":{\"unexpected\":true},\"id\":null,\"name\":\"x\"},"
+				+ "\"metadata\":{},\"score\":null}";
+
+		assertThatThrownBy(() -> mapper.readValue(json, Document.class)).isInstanceOf(ValueInstantiationException.class)
+			.hasRootCauseInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Unsupported data type for deserialized Media");
 	}
 
 	/**


### PR DESCRIPTION
**Summary**

Fixes the `Document` JSON round trip for URI-backed media reported in #6834.

**Problem**

`Document` is documented to support a Jackson JSON round trip, but serializing a
`Document` that contains URI/string-backed media fails:

```
Document["media"] -> Media["dataAsByteArray"]
IllegalStateException: Media data is not a byte[]
```

Jackson auto-detects `Media#getDataAsByteArray()` as a bean property and invokes it
during serialization even when the media data is not a `byte[]`.

**Changes**

- Mark `Media#getDataAsByteArray()` with `@JsonIgnore` so the derived accessor is no
  longer treated as a JSON property.
- Add a Jackson property-based `@JsonCreator` to `Media` so it can be read back from
  JSON (previously impossible: no default constructor, no setters).
- Normalize the materialized MIME type (a `MimeType` instance, a string, or Jackson's
  map representation) back to `MimeType` via `MimeType#valueOf`.
- Add regression tests for the URI-backed media round trip and for the byte[] data
  round-trip behavior (data is restored as its base64 string).

**Notes**

- After a round trip the media data is normalized to a `String`: `byte[]` data comes
  back as its base64 representation and `URL` data as its string form;
  `Media#getDataAsByteArray()` throws for non-`byte[]` data after deserialization.
- The `@JsonCreator` constructor is `private`, keeping the public API unchanged.

**Checklist**

- [x] Commits include a `Signed-off-by` line (DCO)
- [x] Branch is rebased on the latest `main`
- [x] Unit tests added/updated
- [x] Build passes: `./mvnw -pl spring-ai-commons verify`

Fixes #6834
