### PR TITLE
Allow decorating the tool search tool callback

### DIFF
--- a/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
+++ b/advisors/spring-ai-tool-search-advisor/src/main/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisor.java
@@ -139,6 +139,25 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 		return "ToolSearchToolCallingAdvisor";
 	}
 
+	/**
+	 * Returns the tool callback backing the built-in tool search tool.
+	 * <p>
+	 * Subclasses may override this to decorate the callback, for example to report the
+	 * search to a UI alongside the tool calls that follow it, or to record metrics.
+	 * Without a decorated callback the search is the one tool call an application cannot
+	 * observe, because it is the one tool the application does not supply.
+	 * <p>
+	 * The tool set bound to each iteration and the tool name that
+	 * {@code extractToolNameReferences} looks for both come from this method, so an
+	 * override that renames the tool stays self-consistent. Implementations should return
+	 * the same instance on every call.
+	 * @return the tool search tool callback
+	 * @since 2.0.2
+	 */
+	protected ToolCallback toolSearchToolCallback() {
+		return this.toolSearchToolCallback;
+	}
+
 	// -------------------------------------------------------------------------
 	// Sync hooks
 	// -------------------------------------------------------------------------
@@ -246,7 +265,7 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 		ToolCallingChatOptions toolOptions = Objects
 			.requireNonNull((ToolCallingChatOptions) chatClientRequest.prompt().getOptions());
 
-		Set<ToolCallback> selectedToolCallbacks = new HashSet<>(List.of(this.toolSearchToolCallback));
+		Set<ToolCallback> selectedToolCallbacks = new HashSet<>(List.of(this.toolSearchToolCallback()));
 
 		var cachedToolCallbacks = (Map<String, ToolCallback>) chatClientRequest.context()
 			.get(CACHED_TOOL_CALLBACKS_KEY);
