### PR TITLE
fix(openai): expose reasoning_content incremental delta for streaming UX

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -133,6 +133,8 @@ public final class OpenAiChatModel implements ChatModel {
 
 	private static final String REASONING_CONTENT = "reasoningContent";
 
+	private static final String REASONING_CONTENT_DELTA = "reasoningContentDelta";
+
 	static final String TOOL_CALL_ADDITIONAL_PROPERTIES_METADATA_KEY = "openai.tool_calls.additional_properties";
 
 	private static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<>() {
@@ -276,6 +278,7 @@ public final class OpenAiChatModel implements ChatModel {
 			RequestOptions requestOptions = this.buildRequestOptions(prompt);
 			ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
 			ConcurrentHashMap<String, String> reasoningMap = new ConcurrentHashMap<>();
+			ConcurrentHashMap<String, String> reasoningPrevMap = new ConcurrentHashMap<>();
 			final ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(AiProvider.OPENAI.value())
@@ -336,8 +339,11 @@ public final class OpenAiChatModel implements ChatModel {
 					// Accumulate reasoning fragments across the streamed chunks so the
 					// final response of this stream carries the full reasoning content,
 					// surviving last-wins metadata aggregation (e.g. MessageAggregator).
-					String accumulatedReasoning = reasoningMap.merge(id + ":" + choice.index(),
-							getReasoningContent(choice), String::concat);
+					String key = id + ":" + choice.index();
+					String accumulatedReasoning = reasoningMap.merge(key, getReasoningContent(choice), String::concat);
+					String prevReasoning = reasoningPrevMap.getOrDefault(key, "");
+					String reasoningDelta = accumulatedReasoning.substring(prevReasoning.length());
+					reasoningPrevMap.put(key, accumulatedReasoning);
 
 					Map<String, Object> metadata = Map.of("id", id, //
 							"role", roleMap.getOrDefault(id, ""), //
@@ -345,7 +351,8 @@ public final class OpenAiChatModel implements ChatModel {
 							"finishReason", choice.finishReason().value(), //
 							"refusal", choice.message().refusal().orElse(""), //
 							"annotations", choice.message().annotations().orElseGet(List::of), //
-							REASONING_CONTENT, accumulatedReasoning //
+							REASONING_CONTENT, accumulatedReasoning, //
+							REASONING_CONTENT_DELTA, reasoningDelta //
 					);
 
 					return buildGeneration(choice, metadata, request);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -924,6 +924,26 @@ class OpenAiChatModelTests {
 			.isEqualTo("Think step one. Think step two.");
 	}
 
+	@Test
+	void streamingReasoningContentDeltaExposedForTypewriterUx() { // gh-6833
+		List<ChatCompletionChunk> chunks = List.of(
+				streamingChunk(delta -> delta.role(ChatCompletionChunk.Choice.Delta.Role.ASSISTANT)
+					.putAdditionalProperty("reasoning_content", JsonValue.from("Think step one. ")), null),
+				streamingChunk(
+						delta -> delta.putAdditionalProperty("reasoning_content", JsonValue.from("Think step two.")),
+						null),
+				streamingChunk(delta -> delta.content("Hello"), ChatCompletionChunk.Choice.FinishReason.STOP));
+
+		List<ChatResponse> responses = streamResponses(chunks).collectList().block();
+
+		assertThat(responses).hasSize(3);
+		assertThat(responses.get(0).getResult().getOutput().getMetadata().get("reasoningContentDelta"))
+			.isEqualTo("Think step one. ");
+		assertThat(responses.get(1).getResult().getOutput().getMetadata().get("reasoningContentDelta"))
+			.isEqualTo("Think step two.");
+		assertThat(responses.get(2).getResult().getOutput().getMetadata().get("reasoningContentDelta")).isEqualTo("");
+	}
+
 	private AssistantMessage aggregateStreaming(List<ChatCompletionChunk> chunks) {
 		Flux<ChatResponse> responses = streamResponses(chunks);
 


### PR DESCRIPTION
Fixes #6833.

The `OpenAiChatModel` was aggregating the `reasoning_content` completely in every chunk metadata. For frontend applications consuming SSE, it makes it impossible to correctly build typewriter effects for reasoning because each chunk contained the fully accumulated reasoning instead of just the increment. 

This commit tracks the previous chunk's accumulated reasoning content via a `reasoningPrevMap` and adds the calculated delta into the `reasoningContentDelta` metadata field. The full string is kept in `reasoningContent` for replay capabilities, ensuring full backward compatibility. Tests were added to verify the chunk delta behavior.