### PR TITLE
Configure Redis vector store metadata fields

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.vectorstore.redis.autoconfigure;
 
+import java.util.List;
+
 import io.micrometer.observation.ObservationRegistry;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.JedisClientConfig;
@@ -70,6 +72,7 @@ public class RedisVectorStoreAutoConfiguration {
 	 * @param jedisConnectionFactory the Jedis connection factory
 	 * @param observationRegistry the observation registry
 	 * @param convention the custom observation convention
+	 * @param metadataFields the custom metadata fields
 	 * @param batchingStrategy the batching strategy
 	 * @return the configured Redis vector store
 	 */
@@ -79,6 +82,7 @@ public class RedisVectorStoreAutoConfiguration {
 			final RedisVectorStoreProperties properties, final JedisConnectionFactory jedisConnectionFactory,
 			final ObjectProvider<ObservationRegistry> observationRegistry,
 			final ObjectProvider<VectorStoreObservationConvention> convention,
+			final ObjectProvider<List<RedisVectorStore.MetadataField>> metadataFields,
 			final BatchingStrategy batchingStrategy) {
 
 		RedisClient jedisClient = jedisClient(jedisConnectionFactory);
@@ -88,7 +92,8 @@ public class RedisVectorStoreAutoConfiguration {
 			.customObservationConvention(convention.getIfAvailable())
 			.batchingStrategy(batchingStrategy)
 			.indexName(properties.getIndexName())
-			.prefix(properties.getPrefix());
+			.prefix(properties.getPrefix())
+			.metadataFields(metadataFields.getIfAvailable(List::of));
 
 		// Configure HNSW parameters if available
 		hnswConfiguration(builder, properties);

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/test/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/test/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfigurationIT.java
@@ -139,6 +139,24 @@ class RedisVectorStoreAutoConfigurationIT {
 		});
 	}
 
+	@Test
+	void customMetadataFieldsAreApplied() {
+		this.contextRunner.withUserConfiguration(MetadataFieldsConfig.class)
+			.withPropertyValues("spring.ai.vectorstore.redis.index-name=metadata-fields-index")
+			.run(context -> {
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+				Document document = new Document("Custom metadata", Map.of("conversationId", "conversation-1"));
+
+				vectorStore.add(List.of(document));
+
+				List<Document> results = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("metadata")
+					.filterExpression("conversationId == 'conversation-1'")
+					.build());
+				assertThat(results).extracting(Document::getId).contains(document.getId());
+			});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class Config {
 
@@ -150,6 +168,16 @@ class RedisVectorStoreAutoConfigurationIT {
 		@Bean
 		public EmbeddingModel embeddingModel() {
 			return new TransformersEmbeddingModel();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class MetadataFieldsConfig {
+
+		@Bean
+		List<RedisVectorStore.MetadataField> metadataFields() {
+			return List.of(RedisVectorStore.MetadataField.tag("conversationId"));
 		}
 
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
@@ -82,6 +82,16 @@ vectorStore.add(documents);
 List<Document> results = this.vectorStore.similaritySearch(SearchRequest.builder().query("Spring").topK(5).build());
 ----
 
+To include custom metadata fields in the auto-configured Redis schema, define a `List<RedisVectorStore.MetadataField>` bean:
+
+[source,java]
+----
+@Bean
+List<RedisVectorStore.MetadataField> redisMetadataFields() {
+    return List.of(RedisVectorStore.MetadataField.tag("conversationId"));
+}
+----
+
 [[redisvector-properties]]
 === Configuration Properties
 


### PR DESCRIPTION
Allow applications using Redis vector store auto-configuration to contribute custom schema fields through a `List<RedisVectorStore.MetadataField>` bean. This preserves the existing defaults while supporting metadata filters such as `conversationId` without replacing the auto-configured vector store.

The change includes an end-to-end Testcontainers regression test and reference documentation for the extension point.

Fixes #6308

Verification:
- `./mvnw -pl auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis -DskipTests package`
- `./mvnw -pl auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis process-sources`

The focused Testcontainers test could not run locally because Docker is unavailable; it compiled successfully and is included for CI.