### PR TITLE
Fix JSON-RPC error responses in MCP transports

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxJsonRpcErrorResponse.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxJsonRpcErrorResponse.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import java.io.IOException;
+
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+/**
+ * Creates JSON-RPC error responses for WebFlux server transports.
+ *
+ * @author Taewoong Kim
+ */
+final class WebFluxJsonRpcErrorResponse {
+
+	private static final Log logger = LogFactory.getLog(WebFluxJsonRpcErrorResponse.class);
+
+	private WebFluxJsonRpcErrorResponse() {
+	}
+
+	static Mono<ServerResponse> create(McpJsonMapper jsonMapper, HttpStatus status, @Nullable Object requestId,
+			McpError mcpError) {
+		try {
+			// JSONRPCResponse requires a non-null id, but transport errors can occur
+			// before a JSON-RPC request id is available.
+			Object errorResponse = requestId != null
+					? McpSchema.JSONRPCResponse.error(requestId, mcpError.getJsonRpcError())
+					: new JsonRpcErrorResponse(McpSchema.JSONRPC_VERSION, mcpError.getJsonRpcError());
+			String json = jsonMapper.writeValueAsString(errorResponse);
+			return ServerResponse.status(status).contentType(MediaType.APPLICATION_JSON).bodyValue(json);
+		}
+		catch (IOException e) {
+			if (logger.isErrorEnabled()) {
+				logger.error("Failed to serialize JSON-RPC error response: " + e.getMessage());
+			}
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+		}
+	}
+
+	static @Nullable Object requestId(McpSchema.@Nullable JSONRPCMessage message) {
+		return message instanceof McpSchema.JSONRPCRequest request ? request.id() : null;
+	}
+
+	private record JsonRpcErrorResponse(String jsonrpc, McpSchema.JSONRPCResponse.JSONRPCError error) {
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
@@ -87,6 +87,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Christian Tzolov
  * @author Alexandros Pappas
  * @author Dariusz Jędrzejczyk
+ * @author Taewoong Kim
  * @see McpServerTransport
  * @see ServerSentEvent
  * @deprecated The SSE transport has been deprecated in the 2025-03-26 version of the
@@ -424,26 +425,39 @@ public final class WebFluxSseServerTransportProvider implements McpServerTranspo
 		}
 
 		if (request.queryParam("sessionId").isEmpty()) {
-			return ServerResponse.badRequest()
-				.bodyValue(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
-					.message("Session ID missing in message endpoint")
-					.build());
+			return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, null,
+					McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
+						.message("Session ID missing in message endpoint")
+						.build());
 		}
 
 		McpServerSession session = this.sessions.get(request.queryParam("sessionId").get());
 
 		if (session == null) {
-			return ServerResponse.status(HttpStatus.NOT_FOUND)
-				.bodyValue(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Session not found: " + request.queryParam("sessionId").get())
-					.build());
+			return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.NOT_FOUND, null,
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Session not found: " + request.queryParam("sessionId").get())
+						.build());
 		}
 
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
 
 		return request.bodyToMono(String.class).flatMap(body -> {
+			McpSchema.JSONRPCMessage message;
 			try {
-				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+				message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+			}
+			catch (IllegalArgumentException | IOException e) {
+				if (logger.isErrorEnabled()) {
+					logger.error("Failed to deserialize message: " + e.getMessage());
+				}
+				return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, null,
+						McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+							.message("Invalid message format")
+							.build());
+			}
+
+			try {
 				return session.handle(message).flatMap(response -> ServerResponse.ok().build()).onErrorResume(error -> {
 					if (logger.isErrorEnabled()) {
 						logger.error("Error processing  message: " + error.getMessage());
@@ -451,20 +465,22 @@ public final class WebFluxSseServerTransportProvider implements McpServerTranspo
 					// TODO: instead of signalling the error, just respond with 200 OK
 					// - the error is signalled on the SSE connection
 					// return ServerResponse.ok().build();
-					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-						.bodyValue(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-							.message("Internal server error. Check server logs for details.")
-							.build());
+					return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR,
+							WebFluxJsonRpcErrorResponse.requestId(message),
+							McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+								.message("Internal server error. Check server logs for details.")
+								.build());
 				});
 			}
-			catch (IllegalArgumentException | IOException e) {
+			catch (IllegalArgumentException e) {
 				if (logger.isErrorEnabled()) {
-					logger.error("Failed to deserialize message: " + e.getMessage());
+					logger.error("Failed to process message: " + e.getMessage());
 				}
-				return ServerResponse.badRequest()
-					.bodyValue(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
-						.message("Invalid message format")
-						.build());
+				return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST,
+						WebFluxJsonRpcErrorResponse.requestId(message),
+						McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+							.message("Invalid message format")
+							.build());
 			}
 		}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext));
 	}

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
@@ -47,6 +47,7 @@ import org.springframework.web.reactive.function.server.ServerResponse;
  * Implementation of a WebFlux based {@link McpStatelessServerTransport}.
  *
  * @author Dariusz Jędrzejczyk
