### PR TITLE
Preserve advisor-injected messages across streaming tool calls

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.chat.client.advisor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -396,8 +397,27 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 				// Recursive call with updated conversation history
 				List<Message> nextInstructions = this.doGetNextInstructionsForToolCallStream(finalRequest,
 						finalAggregatedResponse, toolExecutionResult);
+				// Compare against what the un-overridden default would have produced for
+				// these exact inputs, not against conversationHistory() directly: the
+				// default itself reshapes that list (e.g. trims it to [system, last] when
+				// conversationHistoryEnabled is false), and diffing against the raw
+				// history
+				// would misidentify that reshaping as subclass-injected content. Diffing
+				// against the default isolates only what an override actually added.
+				List<Message> defaultInstructions = this.defaultNextInstructionsForToolCallStream(finalRequest,
+						toolExecutionResult);
+				List<Message> baseHistory = toolExecutionResult.conversationHistory();
+				List<Message> nextFullTurnHistory = baseHistory;
+				if (!nextInstructions.equals(defaultInstructions)) {
+					List<Message> injected = new ArrayList<>(nextInstructions);
+					injected.removeAll(defaultInstructions);
+					if (!injected.isEmpty()) {
+						nextFullTurnHistory = new ArrayList<>(baseHistory);
+						nextFullTurnHistory.addAll(injected);
+					}
+				}
 				return this.internalStream(streamAdvisorChain, originalRequest, optionsCopy, nextInstructions,
-						toolExecutionResult.conversationHistory(), usageAccumulator);
+						nextFullTurnHistory, usageAccumulator);
 			}
 		});
 		return toolCallFlux.subscribeOn(Schedulers.boundedElastic());
@@ -461,6 +481,17 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 	 */
 	protected List<Message> doGetNextInstructionsForToolCallStream(ChatClientRequest chatClientRequest,
 			ChatClientResponse chatClientResponse, ToolExecutionResult toolExecutionResult) {
+		return this.defaultNextInstructionsForToolCallStream(chatClientRequest, toolExecutionResult);
+	}
+
+	/**
+	 * The default (non-overridden) computation behind
+	 * {@link #doGetNextInstructionsForToolCallStream}. Kept separate so the streaming
+	 * loop can compare a subclass override's result against this baseline and identify
+	 * exactly which messages, if any, the override added.
+	 */
+	private List<Message> defaultNextInstructionsForToolCallStream(ChatClientRequest chatClientRequest,
+			ToolExecutionResult toolExecutionResult) {
 
 		if (!this.conversationHistoryEnabled) {
 			List<Message> history = toolExecutionResult.conversationHistory();

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.chat.client.advisor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 
 import io.micrometer.observation.ObservationRegistry;
@@ -1138,6 +1139,83 @@ public class ToolCallingAdvisorTests {
 		// Must be the complete, untrimmed round1History (3 messages), not the trimmed
 		// 2-message version forwarded to the rest of the chain.
 		assertThat(capturedPrompts.get(1).getInstructions()).isEqualTo(round1History);
+	}
+
+	@Test
+	void streamPreservesMessageInjectedByHookAcrossSubsequentToolCall() {
+		AtomicBoolean feedbackAdded = new AtomicBoolean();
+		UserMessage feedbackMessage = new UserMessage("FOO_BAR_FEEDBACK");
+
+		ToolCallingAdvisor advisor = new ToolCallingAdvisor(this.toolCallingManager,
+				ToolCallingAdvisor.DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER, ToolCallingAdvisor.DEFAULT_ORDER, true) {
+
+			@Override
+			protected List<Message> doGetNextInstructionsForToolCallStream(ChatClientRequest chatClientRequest,
+					ChatClientResponse chatClientResponse, ToolExecutionResult toolExecutionResult) {
+				List<Message> instructions = new ArrayList<>(super.doGetNextInstructionsForToolCallStream(
+						chatClientRequest, chatClientResponse, toolExecutionResult));
+				if (feedbackAdded.compareAndSet(false, true)) {
+					instructions.add(feedbackMessage);
+				}
+				return instructions;
+			}
+		};
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse firstToolCallResponse = createMockResponse(true);
+		ChatClientResponse secondToolCallResponse = createMockResponse(true);
+		ChatClientResponse finalResponse = createMockResponse(false);
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			if (callCount[0] == 1) {
+				return Flux.just(firstToolCallResponse);
+			}
+			else if (callCount[0] == 2) {
+				return Flux.just(secondToolCallResponse);
+			}
+			else {
+				return Flux.just(finalResponse);
+			}
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		ToolResponseMessage.ToolResponse round1Response = new ToolResponseMessage.ToolResponse("tool-1", "testTool",
+				"round1 result");
+		ToolResponseMessage round1ToolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(round1Response))
+			.build();
+		List<Message> round1History = List.of(new UserMessage("test"), AssistantMessage.builder().content("").build(),
+				round1ToolResponseMessage);
+		ToolExecutionResult round1Result = ToolExecutionResult.builder().conversationHistory(round1History).build();
+
+		ToolResponseMessage.ToolResponse round2Response = new ToolResponseMessage.ToolResponse("tool-2", "testTool",
+				"round2 result");
+		ToolResponseMessage round2ToolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(round2Response))
+			.build();
+		List<Message> round2History = new ArrayList<>(round1History);
+		round2History.add(feedbackMessage);
+		round2History.add(AssistantMessage.builder().content("").build());
+		round2History.add(round2ToolResponseMessage);
+		ToolExecutionResult round2Result = ToolExecutionResult.builder().conversationHistory(round2History).build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(round1Result, round2Result);
+
+		advisor.adviseStream(request, realChain).collectList().block();
+
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		verify(this.toolCallingManager, times(2)).executeToolCalls(promptCaptor.capture(), any(ChatResponse.class));
+
+		List<Prompt> capturedPrompts = promptCaptor.getAllValues();
+		// Round 2's request must still contain the message the hook injected after round
+		// 1, not just round1History with round 2's tool-call/response appended.
+		assertThat(capturedPrompts.get(1).getInstructions()).contains(feedbackMessage);
 	}
 
 	@Test


### PR DESCRIPTION
﻿ToolCallingAdvisor's streaming tool-call loop tracked two separate message lists: instructions, sent to the model and visible to doGetNextInstructionsForToolCallStream overrides, and fullTurnHistory, used only to seed the next round's executeToolCalls call. A message an override appended to instructions was never copied into fullTurnHistory, so it was visible for exactly one model request and then silently dropped on the next tool call.

Diff nextInstructions against what the un-overridden default implementation would have produced for the same inputs, not against conversationHistory() directly, since the default itself reshapes that list when conversationHistoryEnabled is false. Comparing against conversationHistory() would misidentify that reshaping as override-injected content. Whatever the diff finds is carried forward into fullTurnHistory alongside the existing history, regardless of conversationHistoryEnabled.

Added a regression test that injects a message after the first tool call and asserts it survives into the request for the second. Confirmed the test fails without the fix and passes with it; the existing test covering the conversationHistoryEnabled false path was also re-verified to still pass, since a naive diff against conversationHistory() breaks it.

Fixes #6842