### PR TITLE
Backfill `additionalProperties: false` in OpenAI strict tool schemas

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1054,12 +1054,16 @@ public final class OpenAiChatModel implements ChatModel {
 	/**
 	 * Rewrites an object schema in place to satisfy OpenAI's strict function-calling
 	 * mode: every property must be listed in "required", with optionality expressed via a
-	 * nullable type rather than omission from "required". {@link JsonSchemaGenerator}
+	 * nullable type rather than omission from "required", and every object level must pin
+	 * {@code "additionalProperties"} to {@code false}. {@link JsonSchemaGenerator}
 	 * produces conventional JSON Schema instead - it omits
 	 * {@code @ToolParam(required = false)} properties from "required" - so this widens
 	 * the type of each such property to also accept {@code null} and backfills "required"
-	 * with every property key. Recurses into nested object/array-item schemas and
-	 * {@code $defs} definitions so their own optional properties are fixed up too.
+	 * with every property key. Schemas from other sources (MCP servers, hand-written
+	 * inputSchema JSON) may also lack "additionalProperties", so it is backfilled with
+	 * {@code false} wherever absent; an explicit value is preserved. Recurses into nested
+	 * object/array-item schemas and {@code $defs} definitions so their own optional
+	 * properties are fixed up too.
 	 */
 	@SuppressWarnings("unchecked")
 	private static void applyStrictModeRequirements(Map<String, Object> schema) {
@@ -1071,7 +1075,13 @@ public final class OpenAiChatModel implements ChatModel {
 			}
 		}
 
-		if (!(schema.get("properties") instanceof Map<?, ?> properties) || properties.isEmpty()) {
+		if (!(schema.get("properties") instanceof Map<?, ?> properties)) {
+			return;
+		}
+
+		schema.putIfAbsent("additionalProperties", false);
+
+		if (properties.isEmpty()) {
 			return;
 		}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -1385,6 +1385,144 @@ class OpenAiChatModelTests {
 	}
 
 	@Test
+	void toolStrictTrueBackfillsAdditionalPropertiesFalseAtEveryObjectLevel() {
+		ToolCallingManager mockToolCallingManager = mock(ToolCallingManager.class);
+
+		// Schemas from MCP servers or hand-written inputSchema JSON typically lack
+		// "additionalProperties", which OpenAI strict mode requires to be false on
+		// every object level.
+		ToolDefinition toolDefinition = ToolDefinition.builder()
+			.name("get_weather")
+			.description("Get weather")
+			.inputSchema("""
+					{
+						"type": "object",
+						"$defs": {
+							"Address": {
+								"type": "object",
+								"properties": { "city": { "type": "string" } },
+								"required": ["city"]
+							}
+						},
+						"properties": {
+							"location": { "type": "string" },
+							"details": {
+								"type": "object",
+								"properties": { "zip": { "type": "string" } },
+								"required": ["zip"]
+							},
+							"tags": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": { "name": { "type": "string" } },
+									"required": ["name"]
+								}
+							}
+						},
+						"required": ["location", "details", "tags"]
+					}
+					""")
+			.build();
+
+		when(mockToolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of(toolDefinition));
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gpt-4.1").strict(true).build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.toolCallingManager(mockToolCallingManager)
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), false);
+
+		FunctionDefinition functionDef = request.tools().orElseThrow().get(0).function().orElseThrow().function();
+		Map<String, JsonValue> parameters = functionDef.parameters().orElseThrow()._additionalProperties();
+
+		assertThat(parameters.get("additionalProperties").convert(Boolean.class)).isFalse();
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> properties = parameters.get("properties").convert(Map.class);
+		@SuppressWarnings("unchecked")
+		Map<String, Object> detailsSchema = (Map<String, Object>) properties.get("details");
+		assertThat(detailsSchema.get("additionalProperties")).isEqualTo(false);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> tagsSchema = (Map<String, Object>) properties.get("tags");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> tagsItemsSchema = (Map<String, Object>) tagsSchema.get("items");
+		assertThat(tagsItemsSchema.get("additionalProperties")).isEqualTo(false);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> defs = parameters.get("$defs").convert(Map.class);
+		@SuppressWarnings("unchecked")
+		Map<String, Object> addressSchema = (Map<String, Object>) defs.get("Address");
+		assertThat(addressSchema.get("additionalProperties")).isEqualTo(false);
+	}
+
+	@Test
+	void toolStrictTruePreservesExplicitAdditionalProperties() {
+		ToolCallingManager mockToolCallingManager = mock(ToolCallingManager.class);
+
+		// A Map<K,V>-style schema declares "additionalProperties" as a type reference;
+		// the strict-mode rewrite must not clobber an explicit value.
+		ToolDefinition toolDefinition = ToolDefinition.builder()
+			.name("get_weather")
+			.description("Get weather")
+			.inputSchema(
+					"{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":{\"type\":\"string\"}}")
+			.build();
+
+		when(mockToolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of(toolDefinition));
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gpt-4.1").strict(true).build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.toolCallingManager(mockToolCallingManager)
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), false);
+
+		FunctionDefinition functionDef = request.tools().orElseThrow().get(0).function().orElseThrow().function();
+		Map<String, JsonValue> parameters = functionDef.parameters().orElseThrow()._additionalProperties();
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> explicitAdditionalProperties = parameters.get("additionalProperties").convert(Map.class);
+		assertThat(explicitAdditionalProperties).isEqualTo(Map.of("type", "string"));
+	}
+
+	@Test
+	void toolStrictFalseLeavesAdditionalPropertiesAbsent() {
+		ToolCallingManager mockToolCallingManager = mock(ToolCallingManager.class);
+
+		ToolDefinition toolDefinition = ToolDefinition.builder()
+			.name("get_weather")
+			.description("Get weather")
+			.inputSchema("{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}}}")
+			.build();
+
+		when(mockToolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of(toolDefinition));
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("gpt-4.1").strict(false).build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.toolCallingManager(mockToolCallingManager)
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(new Prompt("test", options), false);
+
+		FunctionDefinition functionDef = request.tools().orElseThrow().get(0).function().orElseThrow().function();
+		Map<String, JsonValue> parameters = functionDef.parameters().orElseThrow()._additionalProperties();
+
+		assertThat(parameters).doesNotContainKey("additionalProperties");
+	}
+
+	@Test
 	void toolStrictFalseOverrideAtRequestLevel() {
 		ToolCallingManager mockToolCallingManager = mock(ToolCallingManager.class);
 


### PR DESCRIPTION
TLDR; When a caller turns on OpenAI's strict tool-calling mode, Spring AI rewrites each tool's JSON schema to meet OpenAI's strict-mode contract but it only handles half of it. It fills in the "required" list and makes optional fields nullable, yet never adds `additionalProperties: false`, which OpenAI also demands on every object in the schema. Tools whose schemas were generated by Spring AI happen to work because the generator adds it earlier, but tools from MCP servers or with hand-written schemas get rejected by the OpenAI API. This change makes the strict-mode rewrite fill in `additionalProperties: false` wherever it is missing.

## Problem

`OpenAiChatModel#applyStrictModeRequirements` rewrites a tool's input schema when `OpenAiChatOptions#strict(true)` is set: it backfills `required` with every property key and widens previously optional properties to nullable types, recursing into `$defs`, nested object properties, and array items.

OpenAI's strict function-calling mode additionally requires `additionalProperties: false` on every object level, and rejects requests otherwise with:

> Invalid schema for function '...': 'additionalProperties' is required to be supplied and to be false.

The rewrite never emits it. Schemas produced by `JsonSchemaGenerator` are unaffected because `forbidAdditionalProperties` already adds it recursively by default — which is why the gap is invisible on the `@Tool`/`FunctionToolCallback` path. Any schema from another source hits the 400 under strict mode:

- MCP tool schemas (servers rarely emit `additionalProperties: false`)
- hand-written `ToolDefinition#inputSchema` JSON
- schemas generated with `SchemaOption.ALLOW_ADDITIONAL_PROPERTIES_BY_DEFAULT`

See #4422