### PR TITLE
Qualify the chat memory UDT keyspace in the statement

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/main/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryConfig.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/main/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryConfig.java
@@ -204,14 +204,20 @@ public final class CassandraChatMemoryRepositoryConfig {
 
 	private void ensureMessageTypeExist() {
 
-		SimpleStatement stmt = SchemaBuilder.createType(this.messageUDT)
+		// Qualify the keyspace in the statement rather than setting it per request. A
+		// per-request keyspace requires native protocol V5, and servers such as Astra DB
+		// cap at V4, where the driver rejects the statement before it reaches the server.
+		SimpleStatement stmt = SchemaBuilder.createType(this.schema.keyspace, this.messageUDT)
 			.ifNotExists()
 			.withField(this.messageUdtTimestampColumn, DataTypes.TIMESTAMP)
 			.withField(this.messageUdtTypeColumn, DataTypes.TEXT)
 			.withField(this.messageUdtContentColumn, DataTypes.TEXT)
 			.build();
 
-		this.session.execute(stmt.setKeyspace(this.schema.keyspace));
+		if (logger.isDebugEnabled()) {
+			logger.debug("Executing " + stmt.getQuery());
+		}
+		this.session.execute(stmt);
 	}
 
 	private void ensureTableColumnsExist() {

--- a/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/test/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryProtocolV4IT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/test/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryProtocolV4IT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.cassandra;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.cassandra.CassandraContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Schema initialisation must not depend on a per-request keyspace, which the driver
+ * permits only on native protocol V5. Astra DB caps at V4, so the session here is pinned
+ * to V4 to cover that case.
+ *
+ * Use `mvn failsafe:integration-test -Dit.test=CassandraChatMemoryRepositoryProtocolV4IT`
+ *
+ * @author Mick Semb Wever
+ */
+@Testcontainers
+class CassandraChatMemoryRepositoryProtocolV4IT {
+
+	@Container
+	static CassandraContainer cassandraContainer = new CassandraContainer(CassandraImage.DEFAULT_IMAGE);
+
+	@Test
+	void schemaInitialisationAndRoundTripOnProtocolV4() {
+		try (CqlSession session = protocolV4Session()) {
+
+			assertThat(session.getContext().getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
+
+			var conf = CassandraChatMemoryRepositoryConfig.builder()
+				.withCqlSession(session)
+				.withKeyspaceName("test_" + CassandraChatMemoryRepositoryConfig.DEFAULT_KEYSPACE_NAME + "_v4")
+				.build();
+
+			conf.dropKeyspace();
+
+			CassandraChatMemoryRepository memory = CassandraChatMemoryRepository.create(conf);
+			conf.checkSchemaValid();
+
+			var conversationId = UUID.randomUUID().toString();
+			var messages = List.<Message>of(new UserMessage("Message from user"),
+					new AssistantMessage("Message from assistant"));
+
+			memory.saveAll(conversationId, messages);
+
+			assertThat(memory.findByConversationId(conversationId)).extracting(Message::getText)
+				.containsExactly("Message from user", "Message from assistant");
+		}
+	}
+
+	private static CqlSession protocolV4Session() {
+		DriverConfigLoader configLoader = DriverConfigLoader.programmaticBuilder()
+			.withString(DefaultDriverOption.PROTOCOL_VERSION, DefaultProtocolVersion.V4.name())
+			.build();
+
+		return new CqlSessionBuilder().addContactPoint(cassandraContainer.getContactPoint())
+			.withLocalDatacenter(cassandraContainer.getLocalDatacenter())
+			.withConfigLoader(configLoader)
+			.build();
+	}
+
+}


### PR DESCRIPTION
Fixes #6877

## Problem

`CassandraChatMemoryRepositoryConfig.ensureMessageTypeExist()` set the keyspace per request on its `CREATE TYPE`:

```java
SimpleStatement stmt = SchemaBuilder.createType(this.messageUDT)
    .ifNotExists()
    ...
this.session.execute(stmt.setKeyspace(this.schema.keyspace));
```

The driver permits a per-request keyspace only on native protocol V5 and above (`DefaultProtocolVersionRegistry.supports`, `DefaultProtocolFeature.PER_REQUEST_KEYSPACE`), so on a V4 connection the statement is rejected client-side and the bean fails to instantiate:

```
Failed to instantiate [org.springframework.ai.chat.memory.repository.cassandra.CassandraChatMemoryRepository]:
Factory method 'cassandraChatMemoryRepository' threw exception with message:
Can't use per-request keyspace with protocol V4
```

That makes `initialize-schema=true`, the module default, unusable against any server negotiating V4. Astra DB is the case that matters in practice, since its CQL front end caps at V4. There is no workaround short of `initialize-schema=false` plus hand-written DDL, because the method has no metadata guard and so runs on every startup.

## Change

`SchemaBuilder.createType` has a keyspace-taking overload, so qualifying the type in the statement is enough and works on every protocol version. One statement changed, plus a debug log matching the idiom in the neighbouring `ensureTableColumnsExist()`.

## Test

`CassandraChatMemoryRepositoryProtocolV4IT` pins the session to V4 with a programmatic `DriverConfigLoader`, asserts the negotiated version, then initialises the schema, validates it, and round-trips two messages.

Verified both directions against `cassandra:5.0` in Testcontainers:

| | result |
|---|---|
| new IT, without this change | `IllegalArgumentException: Can't use per-request keyspace with protocol V4` |
| new IT, with this change | `Tests run: 1, Failures: 0, Errors: 0` |
| existing `CassandraChatMemoryRepositoryIT` | `Tests run: 9, Failures: 0, Errors: 0` |

`format-check` and `checkstyle-check` pass on the module.

## Note on provenance

Per the contributor guide's note about coding agents: the diagnosis, the change, and the test were produced with Claude Code and are recorded in the commit's `Co-Authored-By` trailer. I have read the change and run the tests above.
