### PR TITLE
Fix nested NOT negation in filter expressions

### DIFF
--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterHelper.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterHelper.java
@@ -63,6 +63,11 @@ public final class FilterHelper {
 	 * 	NOT(a IN [...]) = a NIN [...]
 	 * 	NOT(a NIN [...]) = a IN [...]
 	 * </pre>
+	 *
+	 * The returned operand is the negation of {@code operand} itself, so callers holding
+	 * a {@link Filter.ExpressionType#NOT} node must pass that node's
+	 * {@link Filter.Expression#left() operand} rather than the node, otherwise the
+	 * negation is applied one time too many.
 	 * @param operand Filter expression to negate.
 	 * @return Returns a negation of the input expression.
 	 */
@@ -79,7 +84,7 @@ public final class FilterHelper {
 		else if (operand instanceof Filter.Expression exp) {
 			switch (exp.type()) {
 				case NOT: // NOT(NOT(a)) = a
-					return negate(exp.left());
+					return exp.left();
 				case AND: // NOT(a AND b) = NOT(a) OR NOT(b)
 				case OR: // NOT(a OR b) = NOT(a) AND NOT(b)
 					return new Filter.Expression(TYPE_NEGATION_MAP.get(exp.type()), negate(exp.left()),

--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/converter/AbstractFilterExpressionConverter.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/converter/AbstractFilterExpressionConverter.java
@@ -127,8 +127,9 @@ public abstract class AbstractFilterExpressionConverter implements FilterExpress
 		// Default behavior is to convert the NOT expression into its semantically
 		// equivalent negation expression.
 		// Effectively removing the NOT types form the boolean expression tree before
-		// passing it to the doExpression.
-		this.convertOperand(FilterHelper.negate(expression), context);
+		// passing it to the doExpression. The NOT node's operand is negated, not the node
+		// itself, so that a nested NOT cancels out instead of being negated again.
+		this.convertOperand(FilterHelper.negate(expression.left()), context);
 	}
 
 	/**

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterHelperTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterHelperTests.java
@@ -38,17 +38,17 @@ public class FilterHelperTests {
 		assertThat(new FilterExpressionTextParser().parse("NOT key == 'UK' ")).isEqualTo(new Filter.Expression(
 				ExpressionType.NOT, new Filter.Expression(ExpressionType.EQ, new Key("key"), new Value("UK")), null));
 
-		assertThat(FilterHelper.negate(new FilterExpressionTextParser().parse("NOT key == 'UK' ")))
+		assertThat(FilterHelper.negate(new FilterExpressionTextParser().parse("NOT key == 'UK' ").left()))
 			.isEqualTo(new Filter.Expression(ExpressionType.NE, new Key("key"), new Value("UK")));
 
-		assertThat(FilterHelper.negate(new FilterExpressionTextParser().parse("NOT (key == 'UK') ")))
+		assertThat(FilterHelper.negate(new FilterExpressionTextParser().parse("NOT (key == 'UK') ").left()))
 			.isEqualTo(new Filter.Group(new Filter.Expression(ExpressionType.NE, new Key("key"), new Value("UK"))));
 	}
 
 	@Test
 	public void negateNE() {
 		var exp = new FilterExpressionTextParser().parse("NOT key != 'UK' ");
-		assertThat(FilterHelper.negate(exp))
+		assertThat(FilterHelper.negate(exp.left()))
 			.isEqualTo(new Filter.Expression(ExpressionType.EQ, new Key("key"), new Value("UK")));
 
 	}
@@ -56,7 +56,7 @@ public class FilterHelperTests {
 	@Test
 	public void negateGT() {
 		var exp = new FilterExpressionTextParser().parse("NOT key > 13 ");
-		assertThat(FilterHelper.negate(exp))
+		assertThat(FilterHelper.negate(exp.left()))
 			.isEqualTo(new Filter.Expression(ExpressionType.LTE, new Key("key"), new Value(13)));
 
 	}
@@ -64,49 +64,49 @@ public class FilterHelperTests {
 	@Test
 	public void negateGTE() {
 		var exp = new FilterExpressionTextParser().parse("NOT key >= 13 ");
-		assertThat(FilterHelper.negate(exp))
+		assertThat(FilterHelper.negate(exp.left()))
 			.isEqualTo(new Filter.Expression(ExpressionType.LT, new Key("key"), new Value(13)));
 	}
 
 	@Test
 	public void negateLT() {
 		var exp = new FilterExpressionTextParser().parse("NOT key < 13 ");
-		assertThat(FilterHelper.negate(exp))
+		assertThat(FilterHelper.negate(exp.left()))
 			.isEqualTo(new Filter.Expression(ExpressionType.GTE, new Key("key"), new Value(13)));
 	}
 
 	@Test
 	public void negateLTE() {
 		var exp = new FilterExpressionTextParser().parse("NOT key <= 13 ");
-		assertThat(FilterHelper.negate(exp))
+		assertThat(FilterHelper.negate(exp.left()))
 			.isEqualTo(new Filter.Expression(ExpressionType.GT, new Key("key"), new Value(13)));
 	}
 
 	@Test
 	public void negateIN() {
 		var exp = new FilterExpressionTextParser().parse("NOT key IN [11, 12, 13] ");
-		assertThat(FilterHelper.negate(exp))
+		assertThat(FilterHelper.negate(exp.left()))
 			.isEqualTo(new Filter.Expression(ExpressionType.NIN, new Key("key"), new Value(List.of(11, 12, 13))));
 	}
 
 	@Test
 	public void negateNIN() {
 		var exp = new FilterExpressionTextParser().parse("NOT key NIN [11, 12, 13] ");
-		assertThat(FilterHelper.negate(exp))
+		assertThat(FilterHelper.negate(exp.left()))
 			.isEqualTo(new Filter.Expression(ExpressionType.IN, new Key("key"), new Value(List.of(11, 12, 13))));
 	}
 
 	@Test
 	public void negateNIN2() {
 		var exp = new FilterExpressionTextParser().parse("NOT key NOT IN [11, 12, 13] ");
-		assertThat(FilterHelper.negate(exp))
+		assertThat(FilterHelper.negate(exp.left()))
 			.isEqualTo(new Filter.Expression(ExpressionType.IN, new Key("key"), new Value(List.of(11, 12, 13))));
 	}
 
 	@Test
 	public void negateAND() {
 		var exp = new FilterExpressionTextParser().parse("NOT(key >= 11 AND key < 13)");
-		assertThat(FilterHelper.negate(exp)).isEqualTo(new Filter.Group(new Filter.Expression(ExpressionType.OR,
+		assertThat(FilterHelper.negate(exp.left())).isEqualTo(new Filter.Group(new Filter.Expression(ExpressionType.OR,
 				new Filter.Expression(ExpressionType.LT, new Key("key"), new Value(11)),
 				new Filter.Expression(ExpressionType.GTE, new Key("key"), new Value(13)))));
 	}
@@ -114,16 +114,18 @@ public class FilterHelperTests {
 	@Test
 	public void negateOR() {
 		var exp = new FilterExpressionTextParser().parse("NOT(key >= 11 OR key < 13)");
-		assertThat(FilterHelper.negate(exp)).isEqualTo(new Filter.Group(new Filter.Expression(ExpressionType.AND,
+		assertThat(FilterHelper.negate(exp.left())).isEqualTo(new Filter.Group(new Filter.Expression(ExpressionType.AND,
 				new Filter.Expression(ExpressionType.LT, new Key("key"), new Value(11)),
 				new Filter.Expression(ExpressionType.GTE, new Key("key"), new Value(13)))));
 	}
 
 	@Test
 	public void negateNot() {
+		// NOT(NOT(a)) = a, so the two negations cancel out instead of collapsing into
+		// a single one.
 		var exp = new FilterExpressionTextParser().parse("NOT NOT(key >= 11)");
-		assertThat(FilterHelper.negate(exp))
-			.isEqualTo(new Filter.Group(new Filter.Expression(ExpressionType.LT, new Key("key"), new Value(11))));
+		assertThat(FilterHelper.negate(exp.left()))
+			.isEqualTo(new Filter.Group(new Filter.Expression(ExpressionType.GTE, new Key("key"), new Value(11))));
 	}
 
 	@Test
@@ -133,8 +135,37 @@ public class FilterHelperTests {
 				new Filter.Expression(ExpressionType.NOT, new Filter.Group(new Filter.Expression(ExpressionType.NOT,
 						new Filter.Group(new Filter.Expression(ExpressionType.GTE, new Key("key"), new Value(11)))))));
 
-		assertThat(FilterHelper.negate(exp))
-			.isEqualTo(new Filter.Group(new Filter.Expression(ExpressionType.LT, new Key("key"), new Value(11))));
+		assertThat(FilterHelper.negate(exp.left()))
+			.isEqualTo(new Filter.Group(new Filter.Expression(ExpressionType.GTE, new Key("key"), new Value(11))));
+	}
+
+	@Test
+	public void nestedNotIsCancelledNotNegatedAgain() {
+		// A NOT nested inside another expression must cancel the enclosing negation
+		// rather than be negated a second time.
+		var converter = new PrintFilterExpressionConverter();
+		var parser = new FilterExpressionTextParser();
+
+		// NOT(NOT(a)) = a
+		assertThat(converter.convertExpression(parser.parse("NOT(NOT(key == 'UK'))"))).isEqualTo("(key EQ \"UK\")");
+
+		// NOT(NOT(NOT(a))) = NOT(a)
+		assertThat(converter.convertExpression(parser.parse("NOT(NOT(NOT(key == 'UK')))")))
+			.isEqualTo("((key NE \"UK\"))");
+
+		// NOT(a AND NOT(b)) = NOT(a) OR b
+		assertThat(converter.convertExpression(parser.parse("NOT(key == 'UK' AND city == 'London')")))
+			.isEqualTo("(key NE \"UK\" OR city NE \"London\")");
+		assertThat(converter.convertExpression(parser.parse("NOT(key == 'UK' AND NOT(city == 'London'))")))
+			.isEqualTo("(key NE \"UK\" OR (city EQ \"London\"))");
+
+		// NOT(a OR NOT(b)) = NOT(a) AND b
+		assertThat(converter.convertExpression(parser.parse("NOT(key >= 11 OR NOT(city == 'London'))")))
+			.isEqualTo("(key LT 11 AND (city EQ \"London\"))");
+
+		// NOT(NOT(a AND b)) = a AND b
+		assertThat(converter.convertExpression(parser.parse("NOT(NOT(key >= 11 AND key < 13))")))
+			.isEqualTo("(key GTE 11 AND key LT 13)");
 	}
 
 	@Test

--- a/vector-stores/spring-ai-bedrock-knowledgebase-store/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/BedrockKnowledgeBaseFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-bedrock-knowledgebase-store/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/BedrockKnowledgeBaseFilterExpressionConverter.java
@@ -84,7 +84,7 @@ public class BedrockKnowledgeBaseFilterExpressionConverter {
 	}
 
 	private RetrievalFilter convertNot(final Expression expression) {
-		Filter.Operand negated = FilterHelper.negate(expression);
+		Filter.Operand negated = FilterHelper.negate(expression.left());
 		if (negated instanceof Expression negatedExpr) {
 			return convert(negatedExpr);
 		}

--- a/vector-stores/spring-ai-bedrock-knowledgebase-store/src/test/java/org/springframework/ai/vectorstore/bedrockknowledgebase/BedrockKnowledgeBaseFilterExpressionConverterTest.java
+++ b/vector-stores/spring-ai-bedrock-knowledgebase-store/src/test/java/org/springframework/ai/vectorstore/bedrockknowledgebase/BedrockKnowledgeBaseFilterExpressionConverterTest.java
@@ -240,6 +240,50 @@ class BedrockKnowledgeBaseFilterExpressionConverterTest {
 		}
 
 		@Test
+		void shouldConvertNot() {
+			// NOT(department == 'HR')
+			Expression eq = new Expression(ExpressionType.EQ, new Key("department"), new Value("HR"));
+			Expression notExpr = new Expression(ExpressionType.NOT, eq, null);
+
+			RetrievalFilter result = BedrockKnowledgeBaseFilterExpressionConverterTest.this.converter
+				.convertExpression(notExpr);
+
+			assertThat(result.notEquals()).isNotNull();
+		}
+
+		@Test
+		void shouldCancelNestedNot() {
+			// NOT(NOT(department == 'HR')) is department == 'HR'
+			Expression eq = new Expression(ExpressionType.EQ, new Key("department"), new Value("HR"));
+			Expression notNotExpr = new Expression(ExpressionType.NOT, new Expression(ExpressionType.NOT, eq, null),
+					null);
+
+			RetrievalFilter result = BedrockKnowledgeBaseFilterExpressionConverterTest.this.converter
+				.convertExpression(notNotExpr);
+
+			assertThat(result.equalsValue()).isNotNull();
+		}
+
+		@Test
+		void shouldCancelNotNestedInsideAnd() {
+			// NOT(department == 'HR' AND NOT(year > 2020)) is
+			// department != 'HR' OR year > 2020
+			Expression dept = new Expression(ExpressionType.EQ, new Key("department"), new Value("HR"));
+			Expression year = new Expression(ExpressionType.GT, new Key("year"), new Value(2020));
+			Expression andExpr = new Expression(ExpressionType.AND, dept,
+					new Expression(ExpressionType.NOT, year, null));
+			Expression notExpr = new Expression(ExpressionType.NOT, andExpr, null);
+
+			RetrievalFilter result = BedrockKnowledgeBaseFilterExpressionConverterTest.this.converter
+				.convertExpression(notExpr);
+
+			assertThat(result.orAll()).hasSize(2);
+			assertThat(result.orAll().get(0).notEquals()).isNotNull();
+			// The nested NOT cancels out, so the second clause keeps its GT operator.
+			assertThat(result.orAll().get(1).greaterThan()).isNotNull();
+		}
+
+		@Test
 		void shouldConvertTripleAnd() {
 			// a == 1 AND b == 2 AND c == 3
 			Expression a = new Expression(ExpressionType.EQ, new Key("a"), new Value(1));

--- a/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/coherence/CoherenceFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/coherence/CoherenceFilterExpressionConverter.java
@@ -54,7 +54,7 @@ public class CoherenceFilterExpressionConverter {
 
 	private Filter<?> convert(Expression expression) {
 		if (expression.type() == ExpressionType.NOT) {
-			return convert(FilterHelper.negate(expression));
+			return convert(FilterHelper.negate(expression.left()));
 		}
 		Assert.state(expression.right() != null, "expression is expected to have a right operand");
 		return switch (expression.type()) {


### PR DESCRIPTION
`negate()` called itself on a NOT node's operand instead of just returning it, so a NOT sitting inside a larger expression got negated a second time rather than cancelling out. Every caller passes the NOT node itself, which happens to undo the extra negation at the top level. That's why plain NOT always looked fine and only nested ones came out wrong.

In practice `NOT(NOT(a))` became `NOT(a)`, and `NOT(a AND NOT(b))` became `NOT(a) OR NOT(b)`, so any store on the default `doNot()` quietly returned the wrong documents. `SimpleVectorStore` just flips the boolean and was always correct, which meant the in-memory store and the real ones disagreed on the same filter. `negate()` now returns the negation of what it was handed, the way the javadoc already describes it, and the three callers pass the NOT node's operand instead of the node.