### PR TITLE
Preserve Bedrock reasoning content in streaming

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -60,6 +60,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.Message;
 import software.amazon.awssdk.services.bedrockruntime.model.OutputConfig;
 import software.amazon.awssdk.services.bedrockruntime.model.OutputFormat;
 import software.amazon.awssdk.services.bedrockruntime.model.OutputFormatStructure;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningContentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.S3Location;
 import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
@@ -815,7 +816,8 @@ public class BedrockProxyChatModel implements ChatModel {
 
 			Flux<ChatResponse> chatResponses = new ConverseChatResponseStream(this.bedrockRuntimeAsyncClient,
 					converseStreamRequest, accumulatedUsage)
-				.stream();
+				.stream()
+				.map(this::toBedrockStreamingChatResponse);
 
 			ChatOptions options = prompt.getOptions();
 			Assert.state(options != null, "Prompt options must not be null");
@@ -827,6 +829,35 @@ public class BedrockProxyChatModel implements ChatModel {
 
 			return new MessageAggregator().aggregate(chatResponseFlux, observationContext::setResponse);
 		});
+	}
+
+	private ChatResponse toBedrockStreamingChatResponse(ChatResponse chatResponse) {
+		Generation generation = chatResponse.getResult();
+		if (generation == null) {
+			return chatResponse;
+		}
+
+		AssistantMessage output = generation.getOutput();
+		Object reasoningContent = output.getMetadata().get(ReasoningContentBlock.class.getName());
+		if (!(reasoningContent instanceof List<?> reasoningContentBlocks) || reasoningContentBlocks.isEmpty()) {
+			return chatResponse;
+		}
+
+		List<BedrockReasoningContent> reasoningContents = reasoningContentBlocks.stream()
+			.map(ReasoningContentBlock.class::cast)
+			.map(BedrockReasoningContent::from)
+			.toList();
+		Map<String, Object> properties = new HashMap<>(output.getMetadata());
+		properties.remove(ReasoningContentBlock.class.getName());
+		BedrockAssistantMessage assistantMessage = BedrockAssistantMessage.builder()
+			.content(output.getText())
+			.properties(properties)
+			.toolCalls(output.getToolCalls())
+			.media(output.getMedia())
+			.reasoningContents(reasoningContents)
+			.build();
+		return new ChatResponse(List.of(new Generation(assistantMessage, generation.getMetadata())),
+				chatResponse.getMetadata());
 	}
 
 	/**

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseChatResponseStream.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseChatResponseStream.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.bedrock.converse.api;
 
+import java.io.ByteArrayOutputStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDelta;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDeltaEvent;
@@ -37,6 +39,9 @@ import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamMetada
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
 import software.amazon.awssdk.services.bedrockruntime.model.MessageStopEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningContentBlockDelta;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningTextBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -75,6 +80,8 @@ public class ConverseChatResponseStream implements ConverseStreamResponseHandler
 	private final AtomicReference<String> stopReason = new AtomicReference<>();
 
 	private final Map<Integer, StreamingToolCallBuilder> toolUseMap = new ConcurrentHashMap<>();
+
+	private final Map<Integer, StreamingReasoningContentBuilder> reasoningContentMap = new ConcurrentHashMap<>();
 
 	private final Sinks.Many<ChatResponse> eventSink = Sinks.many().multicast().onBackpressureBuffer();
 
@@ -119,6 +126,11 @@ public class ConverseChatResponseStream implements ConverseStreamResponseHandler
 		else if (ContentBlockDelta.Type.TEXT.equals(event.delta().type())) {
 			this.emitChatResponse(new Generation(AssistantMessage.builder().content(event.delta().text()).build()));
 		}
+		else if (ContentBlockDelta.Type.REASONING_CONTENT.equals(event.delta().type())) {
+			this.reasoningContentMap
+				.computeIfAbsent(event.contentBlockIndex(), key -> new StreamingReasoningContentBuilder())
+				.delta(event.delta().reasoningContent());
+		}
 	}
 
 	@Override
@@ -144,13 +156,18 @@ public class ConverseChatResponseStream implements ConverseStreamResponseHandler
 			.map(StreamingToolCallBuilder::build)
 			.toList();
 
-		if (!toolCalls.isEmpty()) {
-			this.emitChatResponse(new Generation(AssistantMessage.builder().content("").toolCalls(toolCalls).build(),
-					generationMetadata));
+		List<ReasoningContentBlock> reasoningContents = this.reasoningContentMap.entrySet()
+			.stream()
+			.sorted(Map.Entry.comparingByKey())
+			.map(Map.Entry::getValue)
+			.map(StreamingReasoningContentBuilder::build)
+			.toList();
+
+		AssistantMessage.Builder<?> messageBuilder = AssistantMessage.builder().content("").toolCalls(toolCalls);
+		if (!reasoningContents.isEmpty()) {
+			messageBuilder.properties(Map.of(ReasoningContentBlock.class.getName(), reasoningContents));
 		}
-		else {
-			this.emitChatResponse(new Generation(AssistantMessage.builder().content("").build(), generationMetadata));
-		}
+		this.emitChatResponse(new Generation(messageBuilder.build(), generationMetadata));
 	}
 
 	private void mergeNativeTokenUsage(TokenUsage tokenUsage) {
@@ -230,6 +247,55 @@ public class ConverseChatResponseStream implements ConverseStreamResponseHandler
 		this.bedrockRuntimeAsyncClient.converseStream(this.converseStreamRequest, responseHandler);
 
 		return this.eventSink.asFlux();
+	}
+
+	private static final class StreamingReasoningContentBuilder {
+
+		private @Nullable StringBuilder text;
+
+		private @Nullable StringBuilder signature;
+
+		private @Nullable ByteArrayOutputStream redactedContent;
+
+		void delta(ReasoningContentBlockDelta delta) {
+			switch (delta.type()) {
+				case TEXT -> {
+					if (this.text == null) {
+						this.text = new StringBuilder();
+					}
+					this.text.append(delta.text());
+				}
+				case SIGNATURE -> {
+					if (this.signature == null) {
+						this.signature = new StringBuilder();
+					}
+					this.signature.append(delta.signature());
+				}
+				case REDACTED_CONTENT -> {
+					if (this.redactedContent == null) {
+						this.redactedContent = new ByteArrayOutputStream();
+					}
+					this.redactedContent.writeBytes(delta.redactedContent().asByteArray());
+				}
+				case UNKNOWN_TO_SDK_VERSION -> {
+				}
+			}
+		}
+
+		ReasoningContentBlock build() {
+			if (this.redactedContent != null) {
+				return ReasoningContentBlock.builder()
+					.redactedContent(SdkBytes.fromByteArray(this.redactedContent.toByteArray()))
+					.build();
+			}
+			return ReasoningContentBlock.builder()
+				.reasoningText(ReasoningTextBlock.builder()
+					.text(this.text != null ? this.text.toString() : null)
+					.signature(this.signature != null ? this.signature.toString() : null)
+					.build())
+				.build();
+		}
+
 	}
 
 }

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelReasoningTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelReasoningTests.java
@@ -17,7 +17,10 @@
 package org.springframework.ai.bedrock.converse;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,25 +28,37 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.document.internal.MapDocument;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDelta;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDeltaEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockStart;
 import software.amazon.awssdk.services.bedrockruntime.model.ConversationRole;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseMetrics;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseOutput;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
 import software.amazon.awssdk.services.bedrockruntime.model.Message;
 import software.amazon.awssdk.services.bedrockruntime.model.ReasoningContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningContentBlockDelta;
 import software.amazon.awssdk.services.bedrockruntime.model.ReasoningTextBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
 import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 import software.amazon.awssdk.services.bedrockruntime.model.ToolUseBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ToolUseBlockDelta;
+import software.amazon.awssdk.services.bedrockruntime.model.ToolUseBlockStart;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionResult;
@@ -53,6 +68,7 @@ import org.springframework.ai.tool.function.FunctionToolCallback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -194,6 +210,85 @@ class BedrockProxyChatModelReasoningTests {
 		// reasoning block on replay.
 		assertThat(indexOfType(content, ContentBlock.Type.REASONING_CONTENT)).isEqualTo(-1);
 		assertThat(indexOfType(content, ContentBlock.Type.TOOL_USE)).isGreaterThanOrEqualTo(0);
+	}
+
+	@Test
+	void streamingReasoningContentSurvivesAggregationAndReplay() {
+		byte[] redacted = "redacted-reasoning".getBytes(StandardCharsets.UTF_8);
+		AtomicReference<ConverseStreamResponseHandler> handlerRef = new AtomicReference<>();
+		doAnswer(invocation -> {
+			handlerRef.set(invocation.getArgument(1));
+			return CompletableFuture.completedFuture(null);
+		}).when(this.bedrockRuntimeAsyncClient)
+			.converseStream(isA(ConverseStreamRequest.class), isA(ConverseStreamResponseHandler.class));
+
+		CompletableFuture<List<ChatResponse>> chunksFuture = this.chatModel.stream(new Prompt("Use the weather tool"))
+			.collectList()
+			.toFuture();
+		ConverseStreamResponseHandler handler = handlerRef.get();
+		handler.onEventStream(SdkPublisher.fromIterable(streamEvents(redacted)));
+		handler.complete();
+		List<ChatResponse> chunks = chunksFuture.join();
+		AtomicReference<ChatResponse> aggregated = new AtomicReference<>();
+		new MessageAggregator().aggregate(Flux.fromIterable(chunks), aggregated::set).blockLast();
+
+		AssistantMessage output = aggregated.get().getResult().getOutput();
+		assertThat(output).isInstanceOf(BedrockAssistantMessage.class);
+		assertThat(output.getText()).isEqualTo("Ordinary text");
+		assertThat(output.getToolCalls()).singleElement().satisfies(toolCall -> {
+			assertThat(toolCall.name()).isEqualTo("getCurrentWeather");
+			assertThat(toolCall.arguments()).isEqualTo("{\"location\":\"Paris\"}");
+		});
+
+		List<BedrockReasoningContent> reasoningContents = ((BedrockAssistantMessage) output).getReasoningContents();
+		assertThat(reasoningContents).hasSize(2);
+		assertThat(reasoningContents.get(0).getRedactedContent()).isEqualTo(redacted);
+		assertThat(reasoningContents.get(1).getText()).isEqualTo("Think before using the tool.");
+		assertThat(reasoningContents.get(1).getSignature()).isEqualTo("signed-reasoning");
+
+		ConverseRequest replay = this.chatModel
+			.createRequest(new Prompt(List.of(output), BedrockChatOptions.builder().build()));
+		List<ContentBlock> replayedContent = replay.messages().get(0).content();
+		assertThat(replayedContent.stream().filter(block -> block.type() == ContentBlock.Type.REASONING_CONTENT))
+			.map(ContentBlock::reasoningContent)
+			.containsExactly(reasoningContents.get(0).toContentBlock().reasoningContent(),
+					reasoningContents.get(1).toContentBlock().reasoningContent());
+		assertThat(indexOfType(replayedContent, ContentBlock.Type.REASONING_CONTENT))
+			.isLessThan(indexOfType(replayedContent, ContentBlock.Type.TOOL_USE));
+	}
+
+	private static List<ConverseStreamOutput> streamEvents(byte[] redacted) {
+		List<ConverseStreamOutput> events = new ArrayList<>();
+		events.add(reasoningDelta(1, ReasoningContentBlockDelta.fromText("Think before ")));
+		events.add(reasoningDelta(0, ReasoningContentBlockDelta.fromRedactedContent(SdkBytes.fromByteArray(redacted))));
+		events.add(reasoningDelta(1, ReasoningContentBlockDelta.fromText("using the tool.")));
+		events.add(reasoningDelta(1, ReasoningContentBlockDelta.fromSignature("signed-")));
+		events.add(reasoningDelta(1, ReasoningContentBlockDelta.fromSignature("reasoning")));
+		events.add(ConverseStreamOutput.contentBlockStartBuilder()
+			.contentBlockIndex(2)
+			.start(ContentBlockStart
+				.fromToolUse(ToolUseBlockStart.builder().toolUseId("tooluse_123").name("getCurrentWeather").build()))
+			.build());
+		events.add(ConverseStreamOutput.contentBlockDeltaBuilder()
+			.contentBlockIndex(2)
+			.delta(ContentBlockDelta.fromToolUse(ToolUseBlockDelta.builder().input("{\"location\":\"Paris\"}").build()))
+			.build());
+		events.add(ConverseStreamOutput.contentBlockDeltaBuilder()
+			.contentBlockIndex(3)
+			.delta(ContentBlockDelta.fromText("Ordinary text"))
+			.build());
+		events.add(ConverseStreamOutput.messageStopBuilder().stopReason(StopReason.TOOL_USE).build());
+		events.add(ConverseStreamOutput.metadataBuilder()
+			.usage(TokenUsage.builder().inputTokens(10).outputTokens(20).totalTokens(30).build())
+			.build());
+		return events;
+	}
+
+	private static ContentBlockDeltaEvent reasoningDelta(int index, ReasoningContentBlockDelta delta) {
+		return ConverseStreamOutput.contentBlockDeltaBuilder()
+			.contentBlockIndex(index)
+			.delta(ContentBlockDelta.fromReasoningContent(delta))
+			.build();
 	}
 
 	private void runToolLoop() {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -61,6 +61,8 @@ public class MessageAggregator {
 		AtomicReference<StringBuilder> outputWithoutThoughtsRef = new AtomicReference<>(new StringBuilder());
 		AtomicReference<Map<String, Object>> messageMetadataMapRef = new AtomicReference<>();
 		AtomicReference<List<ToolCall>> toolCallsRef = new AtomicReference<>(new ArrayList<>());
+		AtomicReference<AssistantMessage> assistantMessageRef = new AtomicReference<>(
+				AssistantMessage.builder().build());
 
 		// ChatGeneration Metadata
 		AtomicReference<ChatGenerationMetadata> generationMetadataRef = new AtomicReference<>(
@@ -83,6 +85,7 @@ public class MessageAggregator {
 			outputWithoutThoughtsRef.set(new StringBuilder());
 			messageMetadataMapRef.set(new HashMap<>());
 			toolCallsRef.set(new ArrayList<>());
+			assistantMessageRef.set(AssistantMessage.builder().build());
 			metadataIdRef.set("");
 			metadataModelRef.set("");
 			metadataUsagePromptTokensRef.set(0);
@@ -115,6 +118,10 @@ public class MessageAggregator {
 					messageMetadataMapRef.get().putAll(chatResponse.getResult().getOutput().getMetadata());
 				}
 				AssistantMessage outputMessage = chatResponse.getResult().getOutput();
+				if (outputMessage.getClass() != AssistantMessage.class
+						|| assistantMessageRef.get().getClass() == AssistantMessage.class) {
+					assistantMessageRef.set(outputMessage);
+				}
 				if (!CollectionUtils.isEmpty(outputMessage.getToolCalls())) {
 					toolCallsRef.get().addAll(outputMessage.getToolCalls());
 				}
@@ -165,28 +172,18 @@ public class MessageAggregator {
 				.promptMetadata(metadataPromptMetadataRef.get())
 				.build();
 
-			AssistantMessage finalAssistantMessage;
 			var messageMetadata = messageMetadataMapRef.get();
 			if (!thoughtsRef.get().isEmpty()) {
 				messageMetadata.put("thoughts", thoughtsRef.get().toString());
 				messageMetadata.put("outputWithoutThoughts", outputWithoutThoughtsRef.get().toString());
 			}
 			List<ToolCall> collectedToolCalls = toolCallsRef.get();
-
-			if (!CollectionUtils.isEmpty(collectedToolCalls)) {
-
-				finalAssistantMessage = AssistantMessage.builder()
-					.content(messageTextContentRef.get().toString())
-					.properties(messageMetadata)
-					.toolCalls(collectedToolCalls)
-					.build();
-			}
-			else {
-				finalAssistantMessage = AssistantMessage.builder()
-					.content(messageTextContentRef.get().toString())
-					.properties(messageMetadata)
-					.build();
-			}
+			AssistantMessage finalAssistantMessage = assistantMessageRef.get()
+				.mutate()
+				.content(messageTextContentRef.get().toString())
+				.properties(messageMetadata)
+				.toolCalls(collectedToolCalls)
+				.build();
 			onAggregationComplete.accept(new ChatResponse(List.of(new Generation(finalAssistantMessage,
 
 					generationMetadataRef.get())), chatResponseMetadata));
@@ -196,6 +193,7 @@ public class MessageAggregator {
 			outputWithoutThoughtsRef.set(new StringBuilder());
 			messageMetadataMapRef.set(new HashMap<>());
 			toolCallsRef.set(new ArrayList<>());
+			assistantMessageRef.set(AssistantMessage.builder().build());
 			metadataIdRef.set("");
 			metadataModelRef.set("");
 			metadataUsagePromptTokensRef.set(0);

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.model;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.EmptyRateLimit;
 import org.springframework.ai.chat.metadata.RateLimit;
+import org.springframework.ai.content.Media;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,9 +62,96 @@ class MessageAggregatorTests {
 		assertThat(aggregated.get().getMetadata().getRateLimit()).isInstanceOf(EmptyRateLimit.class);
 	}
 
+	@Test
+	void assistantMessageSubtypeSurvivesAggregation() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id", "function", "test", "{}");
+		Flux<ChatResponse> responses = Flux.just(
+				chunk(TestAssistantMessage.builder()
+					.content("Hello")
+					.properties(Map.of("first", true))
+					.marker("state")
+					.build()),
+				chunk(TestAssistantMessage.builder()
+					.content(" world")
+					.properties(Map.of("second", true))
+					.toolCalls(List.of(toolCall))
+					.marker("state")
+					.build()));
+
+		AtomicReference<ChatResponse> aggregated = new AtomicReference<>();
+		new MessageAggregator().aggregate(responses, aggregated::set).blockLast();
+
+		AssistantMessage output = aggregated.get().getResult().getOutput();
+		assertThat(output).isInstanceOf(TestAssistantMessage.class);
+		assertThat(((TestAssistantMessage) output).marker).isEqualTo("state");
+		assertThat(output.getText()).isEqualTo("Hello world");
+		assertThat(output.getMetadata()).containsEntry("first", true).containsEntry("second", true);
+		assertThat(output.getToolCalls()).containsExactly(toolCall);
+	}
+
+	@Test
+	void assistantMessageSubtypeSurvivesLaterPlainTerminalChunk() {
+		Flux<ChatResponse> responses = Flux.just(
+				chunk(TestAssistantMessage.builder().content("Hello").marker("state").build()),
+				chunk(AssistantMessage.builder().content(" world").build()));
+
+		AtomicReference<ChatResponse> aggregated = new AtomicReference<>();
+		new MessageAggregator().aggregate(responses, aggregated::set).blockLast();
+
+		AssistantMessage output = aggregated.get().getResult().getOutput();
+		assertThat(output).isInstanceOf(TestAssistantMessage.class);
+		assertThat(((TestAssistantMessage) output).marker).isEqualTo("state");
+		assertThat(output.getText()).isEqualTo("Hello world");
+	}
+
 	private static ChatResponse chunk(String text, RateLimit rateLimit) {
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().rateLimit(rateLimit).build();
 		return new ChatResponse(List.of(new Generation(new AssistantMessage(text))), metadata);
+	}
+
+	private static ChatResponse chunk(AssistantMessage message) {
+		return new ChatResponse(List.of(new Generation(message)));
+	}
+
+	private static final class TestAssistantMessage extends AssistantMessage {
+
+		private final String marker;
+
+		private TestAssistantMessage(String content, Map<String, Object> properties, List<ToolCall> toolCalls,
+				List<Media> media, String marker) {
+			super(content, properties, toolCalls, media);
+			this.marker = marker;
+		}
+
+		@Override
+		public Builder mutate() {
+			return builder().content(getText())
+				.properties(getMetadata())
+				.toolCalls(getToolCalls())
+				.media(getMedia())
+				.marker(this.marker);
+		}
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		private static final class Builder extends AssistantMessage.Builder<Builder> {
+
+			private String marker;
+
+			Builder marker(String marker) {
+				this.marker = marker;
+				return self();
+			}
+
+			@Override
+			public TestAssistantMessage build() {
+				return new TestAssistantMessage(this.content, this.properties, this.toolCalls, this.media, this.marker);
+			}
+
+		}
+
 	}
 
 	private static final class TestRateLimit implements RateLimit {


### PR DESCRIPTION
Fixes #6845

Preserve Bedrock Converse reasoning content in streaming responses so that extended thinking continues to work across tool-calling turns.

The streaming path was losing reasoning state in two places:

- `ConverseChatResponseStream` did not preserve `REASONING_CONTENT` deltas.
- `MessageAggregator` rebuilt the aggregated output as a plain `AssistantMessage`, losing provider-specific message state.

This change:

- Preserves reasoning text, signatures, and redacted content from Converse streaming responses.
- Preserves `AssistantMessage` subclasses during stream aggregation.
- Reuses the existing Bedrock-specific reasoning carriers and tool replay behavior introduced for the non-streaming path.
- Keeps the existing generic `AssistantMessage` API unchanged.

Tests cover streaming reasoning content and `AssistantMessage` subtype preservation during aggregation.