### PR TITLE
Process missing `ToolCallback` errors

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -293,7 +293,17 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 					logger.warn(POSSIBLE_LLM_TOOL_NAME_CHANGE_WARNING_START + toolName
 							+ POSSIBLE_LLM_TOOL_NAME_CHANGE_WARNING_END);
 				}
-				throw new IllegalStateException("No ToolCallback found for tool name: " + toolName);
+				ToolDefinition toolDefinition = ToolDefinition.builder()
+					.name(toolName)
+					.description("Tool requested by the chat model")
+					.inputSchema("{}")
+					.build();
+				ToolExecutionException exception = new ToolExecutionException(toolDefinition,
+						new IllegalStateException("No ToolCallback found for tool name: " + toolName));
+				String toolCallResult = this.toolExecutionExceptionProcessor.process(exception);
+				toolResponses.add(new ToolResponseMessage.ToolResponse(toolCall.id(), toolName,
+						toolCallResult != null ? toolCallResult : ""));
+				continue;
 			}
 
 			if (returnDirect == null) {

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTests.java
@@ -144,11 +144,16 @@ class DefaultToolCallingManagerTests {
 	}
 
 	@Test
-	void whenToolCallbackFallbackIsDefaultThenUnlistedToolIsRejected() {
+	void whenToolCallbackFallbackIsDefaultThenUnlistedToolErrorIsProcessed() {
 		ToolCallback resolverOnlyTool = new TestToolCallback("resolverOnlyTool");
 		ToolCallbackResolver toolCallbackResolver = new StaticToolCallbackResolver(List.of(resolverOnlyTool));
 		ToolCallingManager toolCallingManager = DefaultToolCallingManager.builder()
 			.toolCallbackResolver(toolCallbackResolver)
+			.toolExecutionExceptionProcessor(exception -> {
+				assertThat(exception.getToolDefinition().name()).isEqualTo("resolverOnlyTool");
+				assertThat(exception.getCause()).isInstanceOf(IllegalStateException.class);
+				return "Tool is not available";
+			})
 			.build();
 
 		Prompt prompt = new Prompt(new UserMessage("Hello"), ToolCallingChatOptions.builder().build());
@@ -161,9 +166,12 @@ class DefaultToolCallingManagerTests {
 				.build())))
 			.build();
 
-		assertThatThrownBy(() -> toolCallingManager.executeToolCalls(prompt, chatResponse))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("No ToolCallback found for tool name: resolverOnlyTool");
+		ToolExecutionResult toolExecutionResult = toolCallingManager.executeToolCalls(prompt, chatResponse);
+
+		ToolResponseMessage expectedToolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponse("resolverOnlyTool", "resolverOnlyTool", "Tool is not available")))
+			.build();
+		assertThat(toolExecutionResult.conversationHistory()).contains(expectedToolResponse);
 	}
 
 	@Test


### PR DESCRIPTION
Route missing tool callback failures through the configured `ToolExecutionExceptionProcessor` instead of throwing a raw `IllegalStateException`. The processed message is returned as the tool response, matching failures raised while invoking a resolved callback.

A regression test verifies that a custom processor receives the missing tool definition and controls the returned response.

Fixes #6816

Tested with: `./mvnw -pl spring-ai-model -Dtest=DefaultToolCallingManagerTests test`