### PR TITLE
Restore honoring the configured OpenAI timeout

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/AbstractOpenAiProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/AbstractOpenAiProperties.java
@@ -89,9 +89,10 @@ public class AbstractOpenAiProperties {
 	private boolean isGitHubModels;
 
 	/**
-	 * Request timeout for OpenAI client.
+	 * Request timeout for OpenAI client. When {@code null}, the value is inherited from
+	 * the common properties, falling back to {@link #DEFAULT_TIMEOUT}.
 	 */
-	private Duration timeout = DEFAULT_TIMEOUT;
+	private @Nullable Duration timeout;
 
 	/**
 	 * Maximum number of retries for OpenAI client.
@@ -199,11 +200,14 @@ public class AbstractOpenAiProperties {
 		this.isGitHubModels = gitHubModels;
 	}
 
-	public Duration getTimeout() {
+	/**
+	 * Return the configured request timeout, or {@code null} when not set.
+	 */
+	public @Nullable Duration getTimeout() {
 		return this.timeout;
 	}
 
-	public void setTimeout(Duration timeout) {
+	public void setTimeout(@Nullable Duration timeout) {
 		this.timeout = timeout;
 	}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechAutoConfiguration.java
@@ -24,6 +24,7 @@ import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAutoConfigurationUtil.ResolvedConnectionProperties;
 import org.springframework.ai.openai.OpenAiAudioSpeechModel;
 import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
@@ -72,7 +73,7 @@ public class OpenAiAudioSpeechAutoConfiguration {
 			.build();
 	}
 
-	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
+	private OpenAIClient openAiClient(ResolvedConnectionProperties commonProperties,
 			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
 			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfiguration.java
@@ -25,6 +25,7 @@ import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAutoConfigurationUtil.ResolvedConnectionProperties;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
@@ -73,7 +74,7 @@ public class OpenAiAudioTranscriptionAutoConfiguration {
 			.build();
 	}
 
-	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
+	private OpenAIClient openAiClient(ResolvedConnectionProperties commonProperties,
 			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
 			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
@@ -89,7 +90,7 @@ public class OpenAiAudioTranscriptionAutoConfiguration {
 				meterRegistryToUse, httpClientCustomizers);
 	}
 
-	private OpenAIClientAsync openAiClientAsync(OpenAiCommonProperties commonProperties,
+	private OpenAIClientAsync openAiClientAsync(ResolvedConnectionProperties commonProperties,
 			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
 			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtil.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtil.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.time.Duration;
+
 import org.springframework.util.StringUtils;
 
 public final class OpenAiAutoConfigurationUtil {
@@ -45,8 +47,12 @@ public final class OpenAiAutoConfigurationUtil {
 		resolved.setCredential(modelProperties.getCredential() != null ? modelProperties.getCredential()
 				: commonProperties.getCredential());
 
-		resolved.setTimeout(!modelProperties.getTimeout().equals(OpenAiCommonProperties.DEFAULT_TIMEOUT)
-				? modelProperties.getTimeout() : commonProperties.getTimeout());
+		// A null timeout means "not configured", so the model-level value only wins when
+		// it was actually set. The resolved value is always non-null: it is what the
+		// OpenAI client is built with.
+		Duration timeout = modelProperties.getTimeout() != null ? modelProperties.getTimeout()
+				: commonProperties.getTimeout();
+		resolved.setTimeout(timeout != null ? timeout : OpenAiCommonProperties.DEFAULT_TIMEOUT);
 
 		resolved.setModel(StringUtils.hasText(modelProperties.getModel()) ? modelProperties.getModel()
 				: commonProperties.getModel());
@@ -77,6 +83,16 @@ public final class OpenAiAutoConfigurationUtil {
 	}
 
 	public static class ResolvedConnectionProperties extends OpenAiCommonProperties {
+
+		/**
+		 * Unlike the properties it is resolved from, a resolved timeout is always
+		 * present: it is what the OpenAI client is built with.
+		 */
+		@Override
+		public Duration getTimeout() {
+			Duration timeout = super.getTimeout();
+			return timeout != null ? timeout : DEFAULT_TIMEOUT;
+		}
 
 	}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAutoConfigurationUtil.ResolvedConnectionProperties;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
@@ -91,7 +92,7 @@ public class OpenAiChatAutoConfiguration {
 		return chatModel;
 	}
 
-	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
+	private OpenAIClient openAiClient(ResolvedConnectionProperties commonProperties,
 			ObjectProvider<ObservationRegistry> observationRegistry, @Nullable MeterRegistry meterRegistry,
 			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 
@@ -104,7 +105,7 @@ public class OpenAiChatAutoConfiguration {
 				meterRegistry, httpClientCustomizers);
 	}
 
-	private OpenAIClientAsync openAiClientAsync(OpenAiCommonProperties commonProperties,
+	private OpenAIClientAsync openAiClientAsync(ResolvedConnectionProperties commonProperties,
 			ObjectProvider<ObservationRegistry> observationRegistry, @Nullable MeterRegistry meterRegistry,
 			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatProperties.java
@@ -316,6 +316,7 @@ public class OpenAiChatProperties extends AbstractOpenAiProperties {
 
 	public OpenAiChatOptions toOptions() {
 		return OpenAiChatOptions.builder()
+			.timeout(this.getTimeout())
 			.model(this.model)
 			.frequencyPenalty(this.frequencyPenalty)
 			.logitBias(this.logitBias)

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingAutoConfiguration.java
@@ -25,6 +25,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.embedding.observation.EmbeddingModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAutoConfigurationUtil.ResolvedConnectionProperties;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
@@ -80,7 +81,7 @@ public class OpenAiEmbeddingAutoConfiguration {
 		return embeddingModel;
 	}
 
-	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
+	private OpenAIClient openAiClient(ResolvedConnectionProperties commonProperties,
 			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
 			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageAutoConfiguration.java
@@ -25,6 +25,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.image.observation.ImageModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAutoConfigurationUtil.ResolvedConnectionProperties;
 import org.springframework.ai.openai.OpenAiImageModel;
 import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
@@ -79,7 +80,7 @@ public class OpenAiImageAutoConfiguration {
 		return imageModel;
 	}
 
-	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
+	private OpenAIClient openAiClient(ResolvedConnectionProperties commonProperties,
 			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
 			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModerationAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModerationAutoConfiguration.java
@@ -24,6 +24,7 @@ import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAutoConfigurationUtil.ResolvedConnectionProperties;
 import org.springframework.ai.openai.OpenAiModerationModel;
 import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
@@ -72,7 +73,7 @@ public class OpenAiModerationAutoConfiguration {
 			.build();
 	}
 
-	private OpenAIClient openAiClient(OpenAiCommonProperties commonProperties,
+	private OpenAIClient openAiClient(ResolvedConnectionProperties commonProperties,
 			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
 			List<OpenAiHttpClientBuilderCustomizer> httpClientCustomizers) {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtilTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationUtilTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +32,43 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Ilayaperumal Gopinathan
  */
 public class OpenAiAutoConfigurationUtilTests {
+
+	@Test
+	void modelTimeoutTakesPrecedenceOverCommonTimeout() {
+		var common = properties(null);
+		common.setTimeout(Duration.ofMinutes(10));
+		var model = properties(null);
+		model.setTimeout(Duration.ofMinutes(30));
+
+		assertThat(OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model).getTimeout())
+			.isEqualTo(Duration.ofMinutes(30));
+	}
+
+	@Test
+	void commonTimeoutUsedWhenModelTimeoutIsNotSet() {
+		var common = properties(null);
+		common.setTimeout(Duration.ofMinutes(30));
+
+		assertThat(OpenAiAutoConfigurationUtil.resolveCommonProperties(common, properties(null)).getTimeout())
+			.isEqualTo(Duration.ofMinutes(30));
+	}
+
+	@Test
+	void explicitModelTimeoutMatchingTheDefaultIsNotTreatedAsUnset() {
+		var common = properties(null);
+		common.setTimeout(Duration.ofMinutes(30));
+		var model = properties(null);
+		model.setTimeout(AbstractOpenAiProperties.DEFAULT_TIMEOUT);
+
+		assertThat(OpenAiAutoConfigurationUtil.resolveCommonProperties(common, model).getTimeout())
+			.isEqualTo(AbstractOpenAiProperties.DEFAULT_TIMEOUT);
+	}
+
+	@Test
+	void defaultTimeoutUsedWhenNeitherIsSet() {
+		assertThat(OpenAiAutoConfigurationUtil.resolveCommonProperties(properties(null), properties(null)).getTimeout())
+			.isEqualTo(AbstractOpenAiProperties.DEFAULT_TIMEOUT);
+	}
 
 	@Test
 	void modelApiKeyTakesPrecedenceOverCommonApiKey() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatPropertiesTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -62,6 +64,41 @@ public class OpenAiChatPropertiesTests {
 				var options = chatProperties.toOptions();
 				assertThat(options.getModel()).isEqualTo("MODEL_XYZ");
 				assertThat(options.getTemperature()).isEqualTo(0.55);
+			});
+	}
+
+	@Test
+	public void configuredTimeoutReachesTheChatModelOptions() {
+
+		this.contextRunner.withPropertyValues(
+		// @formatter:off
+				"spring.ai.openai.api-key=abc123",
+				"spring.ai.openai.chat.timeout=30m")
+				// @formatter:on
+			.withConfiguration(
+					AutoConfigurations.of(OpenAiChatAutoConfiguration.class, ToolCallingAutoConfiguration.class))
+			.run(context -> {
+				var chatModel = context.getBean(OpenAiChatModel.class);
+				assertThat(chatModel.getOptions().getTimeout()).isEqualTo(Duration.ofMinutes(30));
+			});
+	}
+
+	@Test
+	public void unsetChatTimeoutLeavesTheOptionsTimeoutNull() {
+
+		// The chat options carry no timeout, so requests do not override the timeout the
+		// OpenAI client was built with. Resolution of the common-level timeout is covered
+		// by OpenAiAutoConfigurationUtilTests.
+		this.contextRunner.withPropertyValues(
+		// @formatter:off
+				"spring.ai.openai.api-key=abc123",
+				"spring.ai.openai.timeout=30m")
+				// @formatter:on
+			.withConfiguration(
+					AutoConfigurations.of(OpenAiChatAutoConfiguration.class, ToolCallingAutoConfiguration.class))
+			.run(context -> {
+				var chatModel = context.getBean(OpenAiChatModel.class);
+				assertThat(chatModel.getOptions().getTimeout()).isNull();
 			});
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/AbstractOpenAiOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/AbstractOpenAiOptions.java
@@ -88,9 +88,10 @@ public class AbstractOpenAiOptions {
 	private final boolean isGitHubModels;
 
 	/**
-	 * Request timeout for OpenAI client.
+	 * Request timeout for OpenAI client. When {@code null}, the timeout configured on the
+	 * OpenAI client is used.
 	 */
-	private final Duration timeout;
+	private final @Nullable Duration timeout;
 
 	/**
 	 * Maximum number of retries for OpenAI client.
@@ -121,7 +122,7 @@ public class AbstractOpenAiOptions {
 		this.organizationId = organizationId;
 		this.isMicrosoftFoundry = isMicrosoftFoundry != null ? isMicrosoftFoundry : false;
 		this.isGitHubModels = isGitHubModels != null ? isGitHubModels : false;
-		this.timeout = timeout != null ? timeout : DEFAULT_TIMEOUT;
+		this.timeout = timeout;
 		this.maxRetries = maxRetries != null ? maxRetries : DEFAULT_MAX_RETRIES;
 		this.proxy = proxy;
 		this.customHeaders = customHeaders != null ? Map.copyOf(customHeaders) : null;
@@ -170,7 +171,11 @@ public class AbstractOpenAiOptions {
 		return this.isGitHubModels;
 	}
 
-	public Duration getTimeout() {
+	/**
+	 * Return the request timeout, or {@code null} to inherit the timeout configured on
+	 * the OpenAI client.
+	 */
+	public @Nullable Duration getTimeout() {
 		return this.timeout;
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
@@ -91,9 +91,9 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 						this.options.getCredential(), this.options.getMicrosoftDeploymentName(),
 						this.options.getMicrosoftFoundryServiceVersion(), this.options.getOrganizationId(),
 						this.options.isMicrosoftFoundry(), this.options.isGitHubModels(), this.options.getModel(),
-						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(), ObservationRegistry.NOOP, null,
-						builder.httpClientCustomizers));
+						Objects.requireNonNullElse(this.options.getTimeout(), AbstractOpenAiOptions.DEFAULT_TIMEOUT),
+						this.options.getMaxRetries(), this.options.getProxy(), this.options.getCustomHeaders(),
+						ObservationRegistry.NOOP, null, builder.httpClientCustomizers));
 		this.streamScheduler = Objects.requireNonNullElse(builder.streamScheduler, DEFAULT_STREAM_SCHEDULER);
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -390,15 +390,17 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 							options.getCredential(), options.getMicrosoftDeploymentName(),
 							options.getMicrosoftFoundryServiceVersion(), options.getOrganizationId(),
 							options.isMicrosoftFoundry(), options.isGitHubModels(), options.getModel(),
-							options.getTimeout(), options.getMaxRetries(), options.getProxy(),
-							options.getCustomHeaders(), ObservationRegistry.NOOP, null, this.httpClientCustomizers));
+							Objects.requireNonNullElse(options.getTimeout(), AbstractOpenAiOptions.DEFAULT_TIMEOUT),
+							options.getMaxRetries(), options.getProxy(), options.getCustomHeaders(),
+							ObservationRegistry.NOOP, null, this.httpClientCustomizers));
 			var openAiClientAsync = Objects.requireNonNullElseGet(this.openAiClientAsync,
 					() -> OpenAiSetup.setupAsyncClient(options.getBaseUrl(), options.getApiKey(),
 							options.getCredential(), options.getMicrosoftDeploymentName(),
 							options.getMicrosoftFoundryServiceVersion(), options.getOrganizationId(),
 							options.isMicrosoftFoundry(), options.isGitHubModels(), options.getModel(),
-							options.getTimeout(), options.getMaxRetries(), options.getProxy(),
-							options.getCustomHeaders(), ObservationRegistry.NOOP, null, this.httpClientCustomizers));
+							Objects.requireNonNullElse(options.getTimeout(), AbstractOpenAiOptions.DEFAULT_TIMEOUT),
+							options.getMaxRetries(), options.getProxy(), options.getCustomHeaders(),
+							ObservationRegistry.NOOP, null, this.httpClientCustomizers));
 
 			return new OpenAiAudioTranscriptionModel(openAiClient, openAiClientAsync, options);
 		}

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1612,18 +1612,24 @@ public final class OpenAiChatModel implements ChatModel {
 							resolvedOptions.getCredential(), resolvedOptions.getMicrosoftDeploymentName(),
 							resolvedOptions.getMicrosoftFoundryServiceVersion(), resolvedOptions.getOrganizationId(),
 							resolvedOptions.isMicrosoftFoundry(), resolvedOptions.isGitHubModels(),
-							resolvedOptions.getModel(), resolvedOptions.getTimeout(), resolvedOptions.getMaxRetries(),
-							resolvedOptions.getProxy(), resolvedOptions.getCustomHeaders(), resolvedObservationRegistry,
-							this.meterRegistry, this.httpClientCustomizers));
+							resolvedOptions.getModel(),
+							Objects.requireNonNullElse(resolvedOptions.getTimeout(),
+									AbstractOpenAiOptions.DEFAULT_TIMEOUT),
+							resolvedOptions.getMaxRetries(), resolvedOptions.getProxy(),
+							resolvedOptions.getCustomHeaders(), resolvedObservationRegistry, this.meterRegistry,
+							this.httpClientCustomizers));
 
 			OpenAIClientAsync resolvedClientAsync = Objects.requireNonNullElseGet(this.openAiClientAsync,
 					() -> OpenAiSetup.setupAsyncClient(resolvedOptions.getBaseUrl(), resolvedOptions.getApiKey(),
 							resolvedOptions.getCredential(), resolvedOptions.getMicrosoftDeploymentName(),
 							resolvedOptions.getMicrosoftFoundryServiceVersion(), resolvedOptions.getOrganizationId(),
 							resolvedOptions.isMicrosoftFoundry(), resolvedOptions.isGitHubModels(),
-							resolvedOptions.getModel(), resolvedOptions.getTimeout(), resolvedOptions.getMaxRetries(),
-							resolvedOptions.getProxy(), resolvedOptions.getCustomHeaders(), resolvedObservationRegistry,
-							this.meterRegistry, this.httpClientCustomizers));
+							resolvedOptions.getModel(),
+							Objects.requireNonNullElse(resolvedOptions.getTimeout(),
+									AbstractOpenAiOptions.DEFAULT_TIMEOUT),
+							resolvedOptions.getMaxRetries(), resolvedOptions.getProxy(),
+							resolvedOptions.getCustomHeaders(), resolvedObservationRegistry, this.meterRegistry,
+							this.httpClientCustomizers));
 
 			ToolCallingManager resolvedToolCallingManager = Objects.requireNonNullElse(this.toolCallingManager,
 					ToolCallingManager.builder().observationRegistry(resolvedObservationRegistry).build());

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -109,9 +109,10 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 	private final boolean isGitHubModels;
 
 	/**
-	 * Request timeout for OpenAI client.
+	 * Request timeout for OpenAI client. When {@code null}, the timeout configured on the
+	 * OpenAI client is used.
 	 */