@@ -297,7 +316,7 @@ public class ToolSearchToolCallingAdvisor extends ToolCallingAdvisor {
 			.filter(m -> m.getMessageType() == MessageType.TOOL)
 			.map(m -> ((ToolResponseMessage) m).getResponses()
 				.stream()
-				.filter(r -> r.name().equalsIgnoreCase(this.toolSearchToolCallback.getToolDefinition().name()))
+				.filter(r -> r.name().equalsIgnoreCase(this.toolSearchToolCallback().getToolDefinition().name()))
 				.toList())
 			.filter(responses -> !responses.isEmpty())
 			.toList();

--- a/advisors/spring-ai-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisorCallTests.java
+++ b/advisors/spring-ai-tool-search-advisor/src/test/java/org/springframework/ai/chat/client/advisor/toolsearch/ToolSearchToolCallingAdvisorCallTests.java
@@ -82,6 +82,8 @@ public class ToolSearchToolCallingAdvisorCallTests {
 	@Mock
 	private ToolIndex toolIndex;
 
+	private static final String DECORATED_TOOL_NAME = "decoratedToolSearchTool";
+
 	@Test
 	void whenToolIndexIsNullThenThrow() {
 		assertThatThrownBy(() -> ToolSearchToolCallingAdvisor.builder().build())
@@ -607,6 +609,61 @@ public class ToolSearchToolCallingAdvisorCallTests {
 	}
 
 	@Test
+	void overriddenToolSearchToolCallbackIsBoundAndDrivesReferenceExtraction() {
+		DecoratingAdvisor advisor = new DecoratingAdvisor(this.toolCallingManager, this.toolIndex);
+
+		ToolCallback weatherTool = mock(ToolCallback.class);
+		ToolDefinition weatherToolDefinition = DefaultToolDefinition.builder()
+			.name("weatherTool")
+			.description("Gets weather")
+			.inputSchema("{}")
+			.build();
+		when(weatherTool.getToolDefinition()).thenReturn(weatherToolDefinition);
+
+		TestToolCallingChatOptions toolOptions = new TestToolCallingChatOptions();
+		toolOptions.setToolCallbacks(List.of(weatherTool));
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class)))
+			.thenReturn(List.of(weatherToolDefinition));
+
+		// The search response carries the decorated tool's name, not the built-in one.
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id1", DECORATED_TOOL_NAME, "[\"weatherTool\"]")))
+			.build();
+
+		Map<String, Object> context = new ConcurrentHashMap<>();
+		context.put(ChatMemory.CONVERSATION_ID, "test-session-id");
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(new Prompt(List.of(new UserMessage("test"), toolResponseMessage), toolOptions))
+			.build()
+			.mutate()
+			.context(context)
+			.build();
+
+		ChatClientRequest[] capturedRequest = new ChatClientRequest[1];
+		CallAdvisor capturingAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			capturedRequest[0] = req;
+			return createMockResponse(false);
+		});
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, capturingAdvisor))
+			.build();
+
+		advisor.adviseCall(request, realChain);
+
+		assertThat(capturedRequest[0]).isNotNull();
+		ToolCallingChatOptions capturedOptions = (ToolCallingChatOptions) capturedRequest[0].prompt().getOptions();
+
+		// The bound search tool is the override rather than the built-in callback, and
+		// reference extraction matched the override's name, so the searched tool was
+		// bound
+		// too. Matching against the built-in name would have found no search response.
+		assertThat(capturedOptions.getToolCallbacks()).contains(advisor.decorated);
+		assertThat(capturedOptions.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder(DECORATED_TOOL_NAME, "weatherTool");
+	}
+
+	@Test
 	void toolSearchToolUsesLlmMaxResultsOverAdvisorDefault() {
 		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
 			.toolCallingManager(this.toolCallingManager)
@@ -889,6 +946,47 @@ public class ToolSearchToolCallingAdvisorCallTests {
 
 	private ChatClientResponse createMockResponse(boolean hasToolCalls) {
 		return createMockResponse(hasToolCalls, new ConcurrentHashMap<>());
+	}
+
+	/**
+	 * Wraps the built-in search tool the way an application that renders tool calls
+	 * would, renaming it so the two places the advisor reads the callback can be told
+	 * apart.
+	 */
+	private static final class DecoratingAdvisor extends ToolSearchToolCallingAdvisor {
+
+		private final ToolCallback decorated;
+
+		private DecoratingAdvisor(ToolCallingManager toolCallingManager, ToolIndex toolIndex) {
+			super(toolCallingManager, DEFAULT_ORDER, DEFAULT_TOOL_EXECUTION_ELIGIBILITY_CHECKER, toolIndex,
+					"\n\nTool search suffix", true, null, true, ChatMemory.CONVERSATION_ID,
+					new LruEvictionStrategy(10));
+			this.decorated = new RenamedToolCallback(super.toolSearchToolCallback());
+		}
+
+		@Override
+		protected ToolCallback toolSearchToolCallback() {
+			return this.decorated;
+		}
+
+	}
+
+	private record RenamedToolCallback(ToolCallback delegate) implements ToolCallback {
+
+		@Override
+		public ToolDefinition getToolDefinition() {
+			return DefaultToolDefinition.builder()
+				.name(DECORATED_TOOL_NAME)
+				.description(this.delegate.getToolDefinition().description())
+				.inputSchema(this.delegate.getToolDefinition().inputSchema())
+				.build();
+		}
+
+		@Override
+		public String call(String toolInput) {
+			return this.delegate.call(toolInput);
+		}
+
 	}
 
 	private static class TerminalCallAdvisor implements CallAdvisor {


### PR DESCRIPTION
`ToolSearchToolCallingAdvisor` builds its search tool callback in the constructor and keeps it in a private field, which it reads in two places:

- `prepareIteration` — the tool set bound to every iteration of the loop
- `extractToolNameReferences` — the tool name that search responses are matched against

Neither is overridable, so the search tool is the one tool call an application cannot decorate — it is the one tool the application does not supply. For an application that renders tool calls in its UI, that means the search itself is a silent pause with nothing on screen, while every tool call it discovers is reported normally. Decorating tool callbacks is otherwise the ordinary way to add UI reporting, metrics, or auditing, and the search is the single hole in it.

This adds a `protected toolSearchToolCallback()` accessor and routes both reads through it.

The second half is the part I'd ask you to look at, because it is more than visibility: the two reads are currently independent, and routing both through one method makes them agree by construction. A subclass that wraps the callback no longer has to keep the bound tool and the name the extraction matches in step by hand — they come from the same place.

The field is still assigned directly in the constructor, so no overridable method is invoked during construction.

### Test

`ToolSearchToolCallingAdvisorCallTests.overriddenToolSearchToolCallbackIsBoundAndDrivesReferenceExtraction` covers both reads with one override: a subclass decorates the callback *and* renames it, then the test asserts that the decorated instance is bound and that a search response carrying the new name still resolves the searched tool. That second assertion only passes if the extraction went through the accessor too — reverting just that one call site fails the test.

`./mvnw test -pl advisors/spring-ai-tool-search-advisor -am` is green (21 tests in that class, 0 failures); checkstyle and spring-javaformat clean.

### Context

Found while building a streaming agent that badges every tool call in its UI. The workaround without this is to vendor the advisor source, which is what we are doing today.
