### PR TITLE
#6832 configurable PgVectorStore distance type

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/main/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/main/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStoreAutoConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link AutoConfiguration Auto-configuration} for PostgreSQL Vector Store.
@@ -86,10 +87,14 @@ public class PgVectorStoreAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public PgDistanceType distanceType(PgVectorStoreProperties properties) {
+		if (!StringUtils.hasText(properties.getDistanceType())) {
+			return PgVectorStore.COSINE_DISTANCE;
+		}
 		return switch (properties.getDistanceType()) {
 			case "EUCLIDEAN_DISTANCE" -> PgVectorStore.EUCLIDEAN_DISTANCE;
 			case "NEGATIVE_INNER_PRODUCT" -> PgVectorStore.NEGATIVE_INNER_PRODUCT;
-			default -> PgVectorStore.COSINE_DISTANCE;
+			case "COSINE_DISTANCE" -> PgVectorStore.COSINE_DISTANCE;
+			default -> throw new IllegalArgumentException("Unsupported distance type: " + properties.getDistanceType());
 		};
 	}
 

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/main/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/main/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStoreAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.vectorstore.SpringAIVectorStoreTypes;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationConvention;
+import org.springframework.ai.vectorstore.pgvector.PgDistanceType;
 import org.springframework.ai.vectorstore.pgvector.PgVectorStore;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -61,7 +62,7 @@ public class PgVectorStoreAutoConfiguration {
 	public PgVectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
 			PgVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
-			BatchingStrategy batchingStrategy) {
+			BatchingStrategy batchingStrategy, PgDistanceType distanceType) {
 
 		var initializeSchema = properties.isInitializeSchema();
 
@@ -71,7 +72,7 @@ public class PgVectorStoreAutoConfiguration {
 			.vectorTableName(properties.getTableName())
 			.vectorTableValidationsEnabled(properties.isSchemaValidation())
 			.dimensions(properties.getDimensions())
-			.distanceType(properties.getDistanceType())
+			.distanceType(distanceType)
 			.removeExistingVectorStoreTable(properties.isRemoveExistingVectorStoreTable())
 			.indexType(properties.getIndexType())
 			.initializeSchema(initializeSchema)
@@ -80,6 +81,16 @@ public class PgVectorStoreAutoConfiguration {
 			.batchingStrategy(batchingStrategy)
 			.maxDocumentBatchSize(properties.getMaxDocumentBatchSize())
 			.build();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public PgDistanceType distanceType(PgVectorStoreProperties properties) {
+		return switch (properties.getDistanceType()) {
+			case "EUCLIDEAN_DISTANCE" -> PgVectorStore.EUCLIDEAN_DISTANCE;
+			case "NEGATIVE_INNER_PRODUCT" -> PgVectorStore.NEGATIVE_INNER_PRODUCT;
+			default -> PgVectorStore.COSINE_DISTANCE;
+		};
 	}
 
 }

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/main/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/main/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStoreProperties.java
@@ -17,7 +17,6 @@
 package org.springframework.ai.vectorstore.pgvector.autoconfigure;
 
 import org.springframework.ai.vectorstore.pgvector.PgVectorStore;
-import org.springframework.ai.vectorstore.pgvector.PgVectorStore.PgDistanceType;
 import org.springframework.ai.vectorstore.pgvector.PgVectorStore.PgIndexType;
 import org.springframework.ai.vectorstore.properties.CommonVectorStoreProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -38,7 +37,7 @@ public class PgVectorStoreProperties extends CommonVectorStoreProperties {
 
 	private PgIndexType indexType = PgIndexType.HNSW;
 
-	private PgDistanceType distanceType = PgDistanceType.COSINE_DISTANCE;
+	private String distanceType="COSINE_DISTANCE";
 
 	private boolean removeExistingVectorStoreTable = false;
 
@@ -69,11 +68,11 @@ public class PgVectorStoreProperties extends CommonVectorStoreProperties {
 		this.indexType = createIndexMethod;
 	}
 
-	public PgDistanceType getDistanceType() {
+	public String getDistanceType() {
 		return this.distanceType;
 	}
 
-	public void setDistanceType(PgDistanceType distanceType) {
+	public void setDistanceType(String distanceType) {
 		this.distanceType = distanceType;
 	}
 

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/test/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStorePropertiesTests.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/test/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStorePropertiesTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.vectorstore.pgvector.autoconfigure;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.vectorstore.pgvector.PgVectorStore;
-import org.springframework.ai.vectorstore.pgvector.PgVectorStore.PgDistanceType;
 import org.springframework.ai.vectorstore.pgvector.PgVectorStore.PgIndexType;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +32,7 @@ public class PgVectorStorePropertiesTests {
 	public void defaultValues() {
 		var props = new PgVectorStoreProperties();
 		assertThat(props.getDimensions()).isEqualTo(PgVectorStore.INVALID_EMBEDDING_DIMENSION);
-		assertThat(props.getDistanceType()).isEqualTo(PgDistanceType.COSINE_DISTANCE);
+		assertThat(props.getDistanceType()).isEqualTo("COSINE_DISTANCE");
 		assertThat(props.getIndexType()).isEqualTo(PgIndexType.HNSW);
 		assertThat(props.isRemoveExistingVectorStoreTable()).isFalse();
 
@@ -48,7 +47,7 @@ public class PgVectorStorePropertiesTests {
 		var props = new PgVectorStoreProperties();
 
 		props.setDimensions(1536);
-		props.setDistanceType(PgDistanceType.EUCLIDEAN_DISTANCE);
+		props.setDistanceType("EUCLIDEAN_DISTANCE");
 		props.setIndexType(PgIndexType.IVFFLAT);
 		props.setRemoveExistingVectorStoreTable(true);
 
@@ -57,7 +56,7 @@ public class PgVectorStorePropertiesTests {
 		props.setTableName("my_vector_table");
 
 		assertThat(props.getDimensions()).isEqualTo(1536);
-		assertThat(props.getDistanceType()).isEqualTo(PgDistanceType.EUCLIDEAN_DISTANCE);
+		assertThat(props.getDistanceType()).isEqualTo("EUCLIDEAN_DISTANCE");
 		assertThat(props.getIndexType()).isEqualTo(PgIndexType.IVFFLAT);
 		assertThat(props.isRemoveExistingVectorStoreTable()).isTrue();
 

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgDistanceType.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgDistanceType.java
@@ -1,4 +1,50 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ai.vectorstore.pgvector;
 
-public record PgDistanceType(String name, String operator, String index, String similaritySearchSqlTemplate) {
+/**
+ * Interface representing a distance type for pgvector operations.
+ *
+ * @author Spring AI Team
+ */
+public interface PgDistanceType {
+
+	/**
+	 * Returns the name of the distance type.
+	 * @return the name
+	 */
+	String name();
+
+	/**
+	 * Returns the operator used in PostgreSQL queries.
+	 * @return the operator
+	 */
+	String operator();
+
+	/**
+	 * Returns the index type used for the vector index.
+	 * @return the index type
+	 */
+	String index();
+
+	/**
+	 * Returns the SQL template for similarity search queries.
+	 * @return the similarity search SQL template
+	 */
+	String similaritySearchSqlTemplate();
+
 }

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgDistanceType.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgDistanceType.java
@@ -19,7 +19,9 @@ package org.springframework.ai.vectorstore.pgvector;
 /**
  * Interface representing a distance type for pgvector operations.
  *
- * @author Spring AI Team
+ * @author Martin Grofcik
+ *
+ * @since 2.0.2
  */
 public interface PgDistanceType {
 

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgDistanceType.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgDistanceType.java
@@ -1,0 +1,4 @@
+package org.springframework.ai.vectorstore.pgvector;
+
+public record PgDistanceType(String name, String operator, String index, String similaritySearchSqlTemplate) {
+}

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
@@ -176,10 +176,21 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	private static final Log logger = LogFactory.getLog(PgVectorStore.class);
 
+	static final PgDistanceType EUCLIDEAN_DISTANCE = new PgDistanceType("EUCLIDEAN_DISTANCE", "<->",
+			"vector_l2_ops",
+			"SELECT *, embedding <-> ? AS distance FROM %s WHERE embedding <-> ? < ? %s ORDER BY distance LIMIT ? ");
+
+	static final PgDistanceType NEGATIVE_INNER_PRODUCT = new PgDistanceType("NEGATIVE_INNER_PRODUCT", "<#>",
+			"vector_ip_ops",
+			"SELECT *, (1 + (embedding <#> ?)) AS distance FROM %s WHERE (1 + (embedding <#> ?)) < ? %s ORDER BY distance LIMIT ? ");
+
+	static final PgDistanceType COSINE_DISTANCE = new PgDistanceType("COSINE_DISTANCE", "<=>",
+			"vector_cosine_ops",
+			"SELECT *, embedding <=> ? AS distance FROM %s WHERE embedding <=> ? < ? %s ORDER BY distance LIMIT ? ");
+
 	private static final Map<PgDistanceType, VectorStoreSimilarityMetric> SIMILARITY_TYPE_MAPPING = Map.of(
-			PgDistanceType.COSINE_DISTANCE, VectorStoreSimilarityMetric.COSINE, PgDistanceType.EUCLIDEAN_DISTANCE,
-			VectorStoreSimilarityMetric.EUCLIDEAN, PgDistanceType.NEGATIVE_INNER_PRODUCT,
-			VectorStoreSimilarityMetric.DOT);
+			COSINE_DISTANCE, VectorStoreSimilarityMetric.COSINE, EUCLIDEAN_DISTANCE,
+			VectorStoreSimilarityMetric.EUCLIDEAN, NEGATIVE_INNER_PRODUCT, VectorStoreSimilarityMetric.DOT);
 
 	public final FilterExpressionConverter filterExpressionConverter = new PgVectorFilterExpressionConverter();
 
@@ -370,7 +381,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 		PGvector queryEmbedding = getQueryEmbedding(request.getQuery());
 
 		return this.jdbcTemplate.query(
-				String.format(this.getDistanceType().similaritySearchSqlTemplate, getFullyQualifiedTableName(),
+				String.format(this.getDistanceType().similaritySearchSqlTemplate(), getFullyQualifiedTableName(),
 						jsonPathFilter),
 				this.documentRowMapper, queryEmbedding, queryEmbedding, distance, request.getTopK());
 	}
@@ -394,7 +405,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 	}
 
 	private String comparisonOperator() {
-		return this.getDistanceType().operator;
+		return this.getDistanceType().operator();
 	}
 
 	// ---------------------------------------------------------------------------------
@@ -453,7 +464,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 			this.jdbcTemplate.execute(String.format("""
 					CREATE INDEX IF NOT EXISTS %s ON %s USING %s (embedding %s)
 					""", this.getVectorIndexName(), this.getFullyQualifiedTableName(), this.createIndexMethod,
-					this.getDistanceType().index));
+					this.getDistanceType().index()));
 		}
 
 		validateTableSchemaIfEnabled();
@@ -574,43 +585,6 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	}
 
-	/**
-	 * Defaults to CosineDistance. But if vectors are normalized to length 1 (like OpenAI
-	 * embeddings), use inner product (NegativeInnerProduct) for best performance.
-	 */
-	public enum PgDistanceType {
-
-		// NOTE: works only if vectors are normalized to length 1 (like OpenAI
-		// embeddings), use inner product for best performance.
-		// The Sentence transformers are NOT normalized:
-		// https://github.com/UKPLab/sentence-transformers/issues/233
-		EUCLIDEAN_DISTANCE("<->", "vector_l2_ops",
-				"SELECT *, embedding <-> ? AS distance FROM %s WHERE embedding <-> ? < ? %s ORDER BY distance LIMIT ? "),
-
-		// NOTE: works only if vectors are normalized to length 1 (like OpenAI
-		// embeddings), use inner product for best performance.
-		// The Sentence transformers are NOT normalized:
-		// https://github.com/UKPLab/sentence-transformers/issues/233
-		NEGATIVE_INNER_PRODUCT("<#>", "vector_ip_ops",
-				"SELECT *, (1 + (embedding <#> ?)) AS distance FROM %s WHERE (1 + (embedding <#> ?)) < ? %s ORDER BY distance LIMIT ? "),
-
-		COSINE_DISTANCE("<=>", "vector_cosine_ops",
-				"SELECT *, embedding <=> ? AS distance FROM %s WHERE embedding <=> ? < ? %s ORDER BY distance LIMIT ? ");
-
-		public final String operator;
-
-		public final String index;
-
-		public final String similaritySearchSqlTemplate;
-
-		PgDistanceType(String operator, String index, String sqlTemplate) {
-			this.operator = operator;
-			this.index = index;
-			this.similaritySearchSqlTemplate = sqlTemplate;
-		}
-
-	}
-
 	private static class DocumentRowMapper implements RowMapper<Document> {
 
 		private static final String COLUMN_METADATA = "metadata";
@@ -668,7 +642,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 		private int dimensions = PgVectorStore.INVALID_EMBEDDING_DIMENSION;
 
-		private PgDistanceType distanceType = PgDistanceType.COSINE_DISTANCE;
+		private PgDistanceType distanceType = COSINE_DISTANCE;
 
 		private boolean removeExistingVectorStoreTable = false;
 

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
@@ -81,7 +81,7 @@ import org.springframework.util.StringUtils;
  * <pre>{@code
  * PgVectorStore vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel)
  *     .dimensions(1536) // Optional: defaults to model dimensions or 1536
- *     .distanceType(PgDistanceType.COSINE_DISTANCE)
+ *     .distanceType(PgVectorStore.COSINE_DISTANCE)
  *     .indexType(PgIndexType.HNSW)
  *     .build();
  *
@@ -107,7 +107,7 @@ import org.springframework.util.StringUtils;
  * PgVectorStore vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel)
  *     .schemaName("custom_schema")
  *     .vectorTableName("custom_vectors")
- *     .distanceType(PgDistanceType.NEGATIVE_INNER_PRODUCT)
+ *     .distanceType(PgVectorStore.NEGATIVE_INNER_PRODUCT)
  *     .removeExistingVectorStoreTable(true)
  *     .initializeSchema(true)
  *     .maxDocumentBatchSize(1000)
@@ -154,6 +154,7 @@ import org.springframework.util.StringUtils;
  * @author Jonghoon Park
  * @author Yanming Zhou
  * @author Siarhei Dudzin
+ * @author Martin Grofcik
  * @since 1.0.0
  */
 public class PgVectorStore extends AbstractObservationVectorStore implements InitializingBean {
@@ -179,60 +180,38 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 	/**
 	 * Default implementation of {@link PgDistanceType}.
 	 */
-	private static final class DefaultPgDistanceType implements PgDistanceType {
-
-		private final String name;
-
-		private final String operator;
-
-		private final String index;
-
-		private final String similaritySearchSqlTemplate;
-
-		DefaultPgDistanceType(String name, String operator, String index, String similaritySearchSqlTemplate) {
-			this.name = name;
-			this.operator = operator;
-			this.index = index;
-			this.similaritySearchSqlTemplate = similaritySearchSqlTemplate;
-		}
-
-		@Override
-		public String name() {
-			return this.name;
-		}
-
-		@Override
-		public String operator() {
-			return this.operator;
-		}
-
-		@Override
-		public String index() {
-			return this.index;
-		}
-
-		@Override
-		public String similaritySearchSqlTemplate() {
-			return this.similaritySearchSqlTemplate;
-		}
-
+	private record DefaultPgDistanceType(String name, String operator, String index,
+			String similaritySearchSqlTemplate) implements org.springframework.ai.vectorstore.pgvector.PgDistanceType {
 	}
 
-	public static final PgDistanceType EUCLIDEAN_DISTANCE = new DefaultPgDistanceType("EUCLIDEAN_DISTANCE", "<->",
-			"vector_l2_ops",
+	/*
+	 * @since 2.0.2
+	 */
+	public static final org.springframework.ai.vectorstore.pgvector.PgDistanceType EUCLIDEAN_DISTANCE = new DefaultPgDistanceType(
+			"EUCLIDEAN_DISTANCE", "<->", "vector_l2_ops",
 			"SELECT *, embedding <-> ? AS distance FROM %s WHERE embedding <-> ? < ? %s ORDER BY distance LIMIT ? ");
 
-	public static final PgDistanceType NEGATIVE_INNER_PRODUCT = new DefaultPgDistanceType("NEGATIVE_INNER_PRODUCT", "<#>",
-			"vector_ip_ops",
+	/*
+	 * @since 2.0.2
+	 */
+	public static final org.springframework.ai.vectorstore.pgvector.PgDistanceType NEGATIVE_INNER_PRODUCT = new DefaultPgDistanceType(
+			"NEGATIVE_INNER_PRODUCT", "<#>", "vector_ip_ops",
 			"SELECT *, (1 + (embedding <#> ?)) AS distance FROM %s WHERE (1 + (embedding <#> ?)) < ? %s ORDER BY distance LIMIT ? ");
 
-	public static final PgDistanceType COSINE_DISTANCE = new DefaultPgDistanceType("COSINE_DISTANCE", "<=>",
-			"vector_cosine_ops",
+	/**
+	 * Defaults to CosineDistance. But if vectors are normalized to length 1 (like
+	 * OpenAI * embeddings), use inner product (NegativeInnerProduct) for best
+	 * performance.
+	 *
+	 * @since 2.0.2
+	 */
+	public static final org.springframework.ai.vectorstore.pgvector.PgDistanceType COSINE_DISTANCE = new DefaultPgDistanceType(
+			"COSINE_DISTANCE", "<=>", "vector_cosine_ops",
 			"SELECT *, embedding <=> ? AS distance FROM %s WHERE embedding <=> ? < ? %s ORDER BY distance LIMIT ? ");
 
-	public static final Map<PgDistanceType, VectorStoreSimilarityMetric> SIMILARITY_TYPE_MAPPING = Map.of(
-			COSINE_DISTANCE, VectorStoreSimilarityMetric.COSINE, EUCLIDEAN_DISTANCE,
-			VectorStoreSimilarityMetric.EUCLIDEAN, NEGATIVE_INNER_PRODUCT, VectorStoreSimilarityMetric.DOT);
+	private static final Map<org.springframework.ai.vectorstore.pgvector.PgDistanceType, VectorStoreSimilarityMetric> SIMILARITY_TYPE_MAPPING = Map
+		.of(COSINE_DISTANCE, VectorStoreSimilarityMetric.COSINE, EUCLIDEAN_DISTANCE,
+				VectorStoreSimilarityMetric.EUCLIDEAN, NEGATIVE_INNER_PRODUCT, VectorStoreSimilarityMetric.DOT);
 
 	public final FilterExpressionConverter filterExpressionConverter = new PgVectorFilterExpressionConverter();
 
@@ -252,7 +231,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	private final int dimensions;
 
-	private final PgDistanceType distanceType;
+	private final org.springframework.ai.vectorstore.pgvector.PgDistanceType distanceType;
 
 	private final JsonMapper jsonMapper;
 
@@ -301,7 +280,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 		this.maxDocumentBatchSize = builder.maxDocumentBatchSize;
 	}
 
-	public PgDistanceType getDistanceType() {
+	public org.springframework.ai.vectorstore.pgvector.PgDistanceType getDistanceType() {
 		return this.distanceType;
 	}
 
@@ -627,6 +606,47 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	}
 
+	/**
+     * Defaults to CosineDistance. But if vectors are normalized to length 1 (like OpenAI
+     * embeddings), use inner product (NegativeInnerProduct) for best performance.
+     *
+     * @deprecated in favor of
+     * {@link org.springframework.ai.vectorstore.pgvector.PgDistanceType}.
+     */
+	@Deprecated(since = "2.0.2")
+	public enum PgDistanceType {
+
+		// NOTE: works only if vectors are normalized to length 1 (like OpenAI
+		// embeddings), use inner product for best performance.
+		// The Sentence transformers are NOT normalized:
+		// https://github.com/UKPLab/sentence-transformers/issues/233
+		EUCLIDEAN_DISTANCE("<->", "vector_l2_ops",
+				"SELECT *, embedding <-> ? AS distance FROM %s WHERE embedding <-> ? < ? %s ORDER BY distance LIMIT ? "),
+
+		// NOTE: works only if vectors are normalized to length 1 (like OpenAI
+		// embeddings), use inner product for best performance.
+		// The Sentence transformers are NOT normalized:
+		// https://github.com/UKPLab/sentence-transformers/issues/233
+		NEGATIVE_INNER_PRODUCT("<#>", "vector_ip_ops",
+				"SELECT *, (1 + (embedding <#> ?)) AS distance FROM %s WHERE (1 + (embedding <#> ?)) < ? %s ORDER BY distance LIMIT ? "),
+
+		COSINE_DISTANCE("<=>", "vector_cosine_ops",
+				"SELECT *, embedding <=> ? AS distance FROM %s WHERE embedding <=> ? < ? %s ORDER BY distance LIMIT ? ");
+
+		public final String operator;
+
+		public final String index;
+
+		public final String similaritySearchSqlTemplate;
+
+		PgDistanceType(String operator, String index, String sqlTemplate) {
+			this.operator = operator;
+			this.index = index;
+			this.similaritySearchSqlTemplate = sqlTemplate;
+		}
+
+	}
+
 	private static class DocumentRowMapper implements RowMapper<Document> {
 
 		private static final String COLUMN_METADATA = "metadata";
@@ -684,7 +704,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 		private int dimensions = PgVectorStore.INVALID_EMBEDDING_DIMENSION;
 
-		private PgDistanceType distanceType = COSINE_DISTANCE;
+		private org.springframework.ai.vectorstore.pgvector.PgDistanceType distanceType = COSINE_DISTANCE;
 
 		private boolean removeExistingVectorStoreTable = false;
 
@@ -725,7 +745,24 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 			return this;
 		}
 
+		/**
+		 * @deprecated in favor of
+		 * {@link #distanceType(org.springframework.ai.vectorstore.pgvector.PgDistanceType)}
+		 * @param distanceType distanceType to set.
+		 * @return builder.
+		 */
+		@Deprecated(since = "2.0.2")
 		public PgVectorStoreBuilder distanceType(PgDistanceType distanceType) {
+			this.distanceType = switch (distanceType) {
+				case EUCLIDEAN_DISTANCE -> PgVectorStore.EUCLIDEAN_DISTANCE;
+				case NEGATIVE_INNER_PRODUCT -> PgVectorStore.NEGATIVE_INNER_PRODUCT;
+				case COSINE_DISTANCE -> PgVectorStore.COSINE_DISTANCE;
+			};
+			return this;
+		}
+
+		public PgVectorStoreBuilder distanceType(
+				org.springframework.ai.vectorstore.pgvector.PgDistanceType distanceType) {
 			this.distanceType = distanceType;
 			return this;
 		}

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
@@ -218,19 +218,19 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	}
 
-	static final PgDistanceType EUCLIDEAN_DISTANCE = new DefaultPgDistanceType("EUCLIDEAN_DISTANCE", "<->",
+	public static final PgDistanceType EUCLIDEAN_DISTANCE = new DefaultPgDistanceType("EUCLIDEAN_DISTANCE", "<->",
 			"vector_l2_ops",
 			"SELECT *, embedding <-> ? AS distance FROM %s WHERE embedding <-> ? < ? %s ORDER BY distance LIMIT ? ");
 
-	static final PgDistanceType NEGATIVE_INNER_PRODUCT = new DefaultPgDistanceType("NEGATIVE_INNER_PRODUCT", "<#>",
+	public static final PgDistanceType NEGATIVE_INNER_PRODUCT = new DefaultPgDistanceType("NEGATIVE_INNER_PRODUCT", "<#>",
 			"vector_ip_ops",
 			"SELECT *, (1 + (embedding <#> ?)) AS distance FROM %s WHERE (1 + (embedding <#> ?)) < ? %s ORDER BY distance LIMIT ? ");
 
-	static final PgDistanceType COSINE_DISTANCE = new DefaultPgDistanceType("COSINE_DISTANCE", "<=>",
+	public static final PgDistanceType COSINE_DISTANCE = new DefaultPgDistanceType("COSINE_DISTANCE", "<=>",
 			"vector_cosine_ops",
 			"SELECT *, embedding <=> ? AS distance FROM %s WHERE embedding <=> ? < ? %s ORDER BY distance LIMIT ? ");
 
-	private static final Map<PgDistanceType, VectorStoreSimilarityMetric> SIMILARITY_TYPE_MAPPING = Map.of(
+	public static final Map<PgDistanceType, VectorStoreSimilarityMetric> SIMILARITY_TYPE_MAPPING = Map.of(
 			COSINE_DISTANCE, VectorStoreSimilarityMetric.COSINE, EUCLIDEAN_DISTANCE,
 			VectorStoreSimilarityMetric.EUCLIDEAN, NEGATIVE_INNER_PRODUCT, VectorStoreSimilarityMetric.DOT);
 

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
@@ -176,15 +176,57 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	private static final Log logger = LogFactory.getLog(PgVectorStore.class);
 
-	static final PgDistanceType EUCLIDEAN_DISTANCE = new PgDistanceType("EUCLIDEAN_DISTANCE", "<->",
+	/**
+	 * Default implementation of {@link PgDistanceType}.
+	 */
+	private static final class DefaultPgDistanceType implements PgDistanceType {
+
+		private final String name;
+
+		private final String operator;
+
+		private final String index;
+
+		private final String similaritySearchSqlTemplate;
+
+		DefaultPgDistanceType(String name, String operator, String index, String similaritySearchSqlTemplate) {
+			this.name = name;
+			this.operator = operator;
+			this.index = index;
+			this.similaritySearchSqlTemplate = similaritySearchSqlTemplate;
+		}
+
+		@Override
+		public String name() {
+			return this.name;
+		}
+
+		@Override
+		public String operator() {
+			return this.operator;
+		}
+
+		@Override
+		public String index() {
+			return this.index;
+		}
+
+		@Override
+		public String similaritySearchSqlTemplate() {
+			return this.similaritySearchSqlTemplate;
+		}
+
+	}
+
+	static final PgDistanceType EUCLIDEAN_DISTANCE = new DefaultPgDistanceType("EUCLIDEAN_DISTANCE", "<->",
 			"vector_l2_ops",
 			"SELECT *, embedding <-> ? AS distance FROM %s WHERE embedding <-> ? < ? %s ORDER BY distance LIMIT ? ");
 
-	static final PgDistanceType NEGATIVE_INNER_PRODUCT = new PgDistanceType("NEGATIVE_INNER_PRODUCT", "<#>",
+	static final PgDistanceType NEGATIVE_INNER_PRODUCT = new DefaultPgDistanceType("NEGATIVE_INNER_PRODUCT", "<#>",
 			"vector_ip_ops",
 			"SELECT *, (1 + (embedding <#> ?)) AS distance FROM %s WHERE (1 + (embedding <#> ?)) < ? %s ORDER BY distance LIMIT ? ");
 
-	static final PgDistanceType COSINE_DISTANCE = new PgDistanceType("COSINE_DISTANCE", "<=>",
+	static final PgDistanceType COSINE_DISTANCE = new DefaultPgDistanceType("COSINE_DISTANCE", "<=>",
 			"vector_cosine_ops",
 			"SELECT *, embedding <=> ? AS distance FROM %s WHERE embedding <=> ? < ? %s ORDER BY distance LIMIT ? ");
 

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreAutoTruncationIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreAutoTruncationIT.java
@@ -159,7 +159,7 @@ public class PgVectorStoreAutoTruncationIT {
 	public static class TestApplication {
 
 		@Value("${test.spring.ai.vectorstore.pgvector.distanceType}")
-		PgVectorStore.PgDistanceType distanceType;
+		PgDistanceType distanceType;
 
 		@Value("${test.spring.ai.vectorstore.pgvector.initializeSchema:true}")
 		boolean initializeSchema;

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreCustomNamesIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreCustomNamesIT.java
@@ -195,7 +195,6 @@ public class PgVectorStoreCustomNamesIT {
 				.vectorTableName(this.vectorTableName)
 				.vectorTableValidationsEnabled(this.schemaValidation)
 				.dimensions(this.dimensions)
-				.distanceType(PgVectorStore.PgDistanceType.COSINE_DISTANCE)
 				.removeExistingVectorStoreTable(true)
 				.indexType(PgIndexType.HNSW)
 				.initializeSchema(true)

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.*;
  */
 class PgVectorStoreDistanceTypeTests {
 
-	public static final TestPgDistanceType CUSTOM_DISTANCE_TYPE = new TestPgDistanceType("CUSTOM", "<custom>",
+	private static final TestPgDistanceType CUSTOM_DISTANCE_TYPE = new TestPgDistanceType("CUSTOM", "<custom>",
 			"custom_ops", "SELECT * CUSTOM ?");
 
 	/**

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
@@ -33,12 +33,68 @@ import static org.mockito.Mockito.*;
 /**
  * Unit tests for {@link PgVectorStore} configurable distance type behavior.
  *
- * @author Spring AI Team
  */
 class PgVectorStoreDistanceTypeTests {
 
-	public static final PgDistanceType CUSTOM_DISTANCE_TYPE = new PgDistanceType("CUSTOM", "<custom>", "custom_ops",
-			"SELECT CUSTOM ?");
+	public static final TestPgDistanceType CUSTOM_DISTANCE_TYPE = new TestPgDistanceType("CUSTOM", "<custom>", "custom_ops",
+			"SELECT * CUSTOM ?");
+
+	/**
+	 * Test implementation of {@link PgDistanceType}.
+	 */
+	private static class TestPgDistanceType implements PgDistanceType {
+
+		private final String name;
+
+		private final String operator;
+
+		private final String index;
+
+		private final String similaritySearchSqlTemplate;
+
+		TestPgDistanceType(String name, String operator, String index, String similaritySearchSqlTemplate) {
+			this.name = name;
+			this.operator = operator;
+			this.index = index;
+			this.similaritySearchSqlTemplate = similaritySearchSqlTemplate;
+		}
+
+		@Override
+		public String name() {
+			return this.name;
+		}
+
+		@Override
+		public String operator() {
+			return this.operator;
+		}
+
+		@Override
+		public String index() {
+			return this.index;
+		}
+
+		@Override
+		public String similaritySearchSqlTemplate() {
+			return this.similaritySearchSqlTemplate;
+		}
+
+	}
+
+	@Test
+	void shouldUseCosineDistanceByDefault() {
+		// Given
+		var jdbcTemplate = mock(JdbcTemplate.class);
+		var embeddingModel = mock(EmbeddingModel.class);
+
+		// When
+		var vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel).build();
+
+		// Then
+		assertThat(vectorStore.getDistanceType()).isEqualTo(PgVectorStore.COSINE_DISTANCE);
+		assertThat(vectorStore.getDistanceType().operator()).isEqualTo("<=>");
+		assertThat(vectorStore.getDistanceType().index()).isEqualTo("vector_cosine_ops");
+	}
 
 	@Test
 	void shouldUseCustomDistanceType() {
@@ -55,11 +111,11 @@ class PgVectorStoreDistanceTypeTests {
 		assertThat(vectorStore.getDistanceType()).isEqualTo(CUSTOM_DISTANCE_TYPE);
 		assertThat(vectorStore.getDistanceType().operator()).isEqualTo("<custom>");
 		assertThat(vectorStore.getDistanceType().index()).isEqualTo("custom_ops");
-		assertThat(vectorStore.getDistanceType().similaritySearchSqlTemplate()).isEqualTo("SELECT CUSTOM ?");
 	}
 
+
 	@Test
-	void similaritySearchShouldUseConfiguredDistanceType() {
+	void similaritySearchShouldUseConfiguredDistanceTypeOperator() {
 		// Given
 		var jdbcTemplate = mock(JdbcTemplate.class);
 		var embeddingModel = mock(EmbeddingModel.class);
@@ -88,7 +144,7 @@ class PgVectorStoreDistanceTypeTests {
 		String sql = sqlCaptor.getValue();
 
 		// Verify that the custom distance operator is used in the SQL
-		assertThat(sql).contains("SELECT CUSTOM ?")
+		assertThat(sql).contains("SELECT * CUSTOM ?")
 				.doesNotContain("<->","<=>","<#>");
 	}
 

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
@@ -36,48 +36,15 @@ import static org.mockito.Mockito.*;
  */
 class PgVectorStoreDistanceTypeTests {
 
-	public static final TestPgDistanceType CUSTOM_DISTANCE_TYPE = new TestPgDistanceType("CUSTOM", "<custom>", "custom_ops",
-			"SELECT * CUSTOM ?");
+	public static final TestPgDistanceType CUSTOM_DISTANCE_TYPE = new TestPgDistanceType("CUSTOM", "<custom>",
+			"custom_ops", "SELECT * CUSTOM ?");
 
 	/**
 	 * Test implementation of {@link PgDistanceType}.
 	 */
-	private static class TestPgDistanceType implements PgDistanceType {
+		private record TestPgDistanceType(String name, String operator, String index,
+										  String similaritySearchSqlTemplate) implements PgDistanceType {
 
-		private final String name;
-
-		private final String operator;
-
-		private final String index;
-
-		private final String similaritySearchSqlTemplate;
-
-		TestPgDistanceType(String name, String operator, String index, String similaritySearchSqlTemplate) {
-			this.name = name;
-			this.operator = operator;
-			this.index = index;
-			this.similaritySearchSqlTemplate = similaritySearchSqlTemplate;
-		}
-
-		@Override
-		public String name() {
-			return this.name;
-		}
-
-		@Override
-		public String operator() {
-			return this.operator;
-		}
-
-		@Override
-		public String index() {
-			return this.index;
-		}
-
-		@Override
-		public String similaritySearchSqlTemplate() {
-			return this.similaritySearchSqlTemplate;
-		}
 
 	}
 
@@ -104,15 +71,14 @@ class PgVectorStoreDistanceTypeTests {
 
 		// When
 		var vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel)
-				.distanceType(CUSTOM_DISTANCE_TYPE)
-				.build();
+			.distanceType(CUSTOM_DISTANCE_TYPE)
+			.build();
 
 		// Then
 		assertThat(vectorStore.getDistanceType()).isEqualTo(CUSTOM_DISTANCE_TYPE);
 		assertThat(vectorStore.getDistanceType().operator()).isEqualTo("<custom>");
 		assertThat(vectorStore.getDistanceType().index()).isEqualTo("custom_ops");
 	}
-
 
 	@Test
 	void similaritySearchShouldUseConfiguredDistanceTypeOperator() {
@@ -121,19 +87,14 @@ class PgVectorStoreDistanceTypeTests {
 		var embeddingModel = mock(EmbeddingModel.class);
 		when(embeddingModel.dimensions()).thenReturn(3);
 		when(embeddingModel.embed(anyString())).thenReturn(new float[] { 0.1f, 0.2f, 0.3f });
-		when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(), any(), any(), any()))
-				.thenReturn(List.of());
+		when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(), any(), any(), any())).thenReturn(List.of());
 
 		var vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel)
-				.distanceType(CUSTOM_DISTANCE_TYPE)
-				.initializeSchema(false)
-				.build();
+			.distanceType(CUSTOM_DISTANCE_TYPE)
+			.initializeSchema(false)
+			.build();
 
-		var request = SearchRequest.builder()
-				.query("test query")
-				.topK(5)
-				.similarityThresholdAll()
-				.build();
+		var request = SearchRequest.builder().query("test query").topK(5).similarityThresholdAll().build();
 
 		// When
 		vectorStore.doSimilaritySearch(request);
@@ -144,8 +105,7 @@ class PgVectorStoreDistanceTypeTests {
 		String sql = sqlCaptor.getValue();
 
 		// Verify that the custom distance operator is used in the SQL
-		assertThat(sql).contains("SELECT * CUSTOM ?")
-				.doesNotContain("<->","<=>","<#>");
+		assertThat(sql).contains("SELECT * CUSTOM ?").doesNotContain("<->", "<=>", "<#>");
 	}
 
 }

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreDistanceTypeTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.pgvector;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link PgVectorStore} configurable distance type behavior.
+ *
+ * @author Spring AI Team
+ */
+class PgVectorStoreDistanceTypeTests {
+
+	public static final PgDistanceType CUSTOM_DISTANCE_TYPE = new PgDistanceType("CUSTOM", "<custom>", "custom_ops",
+			"SELECT CUSTOM ?");
+
+	@Test
+	void shouldUseCustomDistanceType() {
+		// Given
+		var jdbcTemplate = mock(JdbcTemplate.class);
+		var embeddingModel = mock(EmbeddingModel.class);
+
+		// When
+		var vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel)
+				.distanceType(CUSTOM_DISTANCE_TYPE)
+				.build();
+
+		// Then
+		assertThat(vectorStore.getDistanceType()).isEqualTo(CUSTOM_DISTANCE_TYPE);
+		assertThat(vectorStore.getDistanceType().operator()).isEqualTo("<custom>");
+		assertThat(vectorStore.getDistanceType().index()).isEqualTo("custom_ops");
+		assertThat(vectorStore.getDistanceType().similaritySearchSqlTemplate()).isEqualTo("SELECT CUSTOM ?");
+	}
+
+	@Test
+	void similaritySearchShouldUseConfiguredDistanceType() {
+		// Given
+		var jdbcTemplate = mock(JdbcTemplate.class);
+		var embeddingModel = mock(EmbeddingModel.class);
+		when(embeddingModel.dimensions()).thenReturn(3);
+		when(embeddingModel.embed(anyString())).thenReturn(new float[] { 0.1f, 0.2f, 0.3f });
+		when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(), any(), any(), any()))
+				.thenReturn(List.of());
+
+		var vectorStore = PgVectorStore.builder(jdbcTemplate, embeddingModel)
+				.distanceType(CUSTOM_DISTANCE_TYPE)
+				.initializeSchema(false)
+				.build();
+
+		var request = SearchRequest.builder()
+				.query("test query")
+				.topK(5)
+				.similarityThresholdAll()
+				.build();
+
+		// When
+		vectorStore.doSimilaritySearch(request);
+
+		// Then
+		var sqlCaptor = ArgumentCaptor.forClass(String.class);
+		verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), any(), any(), any(), any());
+		String sql = sqlCaptor.getValue();
+
+		// Verify that the custom distance operator is used in the SQL
+		assertThat(sql).contains("SELECT CUSTOM ?")
+				.doesNotContain("<->","<=>","<#>");
+	}
+
+}

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreIT.java
@@ -486,7 +486,7 @@ public class PgVectorStoreIT extends BaseVectorStoreTests {
 	public static class TestApplication {
 
 		@Value("${test.spring.ai.vectorstore.pgvector.distanceType}")
-		PgVectorStore.PgDistanceType distanceType;
+		PgDistanceType distanceType;
 
 		@Value("${test.spring.ai.vectorstore.pgvector.initializeSchema:true}")
 		boolean initializeSchema;

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreObservationIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreObservationIT.java
@@ -187,7 +187,7 @@ public class PgVectorStoreObservationIT {
 		public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
 				ObservationRegistry observationRegistry) {
 			return PgVectorStore.builder(jdbcTemplate, embeddingModel)
-				.distanceType(PgVectorStore.PgDistanceType.COSINE_DISTANCE)
+				.distanceType(PgVectorStore.COSINE_DISTANCE)
 				.indexType(PgIndexType.HNSW)
 				.observationRegistry(observationRegistry)
 				.initializeSchema(true)


### PR DESCRIPTION
Making PgDistanceType configurable enables queries extensions. (e.g. [to implement access based on identities](https://github.com/crystal-processes/crp-flowable-springboot-sample/blob/451a7c807bd53f5bc8b1e3f73c472a3d0cbbb83c/src/main/java/org/springframework/ai/vectorstore/pgvector/IdentityAwarePgVectorStore.java#L353))