-	private final Duration timeout;
+	private final @Nullable Duration timeout;
 
 	/**
 	 * Maximum number of retries for OpenAI client.
@@ -217,7 +218,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 		this.organizationId = organizationId;
 		this.isMicrosoftFoundry = (isMicrosoftFoundry != null ? isMicrosoftFoundry : false);
 		this.isGitHubModels = (isGitHubModels != null ? isGitHubModels : false);
-		this.timeout = (timeout != null ? timeout : AbstractOpenAiOptions.DEFAULT_TIMEOUT);
+		this.timeout = timeout;
 		this.maxRetries = (maxRetries != null ? maxRetries : AbstractOpenAiOptions.DEFAULT_MAX_RETRIES);
 		this.proxy = proxy;
 		this.customHeaders = (customHeaders != null ? Map.copyOf(customHeaders) : null);
@@ -303,7 +304,11 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 		return this.isGitHubModels;
 	}
 
-	public Duration getTimeout() {
+	/**
+	 * Return the request timeout, or {@code null} to inherit the timeout configured on
+	 * the OpenAI client.
+	 */
+	public @Nullable Duration getTimeout() {
 		return this.timeout;
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
@@ -195,9 +195,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 						this.options.getCredential(), this.options.getMicrosoftDeploymentName(),
 						this.options.getMicrosoftFoundryServiceVersion(), this.options.getOrganizationId(),
 						this.options.isMicrosoftFoundry(), this.options.isGitHubModels(), this.options.getModel(),
-						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(), this.observationRegistry, null,
-						builder.httpClientCustomizers));
+						Objects.requireNonNullElse(this.options.getTimeout(), AbstractOpenAiOptions.DEFAULT_TIMEOUT),
+						this.options.getMaxRetries(), this.options.getProxy(), this.options.getCustomHeaders(),
+						this.observationRegistry, null, builder.httpClientCustomizers));
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
@@ -167,9 +167,9 @@ public class OpenAiImageModel implements ImageModel {
 						this.options.getCredential(), this.options.getMicrosoftDeploymentName(),
 						this.options.getMicrosoftFoundryServiceVersion(), this.options.getOrganizationId(),
 						this.options.isMicrosoftFoundry(), this.options.isGitHubModels(), this.options.getModel(),
-						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(), this.observationRegistry, null,
-						builder.httpClientCustomizers));
+						Objects.requireNonNullElse(this.options.getTimeout(), AbstractOpenAiOptions.DEFAULT_TIMEOUT),
+						this.options.getMaxRetries(), this.options.getProxy(), this.options.getCustomHeaders(),
+						this.observationRegistry, null, builder.httpClientCustomizers));
 	}
 
 	/**

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
@@ -72,9 +72,9 @@ public final class OpenAiModerationModel implements ModerationModel {
 						this.options.getCredential(), this.options.getMicrosoftDeploymentName(),
 						this.options.getMicrosoftFoundryServiceVersion(), this.options.getOrganizationId(),
 						this.options.isMicrosoftFoundry(), this.options.isGitHubModels(), this.options.getModel(),
-						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders(), ObservationRegistry.NOOP, null,
-						builder.httpClientCustomizers));
+						Objects.requireNonNullElse(this.options.getTimeout(), AbstractOpenAiOptions.DEFAULT_TIMEOUT),
+						this.options.getMaxRetries(), this.options.getProxy(), this.options.getCustomHeaders(),
+						ObservationRegistry.NOOP, null, builder.httpClientCustomizers));
 	}
 
 	public static Builder builder() {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -1582,4 +1582,49 @@ class OpenAiChatModelTests {
 		assertThat(value.getTimeout().request()).isEqualTo(expectedTimeout);
 	}
 
+	@Test
+	void unsetTimeoutIsNotPropagatedToRequestOptions() {
+		ChatService chatService = mock(ChatService.class);
+		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
+		when(this.openAiClient.chat()).thenReturn(chatService);
+		when(chatService.completions()).thenReturn(chatCompletionService);
+		when(chatCompletionService.create(any(ChatCompletionCreateParams.class), any(RequestOptions.class)))
+			.thenReturn(ChatCompletion.builder()
+				.id("test-id")
+				.created(1777799928)
+				.model("test-model")
+				.usage(CompletionUsage.builder().promptTokens(1).completionTokens(1).totalTokens(2).build())
+				.addChoice(ChatCompletion.Choice.builder()
+					.finishReason(ChatCompletion.Choice.FinishReason.STOP)
+					.index(0)
+					.logprobs(Optional.empty())
+					.message(ChatCompletionMessage.builder()
+						.content("hello")
+						.refusal(Optional.empty())
+						.role(JsonValue.from("assistant"))
+						.annotations(List.of())
+						.toolCalls(List.of())
+						.build())
+					.build())
+				.build());
+
+		// No timeout set: the request must not override the timeout configured on the
+		// OpenAI client, otherwise long streaming turns are cut short by OkHttp's
+		// callTimeout.
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		assertThat(options.getTimeout()).isNull();
+
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		chatModel.call(new Prompt("hi", options));
+
+		ArgumentCaptor<RequestOptions> argumentCaptor = ArgumentCaptor.forClass(RequestOptions.class);
+		verify(chatCompletionService).create(any(ChatCompletionCreateParams.class), argumentCaptor.capture());
+		assertThat(argumentCaptor.getValue().getTimeout()).isNull();
+	}
+
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatOptionsTests.java
@@ -501,6 +501,21 @@ public class OpenAiChatOptionsTests extends AbstractChatOptionsTests<OpenAiChatO
 	}
 
 	@Test
+	void testTimeoutIsNullWhenUnset() {
+		assertThat(OpenAiChatOptions.builder().build().getTimeout()).isNull();
+	}
+
+	@Test
+	void testCombineWithKeepsTimeoutWhenOverrideLeavesItUnset() {
+		OpenAiChatOptions base = OpenAiChatOptions.builder().timeout(java.time.Duration.ofMinutes(30)).build();
+
+		OpenAiChatOptions merged = base.mutate().combineWith(OpenAiChatOptions.builder().model("override")).build();
+
+		assertThat(merged.getTimeout()).isEqualTo(java.time.Duration.ofMinutes(30));
+		assertThat(merged.getModel()).isEqualTo("override");
+	}
+
+	@Test
 	void testCombineWith() {
 		OpenAiChatOptions base = OpenAiChatOptions.builder()
 			.model("base-model")


### PR DESCRIPTION
## Problem

Since 2.0.1, every OpenAI call is hard-capped at 60s and both `spring.ai.openai.timeout` and `spring.ai.openai.chat.timeout` are silently ignored for chat.

#6648 (commit c99f6f3bb) made `OpenAiChatModel` pass a per-request `RequestOptions.timeout` derived from `prompt.getOptions().getTimeout()`. Per-request options override the client's timeout in the SDK (`requestOptions.applyDefaults(RequestOptions.from(clientOptions))`).

But `OpenAiChatOptions.getTimeout()` could never return null — both `OpenAiChatOptions` and `AbstractOpenAiOptions` substituted `DEFAULT_TIMEOUT` (60s) whenever the field was unset. The `if (chatOptions.getTimeout() != null)` guard in `buildRequestOptions` was therefore dead code, and every request carried 60s.

Meanwhile `OpenAiChatProperties.toOptions()` never called `.timeout(...)`, so the configured value only ever reached the OkHttp client (via `OpenAiAutoConfigurationUtil.resolveCommonProperties` → `OpenAiSetup`) and was then overridden per call.

`SpringAiOpenAiHttpClient.newCall` maps the per-call timeout onto OkHttp's `callTimeout`, which bounds the *entire* call including the SSE body. Streaming turns whose single HTTP round exceeded 60s were aborted:

```
IllegalStateException: Stream processing failed
  <- OpenAIIoException: Stream failed
    <- java.io.InterruptedIOException: timeout
      <- okhttp3.internal.http2.StreamResetException: stream was reset: CANCEL
```

This shows up as intermittent failures on long tool-calling agent turns.

## Fix

- `AbstractOpenAiOptions` / `OpenAiChatOptions`: keep `timeout` null when unset. `getTimeout()` is now `@Nullable` and null means "inherit the timeout configured on the OpenAI client". An explicitly set timeout still propagates, preserving the intent of #6648. This mirrors `AnthropicChatOptions`, which already behaves this way.
- `OpenAiChatAutoConfiguration`: pass `resolvedProperties.getTimeout()` into the chat model's default options so `getOptions().getTimeout()` reflects the effective value. It must be the *resolved* timeout — `chatProperties.getTimeout()` is itself 60s-defaulted and would reintroduce the bug for users who configure only the common `spring.ai.openai.timeout`.
- The six model classes fall back to `DEFAULT_TIMEOUT` where a null timeout would otherwise reach `OpenAiSetup`'s non-null client-builder parameter.

## Tests

- `OpenAiChatOptionsTests`: timeout is null when unset; `combineWith` preserves a set timeout when the override leaves it unset.
- `OpenAiChatModelTests#unsetTimeoutIsNotPropagatedToRequestOptions`: an unset timeout produces `RequestOptions` with no timeout.
- `OpenAiChatPropertiesTests`: the configured timeout reaches the chat model options, for both `spring.ai.openai.chat.timeout` and `spring.ai.openai.timeout`.

All four fail against the current code and pass with this change. Full suites green: 221 tests in `spring-ai-openai`, 26 in `spring-ai-autoconfigure-model-openai`.

See #6648