+ * @author Taewoong Kim
  */
 public final class WebFluxStatelessServerTransport implements McpStatelessServerTransport {
 
@@ -155,10 +156,11 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 								if (logger.isErrorEnabled()) {
 									logger.error("Failed to serialize response: " + e.getMessage());
 								}
-								return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-									.bodyValue(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-										.message("Failed to serialize response")
-										.build());
+								return WebFluxJsonRpcErrorResponse.create(this.jsonMapper,
+										HttpStatus.INTERNAL_SERVER_ERROR, jsonrpcRequest.id(),
+										McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+											.message("Failed to serialize response")
+											.build());
 							}
 						});
 				}
@@ -168,20 +170,20 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 						.then(ServerResponse.accepted().build());
 				}
 				else {
-					return ServerResponse.badRequest()
-						.bodyValue(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
-							.message("The server accepts either requests or notifications")
-							.build());
+					return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, null,
+							McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+								.message("The server accepts either requests or notifications")
+								.build());
 				}
 			}
 			catch (IllegalArgumentException | IOException e) {
 				if (logger.isErrorEnabled()) {
 					logger.error("Failed to deserialize message: " + e.getMessage());
 				}
-				return ServerResponse.badRequest()
-					.bodyValue(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
-						.message("Invalid message format")
-						.build());
+				return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, null,
+						McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+							.message("Invalid message format")
+							.build());
 			}
 		}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext));
 	}

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
@@ -61,6 +61,7 @@ import org.springframework.web.reactive.function.server.ServerResponse;
  * @author Dariusz Jędrzejczyk
  * @author Christian Tzolov
  * @author Dimitar Proynov
+ * @author Taewoong Kim
  */
 public final class WebFluxStreamableServerTransportProvider implements McpStreamableServerTransportProvider {
 
@@ -325,27 +326,30 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 		}
 
 		return request.bodyToMono(String.class).<ServerResponse>flatMap(body -> {
+			McpSchema.@Nullable JSONRPCMessage message = null;
 			try {
-				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+				message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
 				if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest
 						&& jsonrpcRequest.method().equals(McpSchema.METHOD_INITIALIZE)) {
 					return handleInitRequest(jsonrpcRequest, hasMcpSessionIdHeader(request));
 				}
 				if (!hasMcpSessionIdHeader(request)) {
-					return ServerResponse.badRequest()
-						.bodyValue(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
-							.message("Session ID missing")
-							.build());
+					return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST,
+							WebFluxJsonRpcErrorResponse.requestId(message),
+							McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
+								.message("Session ID missing")
+								.build());
 				}
 
 				String sessionId = request.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID);
 				McpStreamableServerSession session = this.sessions.get(sessionId);
 
 				if (session == null || sessionId == null) {
-					return ServerResponse.status(HttpStatus.NOT_FOUND)
-						.bodyValue(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-							.message("Session not found: " + sessionId)
-							.build());
+					return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.NOT_FOUND,
+							WebFluxJsonRpcErrorResponse.requestId(message),
+							McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+								.message("Session not found: " + sessionId)
+								.build());
 				}
 
 				touchSession(sessionId);
