### PR TITLE
Add dimensions and normalize options for Bedrock Text Embeddings V2

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingAutoConfiguration.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.bedrock.titan.BedrockTitanEmbeddingModel;
+import org.springframework.ai.bedrock.titan.BedrockTitanEmbeddingOptions;
 import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
@@ -80,9 +81,13 @@ public class BedrockTitanEmbeddingAutoConfiguration {
 			throw new IllegalArgumentException("InputType property for BedrockTitanEmbeddingModel is missing.");
 		}
 
-		return new BedrockTitanEmbeddingModel(titanEmbeddingApi,
-				observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
-			.withInputType(properties.getInputType());
+		var options = BedrockTitanEmbeddingOptions.builder()
+			.inputType(properties.getInputType())
+			.dimensions(properties.getDimensions())
+			.normalize(properties.getNormalize())
+			.build();
+		return new BedrockTitanEmbeddingModel(titanEmbeddingApi, options,
+				observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP));
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.bedrock.titan.autoconfigure;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.bedrock.titan.BedrockTitanEmbeddingModel.InputType;
 import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingModel;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -42,6 +44,18 @@ public class BedrockTitanEmbeddingProperties {
 	 */
 	private InputType inputType = InputType.IMAGE;
 
+	/**
+	 * Titan Text Embeddings V2 dimensions. Only applicable for
+	 * {@link TitanEmbeddingModel#TITAN_EMBED_TEXT_V2}.
+	 */
+	private @Nullable Integer dimensions;
+
+	/**
+	 * Titan Text Embeddings V2 normalization. Only applicable for
+	 * {@link TitanEmbeddingModel#TITAN_EMBED_TEXT_V2}.
+	 */
+	private @Nullable Boolean normalize;
+
 	public String getModel() {
 		return this.model;
 	}
@@ -56,6 +70,22 @@ public class BedrockTitanEmbeddingProperties {
 
 	public void setInputType(InputType inputType) {
 		this.inputType = inputType;
+	}
+
+	public @Nullable Integer getDimensions() {
+		return this.dimensions;
+	}
+
+	public void setDimensions(Integer dimensions) {
+		this.dimensions = dimensions;
+	}
+
+	public @Nullable Boolean getNormalize() {
+		return this.normalize;
+	}
+
+	public void setNormalize(Boolean normalize) {
+		this.normalize = normalize;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingAutoConfigurationIT.java
@@ -18,7 +18,9 @@ package org.springframework.ai.model.bedrock.titan.autoconfigure;
 
 import java.util.Base64;
 import java.util.List;
+import java.util.stream.IntStream;
 
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.regions.Region;
 
@@ -80,6 +82,27 @@ public class BedrockTitanEmbeddingAutoConfigurationIT {
 			assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
 			assertThat(embeddingModel.dimensions()).isEqualTo(1024);
 		});
+	}
+
+	@Test
+	public void singleV2TextEmbedding() {
+		this.contextRunner.withPropertyValues("spring.ai.bedrock.titan.embedding.input-type=TEXT",
+				"spring.ai.bedrock.titan.embedding.model=" + TitanEmbeddingModel.TITAN_EMBED_TEXT_V2.id(),
+				"spring.ai.bedrock.titan.embedding.dimensions=512", "spring.ai.bedrock.titan.embedding.normalize=false")
+			.run(context -> {
+				BedrockTitanEmbeddingModel embeddingModel = context.getBean(BedrockTitanEmbeddingModel.class);
+				assertThat(embeddingModel).isNotNull();
+
+				EmbeddingResponse embeddingResponse = embeddingModel.embedForResponse(List.of("Hello World"));
+				assertThat(embeddingResponse.getResults()).hasSize(1);
+				assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
+				assertThat(embeddingModel.dimensions()).isEqualTo(512);
+
+				float[] embedding = embeddingResponse.getResult().getOutput();
+				double l2Norm = Math
+					.sqrt(IntStream.range(0, embedding.length).mapToDouble(i -> embedding[i] * embedding[i]).sum());
+				assertThat(l2Norm).isNotCloseTo(1.0, Offset.offset(0.001));
+			});
 	}
 
 	@Test

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModel.java
@@ -59,15 +59,18 @@ public class BedrockTitanEmbeddingModel extends AbstractEmbeddingModel {
 
 	private final ObservationRegistry observationRegistry;
 
-	/**
-	 * Titan Embedding API input types. Could be either text or image (encoded in base64).
-	 */
-	private InputType inputType = InputType.TEXT;
+	private BedrockTitanEmbeddingOptions options;
+
+	public BedrockTitanEmbeddingModel(TitanEmbeddingBedrockApi titanEmbeddingBedrockApi,
+			BedrockTitanEmbeddingOptions options, ObservationRegistry observationRegistry) {
+		this.embeddingApi = titanEmbeddingBedrockApi;
+		this.options = options;
+		this.observationRegistry = observationRegistry;
+	}
 
 	public BedrockTitanEmbeddingModel(TitanEmbeddingBedrockApi titanEmbeddingBedrockApi,
 			ObservationRegistry observationRegistry) {
-		this.embeddingApi = titanEmbeddingBedrockApi;
-		this.observationRegistry = observationRegistry;
+		this(titanEmbeddingBedrockApi, new BedrockTitanEmbeddingOptions(InputType.TEXT), observationRegistry);
 	}
 
 	/**
@@ -75,8 +78,13 @@ public class BedrockTitanEmbeddingModel extends AbstractEmbeddingModel {
 	 * @param inputType the input type to use.
 	 */
 	public BedrockTitanEmbeddingModel withInputType(InputType inputType) {
-		this.inputType = inputType;
+		this.options = new BedrockTitanEmbeddingOptions(inputType, this.options.getDimensions(),
+				this.options.getNormalize());
 		return this;
+	}
+
+	private static InputType getInputTypeOrDefault(BedrockTitanEmbeddingOptions options) {
+		return options.getInputType() != null ? options.getInputType() : InputType.TEXT;
 	}
 
 	@Override
@@ -101,10 +109,11 @@ public class BedrockTitanEmbeddingModel extends AbstractEmbeddingModel {
 			var apiRequest = createTitanEmbeddingRequest(inputContent, request.getOptions());
 
 			try {
+				InputType inputType = getInputTypeOrDefault(this.options);
 				TitanEmbeddingResponse response = Observation
 					.createNotStarted("bedrock.embedding", this.observationRegistry)
 					.lowCardinalityKeyValue("model", "titan")
-					.lowCardinalityKeyValue("input_type", this.inputType.name().toLowerCase(Locale.ROOT))
+					.lowCardinalityKeyValue("input_type", inputType.name().toLowerCase(Locale.ROOT))
 					.highCardinalityKeyValue("input_length", String.valueOf(inputContent.length()))
 					.observe(() -> {
 						TitanEmbeddingResponse r = this.embeddingApi.embedding(apiRequest);
@@ -144,19 +153,24 @@ public class BedrockTitanEmbeddingModel extends AbstractEmbeddingModel {
 
 	private TitanEmbeddingRequest createTitanEmbeddingRequest(String inputContent,
 			@Nullable EmbeddingOptions requestOptions) {
-		InputType inputType = this.inputType;
+		BedrockTitanEmbeddingOptions options = this.options;
 
 		if (requestOptions instanceof BedrockTitanEmbeddingOptions bedrockTitanEmbeddingOptions) {
-			inputType = bedrockTitanEmbeddingOptions.getInputType();
+			options = bedrockTitanEmbeddingOptions;
 		}
 
-		return (inputType == InputType.IMAGE) ? new TitanEmbeddingRequest.Builder().inputImage(inputContent).build()
-				: new TitanEmbeddingRequest.Builder().inputText(inputContent).build();
+		return switch (getInputTypeOrDefault(options)) {
+			case IMAGE -> new TitanEmbeddingRequest.Builder().inputImage(inputContent).build();
+			case TEXT -> new TitanEmbeddingRequest.Builder().inputText(inputContent)
+				.dimensions(options.getDimensions())
+				.normalize(options.getNormalize())
+				.build();
+		};
 	}
 
 	@Override
 	public int dimensions() {
-		if (this.inputType == InputType.IMAGE) {
+		if (this.options.getInputType() == InputType.IMAGE) {
 			if (this.embeddingDimensions.get() < 0) {
 				this.embeddingDimensions.set(dimensions(this, this.embeddingApi.getModelId(),
 						// small base64 encoded image
@@ -168,7 +182,7 @@ public class BedrockTitanEmbeddingModel extends AbstractEmbeddingModel {
 	}
 
 	private String summarizeInput(String input) {
-		if (this.inputType == InputType.IMAGE) {
+		if (this.options.getInputType() == InputType.IMAGE) {
 			return "[image content omitted, length=" + input.length() + "]";
 		}
 		return input.length() > 100 ? input.substring(0, 100) + "..." : input;

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingOptions.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingOptions.java
@@ -36,8 +36,19 @@ public class BedrockTitanEmbeddingOptions implements EmbeddingOptions {
 	 */
 	private final @Nullable InputType inputType;
 
-	protected BedrockTitanEmbeddingOptions(@Nullable InputType inputType) {
+	private final @Nullable Integer dimensions;
+
+	private final @Nullable Boolean normalize;
+
+	protected BedrockTitanEmbeddingOptions(@Nullable InputType inputType, @Nullable Integer dimensions,
+			@Nullable Boolean normalize) {
 		this.inputType = inputType;
+		this.dimensions = dimensions;
+		this.normalize = normalize;
+	}
+
+	protected BedrockTitanEmbeddingOptions(@Nullable InputType inputType) {
+		this(inputType, null, null);
 	}
 
 	public static BedrockTitanEmbeddingOptions.Builder builder() {
@@ -55,12 +66,20 @@ public class BedrockTitanEmbeddingOptions implements EmbeddingOptions {
 
 	@Override
 	public @Nullable Integer getDimensions() {
-		return null;
+		return this.dimensions;
+	}
+
+	public @Nullable Boolean getNormalize() {
+		return this.normalize;
 	}
 
 	public static final class Builder {
 
 		private @Nullable InputType inputType;
+
+		private @Nullable Integer dimensions;
+
+		private @Nullable Boolean normalize;
 
 		public Builder inputType(InputType inputType) {
 			Assert.notNull(inputType, "input type can not be null.");
@@ -69,8 +88,18 @@ public class BedrockTitanEmbeddingOptions implements EmbeddingOptions {
 			return this;
 		}
 
+		public Builder dimensions(@Nullable Integer dimensions) {
+			this.dimensions = dimensions;
+			return this;
+		}
+
+		public Builder normalize(@Nullable Boolean normalize) {
+			this.normalize = normalize;
+			return this;
+		}
+
 		public BedrockTitanEmbeddingOptions build() {
-			return new BedrockTitanEmbeddingOptions(this.inputType);
+			return new BedrockTitanEmbeddingOptions(this.inputType, this.dimensions, this.normalize);
 		}
 
 	}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
@@ -126,12 +126,17 @@ public class TitanEmbeddingBedrockApi extends
 	 * @param inputText The text to compute the embedding for.
 	 * @param inputImage The image to compute the embedding for. Only applicable for the 'Titan Multimodal Embeddings
 	 * G1' model.
+	 * @param dimensions The number of dimensions for the embedding. Only applicable for the 'Titan Text Embeddings V2'
+	 * model.
+	 * @param normalize Whether to normalize the embedding. Only applicable for the 'Titan Text Embeddings V2' model.
 	 */
 	@JsonInclude(Include.NON_NULL)
 	public record TitanEmbeddingRequest(
 			@JsonProperty("inputText") @Nullable String inputText,
-			@JsonProperty("inputImage") @Nullable String inputImage) {
-
+			@JsonProperty("inputImage") @Nullable String inputImage,
+			@JsonProperty("dimensions") @Nullable Integer dimensions,
+			@JsonProperty("normalize") @Nullable Boolean normalize
+	) {
 
 		public static Builder builder() {
 			return new Builder();
@@ -144,6 +149,8 @@ public class TitanEmbeddingBedrockApi extends
 
 			private @Nullable String inputText;
 			private @Nullable String inputImage;
+			private @Nullable Integer dimensions;
+			private @Nullable Boolean normalize;
 
 			public Builder inputText(@Nullable String inputText) {
 				this.inputText = inputText;
@@ -155,13 +162,23 @@ public class TitanEmbeddingBedrockApi extends
 				return this;
 			}
 
+			public Builder dimensions(@Nullable Integer dimensions) {
+				this.dimensions = dimensions;
+				return this;
+			}
+
+			public Builder normalize(@Nullable Boolean normalize) {
+				this.normalize = normalize;
+				return this;
+			}
+
 			public TitanEmbeddingRequest build() {
 				Assert.isTrue(this.inputText != null || this.inputImage != null,
 						"At least one of the inputText or inputImage parameters must be provided!");
 				Assert.isTrue(!(this.inputText != null && this.inputImage != null),
 						"Only one of the inputText or inputImage parameters must be provided!");
 
-				return new TitanEmbeddingRequest(this.inputText, this.inputImage);
+				return new TitanEmbeddingRequest(this.inputText, this.inputImage, this.dimensions, this.normalize);
 			}
 		}
 

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApiIT.java
@@ -19,7 +19,9 @@ package org.springframework.ai.bedrock.titan.api;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.stream.IntStream;
 
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -70,6 +72,31 @@ public class TitanEmbeddingBedrockApiIT {
 		assertThat(response).isNotNull();
 		assertThat(response.inputTextTokenCount()).isEqualTo(7);
 		assertThat(response.embedding()).hasSize(1024);
+	}
+
+	@Test
+	public void embedTextV2WithDimensionsAndNormalize() {
+
+		TitanEmbeddingBedrockApi titanEmbedApi = new TitanEmbeddingBedrockApi(
+				TitanEmbeddingModel.TITAN_EMBED_TEXT_V2.id(), EnvironmentVariableCredentialsProvider.create(),
+				Region.US_EAST_1.id(), new JsonMapper(), Duration.ofMinutes(2));
+
+		TitanEmbeddingRequest request = TitanEmbeddingRequest.builder()
+			.inputText("I like to eat apples.")
+			.dimensions(512)
+			.normalize(false)
+			.build();
+
+		TitanEmbeddingResponse response = titanEmbedApi.embedding(request);
+
+		assertThat(response).isNotNull();
+		assertThat(response.inputTextTokenCount()).isEqualTo(7);
+		assertThat(response.embedding()).hasSize(512);
+
+		double l2Norm = Math.sqrt(IntStream.range(0, response.embedding().length)
+			.mapToDouble(i -> response.embedding()[i] * response.embedding()[i])
+			.sum());
+		assertThat(l2Norm).isNotCloseTo(1.0, Offset.offset(0.001));
 	}
 
 	@Test


### PR DESCRIPTION
The Amazon Bedrock Titan Text Emebddings V2 model supports the options dimensions (default 1024) and normalize (default true). See e.g. https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html

This adds support for setting them.