### PR TITLE
Close `WebMvcStreamableServerTransportProvider` transports on disconnect

### DIFF
--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -352,18 +352,13 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 
 		try {
 			return ServerResponse.sse(sseBuilder -> {
-				sseBuilder.onTimeout(() -> {
-					if (logger.isDebugEnabled()) {
-						logger.debug("SSE connection timed out for session: " + sessionId);
-					}
-				});
-
-				WebMvcStreamableMcpSessionTransport sessionTransport = new WebMvcStreamableMcpSessionTransport(
-						sessionId, sseBuilder);
+				WebMvcStreamableMcpSessionTransport sessionTransport = createSessionTransport(sessionId, sseBuilder);
 
 				// Check if this is a replay request
 				if (!request.headers().header(HttpHeaders.LAST_EVENT_ID).isEmpty()) {
 					String lastId = request.headers().asHttpHeaders().getFirst(HttpHeaders.LAST_EVENT_ID);
+
+					registerSseLifecycle(sseBuilder, sessionId, sessionTransport::close);
 
 					try {
 						session.replay(lastId)
@@ -379,7 +374,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 									if (logger.isErrorEnabled()) {
 										logger.error("Failed to replay message: " + e.getMessage());
 									}
-									sseBuilder.error(e);
+									sessionTransport.close();
 								}
 							});
 					}
@@ -387,7 +382,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 						if (logger.isErrorEnabled()) {
 							logger.error("Failed to replay messages: " + e.getMessage());
 						}
-						sseBuilder.error(e);
+						sessionTransport.close();
 					}
 				}
 				else {
@@ -395,12 +390,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 					McpStreamableServerSession.McpStreamableServerSessionStream listeningStream = session
 						.listeningStream(sessionTransport);
 
-					sseBuilder.onComplete(() -> {
-						if (logger.isDebugEnabled()) {
-							logger.debug("SSE connection completed for session: " + sessionId);
-						}
-						listeningStream.close();
-					});
+					registerSseLifecycle(sseBuilder, sessionId, listeningStream::close);
 				}
 			}, Duration.ZERO);
 		}
@@ -487,19 +477,10 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 			else if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest) {
 				// For streaming responses, we need to return SSE
 				return ServerResponse.sse(sseBuilder -> {
-					sseBuilder.onComplete(() -> {
-						if (logger.isDebugEnabled()) {
-							logger.debug("Request response stream completed for session: " + sessionId);
-						}
-					});
-					sseBuilder.onTimeout(() -> {
-						if (logger.isDebugEnabled()) {
-							logger.debug("Request response stream timed out for session: " + sessionId);
-						}
-					});
+					WebMvcStreamableMcpSessionTransport sessionTransport = createSessionTransport(sessionId,
+							sseBuilder);
 
-					WebMvcStreamableMcpSessionTransport sessionTransport = new WebMvcStreamableMcpSessionTransport(
-							sessionId, sseBuilder);
+					registerSseLifecycle(sseBuilder, sessionId, sessionTransport::close);
 
 					try {
 						session.responseStream(jsonrpcRequest, sessionTransport)
@@ -510,7 +491,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 						if (logger.isErrorEnabled()) {
 							logger.error("Failed to handle request stream: " + e.getMessage());
 						}
-						sseBuilder.error(e);
+						sessionTransport.close();
 					}
 				}, Duration.ZERO);
 			}
@@ -690,6 +671,31 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 		return this.sessions.remove(sessionId);
 	}
 
+	static void registerSseLifecycle(SseBuilder sseBuilder, String sessionId, Runnable onClose) {
+		sseBuilder.onComplete(() -> {
+			if (logger.isDebugEnabled()) {
+				logger.debug("SSE connection completed for session: " + sessionId);
+			}
+			onClose.run();
+		});
+		sseBuilder.onTimeout(() -> {
+			if (logger.isDebugEnabled()) {
+				logger.debug("SSE connection timed out for session: " + sessionId);
+			}
+			onClose.run();
+		});
+		sseBuilder.onError(error -> {
+			if (logger.isDebugEnabled()) {
+				logger.debug("SSE connection errored for session: " + sessionId, error);
+			}
+			onClose.run();
+		});
+	}
+
+	WebMvcStreamableMcpSessionTransport createSessionTransport(String sessionId, SseBuilder sseBuilder) {
+		return new WebMvcStreamableMcpSessionTransport(sessionId, sseBuilder);
+	}
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -703,7 +709,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 	 * underlying SSE builder to prevent race conditions when multiple threads attempt to
 	 * send messages concurrently.
 	 */