@@ -373,20 +377,21 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 								ServerSentEvent.class);
 				}
 				else {
-					return ServerResponse.badRequest()
-						.bodyValue(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
-							.message("Unknown message type")
-							.build());
+					return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, null,
+							McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+								.message("Unknown message type")
+								.build());
 				}
 			}
 			catch (IllegalArgumentException | IOException e) {
 				if (logger.isErrorEnabled()) {
 					logger.error("Failed to deserialize message: " + e.getMessage());
 				}
-				return ServerResponse.badRequest()
-					.bodyValue(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
-						.message("Invalid message format")
-						.build());
+				return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST,
+						WebFluxJsonRpcErrorResponse.requestId(message),
+						McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+							.message("Invalid message format")
+							.build());
 			}
 		})
 			.switchIfEmpty(ServerResponse.badRequest().build())
@@ -437,22 +442,24 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 	private Mono<ServerResponse> handleInitRequest(final McpSchema.JSONRPCRequest jsonrpcRequest,
 			final boolean hasMcpSessionIdHeader) {
 		if (this.sessionFactory == null) {
-			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.bodyValue(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Session factory not initialized")
-					.build());
+			return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR,
+					jsonrpcRequest.id(),
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Session factory not initialized")
+						.build());
 		}
 		if (hasMcpSessionIdHeader) {
-			return ServerResponse.status(HttpStatus.BAD_REQUEST)
-				.bodyValue(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Session already initialized")
-					.build());
+			return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, jsonrpcRequest.id(),
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Session already initialized")
+						.build());
 		}
 		if (this.sessions.size() >= this.maxSessions) {
-			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE)
-				.bodyValue(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Max number of sessions reached")
-					.build());
+			return WebFluxJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.SERVICE_UNAVAILABLE,
+					jsonrpcRequest.id(),
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Max number of sessions reached")
+						.build());
 		}
 		var typeReference = new TypeRef<McpSchema.InitializeRequest>() {
 		};

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProviderTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProviderTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp.server.webflux.transport;
 import java.util.Map;
 
 import io.modelcontextprotocol.spec.McpServerSession;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link WebFluxSseServerTransportProvider}.
  *
  * @author Dimitar Proynov
