### PR TITLE
Expose AWS SDK version BOM

### DIFF
--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -63,6 +63,17 @@
 	<dependencyManagement>
 		<dependencies>
 
+			<!-- AWS SDK -->
+
+			<!-- NOTE: keep aligned with awssdk.version in the parent POM -->
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>2.51.2</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<!-- Spring AI commons -->
 
 			<dependency>


### PR DESCRIPTION
Expose the AWS SDK version selected by Spring AI through the published Spring AI BOM so Gradle and Maven consumers can align all AWS SDK modules without duplicating the version.

This makes it easier for consuming projects to pin the AWS SDK version to the one that Spring-AI wants.  For example, if using spring-cloud-aws and spring-ai at the same time, currently, spring-cloud-aws wants AWS SDK version 2.47.x, but the bedrock dependencies in Spring-AI want 2.51.2.  Without pinning the AWS SDK version, this can lead to mixed versions of AWS modules landing on the runtime classpath that are not compatible.

By exposing the version int he BOM, gradle consumers can pin the SDK version with something like this:

```
implementation(enforcedPlatform("org.springframework.ai:spring-ai-bom:2.0.2"))
implementation("software.amazon.awssdk:bedrockruntime")
```

Without this change, we have to hard code the AWS SDK version that Spring-AI uses instead like this:

```
implementation(enforcedPlatform("software.amazon.awssdk:bom:2.51.2"))
```

but the risk with *that* is if Spring-AI needs a newer SDK version, then we might pin the wrong version.

Hopefully make sense.

See also: https://github.com/awspring/spring-cloud-aws/issues/1686