### PR TITLE
fix(openai): tolerate empty id/name in ChunkMerger when converting streaming tool call chunks

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1304,12 +1304,15 @@ public final class OpenAiChatModel implements ChatModel {
 							.builder();
 						Function function = tc.function()
 							.orElseThrow(() -> new IllegalStateException("Tool call function is missing"));
-						String id = tc.id()
-							.filter(StringUtils::hasText)
-							.orElseThrow(() -> new IllegalStateException("Tool call id is missing"));
-						String name = function.name()
-							.filter(StringUtils::hasText)
-							.orElseThrow(() -> new IllegalStateException("Tool call function name is missing"));
+						// After merging streaming chunks, id and name may arrive as
+						// empty strings on continuation deltas from some
+						// OpenAI-compatible providers (e.g. vLLM, DeepSeek). Using
+						// orElse("") instead of orElseThrow avoids a
+						// NoSuchElementException that aborts the entire stream; the
+						// complete values will be present on the final aggregated chunk.
+						// See: https://github.com/spring-projects/spring-ai/issues/6762
+						String id = tc.id().filter(StringUtils::hasText).orElse("");
+						String name = function.name().filter(StringUtils::hasText).orElse("");
 						toolCallBuilder.putAllAdditionalProperties(tc._additionalProperties());
 						toolCallBuilder.id(id);
 						toolCallBuilder.function(ChatCompletionMessageFunctionToolCall.Function.builder()

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
@@ -115,40 +115,68 @@ class OpenAiChatModelChunkMergerTests {
 		assertThat(toolCalls.get(1).function().orElseThrow().arguments()).contains("{\"b\": 2}");
 	}
 
-	@Test
-	void chunkToChatCompletionRequiresToolCallId() {
-		ChatCompletionChunk chunk = chunk(FinishReason.TOOL_CALLS,
+	@Test // gh-6762
+	void chunkToChatCompletionToleratesMissingToolCallIdAfterMerge() {
+		// After merging streaming chunks, some OpenAI-compatible providers (e.g. vLLM,
+		// DeepSeek) send empty-string id/name on continuation deltas. The merged chunk
+		// may therefore have an empty id or name, which must not abort the stream.
+		ChatCompletionChunk nullIdChunk = chunk(FinishReason.TOOL_CALLS,
 				toolCallDelta(0, null, "get_weather", "{\"city\":\"Seoul\"}"));
 		ChatCompletionChunk blankIdChunk = chunk(FinishReason.TOOL_CALLS,
 				toolCallDelta(0, " ", "get_weather", "{\"city\":\"Seoul\"}"));
 
-		assertThatIllegalStateException().isThrownBy(() -> OpenAiChatModel.ChunkMerger.chunkToChatCompletion(chunk))
-			.withMessage("Tool call id is missing");
-		assertThatIllegalStateException()
-			.isThrownBy(() -> OpenAiChatModel.ChunkMerger.chunkToChatCompletion(blankIdChunk))
-			.withMessage("Tool call id is missing");
+		ChatCompletion completionNullId = OpenAiChatModel.ChunkMerger.chunkToChatCompletion(nullIdChunk);
+		assertThat(completionNullId.choices().get(0).message().toolCalls()).isPresent();
+		assertThat(completionNullId.choices().get(0).message().toolCalls().get().get(0).function().orElseThrow().id())
+			.isEmpty();
+
+		ChatCompletion completionBlankId = OpenAiChatModel.ChunkMerger.chunkToChatCompletion(blankIdChunk);
+		assertThat(completionBlankId.choices().get(0).message().toolCalls()).isPresent();
+		assertThat(completionBlankId.choices().get(0).message().toolCalls().get().get(0).function().orElseThrow().id())
+			.isEmpty();
 	}
 
-	@Test
-	void chunkToChatCompletionRequiresToolCallFunction() {
-		ChatCompletionChunk chunk = chunk(FinishReason.TOOL_CALLS, toolCallDeltaWithoutFunction(0, "call_1"));
-
-		assertThatIllegalStateException().isThrownBy(() -> OpenAiChatModel.ChunkMerger.chunkToChatCompletion(chunk))
-			.withMessage("Tool call function is missing");
-	}
-
-	@Test
-	void chunkToChatCompletionRequiresToolCallFunctionName() {
-		ChatCompletionChunk chunk = chunk(FinishReason.TOOL_CALLS,
+	@Test // gh-6762
+	void chunkToChatCompletionToleratesMissingToolCallFunctionNameAfterMerge() {
+		// Same rationale as above: empty name on continuation delta must not abort
+		// stream.
+		ChatCompletionChunk nullNameChunk = chunk(FinishReason.TOOL_CALLS,
 				toolCallDelta(0, "call_1", null, "{\"city\":\"Seoul\"}"));
 		ChatCompletionChunk blankNameChunk = chunk(FinishReason.TOOL_CALLS,
 				toolCallDelta(0, "call_1", " ", "{\"city\":\"Seoul\"}"));
 
+		ChatCompletion completionNullName = OpenAiChatModel.ChunkMerger.chunkToChatCompletion(nullNameChunk);
+		assertThat(completionNullName.choices().get(0).message().toolCalls()).isPresent();
+		ChatCompletionMessageFunctionToolCall tcNullName = completionNullName.choices()
+			.get(0)
+			.message()
+			.toolCalls()
+			.orElseThrow()
+			.get(0)
+			.function()
+			.orElseThrow();
+		assertThat(tcNullName.function().name()).isEmpty();
+
+		ChatCompletion completionBlankName = OpenAiChatModel.ChunkMerger.chunkToChatCompletion(blankNameChunk);
+		assertThat(completionBlankName.choices().get(0).message().toolCalls()).isPresent();
+		ChatCompletionMessageFunctionToolCall tcBlankName = completionBlankName.choices()
+			.get(0)
+			.message()
+			.toolCalls()
+			.orElseThrow()
+			.get(0)
+			.function()
+			.orElseThrow();
+		assertThat(tcBlankName.function().name()).isEmpty();
+	}
+
+	@Test
+	void chunkToChatCompletionRequiresToolCallFunction() {
+		// The function field is genuinely unrecoverable — there is no fallback value.
+		ChatCompletionChunk chunk = chunk(FinishReason.TOOL_CALLS, toolCallDeltaWithoutFunction(0, "call_1"));
+
 		assertThatIllegalStateException().isThrownBy(() -> OpenAiChatModel.ChunkMerger.chunkToChatCompletion(chunk))
-			.withMessage("Tool call function name is missing");
-		assertThatIllegalStateException()
-			.isThrownBy(() -> OpenAiChatModel.ChunkMerger.chunkToChatCompletion(blankNameChunk))
-			.withMessage("Tool call function name is missing");
+			.withMessage("Tool call function is missing");
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

When using `ChatClient.stream().content()` (or `.chatResponse()`) with tools enabled, streaming fails mid-stream with a `NoSuchElementException` thrown from `OpenAiChatModel$ChunkMerger.chunkToChatCompletion()`.

Closes #6762

## Root cause

The OpenAI streaming protocol sends tool call deltas in multiple chunks:
- **First chunk** carries `id` and `function.name`.
- **Continuation chunks** omit `id` and `function.name` (OpenAI), or send them as empty strings (DeepSeek, vLLM, Ollama).

`ChunkMerger.mergeToolCalls()` already handles this correctly via `firstWithText()`, which returns `""` when no delta across the buffer carries a non-blank value.

However, `chunkToChatCompletion()` then called:

```java
// Before
String id = tc.id()
    .filter(StringUtils::hasText)
    .orElseThrow(() -> new IllegalStateException("Tool call id is missing"));
String name = function.name()
    .filter(StringUtils::hasText)
    .orElseThrow(() -> new IllegalStateException("Tool call function name is missing"));
```

`filter(StringUtils::hasText)` discards the empty string, and `orElseThrow()` aborts the entire stream. The exception surfaces as `java.util.NoSuchElementException: No value present` from `MessageAggregator`.

## Fix

Replace the `orElseThrow()` guards for `id` and `name` with `orElse("")`:

```java
// After
String id = tc.id().filter(StringUtils::hasText).orElse("");
String name = function.name().filter(StringUtils::hasText).orElse("");
```

This is safe because:
- The complete `id` and `name` are always present in the **first** delta for each tool call index; subsequent deltas only carry argument fragments.
- The guard on `function` itself is kept as `orElseThrow()` because a tool call with no function object is unrecoverable regardless.

## Tests

Updated `OpenAiChatModelChunkMergerTests`:
- Replaced the old `chunkToChatCompletionRequiresToolCallId` and `chunkToChatCompletionRequiresToolCallFunctionName` tests (which verified the previous throwing behavior) with `chunkToChatCompletionToleratesMissingToolCallIdAfterMerge` and `chunkToChatCompletionToleratesMissingToolCallFunctionNameAfterMerge` — both annotated `// gh-6762`.
- Retained `chunkToChatCompletionRequiresToolCallFunction`: the function field is genuinely unrecoverable.