+ * @author Taewoong Kim
  */
 class WebFluxSseServerTransportProviderTests {
 
@@ -66,9 +68,22 @@ class WebFluxSseServerTransportProviderTests {
 			.exchange()
 			.expectStatus()
 			.isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
 			.expectBody(String.class)
-			.value(body -> assertThat(body).contains("Internal server error. Check server logs for details.")
-				.doesNotContain(sensitiveDetail));
+			.value(body -> {
+				JsonAssertions.assertThatJson(body).isEqualTo("""
+						{
+							"jsonrpc": "2.0",
+							"id": "1",
+							"error": {
+								"code": -32603,
+								"message": "Internal server error. Check server logs for details."
+							}
+						}
+						""");
+				assertThat(body).doesNotContain(sensitiveDetail);
+			});
 	}
 
 }

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransportTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import io.modelcontextprotocol.server.McpStatelessServerHandler;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link WebFluxStatelessServerTransport}.
+ *
+ * @author Taewoong Kim
+ */
+class WebFluxStatelessServerTransportTests {
+
+	private static final String MALFORMED_REQUEST = """
+			{"jsonrpc":"2.0","id":1,"method":"tools/list""";
+
+	@Test
+	void malformedJsonReturnsJsonRpcErrorResponse() {
+		WebFluxStatelessServerTransport transport = WebFluxStatelessServerTransport.builder().build();
+		transport.setMcpHandler(mock(McpStatelessServerHandler.class));
+
+		WebTestClient client = WebTestClient.bindToRouterFunction(transport.getRouterFunction()).build();
+
+		client.post()
+			.uri("/mcp")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+			.bodyValue(MALFORMED_REQUEST)
+			.exchange()
+			.expectStatus()
+			.isBadRequest()
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
+			.expectBody(String.class)
+			.value(response -> JsonAssertions.assertThatJson(response).isEqualTo("""
+					{
+						"jsonrpc": "2.0",
+						"error": {
+							"code": -32600,
+							"message": "Invalid message format"
+						}
+					}
+					"""));
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProviderTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProviderTests.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpStreamableServerSession;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
@@ -29,7 +30,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link WebFluxStreamableServerTransportProvider}.
  *
  * @author Dimitar Proynov
+ * @author Taewoong Kim
  */
 class WebFluxStreamableServerTransportProviderTests {
 
@@ -128,8 +129,19 @@ class WebFluxStreamableServerTransportProviderTests {
 			.exchange()
 			.expectStatus()
 			.isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
 			.expectBody(String.class)
-			.value(body -> assertThat(body).contains("Max number of sessions reached"));
+			.value(body -> JsonAssertions.assertThatJson(body).isEqualTo("""
+					{
+						"jsonrpc": "2.0",
+						"id": "1",
+						"error": {
+							"code": -32603,
+							"message": "Max number of sessions reached"
+						}
+					}
+					"""));
 	}
 
 	@Test
@@ -159,8 +171,19 @@ class WebFluxStreamableServerTransportProviderTests {
 			.exchange()
 			.expectStatus()
 			.isEqualTo(HttpStatus.BAD_REQUEST)
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
 			.expectBody(String.class)
-			.value(body -> assertThat(body).contains("Session already initialized"));
+			.value(body -> JsonAssertions.assertThatJson(body).isEqualTo("""
+					{
+						"jsonrpc": "2.0",
+						"id": "1",
+						"error": {
+							"code": -32603,
+							"message": "Session already initialized"
+						}
+					}
+					"""));
 	}
 
 }

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcJsonRpcErrorResponse.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcJsonRpcErrorResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc.transport;
+
+import java.io.IOException;
+
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * Creates JSON-RPC error responses for WebMVC server transports.
+ *
+ * @author Taewoong Kim
+ */
+final class WebMvcJsonRpcErrorResponse {
+
+	private static final Log logger = LogFactory.getLog(WebMvcJsonRpcErrorResponse.class);
+
+	private WebMvcJsonRpcErrorResponse() {
+	}
+
+	static ServerResponse create(McpJsonMapper jsonMapper, HttpStatus status, @Nullable Object requestId,
+			McpError mcpError) {
+		try {
+			// JSONRPCResponse requires a non-null id, but transport errors can occur
+			// before a JSON-RPC request id is available.
+			Object errorResponse = requestId != null
+					? McpSchema.JSONRPCResponse.error(requestId, mcpError.getJsonRpcError())
+					: new JsonRpcErrorResponse(McpSchema.JSONRPC_VERSION, mcpError.getJsonRpcError());
+			String json = jsonMapper.writeValueAsString(errorResponse);
+			return ServerResponse.status(status).contentType(MediaType.APPLICATION_JSON).body(json);
+		}
+		catch (IOException e) {
+			if (logger.isErrorEnabled()) {
+				logger.error("Failed to serialize JSON-RPC error response: " + e.getMessage());
+			}
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+		}
+	}
+
+	static @Nullable Object requestId(McpSchema.@Nullable JSONRPCMessage message) {
+		return message instanceof McpSchema.JSONRPCRequest request ? request.id() : null;
+	}
+
+	private record JsonRpcErrorResponse(String jsonrpc, McpSchema.JSONRPCResponse.JSONRPCError error) {
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
@@ -84,6 +84,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  *
  * @author Christian Tzolov
  * @author Alexandros Pappas
+ * @author Taewoong Kim
  * @see McpServerTransportProvider
  * @see RouterFunction
  * @deprecated The SSE transport has been deprecated in the 2025-03-26 version of the
@@ -397,27 +398,28 @@ public final class WebMvcSseServerTransportProvider implements McpServerTranspor
 		}
 
 		if (request.param(SESSION_ID).isEmpty()) {
-			return ServerResponse.badRequest()
-				.body(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
-					.message("Session ID missing in message endpoint")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, null,
+					McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
+						.message("Session ID missing in message endpoint")
+						.build());
 		}
 
 		String sessionId = request.param(SESSION_ID).get();
 		McpServerSession session = this.sessions.get(sessionId);
 
 		if (session == null) {
-			return ServerResponse.status(HttpStatus.NOT_FOUND)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Session not found: " + sessionId)
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.NOT_FOUND, null,
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Session not found: " + sessionId)
+						.build());
 		}
 
+		McpSchema.@Nullable JSONRPCMessage message = null;
 		try {
 			final McpTransportContext transportContext = this.contextExtractor.extract(request);
 
 			String body = request.body(String.class);
-			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+			message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
 
 			// Process the message through the session's handle method
 			session.handle(message).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)).block(); // Block
