### PR TITLE
#6832 configurable PgVectorStore distance type

### DIFF
--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgDistanceType.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgDistanceType.java
@@ -1,0 +1,4 @@
+package org.springframework.ai.vectorstore.pgvector;
+
+public record PgDistanceType(String name, String operator, String index, String similaritySearchSqlTemplate) {
+}

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
@@ -176,10 +176,21 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	private static final Log logger = LogFactory.getLog(PgVectorStore.class);
 
+	static final PgDistanceType EUCLIDEAN_DISTANCE = new PgDistanceType("EUCLIDEAN_DISTANCE", "<->",
+			"vector_l2_ops",
+			"SELECT *, embedding <-> ? AS distance FROM %s WHERE embedding <-> ? < ? %s ORDER BY distance LIMIT ? ");
+
+	static final PgDistanceType NEGATIVE_INNER_PRODUCT = new PgDistanceType("NEGATIVE_INNER_PRODUCT", "<#>",
+			"vector_ip_ops",
+			"SELECT *, (1 + (embedding <#> ?)) AS distance FROM %s WHERE (1 + (embedding <#> ?)) < ? %s ORDER BY distance LIMIT ? ");
+
+	static final PgDistanceType COSINE_DISTANCE = new PgDistanceType("COSINE_DISTANCE", "<=>",
+			"vector_cosine_ops",
+			"SELECT *, embedding <=> ? AS distance FROM %s WHERE embedding <=> ? < ? %s ORDER BY distance LIMIT ? ");
+
 	private static final Map<PgDistanceType, VectorStoreSimilarityMetric> SIMILARITY_TYPE_MAPPING = Map.of(
-			PgDistanceType.COSINE_DISTANCE, VectorStoreSimilarityMetric.COSINE, PgDistanceType.EUCLIDEAN_DISTANCE,
-			VectorStoreSimilarityMetric.EUCLIDEAN, PgDistanceType.NEGATIVE_INNER_PRODUCT,
-			VectorStoreSimilarityMetric.DOT);
+			COSINE_DISTANCE, VectorStoreSimilarityMetric.COSINE, EUCLIDEAN_DISTANCE,
+			VectorStoreSimilarityMetric.EUCLIDEAN, NEGATIVE_INNER_PRODUCT, VectorStoreSimilarityMetric.DOT);
 
 	public final FilterExpressionConverter filterExpressionConverter = new PgVectorFilterExpressionConverter();
 
@@ -370,7 +381,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 		PGvector queryEmbedding = getQueryEmbedding(request.getQuery());
 
 		return this.jdbcTemplate.query(
-				String.format(this.getDistanceType().similaritySearchSqlTemplate, getFullyQualifiedTableName(),
+				String.format(this.getDistanceType().similaritySearchSqlTemplate(), getFullyQualifiedTableName(),
 						jsonPathFilter),
 				this.documentRowMapper, queryEmbedding, queryEmbedding, distance, request.getTopK());
 	}
@@ -394,7 +405,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 	}
 
 	private String comparisonOperator() {
-		return this.getDistanceType().operator;
+		return this.getDistanceType().operator();
 	}
 
 	// ---------------------------------------------------------------------------------
@@ -453,7 +464,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 			this.jdbcTemplate.execute(String.format("""
 					CREATE INDEX IF NOT EXISTS %s ON %s USING %s (embedding %s)
 					""", this.getVectorIndexName(), this.getFullyQualifiedTableName(), this.createIndexMethod,
-					this.getDistanceType().index));
+					this.getDistanceType().index()));
 		}
 
 		validateTableSchemaIfEnabled();
@@ -574,43 +585,6 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	}
 
