### PR TITLE
Add text tool result converter

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -780,7 +780,17 @@ public interface ToolCallResultConverter {
 }
 ----
 
-The default `DefaultToolCallResultConverter` uses Jackson to serialize the result. Configure a custom converter on the `@Tool` annotation (`resultConverter`) or via `ToolMetadata`.
+The default `DefaultToolCallResultConverter` uses Jackson to serialize the result.
+Configure a custom converter on the `@Tool` annotation (`resultConverter`).
+For tools that return plain text, use `TextToolCallResultConverter` to return `String` values unchanged while keeping the default conversion for non-String results:
+
+[source,java]
+----
+@Tool(resultConverter = TextToolCallResultConverter.class)
+String readLog() {
+    return "Log uploaded. Access it at /tmp/log.txt";
+}
+----
 
 [[method-tool-limitations]]
 === Method Tool Limitations

--- a/spring-ai-model/src/main/java/org/springframework/ai/aot/ToolRuntimeHints.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/aot/ToolRuntimeHints.java
@@ -19,6 +19,7 @@ package org.springframework.ai.aot;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.tool.execution.DefaultToolCallResultConverter;
+import org.springframework.ai.tool.execution.TextToolCallResultConverter;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -34,6 +35,7 @@ public class ToolRuntimeHints implements RuntimeHintsRegistrar {
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 		var mcs = MemberCategory.values();
 		hints.reflection().registerType(DefaultToolCallResultConverter.class, mcs);
+		hints.reflection().registerType(TextToolCallResultConverter.class, mcs);
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/TextToolCallResultConverter.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/TextToolCallResultConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.execution;
+
+import java.lang.reflect.Type;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A {@link ToolCallResultConverter} that returns {@link String} results unchanged.
+ *
+ * <p>
+ * Non-String results are converted with {@link DefaultToolCallResultConverter}.
+ *
+ * @author Iuliia Sobolevska
+ * @since 2.0.2
+ */
+public final class TextToolCallResultConverter implements ToolCallResultConverter {
+
+	private static final ToolCallResultConverter DEFAULT_CONVERTER = new DefaultToolCallResultConverter();
+
+	@Override
+	public String convert(@Nullable Object result, @Nullable Type returnType) {
+		if (result instanceof String text) {
+			return text;
+		}
+		return DEFAULT_CONVERTER.convert(result, returnType);
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/aot/ToolRuntimeHintsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/aot/ToolRuntimeHintsTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.aot;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.tool.execution.DefaultToolCallResultConverter;
+import org.springframework.ai.tool.execution.TextToolCallResultConverter;
 import org.springframework.aot.hint.RuntimeHints;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -36,6 +37,7 @@ class ToolRuntimeHintsTests {
 		ToolRuntimeHints toolRuntimeHints = new ToolRuntimeHints();
 		toolRuntimeHints.registerHints(runtimeHints, null);
 		assertThat(runtimeHints).matches(reflection().onType(DefaultToolCallResultConverter.class));
+		assertThat(runtimeHints).matches(reflection().onType(TextToolCallResultConverter.class));
 	}
 
 	@Test
@@ -56,6 +58,7 @@ class ToolRuntimeHintsTests {
 		toolRuntimeHints.registerHints(runtimeHints, customClassLoader);
 
 		assertThat(runtimeHints).matches(reflection().onType(DefaultToolCallResultConverter.class));
+		assertThat(runtimeHints).matches(reflection().onType(TextToolCallResultConverter.class));
 	}
 
 	@Test
@@ -67,6 +70,7 @@ class ToolRuntimeHintsTests {
 		toolRuntimeHints.registerHints(runtimeHints, null);
 
 		assertThat(runtimeHints).matches(reflection().onType(DefaultToolCallResultConverter.class));
+		assertThat(runtimeHints).matches(reflection().onType(TextToolCallResultConverter.class));
 	}
 
 	@Test

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/TextToolCallResultConverterTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/TextToolCallResultConverterTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.execution;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link TextToolCallResultConverter}.
+ *
+ * @author Iuliia Sobolevska
+ */
+class TextToolCallResultConverterTests {
+
+	private final TextToolCallResultConverter converter = new TextToolCallResultConverter();
+
+	@Test
+	void convertStringReturnTypeShouldReturnText() {
+		String result = this.converter.convert("test", String.class);
+
+		assertThat(result).isEqualTo("test");
+	}
+
+	@Test
+	void convertJsonStringReturnTypeShouldReturnText() {
+		String result = this.converter.convert("{\"status\":\"ok\"}", String.class);
+
+		assertThat(result).isEqualTo("{\"status\":\"ok\"}");
+	}
+
+	@Test
+	void convertNullReturnValueShouldReturnNullJson() {
+		String result = this.converter.convert(null, String.class);
+
+		assertThat(result).isEqualTo("null");
+	}
+
+	@Test
+	void convertVoidReturnTypeShouldReturnDoneJson() {
+		String result = this.converter.convert(null, void.class);
+
+		assertThat(result).isEqualTo("\"Done\"");
+	}
+
+	@Test
+	void convertCollectionReturnTypeShouldReturnJson() {
+		List<String> testList = List.of("one", "two", "three");
+		String result = this.converter.convert(testList, List.class);
+
+		assertThat(result).isEqualTo("""
+				["one","two","three"]
+				""".trim());
+	}
+
+	@Test
+	void convertMapReturnTypeShouldReturnJson() {
+		Map<String, Integer> testMap = Map.of("one", 1, "two", 2);
+		String result = this.converter.convert(testMap, Map.class);
+
+		assertThat(result).containsIgnoringWhitespaces("""
+				"one": 1
+				""").containsIgnoringWhitespaces("""
+				"two": 2
+				""");
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.execution.DefaultToolCallResultConverter;
+import org.springframework.ai.tool.execution.TextToolCallResultConverter;
 import org.springframework.ai.tool.execution.ToolCallResultConverter;
 import org.springframework.core.annotation.AliasFor;
 
@@ -97,6 +98,16 @@ class MethodToolCallbackProviderTests {
 			.build();
 		assertThat(provider.getToolCallbacks()).hasSize(1);
 		assertThat(provider.getToolCallbacks()[0].getToolDefinition().name()).isEqualTo("objectTool");
+	}
+
+	@Test
+	void whenToolObjectHasTextResultConverterThenReturnText() {
+		MethodToolCallbackProvider provider = MethodToolCallbackProvider.builder()
+			.toolObjects(new TextResultConverterToolObject())
+			.build();
+
+		assertThat(provider.getToolCallbacks()).hasSize(1);
+		assertThat(provider.getToolCallbacks()[0].call("{}")).isEqualTo("Plain text result");
 	}
 
 	@Test
@@ -210,6 +221,15 @@ class MethodToolCallbackProviderTests {
 		@Tool
 		public Object objectTool() {
 			return "Object tool result";
+		}
+
+	}
+
+	static class TextResultConverterToolObject {
+
+		@Tool(resultConverter = TextToolCallResultConverter.class)
+		public String textTool() {
+			return "Plain text result";
 		}
 
 	}


### PR DESCRIPTION
Add a built-in converter for tools that return plain text. The converter leaves String results unchanged and delegates other result types to the default converter.

Fixes #6849