@@ -431,17 +433,19 @@ public final class WebMvcSseServerTransportProvider implements McpServerTranspor
 			if (logger.isErrorEnabled()) {
 				logger.error("Failed to deserialize message: " + e.getMessage());
 			}
-			return ServerResponse.badRequest()
-				.body(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST).message("Invalid message format").build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST,
+					WebMvcJsonRpcErrorResponse.requestId(message),
+					McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST).message("Invalid message format").build());
 		}
 		catch (Exception e) {
 			if (logger.isErrorEnabled()) {
 				logger.error("Error handling message: " + e.getMessage());
 			}
-			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Internal server error. Check server logs for details.")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR,
+					WebMvcJsonRpcErrorResponse.requestId(message),
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Internal server error. Check server logs for details.")
+						.build());
 		}
 	}
 

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
@@ -50,6 +50,7 @@ import org.springframework.web.servlet.function.ServerResponse;
  * {@link io.modelcontextprotocol.server.transport.WebFluxStatelessServerTransport}
  *
  * @author Christian Tzolov
+ * @author Taewoong Kim
  */
 public final class WebMvcStatelessServerTransport implements McpStatelessServerTransport {
 
@@ -144,10 +145,10 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 
 		var handler = this.mcpHandler;
 		if (handler == null) {
-			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("MCP handler not configured")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR, null,
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("MCP handler not configured")
+						.build());
 		}
 
 		try {
@@ -166,10 +167,11 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 					if (logger.isErrorEnabled()) {
 						logger.error("Failed to handle request: " + e.getMessage());
 					}
-					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-						.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-							.message("Failed to handle request. Check server logs for details.")
-							.build());
+					return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR,
+							jsonrpcRequest.id(),
+							McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+								.message("Failed to handle request. Check server logs for details.")
+								.build());
 				}
 			}
 			else if (message instanceof McpSchema.JSONRPCNotification jsonrpcNotification) {
@@ -183,34 +185,34 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 					if (logger.isErrorEnabled()) {
 						logger.error("Failed to handle notification: " + e.getMessage());
 					}
-					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-						.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-							.message("Failed to handle notification. Check server logs for details.")
-							.build());
+					return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR, null,
+							McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+								.message("Failed to handle notification. Check server logs for details.")
+								.build());
 				}
 			}
 			else {
-				return ServerResponse.badRequest()
-					.body(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
-						.message("The server accepts either requests or notifications")
-						.build());
+				return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, null,
+						McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+							.message("The server accepts either requests or notifications")
+							.build());
 			}
 		}
 		catch (IllegalArgumentException | IOException e) {
 			if (logger.isErrorEnabled()) {
 				logger.error("Failed to deserialize message: " + e.getMessage());
 			}
-			return ServerResponse.badRequest()
-				.body(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST).message("Invalid message format").build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, null,
+					McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST).message("Invalid message format").build());
 		}
 		catch (Exception e) {
 			if (logger.isErrorEnabled()) {
 				logger.error("Unexpected error handling message: " + e.getMessage());
 			}
-			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Internal server error. Check server logs for details.")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR, null,
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Internal server error. Check server logs for details.")
+						.build());
 		}
 	}
 

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -67,6 +67,7 @@ import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
  * @author Christian Tzolov
  * @author Dariusz Jędrzejczyk
  * @author Dimitar Proynov
