### PR TITLE
Fix Media JSON round trips

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/content/Media.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/content/Media.java
@@ -20,7 +20,12 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.ser.std.ToStringSerializer;
 
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
@@ -160,6 +165,12 @@ public class Media {
 		this.data = data;
 	}
 
+	@JsonCreator
+	private Media(@JsonProperty("mimeType") String mimeType, @JsonProperty("data") String data,
+			@JsonProperty("id") @Nullable String id, @JsonProperty("name") @Nullable String name) {
+		this(MimeType.valueOf(mimeType), data, id, name);
+	}
+
 	private static String generateDefaultName(MimeType mimeType) {
 		return NAME_PREFIX + mimeType.getSubtype() + "-" + java.util.UUID.randomUUID();
 	}
@@ -168,6 +179,7 @@ public class Media {
 	 * Get the media MIME type
 	 * @return the media MIME type
 	 */
+	@JsonSerialize(using = ToStringSerializer.class)
 	public MimeType getMimeType() {
 		return this.mimeType;
 	}
@@ -185,6 +197,7 @@ public class Media {
 	 * Get the media data as a byte array
 	 * @return the media data as a byte array
 	 */
+	@JsonIgnore
 	public byte[] getDataAsByteArray() {
 		if (this.data instanceof byte[]) {
 			return (byte[]) this.data;

--- a/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
@@ -393,6 +393,26 @@ public class DocumentTests {
 		assertThat(deserialized).isEqualTo(original);
 	}
 
+	@Test
+	void roundTripUriBackedMediaDocument() throws Exception {
+		JsonMapper mapper = JacksonUtils.getDefaultJsonMapper();
+		Media media = Media.builder()
+			.mimeType(MimeTypeUtils.IMAGE_PNG)
+			// Spring's official GitHub account avatar.
+			.data(URI.create("https://avatars.githubusercontent.com/u/317776"))
+			.name("image")
+			.build();
+		Document document = Document.builder().media(media).build();
+
+		String json = mapper.writeValueAsString(document);
+		Document restored = mapper.readValue(json, Document.class);
+
+		assertThat(json).contains("\"mimeType\":\"image/png\"").doesNotContain("dataAsByteArray");
+		assertThat(restored.getMedia()).returns(media.getMimeType(), Media::getMimeType)
+			.returns(media.getData(), Media::getData)
+			.returns(media.getName(), Media::getName); // gh-6834
+	}
+
 	/**
 	 * Round-trip with all metadata value types that are valid for vector stores (string,
 	 * int, float, boolean).


### PR DESCRIPTION
Closes #6834.

This PR provides a simpler fix, only edits 13 lines:

- Add `@JsonIgnore` to `getDataAsByteArray()`, stop `Jackson` from calling this helper method as a JSON property.
- Use **native** Spring's `MimeType` serialization/deserialization for `MineType` property.

with a simple unittest attached.