### PR TITLE
Close SSE transports on timeout/error and evict sessions with failed SSE writes

### DIFF
--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -238,6 +238,10 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 					if (logger.isErrorEnabled()) {
 						logger.error("Failed to send message to session " + session.getId() + ": " + e.getMessage());
 					}
+					// The SSE write failed, so the client socket is gone: evict the session
+					// and release its resources instead of leaking it until the next DELETE.
+					removeSession(session.getId());
+					session.closeGracefully().onErrorComplete().subscribe();
 				}
 			});
 		});
@@ -352,14 +356,22 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 
 		try {
 			return ServerResponse.sse(sseBuilder -> {
+				WebMvcStreamableMcpSessionTransport sessionTransport = new WebMvcStreamableMcpSessionTransport(
+						sessionId, sseBuilder);
+
 				sseBuilder.onTimeout(() -> {
 					if (logger.isDebugEnabled()) {
 						logger.debug("SSE connection timed out for session: " + sessionId);
 					}
+					sessionTransport.close();
 				});
 
-				WebMvcStreamableMcpSessionTransport sessionTransport = new WebMvcStreamableMcpSessionTransport(
-						sessionId, sseBuilder);
+				sseBuilder.onError(error -> {
+					if (logger.isDebugEnabled()) {
+						logger.debug("SSE connection errored for session: " + sessionId);
+					}
+					sessionTransport.close();
+				});
 
 				// Check if this is a replay request
 				if (!request.headers().header(HttpHeaders.LAST_EVENT_ID).isEmpty()) {


### PR DESCRIPTION
Fixes #6860

## What
WebMvcStreamableServerTransportProvider leaks SSE sockets when clients disconnect without DELETE. Two gaps fixed:

- sseBuilder.onTimeout only logged; onError was not handled at all. Both now close the session transport, freeing the socket immediately.
- notifyClients logged send failures and kept dead sessions. A failed SSE write now evicts the session (removeSession + closeGracefully).

Session slots for silent clients remain covered by the existing idle eviction (sessionIdleTimeout).

## How verified
- Syntax-checked locally; module tests run in CI (local reactor build is blocked by milestone repository access from the contributor network).