-	private class WebMvcStreamableMcpSessionTransport implements McpStreamableServerTransport {
+	class WebMvcStreamableMcpSessionTransport implements McpStreamableServerTransport {
 
 		private final String sessionId;
 
@@ -774,15 +780,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 					if (logger.isErrorEnabled()) {
 						logger.error("Failed to send message to session " + this.sessionId + ": " + e.getMessage());
 					}
-					try {
-						this.sseBuilder.error(e);
-					}
-					catch (Exception errorException) {
-						if (logger.isErrorEnabled()) {
-							logger.error("Failed to send error to SSE builder for session " + this.sessionId + ": "
-									+ errorException.getMessage());
-						}
-					}
+					this.close();
 				}
 				finally {
 					this.lock.unlock();

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProviderTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProviderTests.java
@@ -16,22 +16,30 @@
 
 package org.springframework.ai.mcp.server.webmvc.transport;
 
+import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpStreamableServerSession;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Mono;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.servlet.client.MockMvcWebTestClient;
+import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -191,6 +199,73 @@ class WebMvcStreamableServerTransportProviderTests {
 			.isEqualTo(HttpStatus.BAD_REQUEST)
 			.expectBody(String.class)
 			.value(body -> assertThat(body).contains("Session already initialized"));
+	}
+
+	@Test
+	void sseLifecycleCallbacksCloseStreamOnCompleteTimeoutAndError() {
+		SseBuilder sseBuilder = mock(SseBuilder.class);
+		AtomicInteger closeCount = new AtomicInteger();
+
+		WebMvcStreamableServerTransportProvider.registerSseLifecycle(sseBuilder, "session-1",
+				closeCount::incrementAndGet);
+
+		ArgumentCaptor<Runnable> completeCaptor = ArgumentCaptor.captor();
+		verify(sseBuilder).onComplete(completeCaptor.capture());
+		completeCaptor.getValue().run();
+
+		ArgumentCaptor<Runnable> timeoutCaptor = ArgumentCaptor.captor();
+		verify(sseBuilder).onTimeout(timeoutCaptor.capture());
+		timeoutCaptor.getValue().run();
+
+		ArgumentCaptor<Consumer<Throwable>> errorCaptor = ArgumentCaptor.captor();
+		verify(sseBuilder).onError(errorCaptor.capture());
+		errorCaptor.getValue().accept(new RuntimeException("boom"));
+
+		assertThat(closeCount).hasValue(3);
+	}
+
+	@Test
+	void sseWriteFailureClosesOnlyCurrentTransportWithoutRemovingSession() throws Exception {
+		String sessionId = "session-send-failure";
+		McpStreamableServerSession session = mock(McpStreamableServerSession.class);
+		when(session.getId()).thenReturn(sessionId);
+		when(session.delete()).thenReturn(Mono.empty());
+
+		McpSchema.InitializeResult initResult = McpSchema.InitializeResult
+			.builder("2024-11-05", McpSchema.ServerCapabilities.builder().build(),
+					McpSchema.Implementation.builder("test-server", "1.0.0").build())
+			.build();
+
+		WebMvcStreamableServerTransportProvider provider = WebMvcStreamableServerTransportProvider.builder().build();
+		provider.setSessionFactory(initializeRequest -> new McpStreamableServerSession.McpStreamableServerSessionInit(
+				session, Mono.just(initResult)));
+
+		WebTestClient client = MockMvcWebTestClient.bindToRouterFunction(provider.getRouterFunction()).build();
+
+		client.post()
+			.uri("/mcp")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+			.bodyValue(INITIALIZE_REQUEST)
+			.exchange()
+			.expectStatus()
+			.isOk();
+
+		SseBuilder sseBuilder = mock(SseBuilder.class);
+		when(sseBuilder.id(anyString())).thenReturn(sseBuilder);
+		when(sseBuilder.event(anyString())).thenReturn(sseBuilder);
+		doThrow(new IOException("broken pipe")).when(sseBuilder).data(any());
+
+		var transport = provider.createSessionTransport(sessionId, sseBuilder);
+		McpSchema.JSONRPCMessage message = new McpSchema.JSONRPCNotification("2.0", "server/notification", Map.of());
+		transport.sendMessage(message, "message-1").block();
+
+		verify(sseBuilder).complete();
+
+		// A DELETE with the same id still finds the session instead of returning 404,
+		// proving the write failure closed only the transport and did not remove the
+		// logical MCP session.
+		client.delete().uri("/mcp").header(HttpHeaders.MCP_SESSION_ID, sessionId).exchange().expectStatus().isOk();
 	}
 
 }


### PR DESCRIPTION
  Fixes #6860

Makes the WebMVC Streamable HTTP SSE transport close when the SSE response completes, times out, or errors, and routes SSE write failures through the transport `close()` path instead of only reporting the error to the `SseBuilder`.

It mirrors modelcontextprotocol/java-sdk#1021: listening streams close on timeout/error as well as completion, replay and streaming responses close on lifecycle events, and every lifecycle event uses the same idempotent `close()` (no separate `markClosed()` flag).

Key design point: a write failure closes only the current HTTP/SSE transport and does NOT remove the logical MCP session. Removing the session on a request-specific write failure would break the next request carrying the same `mcp-session-id` and Last-Event-ID replay, so session eviction is intentionally left to DELETE / keep-alive eviction.

  ## Testing

Rewrote both tests without reflection, using a package-private transport factory seam (the provider exposes a `RouterFunction`, so the SDK-style servlet entry-point mocking is not applicable here):

- `sseLifecycleCallbacksCloseStreamOnCompleteTimeoutAndError` asserts all three lifecycle callbacks trigger the close callback.
- `sseWriteFailureClosesOnlyCurrentTransportWithoutRemovingSession` initializes a session over the router, triggers an SSE write failure, verifies the transport is completed, and then deletes the session with the same id, asserting 200 to prove the session was retained.

  ```bash
  mvn -pl mcp/transport/mcp-spring-webmvc -am \
      -Dtest=WebMvcStreamableServerTransportProviderTests \
      -Dsurefire.failIfNoSpecifiedTests=false test

Module unit tests pass, and WebMcpStreamableAsyncServerTransportIT, WebMcpStreamableSyncServerTransportIT, and WebMvcStreamableIT pass.