-	/**
-	 * Defaults to CosineDistance. But if vectors are normalized to length 1 (like OpenAI
-	 * embeddings), use inner product (NegativeInnerProduct) for best performance.
-	 */
-	public enum PgDistanceType {
-
-		// NOTE: works only if vectors are normalized to length 1 (like OpenAI
-		// embeddings), use inner product for best performance.
-		// The Sentence transformers are NOT normalized:
-		// https://github.com/UKPLab/sentence-transformers/issues/233
-		EUCLIDEAN_DISTANCE("<->", "vector_l2_ops",
-				"SELECT *, embedding <-> ? AS distance FROM %s WHERE embedding <-> ? < ? %s ORDER BY distance LIMIT ? "),
-
-		// NOTE: works only if vectors are normalized to length 1 (like OpenAI
-		// embeddings), use inner product for best performance.
-		// The Sentence transformers are NOT normalized:
-		// https://github.com/UKPLab/sentence-transformers/issues/233
-		NEGATIVE_INNER_PRODUCT("<#>", "vector_ip_ops",
-				"SELECT *, (1 + (embedding <#> ?)) AS distance FROM %s WHERE (1 + (embedding <#> ?)) < ? %s ORDER BY distance LIMIT ? "),
-
-		COSINE_DISTANCE("<=>", "vector_cosine_ops",
-				"SELECT *, embedding <=> ? AS distance FROM %s WHERE embedding <=> ? < ? %s ORDER BY distance LIMIT ? ");
-
-		public final String operator;
-
-		public final String index;
-
-		public final String similaritySearchSqlTemplate;
-
-		PgDistanceType(String operator, String index, String sqlTemplate) {
-			this.operator = operator;
-			this.index = index;
-			this.similaritySearchSqlTemplate = sqlTemplate;
-		}
-
-	}
-
 	private static class DocumentRowMapper implements RowMapper<Document> {
 
 		private static final String COLUMN_METADATA = "metadata";
@@ -668,7 +642,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 		private int dimensions = PgVectorStore.INVALID_EMBEDDING_DIMENSION;
 
-		private PgDistanceType distanceType = PgDistanceType.COSINE_DISTANCE;
+		private PgDistanceType distanceType = COSINE_DISTANCE;
 
 		private boolean removeExistingVectorStoreTable = false;
 

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreAutoTruncationIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreAutoTruncationIT.java
@@ -159,7 +159,7 @@ public class PgVectorStoreAutoTruncationIT {
 	public static class TestApplication {
 
 		@Value("${test.spring.ai.vectorstore.pgvector.distanceType}")
-		PgVectorStore.PgDistanceType distanceType;
+		PgDistanceType distanceType;
 
 		@Value("${test.spring.ai.vectorstore.pgvector.initializeSchema:true}")
 		boolean initializeSchema;

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreCustomNamesIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreCustomNamesIT.java
@@ -195,7 +195,6 @@ public class PgVectorStoreCustomNamesIT {
 				.vectorTableName(this.vectorTableName)
 				.vectorTableValidationsEnabled(this.schemaValidation)
 				.dimensions(this.dimensions)
-				.distanceType(PgVectorStore.PgDistanceType.COSINE_DISTANCE)
 				.removeExistingVectorStoreTable(true)
 				.indexType(PgIndexType.HNSW)
 				.initializeSchema(true)

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.pgvector;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link PgVectorStore} configurable distance type behavior.
+ *
+ * @author Spring AI Team
+ */
+class PgVectorStoreDistanceTypeTests {
+
+	public static final PgDistanceType CUSTOM_DISTANCE_TYPE = new PgDistanceType("CUSTOM", "<custom>", "custom_ops",
+			"SELECT CUSTOM ?");
+
+	@Test
+	void shouldUseCustomDistanceType() {
+		// Given
+		var jdbcTemplate = mock(JdbcTemplate.class);
+		var embeddingModel = mock(EmbeddingModel.class);
+
+		// When
+		var vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel)
+				.distanceType(CUSTOM_DISTANCE_TYPE)
+				.build();
+
+		// Then
+		assertThat(vectorStore.getDistanceType()).isEqualTo(CUSTOM_DISTANCE_TYPE);
+		assertThat(vectorStore.getDistanceType().operator()).isEqualTo("<custom>");
+		assertThat(vectorStore.getDistanceType().index()).isEqualTo("custom_ops");
+		assertThat(vectorStore.getDistanceType().similaritySearchSqlTemplate()).isEqualTo("SELECT CUSTOM ?");
+	}
+
+	@Test
+	void similaritySearchShouldUseConfiguredDistanceType() {
+		// Given
+		var jdbcTemplate = mock(JdbcTemplate.class);
+		var embeddingModel = mock(EmbeddingModel.class);
+		when(embeddingModel.dimensions()).thenReturn(3);
+		when(embeddingModel.embed(anyString())).thenReturn(new float[] { 0.1f, 0.2f, 0.3f });
+		when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(), any(), any(), any()))
+				.thenReturn(List.of());
+
+		var vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel)
+				.distanceType(CUSTOM_DISTANCE_TYPE)
+				.initializeSchema(false)
+				.build();
+
+		var request = SearchRequest.builder()
+				.query("test query")
+				.topK(5)
+				.similarityThresholdAll()
+				.build();
+
+		// When
+		vectorStore.doSimilaritySearch(request);
+
+		// Then
+		var sqlCaptor = ArgumentCaptor.forClass(String.class);
+		verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), any(), any(), any(), any());
+		String sql = sqlCaptor.getValue();
+
+		// Verify that the custom distance operator is used in the SQL
+		assertThat(sql).contains("SELECT CUSTOM ?")
+				.doesNotContain("<->","<=>","<#>");
+	}
+
+}

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreIT.java
@@ -486,7 +486,7 @@ public class PgVectorStoreIT extends BaseVectorStoreTests {
 	public static class TestApplication {
 
 		@Value("${test.spring.ai.vectorstore.pgvector.distanceType}")
-		PgVectorStore.PgDistanceType distanceType;
+		PgDistanceType distanceType;
 
 		@Value("${test.spring.ai.vectorstore.pgvector.initializeSchema:true}")
 		boolean initializeSchema;

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreObservationIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreObservationIT.java
@@ -187,7 +187,7 @@ public class PgVectorStoreObservationIT {
 		public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
 				ObservationRegistry observationRegistry) {
 			return PgVectorStore.builder(jdbcTemplate, embeddingModel)
-				.distanceType(PgVectorStore.PgDistanceType.COSINE_DISTANCE)
+				.distanceType(PgVectorStore.COSINE_DISTANCE)
 				.indexType(PgIndexType.HNSW)
 				.observationRegistry(observationRegistry)
 				.initializeSchema(true)


### PR DESCRIPTION
Making PgDistanceType configurable enables queries extensions. (e.g. [to implement access based on identities](https://github.com/crystal-processes/crp-flowable-springboot-sample/blob/451a7c807bd53f5bc8b1e3f73c472a3d0cbbb83c/src/main/java/org/springframework/ai/vectorstore/pgvector/IdentityAwarePgVectorStore.java#L353))