+ * @author Taewoong Kim
  * @see McpStreamableServerTransportProvider
  * @see RouterFunction
  */
@@ -434,17 +435,18 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
 		if (!acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM)
 				|| !acceptHeaders.contains(MediaType.APPLICATION_JSON)) {
-			return ServerResponse.badRequest()
-				.body(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
-					.message("Invalid Accept headers. Expected TEXT_EVENT_STREAM and APPLICATION_JSON")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, null,
+					McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
+						.message("Invalid Accept headers. Expected TEXT_EVENT_STREAM and APPLICATION_JSON")
+						.build());
 		}
 
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
 
+		McpSchema.@Nullable JSONRPCMessage message = null;
 		try {
 			String body = request.body(String.class);
-			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+			message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
 
 			// Handle initialization request
 			if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest
@@ -454,20 +456,20 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 
 			// Handle other messages that require a session
 			if (!hasMcpSessionIdHeader(request)) {
-				return ServerResponse.badRequest()
-					.body(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
-						.message("Session ID missing")
-						.build());
+				return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST,
+						WebMvcJsonRpcErrorResponse.requestId(message),
+						McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND).message("Session ID missing").build());
 			}
 
 			String sessionId = request.headers().header(HttpHeaders.MCP_SESSION_ID).get(0);
 			McpStreamableServerSession session = this.sessions.get(sessionId);
 
 			if (session == null || sessionId == null) {
-				return ServerResponse.status(HttpStatus.NOT_FOUND)
-					.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-						.message("Session not found: " + sessionId)
-						.build());
+				return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.NOT_FOUND,
+						WebMvcJsonRpcErrorResponse.requestId(message),
+						McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+							.message("Session not found: " + sessionId)
+							.build());
 			}
 
 			touchSession(sessionId);
@@ -515,27 +517,27 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 				}, Duration.ZERO);
 			}
 			else {
-				return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-					.body(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
-						.message("Unknown message type")
-						.build());
+				return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR, null,
+						McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST).message("Unknown message type").build());
 			}
 		}
 		catch (IllegalArgumentException | IOException e) {
 			if (logger.isErrorEnabled()) {
 				logger.error("Failed to deserialize message: " + e.getMessage());
 			}
-			return ServerResponse.badRequest()
-				.body(McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST).message("Invalid message format").build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST,
+					WebMvcJsonRpcErrorResponse.requestId(message),
+					McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST).message("Invalid message format").build());
 		}
 		catch (Exception e) {
 			if (logger.isErrorEnabled()) {
 				logger.error("Error handling message: " + e.getMessage());
 			}
-			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Internal server error. Check server logs for details.")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR,
+					WebMvcJsonRpcErrorResponse.requestId(message),
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Internal server error. Check server logs for details.")
+						.build());
 		}
 	}
 
@@ -586,10 +588,10 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 			if (logger.isErrorEnabled()) {
 				logger.error("Failed to delete session " + sessionId + ": " + e.getMessage());
 			}
-			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Internal server error. Check server logs for details.")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR, null,
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Internal server error. Check server logs for details.")
+						.build());
 		}
 	}
 
@@ -599,22 +601,24 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 				});
 		var sf = this.sessionFactory;
 		if (sf == null) {
-			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("SessionFactory not configured")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR,
+					jsonrpcRequest.id(),
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("SessionFactory not configured")
+						.build());
 		}
 		if (hasMcpSessionIdHeader) {
-			return ServerResponse.status(HttpStatus.BAD_REQUEST)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Session already initialized")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.BAD_REQUEST, jsonrpcRequest.id(),
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Session already initialized")
+						.build());
 		}
 		if (this.sessions.size() >= this.maxSessions) {
-			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Max number of sessions reached")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.SERVICE_UNAVAILABLE,
+					jsonrpcRequest.id(),
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Max number of sessions reached")
+						.build());
 		}
 		McpStreamableServerSession.McpStreamableServerSessionInit init = sf.startSession(initializeRequest);
 		this.sessions.put(init.session().getId(), init.session());
