### PR TITLE
Add streaming time-to-first-chunk observability

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -361,7 +361,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			// @formatter:on
 
 			// Aggregate streaming responses and handle tool execution on final response
-			return new MessageAggregator().aggregate(flux, observationContext::setResponse);
+			return new MessageAggregator().aggregate(flux, observationContext::setResponse,
+					observationContext::recordTimeToFirstChunk);
 		});
 	}
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelObservationIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelObservationIT.java
@@ -150,11 +150,14 @@ public class AnthropicChatModelObservationIT {
 			.hasBeenStarted()
 			.hasBeenStopped();
 		if (streaming) {
-			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true")
+				.hasHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString());
 		}
 		else {
 			observationAssert
-				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString());
+				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString())
+				.doesNotHaveHighCardinalityKeyValueWithKey(
+						HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString());
 		}
 	}
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -825,7 +825,8 @@ public class BedrockProxyChatModel implements ChatModel {
 				.doFinally(s -> observation.stop())
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 
-			return new MessageAggregator().aggregate(chatResponseFlux, observationContext::setResponse);
+			return new MessageAggregator().aggregate(chatResponseFlux, observationContext::setResponse,
+					observationContext::recordTimeToFirstChunk);
 		});
 	}
 

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -267,7 +267,8 @@ public class DeepSeekChatModel implements ChatModel {
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 			// @formatter:on
 
-			return new MessageAggregator().aggregate(flux, observationContext::setResponse);
+			return new MessageAggregator().aggregate(flux, observationContext::setResponse,
+					observationContext::recordTimeToFirstChunk);
 
 		});
 	}

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -504,7 +504,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 						aggregatedResponse -> {
 							aggregatedResponseRef.set(aggregatedResponse);
 							observationContext.setResponse(aggregatedResponse);
-						});
+						}, observationContext::recordTimeToFirstChunk);
 
 				return aggregatedFlux.doOnError(observation::error)
 					.doFinally(s -> observation.stop())

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -301,7 +301,8 @@ public class MistralAiChatModel implements ChatModel {
 			.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 			// @formatter:on
 
-			return new MessageAggregator().aggregate(chatResponseFlux, observationContext::setResponse);
+			return new MessageAggregator().aggregate(chatResponseFlux, observationContext::setResponse,
+					observationContext::recordTimeToFirstChunk);
 		});
 
 	}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -353,7 +353,8 @@ public class OllamaChatModel implements ChatModel {
 				.doFinally(s -> observation.stop())
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 
-			return new MessageAggregator().aggregate(chatResponseFlux, observationContext::setResponse);
+			return new MessageAggregator().aggregate(chatResponseFlux, observationContext::setResponse,
+					observationContext::recordTimeToFirstChunk);
 		});
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -362,7 +362,8 @@ public final class OpenAiChatModel implements ChatModel {
 				.doFinally(s -> observation.stop())
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 
-			return new MessageAggregator().aggregate(observedResponses, observationContext::setResponse);
+			return new MessageAggregator().aggregate(observedResponses, observationContext::setResponse,
+					observationContext::recordTimeToFirstChunk);
 
 		});
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelObservationIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelObservationIT.java
@@ -136,11 +136,14 @@ public class OpenAiChatModelObservationIT {
 			.hasBeenStarted()
 			.hasBeenStopped();
 		if (streaming) {
-			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true")
+				.hasHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString());
 		}
 		else {
 			observationAssert
-				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString());
+				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString())
+				.doesNotHaveHighCardinalityKeyValueWithKey(
+						HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString());
 		}
 	}
 

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
@@ -115,6 +115,11 @@ public enum AiObservationAttributes {
 	 * The name of the model that generated the response.
 	 */
 	RESPONSE_MODEL("gen_ai.response.model"),
+	/**
+	 * The time (in seconds) it took to receive the first chunk of a streaming response,
+	 * measured from the start of the model request.
+	 */
+	RESPONSE_TIME_TO_FIRST_CHUNK("gen_ai.response.time_to_first_chunk"),
 
 	// GenAI Usage
 

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationMetricNames.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationMetricNames.java
@@ -34,6 +34,10 @@ public enum AiObservationMetricNames {
 	 */
 	OPERATION_DURATION("gen_ai.client.operation.duration"),
 	/**
+	 * The time to the first chunk of a streaming AI operation.
+	 */
+	OPERATION_TIME_TO_FIRST_CHUNK("gen_ai.client.operation.time_to_first_chunk"),
+	/**
 	 * The number of AI operations.
 	 */
 	TOKEN_USAGE("gen_ai.client.token.usage");

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
@@ -118,6 +118,7 @@ IMPORTANT: The `gen_ai.client.token.usage` metrics measures number of input and 
 |`gen_ai.request.top_p` | The top_p sampling setting for the model request.
 |`gen_ai.response.finish_reasons` | Reasons the model stopped generating tokens, corresponding to each generation received.
 |`gen_ai.response.id` | The unique identifier for the AI response.
+|`gen_ai.response.time_to_first_chunk` | The time (in seconds) between the start of the model request and the first response chunk. Only present for streaming calls that emitted at least one chunk.
 |`gen_ai.usage.cache_creation.input_tokens` | The number of input tokens written to a provider-managed cache.
 |`gen_ai.usage.cache_read.input_tokens` | The number of input tokens served from a provider-managed cache.
 |`gen_ai.usage.input_tokens` | The number of tokens used in the model input (prompt).
@@ -407,6 +408,22 @@ The following shows how base metric names expand to Prometheus time series.
 |Gauge
 |count
 |Number of chat model operations currently in flight
+|===
+
+==== Time to First Chunk
+
+For streaming calls, Spring AI records the elapsed time between the start of the model request and the first `ChatResponse` chunk.
+Unlike `gen_ai.client.operation.duration`, which for streaming is dominated by the full generation time, this metric reflects how long the caller waited before receiving the first chunk.
+It is not recorded for non-streaming calls or for streams that emitted no chunk.
+
+[cols="2,2,1,3", stripes=even]
+|===
+|Metric Name | Type | Unit | Description
+
+|`gen_ai_client_operation_time_to_first_chunk_seconds`
+|Timer
+|seconds
+|Time from the streaming request start to the first chat response chunk
 |===
 
 ==== Token Usage

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -51,6 +52,31 @@ import org.springframework.util.StringUtils;
 public class MessageAggregator {
 
 	private static final Log logger = LogFactory.getLog(MessageAggregator.class);
+
+	/**
+	 * Aggregate a stream of {@link ChatResponse} chunks, additionally notifying a
+	 * callback the first time a chunk is emitted. This is used to measure the time to
+	 * first chunk for streaming observations.
+	 * @param fluxChatResponse the stream of chat response chunks
+	 * @param onAggregationComplete invoked with the aggregated response once the stream
+	 * completes
+	 * @param onFirstChatResponse invoked exactly once, when the first chunk is emitted;
+	 * not invoked for an empty stream
+	 * @return the aggregated stream
+	 * @since 2.0.3
+	 */
+	public Flux<ChatResponse> aggregate(Flux<ChatResponse> fluxChatResponse,
+			Consumer<ChatResponse> onAggregationComplete, Runnable onFirstChatResponse) {
+		AtomicBoolean firstChatResponseReceived = new AtomicBoolean(false);
+		Flux<ChatResponse> firstChunkAwareFlux = fluxChatResponse
+			.doOnSubscribe(subscription -> firstChatResponseReceived.set(false))
+			.doOnNext(chatResponse -> {
+				if (firstChatResponseReceived.compareAndSet(false, true)) {
+					onFirstChatResponse.run();
+				}
+			});
+		return aggregate(firstChunkAwareFlux, onAggregationComplete);
+	}
 
 	public Flux<ChatResponse> aggregate(Flux<ChatResponse> fluxChatResponse,
 			Consumer<ChatResponse> onAggregationComplete) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelMeterObservationHandler.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelMeterObservationHandler.java
@@ -16,11 +16,19 @@
 
 package org.springframework.ai.chat.observation;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.micrometer.common.KeyValue;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 
 import org.springframework.ai.model.observation.ModelUsageMetricsGenerator;
+import org.springframework.ai.observation.conventions.AiObservationMetricNames;
 
 /**
  * Handler for generating metrics from chat model observations.
@@ -38,6 +46,14 @@ public class ChatModelMeterObservationHandler implements ObservationHandler<Chat
 
 	@Override
 	public void onStop(ChatModelObservationContext context) {
+		Double timeToFirstChunk = context.getTimeToFirstChunk();
+		if (timeToFirstChunk != null) {
+			Timer.builder(AiObservationMetricNames.OPERATION_TIME_TO_FIRST_CHUNK.value())
+				.description("Time from the streaming request start to the first chat response chunk")
+				.tags(lowCardinalityTags(context))
+				.register(this.meterRegistry)
+				.record(Duration.ofNanos(Math.round(timeToFirstChunk * 1_000_000_000L)));
+		}
 		if (context.getResponse() != null && context.getResponse().getMetadata() != null
 				&& context.getResponse().getMetadata().getUsage() != null) {
 			ModelUsageMetricsGenerator.generate(context.getResponse().getMetadata().getUsage(), context,
@@ -48,6 +64,14 @@ public class ChatModelMeterObservationHandler implements ObservationHandler<Chat
 	@Override
 	public boolean supportsContext(Observation.Context context) {
 		return context instanceof ChatModelObservationContext;
+	}
+
+	private static List<Tag> lowCardinalityTags(ChatModelObservationContext context) {
+		List<Tag> tags = new ArrayList<>();
+		for (KeyValue keyValue : context.getLowCardinalityKeyValues()) {
+			tags.add(Tag.of(keyValue.getKey(), keyValue.getValue()));
+		}
+		return tags;
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
@@ -33,16 +33,56 @@ import org.springframework.util.Assert;
  */
 public class ChatModelObservationContext extends ModelObservationContext<Prompt, ChatResponse> {
 
+	private static final double NANOS_PER_SECOND = 1_000_000_000.0;
+
 	private final boolean streaming;
+
+	private final long requestStartNanos;
+
+	private @Nullable Double timeToFirstChunk;
 
 	ChatModelObservationContext(Prompt prompt, String provider, boolean streaming) {
 		super(prompt,
 				AiOperationMetadata.builder().operationType(AiOperationType.CHAT.value()).provider(provider).build());
 		this.streaming = streaming;
+		this.requestStartNanos = System.nanoTime();
 	}
 
 	public boolean isStreaming() {
 		return this.streaming;
+	}
+
+	/**
+	 * The elapsed time, in seconds, between the start of the model request and the first
+	 * {@link ChatResponse} chunk emitted by a streaming call, or {@code null} if no chunk
+	 * was received (for example, a non-streaming call or an empty/failed stream).
+	 * @return the time to first chunk in seconds, or {@code null} if not available
+	 * @since 2.0.3
+	 */
+	public @Nullable Double getTimeToFirstChunk() {
+		return this.timeToFirstChunk;
+	}
+
+	/**
+	 * Set the time to first chunk, in seconds.
+	 * @param timeToFirstChunk the time to first chunk in seconds, or {@code null}
+	 * @since 2.0.3
+	 */
+	public void setTimeToFirstChunk(@Nullable Double timeToFirstChunk) {
+		this.timeToFirstChunk = timeToFirstChunk;
+	}
+
+	/**
+	 * Record the time to first chunk as the elapsed time since this context was created,
+	 * measured with {@link System#nanoTime()}. The value is captured only once:
+	 * subsequent invocations (for example, for later chunks in the same stream) are
+	 * ignored.
+	 * @since 2.0.3
+	 */
+	public void recordTimeToFirstChunk() {
+		if (this.timeToFirstChunk == null) {
+			this.timeToFirstChunk = (System.nanoTime() - this.requestStartNanos) / NANOS_PER_SECOND;
+		}
 	}
 
 	public static Builder builder() {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationDocumentation.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationDocumentation.java
@@ -214,6 +214,18 @@ public enum ChatModelObservationDocumentation implements ObservationDocumentatio
 			}
 		},
 
+		/**
+		 * The time (in seconds) to the first chunk of a streaming response, measured from
+		 * the start of the model request. Only present for streaming calls that emitted
+		 * at least one chunk.
+		 */
+		RESPONSE_TIME_TO_FIRST_CHUNK {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.RESPONSE_TIME_TO_FIRST_CHUNK.value();
+			}
+		},
+
 		// Usage
 
 		/**

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
@@ -108,6 +108,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 		// Response
 		keyValues = responseFinishReasons(keyValues, context);
 		keyValues = responseId(keyValues, context);
+		keyValues = responseTimeToFirstChunk(keyValues, context);
 		keyValues = usageCacheWriteInputTokens(keyValues, context);
 		keyValues = usageCacheReadInputTokens(keyValues, context);
 		keyValues = usageInputTokens(keyValues, context);
@@ -242,6 +243,16 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 		if (context.getResponse() != null && StringUtils.hasText(context.getResponse().getMetadata().getId())) {
 			return keyValues.and(ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_ID.asString(),
 					context.getResponse().getMetadata().getId());
+		}
+		return keyValues;
+	}
+
+	protected KeyValues responseTimeToFirstChunk(KeyValues keyValues, ChatModelObservationContext context) {
+		Double timeToFirstChunk = context.getTimeToFirstChunk();
+		if (context.isStreaming() && timeToFirstChunk != null) {
+			return keyValues.and(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString(),
+					String.valueOf(timeToFirstChunk.doubleValue()));
 		}
 		return keyValues;
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.model;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ import org.springframework.ai.chat.metadata.EmptyRateLimit;
 import org.springframework.ai.chat.metadata.RateLimit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for {@link MessageAggregator}.
@@ -36,6 +38,51 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Soby Chacko
  */
 class MessageAggregatorTests {
+
+	@Test
+	void firstChatResponseCallbackInvokedOnceForMultipleChunks() {
+		Flux<ChatResponse> responses = Flux.just(chunk("Hello", new EmptyRateLimit()),
+				chunk(" world", new EmptyRateLimit()), chunk("!", new EmptyRateLimit()));
+
+		AtomicInteger firstChunkCount = new AtomicInteger();
+		new MessageAggregator().aggregate(responses, r -> {
+		}, firstChunkCount::incrementAndGet).blockLast();
+
+		assertThat(firstChunkCount).hasValue(1);
+	}
+
+	@Test
+	void firstChatResponseCallbackInvokedForSingleChunk() {
+		Flux<ChatResponse> responses = Flux.just(chunk("Hello", new EmptyRateLimit()));
+
+		AtomicInteger firstChunkCount = new AtomicInteger();
+		new MessageAggregator().aggregate(responses, r -> {
+		}, firstChunkCount::incrementAndGet).blockLast();
+
+		assertThat(firstChunkCount).hasValue(1);
+	}
+
+	@Test
+	void firstChatResponseCallbackNotInvokedForEmptyStream() {
+		AtomicInteger firstChunkCount = new AtomicInteger();
+		new MessageAggregator().aggregate(Flux.empty(), r -> {
+		}, firstChunkCount::incrementAndGet).blockLast();
+
+		assertThat(firstChunkCount).hasValue(0);
+	}
+
+	@Test
+	void firstChatResponseCallbackInvokedBeforeStreamFailure() {
+		Flux<ChatResponse> responses = Flux.just(chunk("Hello", new EmptyRateLimit()))
+			.concatWith(Flux.error(new IllegalStateException("boom")));
+
+		AtomicInteger firstChunkCount = new AtomicInteger();
+		Flux<ChatResponse> aggregated = new MessageAggregator().aggregate(responses, r -> {
+		}, firstChunkCount::incrementAndGet);
+
+		assertThatThrownBy(aggregated::blockLast).isInstanceOf(IllegalStateException.class);
+		assertThat(firstChunkCount).hasValue(1);
+	}
 
 	@Test
 	void rateLimitFromStreamedChunkSurvivesAggregation() {

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelMeterObservationHandlerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelMeterObservationHandlerTests.java
@@ -146,6 +146,43 @@ class ChatModelMeterObservationHandlerTests {
 	}
 
 	@Test
+	void shouldCreateTimeToFirstChunkMeterWhenRecorded() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+		var observation = Observation
+			.createNotStarted(new DefaultChatModelObservationConvention(), () -> observationContext,
+					this.observationRegistry)
+			.start();
+
+		observationContext.setTimeToFirstChunk(0.25);
+
+		observation.stop();
+
+		assertThat(this.meterRegistry.get(AiObservationMetricNames.OPERATION_TIME_TO_FIRST_CHUNK.value())
+			.tag(LowCardinalityKeyNames.AI_PROVIDER.asString(), "superprovider")
+			.timer()
+			.count()).isEqualTo(1);
+	}
+
+	@Test
+	void shouldNotCreateTimeToFirstChunkMeterWhenNotRecorded() {
+		var observationContext = generateObservationContext();
+		var observation = Observation
+			.createNotStarted(new DefaultChatModelObservationConvention(), () -> observationContext,
+					this.observationRegistry)
+			.start();
+
+		observation.stop();
+
+		assertThat(this.meterRegistry.getMeters()).noneMatch(meter -> meter.getId()
+			.getName()
+			.equals(AiObservationMetricNames.OPERATION_TIME_TO_FIRST_CHUNK.value()));
+	}
+
+	@Test
 	void shouldHandleObservationWithoutResponse() {
 		var observationContext = generateObservationContext();
 		var observation = Observation

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelObservationContextTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelObservationContextTests.java
@@ -72,6 +72,58 @@ class ChatModelObservationContextTests {
 		assertThat(observationContext.isStreaming()).isFalse();
 	}
 
+	@Test
+	void whenNoFirstChunkRecordedThenTimeToFirstChunkIsNull() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+
+		assertThat(observationContext.getTimeToFirstChunk()).isNull();
+	}
+
+	@Test
+	void whenFirstChunkRecordedThenTimeToFirstChunkIsPositive() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+
+		observationContext.recordTimeToFirstChunk();
+
+		assertThat(observationContext.getTimeToFirstChunk()).isNotNull().isGreaterThanOrEqualTo(0.0);
+	}
+
+	@Test
+	void whenFirstChunkRecordedMultipleTimesThenValueIsNotReset() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+
+		observationContext.recordTimeToFirstChunk();
+		Double firstValue = observationContext.getTimeToFirstChunk();
+		observationContext.recordTimeToFirstChunk();
+
+		assertThat(observationContext.getTimeToFirstChunk()).isEqualTo(firstValue);
+	}
+
+	@Test
+	void whenTimeToFirstChunkSetThenReturn() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+
+		observationContext.setTimeToFirstChunk(0.42);
+
+		assertThat(observationContext.getTimeToFirstChunk()).isEqualTo(0.42);
+	}
+
 	private Prompt generatePrompt(ChatOptions chatOptions) {
 		return new Prompt("hello", chatOptions);
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
@@ -192,6 +192,44 @@ class DefaultChatModelObservationConventionTests {
 	}
 
 	@Test
+	void shouldHaveTimeToFirstChunkWhenStreamingAndRecorded() {
+		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+		observationContext.setTimeToFirstChunk(0.123);
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext))
+			.contains(KeyValue.of(HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString(), "0.123"));
+	}
+
+	@Test
+	void shouldNotHaveTimeToFirstChunkWhenStreamingButNotRecorded() {
+		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext)
+			.stream()
+			.map(KeyValue::getKey)
+			.toList()).doesNotContain(HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString());
+	}
+
+	@Test
+	void shouldNotHaveTimeToFirstChunkForNonStreamingCall() {
+		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))
+			.provider("superprovider")
+			.build();
+		observationContext.setTimeToFirstChunk(0.123);
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext)
+			.stream()
+			.map(KeyValue::getKey)
+			.toList()).doesNotContain(HighCardinalityKeyNames.RESPONSE_TIME_TO_FIRST_CHUNK.asString());
+	}
+
+	@Test
 	void shouldHaveKeyValuesWhenCacheTokensDefined() {
 		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))


### PR DESCRIPTION
For streaming ChatModel calls, record the elapsed time between the start of the model request and the first ChatResponse chunk, following the OpenTelemetry GenAI semantic conventions.

The value is captured once, in ChatModelObservationContext, using System.nanoTime() from context creation (inside Flux.deferContextual, right before the provider request) until the first emitted chunk. The first-chunk detection is done in a new
MessageAggregator.aggregate(Flux, Consumer, Runnable) overload, the single point every streaming ChatModel already funnels its chunk Flux through, so no timing logic is duplicated across providers. Each of the seven streaming ChatModels only passes
observationContext::recordTimeToFirstChunk to that overload.

The DefaultChatModelObservationConvention emits the span attribute gen_ai.response.time_to_first_chunk (double, seconds) only for streaming calls that received at least one chunk. The ChatModelMeterObservationHandler records the
gen_ai.client.operation.time_to_first_chunk timer (unit: seconds) with the same low-cardinality tags as gen_ai.client.operation.duration. Both signals are absent for non-streaming calls and for empty streams, and a value measured before a mid-stream failure is preserved.

Fixes #6670



