### PR TITLE
Validate JSON strings before forwarding

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/util/JsonHelper.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/util/JsonHelper.java
@@ -25,6 +25,8 @@ import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectReader;
 import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.core.ParameterizedTypeReference;
@@ -40,6 +42,8 @@ public class JsonHelper {
 
 	private final JsonMapper jsonMapper;
 
+	private final ObjectReader strictJsonReader;
+
 	private static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<>() {
 	};
 
@@ -50,6 +54,7 @@ public class JsonHelper {
 	public JsonHelper(JsonMapper jsonMapper) {
 		Assert.notNull(jsonMapper, "jsonMapper cannot be null");
 		this.jsonMapper = jsonMapper;
+		this.strictJsonReader = this.jsonMapper.reader(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 	}
 
 	/**
@@ -147,7 +152,7 @@ public class JsonHelper {
 	 */
 	private boolean isValidJson(String input) {
 		try {
-			this.jsonMapper.readTree(input);
+			this.strictJsonReader.readTree(input);
 			return true;
 		}
 		catch (JacksonException e) {

--- a/spring-ai-commons/src/test/java/org/springframework/ai/util/JsonHelperTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/util/JsonHelperTests.java
@@ -175,6 +175,41 @@ class JsonHelperTests {
 	}
 
 	@Test
+	void fromJsonStringToJsonShouldForwardValidJson() {
+		assertThat(this.jsonHelper.toJson("""
+				{"status":"ok"}
+				""", true)).isEqualToIgnoringWhitespace("""
+				{"status":"ok"}
+				""");
+		assertThat(this.jsonHelper.toJson("""
+				["ok"]
+				""", true)).isEqualToIgnoringWhitespace("""
+				["ok"]
+				""");
+	}
+
+	@Test
+	void fromStringWithJsonNumberPrefixToJsonShouldNotForwardAsJson() {
+		var json = this.jsonHelper.toJson("22 console logs uploaded", true);
+
+		assertThat(json).isEqualTo("\"22 console logs uploaded\"");
+	}
+
+	@Test
+	void fromStringWithJsonBooleanPrefixToJsonShouldNotForwardAsJson() {
+		var json = this.jsonHelper.toJson("true story", true);
+
+		assertThat(json).isEqualTo("\"true story\"");
+	}
+
+	@Test
+	void fromStringWithJsonNullPrefixToJsonShouldNotForwardAsJson() {
+		var json = this.jsonHelper.toJson("null value", true);
+
+		assertThat(json).isEqualTo("\"null value\"");
+	}
+
+	@Test
 	void fromObjectToString() {
 		var value = this.jsonHelper.convertToTypedObject("John", String.class);
 		Assertions.assertThat(value).isOfAnyClassIn(String.class);

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverterTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverterTests.java
@@ -64,6 +64,18 @@ class DefaultToolCallResultConverterTests {
 	}
 
 	@Test
+	void convertStringWithJsonNumberPrefixShouldReturnJson() {
+		String result = this.converter.convert("22 console logs uploaded", String.class);
+		assertThat(result).isEqualTo("\"22 console logs uploaded\"");
+	}
+
+	@Test
+	void convertStringWithJsonBooleanPrefixShouldReturnJson() {
+		String result = this.converter.convert("true story", String.class);
+		assertThat(result).isEqualTo("\"true story\"");
+	}
+
+	@Test
 	void convertNullReturnValueShouldReturnNullJson() {
 		String result = this.converter.convert(null, String.class);
 		assertThat(result).isEqualTo("null");

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackExceptionHandlingTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackExceptionHandlingTest.java
@@ -49,7 +49,7 @@ public class MethodToolCallbackExceptionHandlingTest {
 		String result = callback.call(toolInput);
 
 		// Verify the result
-		assertThat(result).isEqualTo("3 strings processed: [one, two, three]");
+		assertThat(result).isEqualTo("\"3 strings processed: [one, two, three]\"");
 
 		// Verify
 		String ivalidToolInput = """

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackGenericTypesTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackGenericTypesTest.java
@@ -64,7 +64,7 @@ class MethodToolCallbackGenericTypesTest {
 		String result = callback.call(toolInput);
 
 		// Verify the result
-		assertThat(result).isEqualTo("3 strings processed: [one, two, three]");
+		assertThat(result).isEqualTo("\"3 strings processed: [one, two, three]\"");
 	}
 
 	@Test
@@ -98,7 +98,7 @@ class MethodToolCallbackGenericTypesTest {
 		String result = callback.call(toolInput);
 
 		// Verify the result
-		assertThat(result).isEqualTo("3 entries processed: {one=1, two=2, three=3}");
+		assertThat(result).isEqualTo("\"3 entries processed: {one=1, two=2, three=3}\"");
 	}
 
 	@Test
@@ -135,7 +135,7 @@ class MethodToolCallbackGenericTypesTest {
 		String result = callback.call(toolInput);
 
 		// Verify the result
-		assertThat(result).isEqualTo("2 maps processed: [{a=1, b=2}, {c=3, d=4}]");
+		assertThat(result).isEqualTo("\"2 maps processed: [{a=1, b=2}, {c=3, d=4}]\"");
 	}
 
 	@Test
@@ -170,7 +170,7 @@ class MethodToolCallbackGenericTypesTest {
 		String result = callback.call(toolInput, toolContext);
 
 		// Verify the result
-		assertThat(result).isEqualTo("1 entries processed {foo=bar}");
+		assertThat(result).isEqualTo("\"1 entries processed {foo=bar}\"");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- validate the full JSON document before forwarding a string unchanged from `JsonHelper.toJson(..., true)`
- keep complete JSON object and array strings forwarding as before
- add regressions for JSON-prefix plain text in both `JsonHelper` and the default tool result converter

Fixes #6847

## Tests

- `./mvnw -pl spring-ai-commons -Dtest=JsonHelperTests test`
- `./mvnw -pl spring-ai-model -am -Dtest=DefaultToolCallResultConverterTests -Dsurefire.failIfNoSpecifiedTests=false test`

Both commands reported `BUILD SUCCESS`.