@@ -634,10 +638,11 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 			if (logger.isErrorEnabled()) {
 				logger.error("Failed to initialize session: " + e.getMessage());
 			}
-			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-					.message("Internal server error. Check server logs for details.")
-					.build());
+			return WebMvcJsonRpcErrorResponse.create(this.jsonMapper, HttpStatus.INTERNAL_SERVER_ERROR,
+					jsonrpcRequest.id(),
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Internal server error. Check server logs for details.")
+						.build());
 		}
 	}
 

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProviderTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProviderTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp.server.webmvc.transport;
 import java.util.Map;
 
 import io.modelcontextprotocol.spec.McpServerSession;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
@@ -37,6 +38,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link WebMvcSseServerTransportProvider}.
  *
  * @author Dimitar Proynov
+ * @author Taewoong Kim
  */
 class WebMvcSseServerTransportProviderTests {
 
@@ -67,9 +69,22 @@ class WebMvcSseServerTransportProviderTests {
 			.exchange()
 			.expectStatus()
 			.isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
 			.expectBody(String.class)
-			.value(body -> assertThat(body).contains("Internal server error. Check server logs for details.")
-				.doesNotContain(sensitiveDetail));
+			.value(body -> {
+				JsonAssertions.assertThatJson(body).isEqualTo("""
+						{
+							"jsonrpc": "2.0",
+							"id": "1",
+							"error": {
+								"code": -32603,
+								"message": "Internal server error. Check server logs for details."
+							}
+						}
+						""");
+				assertThat(body).doesNotContain(sensitiveDetail);
+			});
 	}
 
 }

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransportTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.webmvc.transport;
 
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link WebMvcStatelessServerTransport}.
  *
  * @author Dimitar Proynov
