### PR TITLE
Fix NoSuchElementException in `GoogleGenAiChatModel` on empty response candidates

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -519,6 +519,9 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	}
 
 	protected List<Generation> responseCandidateToGeneration(Candidate candidate) {
+		if (candidate == null) {
+			return List.of();
+		}
 
 		// TODO - The candidateIndex (e.g. choice must be assigned to the generation).
 		int candidateIndex = candidate.index().orElse(0);
@@ -527,6 +530,19 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		Map<String, Object> messageMetadata = new HashMap<>();
 		messageMetadata.put("candidateIndex", candidateIndex);
 		messageMetadata.put("finishReason", candidateFinishReason);
+
+		// Safe Guard: Handle candidate responses with empty content (e.g., safety block
+		// or citation grounding chunks)
+		if (candidate.content().isEmpty()) {
+			AssistantMessage assistantMessage = AssistantMessage.builder()
+				.content("")
+				.properties(messageMetadata)
+				.build();
+			ChatGenerationMetadata chatGenerationMetadata = ChatGenerationMetadata.builder()
+				.finishReason(candidateFinishReason.toString())
+				.build();
+			return List.of(new Generation(assistantMessage, chatGenerationMetadata));
+		}
 
 		// Extract thought signatures from response parts if present
 		if (candidate.content().isPresent() && candidate.content().get().parts().isPresent()) {

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.google.genai.Client;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.FinishReason;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.chat.model.Generation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link GoogleGenAiChatModel}.
+ *
+ * @author Enrico Molino
+ */
+@ExtendWith(MockitoExtension.class)
+public class GoogleGenAiChatModelTests {
+
+	@Test
+	void responseCandidateToGeneration_whenContentIsEmpty_doesNotThrow() {
+		GoogleGenAiChatModel model = GoogleGenAiChatModel.builder()
+			.genAiClient(mock(Client.class))
+			.options(GoogleGenAiChatOptions.builder().model("gemini-1.5-pro").build())
+			.build();
+
+		Candidate candidate = mock(Candidate.class);
+		when(candidate.content()).thenReturn(Optional.empty());
+		when(candidate.index()).thenReturn(Optional.of(0));
+		FinishReason finishReason = new FinishReason(FinishReason.Known.STOP);
+		when(candidate.finishReason()).thenReturn(Optional.of(finishReason));
+
+		List<Generation> result = model.responseCandidateToGeneration(candidate);
+
+		assertThat(result).isNotNull();
+		assertThat(result).hasSize(1);
+		Generation generation = result.get(0);
+		assertThat(generation.getOutput()).isNotNull();
+		assertThat(generation.getOutput().getText()).isEmpty();
+		assertThat(generation.getOutput().getMetadata().get("candidateIndex")).isEqualTo(0);
+		assertThat(generation.getOutput().getMetadata().get("finishReason")).isEqualTo(finishReason);
+	}
+
+}


### PR DESCRIPTION
### Summary
This PR fixes an unhandled `java.util.NoSuchElementException: No value present` crash that occurs in `GoogleGenAiChatModel` when a response candidate contains empty content.

### Issue Description
When using `GoogleGenAiChatModel` with native Google Search Grounding (Web Search) enabled, or when Gemini triggers safety-blocked filters, the API response containing candidate structures can return empty content (i.e., `candidate.content().isPresent()` is `false`).

When this happens:
1. `isFunctionCall` evaluates to `false`.
2. The execution path falls into the `else` block of `responseCandidateToGeneration`.
3. Spring AI calls `candidate.content().get()` blindly without checking `.isPresent()`, throwing:
   ```
   java.util.NoSuchElementException: No value present
       at java.base/java.util.Optional.get(Unknown Source)
       at org.springframework.ai.google.genai.GoogleGenAiChatModel.responseCandidateToGeneration(GoogleGenAiChatModel.java:594)
   ```

### Fix Details
- Introduced a robust, early safeguard in `GoogleGenAiChatModel#responseCandidateToGeneration` to verify if `candidate.content().isEmpty()`.
- If empty, the method cleanly builds and returns an empty `Generation` alongside its metadata (including finish reason and candidate index), preventing any blind `.get()` calls or crashes.
- Added a full unit test suite `GoogleGenAiChatModelTests` checking this behavior with mocked candidates.