+ * @author Taewoong Kim
  */
 class WebMvcStatelessServerTransportTests {
 
@@ -45,12 +47,24 @@ class WebMvcStatelessServerTransportTests {
 	private static final String NOTIFICATION = """
 			{"jsonrpc":"2.0","method":"notifications/progress","params":{}}""";
 
+	private static final String MALFORMED_REQUEST = """
+			{"jsonrpc":"2.0","id":1,"method":"tools/list""";
+
 	@Test
 	void requestErrorResponseDoesNotLeakExceptionMessageToClient() {
 		McpStatelessServerHandler handler = mock(McpStatelessServerHandler.class);
 		when(handler.handleRequest(any(), any())).thenReturn(Mono.error(new RuntimeException(SENSITIVE_DETAIL)));
 
-		testMessageDoesntRevealDetails(handler, REQUEST, "Failed to handle request. Check server logs for details.");
+		testErrorResponseDoesntRevealDetails(handler, REQUEST, """
+				{
+					"jsonrpc": "2.0",
+					"id": "1",
+					"error": {
+						"code": -32603,
+						"message": "Failed to handle request. Check server logs for details."
+					}
+				}
+				""");
 	}
 
 	@Test
@@ -58,12 +72,48 @@ class WebMvcStatelessServerTransportTests {
 		McpStatelessServerHandler handler = mock(McpStatelessServerHandler.class);
 		when(handler.handleNotification(any(), any())).thenReturn(Mono.error(new RuntimeException(SENSITIVE_DETAIL)));
 
-		testMessageDoesntRevealDetails(handler, NOTIFICATION,
-				"Failed to handle notification. Check server logs for details.");
+		testErrorResponseDoesntRevealDetails(handler, NOTIFICATION, """
+				{
+					"jsonrpc": "2.0",
+					"error": {
+						"code": -32603,
+						"message": "Failed to handle notification. Check server logs for details."
+					}
+				}
+				""");
 	}
 
-	private void testMessageDoesntRevealDetails(McpStatelessServerHandler handler, String body,
-			String expectedMessage) {
+	@Test
+	void malformedJsonReturnsJsonRpcErrorResponse() {
+		WebMvcStatelessServerTransport transport = WebMvcStatelessServerTransport.builder().build();
+		transport.setMcpHandler(mock(McpStatelessServerHandler.class));
+
+		WebTestClient client = MockMvcWebTestClient.bindToRouterFunction(transport.getRouterFunction()).build();
+
+		client.post()
+			.uri("/mcp")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+			.bodyValue(MALFORMED_REQUEST)
+			.exchange()
+			.expectStatus()
+			.isBadRequest()
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
+			.expectBody(String.class)
+			.value(response -> JsonAssertions.assertThatJson(response).isEqualTo("""
+					{
+						"jsonrpc": "2.0",
+						"error": {
+							"code": -32600,
+							"message": "Invalid message format"
+						}
+					}
+					"""));
+	}
+
+	private void testErrorResponseDoesntRevealDetails(McpStatelessServerHandler handler, String body,
+			String expectedResponse) {
 		WebMvcStatelessServerTransport transport = WebMvcStatelessServerTransport.builder().build();
 		transport.setMcpHandler(handler);
 
@@ -78,7 +128,10 @@ class WebMvcStatelessServerTransportTests {
 			.expectStatus()
 			.isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
 			.expectBody(String.class)
-			.value(response -> assertThat(response).contains(expectedMessage).doesNotContain(SENSITIVE_DETAIL));
+			.value(response -> {
+				JsonAssertions.assertThatJson(response).isEqualTo(expectedResponse);
+				assertThat(response).doesNotContain(SENSITIVE_DETAIL);
+			});
 	}
 
 }

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProviderTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProviderTests.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpStreamableServerSession;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
@@ -41,6 +42,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link WebMvcStreamableServerTransportProvider}.
  *
  * @author Dimitar Proynov
+ * @author Taewoong Kim
  */
 class WebMvcStreamableServerTransportProviderTests {
 
@@ -72,9 +74,22 @@ class WebMvcStreamableServerTransportProviderTests {
 			.exchange()
 			.expectStatus()
 			.isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
 			.expectBody(String.class)
-			.value(body -> assertThat(body).contains("Internal server error. Check server logs for details.")
-				.doesNotContain(sensitiveDetail));
+			.value(body -> {
+				JsonAssertions.assertThatJson(body).isEqualTo("""
+						{
+							"jsonrpc": "2.0",
+							"id": "1",
+							"error": {
+								"code": -32603,
+								"message": "Internal server error. Check server logs for details."
+							}
+						}
+						""");
+				assertThat(body).doesNotContain(sensitiveDetail);
+			});
 	}
 
 	@Test
@@ -158,8 +173,19 @@ class WebMvcStreamableServerTransportProviderTests {
 			.exchange()
 			.expectStatus()
 			.isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
 			.expectBody(String.class)
-			.value(body -> assertThat(body).contains("Max number of sessions reached"));
+			.value(body -> JsonAssertions.assertThatJson(body).isEqualTo("""
+					{
+						"jsonrpc": "2.0",
+						"id": "1",
+						"error": {
+							"code": -32603,
+							"message": "Max number of sessions reached"
+						}
+					}
+					"""));
 	}
 
 	@Test
@@ -189,8 +215,19 @@ class WebMvcStreamableServerTransportProviderTests {
 			.exchange()
 			.expectStatus()
 			.isEqualTo(HttpStatus.BAD_REQUEST)
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
 			.expectBody(String.class)
-			.value(body -> assertThat(body).contains("Session already initialized"));
+			.value(body -> JsonAssertions.assertThatJson(body).isEqualTo("""
+					{
+						"jsonrpc": "2.0",
+						"id": "1",
+						"error": {
+							"code": -32603,
+							"message": "Session already initialized"
+						}
+					}
+					"""));
 	}
 
 }


### PR DESCRIPTION
Fixes #6855

`McpError` is currently written directly to the response body on several transport error paths. Since it extends `RuntimeException`, this serializes the exception fields instead of returning a JSON-RPC error response.

This updates the WebMVC and WebFlux Stateless, SSE, and Streamable transports to return only the JSON-RPC fields as `application/json`. Existing HTTP statuses are retained. Request IDs are included when available and omitted otherwise.

Added tests for the error responses and checked the behavior with HTTP requests as well.