### PR TITLE
Support tool call messages in `MongoChatMemoryRepository`

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/model/chat/memory/repository/mongo/autoconfigure/MongoChatMemoryIndexCreatorAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/model/chat/memory/repository/mongo/autoconfigure/MongoChatMemoryIndexCreatorAutoConfiguration.java
@@ -34,10 +34,11 @@ import org.springframework.data.mongodb.core.index.IndexOperations;
 
 /**
  * Class responsible for creating proper MongoDB indices for the ChatMemory. Creates a
- * main index on the conversationId and timestamp fields, and a TTL index on the timestamp
- * field if the TTL is set in properties.
+ * main index on the conversationId, timestamp and sequenceId fields, and a TTL index on
+ * the timestamp field if the TTL is set in properties.
  *
  * @author Łukasz Jernaś
+ * @author kezhenxu94
  * @see MongoChatMemoryProperties
  * @since 1.1.0
  */
@@ -70,7 +71,9 @@ public class MongoChatMemoryIndexCreatorAutoConfiguration {
 
 	private void createMainIndex() {
 		var indexOps = this.mongoTemplate.indexOps(Conversation.class);
-		var index = new Index().on("conversationId", Sort.Direction.ASC).on("timestamp", Sort.Direction.DESC);
+		var index = new Index().on("conversationId", Sort.Direction.ASC)
+			.on("timestamp", Sort.Direction.DESC)
+			.on("sequenceId", Sort.Direction.DESC);
 
 		// Use reflection to handle API differences across Spring Data MongoDB versions
 		createIndexSafely(indexOps, index);

--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/Conversation.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/Conversation.java
@@ -17,20 +17,77 @@
 package org.springframework.ai.chat.memory.repository.mongo;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
  * A record representing a conversation in MongoDB.
  *
  * @author Lukasz Jernas
+ * @author kezhenxu94
  * @since 1.1.0
  */
 @Document("ai_chat_memory")
-public record Conversation(String conversationId, Message message, Instant timestamp) {
-	public record Message(@Nullable String content, String type, Map<String, Object> metadata) {
+public record Conversation(String conversationId, Message message, Instant timestamp, int sequenceId) {
+
+	/**
+	 * Creates a conversation with a default sequence identifier of {@code 0}. Retained
+	 * for backwards compatibility; prefer the canonical constructor so that the ordering
+	 * of messages within a conversation is deterministic.
+	 * @param conversationId the conversation identifier
+	 * @param message the message
+	 * @param timestamp the timestamp
+	 */
+	public Conversation(String conversationId, Message message, Instant timestamp) {
+		this(conversationId, message, timestamp, 0);
+	}
+
+	/**
+	 * Creates a conversation, defaulting the sequence identifier to {@code 0} when it is
+	 * absent. Used when reading documents written before the sequence identifier was
+	 * introduced, which have no such field.
+	 * @param conversationId the conversation identifier
+	 * @param message the message
+	 * @param timestamp the timestamp
+	 * @param sequenceId the sequence identifier, or {@code null} if absent
+	 */
+	@PersistenceCreator
+	Conversation(String conversationId, Message message, Instant timestamp, @Nullable Integer sequenceId) {
+		this(conversationId, message, timestamp, sequenceId != null ? sequenceId : 0);
+	}
+
+	/**
+	 * The persisted representation of a single chat message.
+	 *
+	 * @param content the textual content of the message, if any
+	 * @param type the {@link org.springframework.ai.chat.messages.MessageType} name
+	 * @param metadata the message metadata
+	 * @param toolCalls the tool calls requested by an assistant message, if any. Absent
+	 * from documents written before tool call persistence was supported.
+	 * @param toolResponses the tool responses carried by a tool message, if any. Absent
+	 * from documents written before tool call persistence was supported.
+	 */
+	public record Message(@Nullable String content, String type, Map<String, Object> metadata,
+			@Nullable List<AssistantMessage.ToolCall> toolCalls,
+			@Nullable List<ToolResponseMessage.ToolResponse> toolResponses) {
+
+		/**
+		 * Creates a message without any tool calls or tool responses. Retained for
+		 * backwards compatibility.
+		 * @param content the textual content of the message, if any
+		 * @param type the message type name
+		 * @param metadata the message metadata
+		 */
+		public Message(@Nullable String content, String type, Map<String, Object> metadata) {
+			this(content, type, metadata, List.of(), List.of());
+		}
+
 	}
 }

--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.chat.memory.repository.mongo;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -40,6 +41,7 @@ import org.springframework.util.Assert;
  * An implementation of {@link ChatMemoryRepository} for MongoDB.
  *
  * @author Lukasz Jernas
+ * @author kezhenxu94
  * @since 1.1.0
  */
 public final class MongoChatMemoryRepository implements ChatMemoryRepository {
@@ -61,27 +63,27 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 	public List<Message> findByConversationId(String conversationId) {
 		var messages = this.mongoTemplate.query(Conversation.class)
 			.matching(Query.query(Criteria.where("conversationId").is(conversationId))
-				.with(Sort.by("timestamp").ascending()));
+				.with(Sort.by("timestamp").ascending().and(Sort.by("sequenceId").ascending())));
 		return messages.stream().map(MongoChatMemoryRepository::mapMessage).filter(Objects::nonNull).toList();
 	}
 
 	@Override
 	public void saveAll(String conversationId, List<Message> messages) {
-		List<Message> persistableMessages = messages.stream()
-			.filter(m -> !(m instanceof ToolResponseMessage)
-					&& !(m instanceof AssistantMessage am && am.hasToolCalls()))
-			.toList();
-		if (logger.isWarnEnabled() && persistableMessages.size() < messages.size()) {
-			logger.warn(
-					"MongoChatMemoryRepository does not support tool call messages. Some messages were filtered out for conversation: "
-							+ conversationId);
-		}
 		deleteByConversationId(conversationId);
-		var conversations = persistableMessages.stream()
-			.map(message -> new Conversation(conversationId,
-					new Conversation.Message(message.getText(), message.getMessageType().name(), message.getMetadata()),
-					Instant.now()))
-			.toList();
+		// A single timestamp is used for the whole batch: BSON dates only have
+		// millisecond precision, so the sequence identifier is what orders the messages
+		// within a conversation.
+		var timestamp = Instant.now();
+		var conversations = new ArrayList<Conversation>(messages.size());
+		for (int i = 0; i < messages.size(); i++) {
+			Message message = messages.get(i);
+			var toolCalls = message instanceof AssistantMessage assistantMessage ? assistantMessage.getToolCalls()
+					: List.<AssistantMessage.ToolCall>of();
+			var toolResponses = message instanceof ToolResponseMessage toolResponseMessage
+					? toolResponseMessage.getResponses() : List.<ToolResponseMessage.ToolResponse>of();
+			conversations.add(new Conversation(conversationId, new Conversation.Message(message.getText(),
+					message.getMessageType().name(), message.getMetadata(), toolCalls, toolResponses), timestamp, i));
+		}
 		this.mongoTemplate.insert(conversations, Conversation.class);
 	}
 
@@ -91,20 +93,41 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 	}
 
 	public static @Nullable Message mapMessage(Conversation conversation) {
-		final String content = Objects.requireNonNullElse(conversation.message().content(), "");
-		return switch (conversation.message().type()) {
-			case "USER" -> UserMessage.builder().text(content).metadata(conversation.message().metadata()).build();
-			case "ASSISTANT" ->
-				AssistantMessage.builder().content(content).properties(conversation.message().metadata()).build();
-			case "SYSTEM" -> SystemMessage.builder().text(content).metadata(conversation.message().metadata()).build();
-			// this implementation doesn't support tool calls message persistence, so
-			// TOOL rows are filtered out by the caller
-			case "TOOL" -> null;
+		final Conversation.Message message = conversation.message();
+		// USER and SYSTEM messages require non-null text content.
+		final String content = Objects.requireNonNullElse(message.content(), "");
+		return switch (message.type()) {
+			case "USER" -> UserMessage.builder().text(content).metadata(message.metadata()).build();
+			case "ASSISTANT" -> AssistantMessage.builder()
+				// Assistant messages carrying only tool calls have no text content, and
+				// null is preserved so that they round-trip unchanged.
+				.content(message.content())
+				.properties(message.metadata())
+				.toolCalls(Objects.requireNonNullElse(message.toolCalls(), List.of()))
+				.build();
+			case "SYSTEM" -> SystemMessage.builder().text(content).metadata(message.metadata()).build();
+			case "TOOL" -> {
+				var toolResponses = message.toolResponses();
+				if (toolResponses == null) {
+					// Documents written before tool call persistence was supported
+					// have no tool response field at all. They would be read back
+					// as empty stubs, so they are skipped to avoid polluting the
+					// LLM conversation context. A tool message that was genuinely
+					// saved without responses stores an empty array instead, and is
+					// preserved.
+					if (logger.isWarnEnabled()) {
+						logger.warn("Skipping tool message without tool responses for conversation: "
+								+ conversation.conversationId());
+					}
+					yield null;
+				}
+				yield ToolResponseMessage.builder().responses(toolResponses).metadata(message.metadata()).build();
+			}
 			default -> {
 				if (logger.isWarnEnabled()) {
-					logger.warn("Unsupported message type: " + conversation.message().type());
+					logger.warn("Unsupported message type: " + message.type());
 				}
-				throw new IllegalStateException("Unsupported message type: " + conversation.message().type());
+				throw new IllegalStateException("Unsupported message type: " + message.type());
 			}
 		};
 	}

--- a/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/test/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-mongodb/src/test/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepositoryIT.java
@@ -16,9 +16,14 @@
 
 package org.springframework.ai.chat.memory.repository.mongo;
 
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.IntStream;
 
+import org.bson.Document;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -40,6 +45,7 @@ import org.springframework.boot.mongodb.autoconfigure.MongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -50,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link MongoChatMemoryRepository}.
  *
  * @author Łukasz Jernaś
+ * @author kezhenxu94
  */
 @SpringBootTest(classes = MongoChatMemoryRepositoryIT.TestConfiguration.class)
 public class MongoChatMemoryRepositoryIT {
@@ -139,14 +146,331 @@ public class MongoChatMemoryRepositoryIT {
 	}
 
 	@Test
-	void toolResponseMessagesAreFilteredOnSave() {
+	void toolResponseMessagesAreRoundTripped() {
 		var conversationId = UUID.randomUUID().toString();
-		var user = new UserMessage("Hello");
+		var responses = List.of(new ToolResponseMessage.ToolResponse("id1", "myTool", "result"),
+				new ToolResponseMessage.ToolResponse("id2", "myOtherTool", "otherResult"),
+				new ToolResponseMessage.ToolResponse("id3", "aThirdTool", "yetAnotherResult"));
+		var toolResponse = ToolResponseMessage.builder().responses(responses).build();
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of(toolResponse));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0)).isInstanceOf(ToolResponseMessage.class);
+		assertThat(results.get(0).getMessageType()).isEqualTo(MessageType.TOOL);
+		assertThat(((ToolResponseMessage) results.get(0)).getResponses()).containsExactlyElementsOf(responses);
+	}
+
+	@Test
+	void assistantMessagesWithToolCallsAreRoundTripped() {
+		var conversationId = UUID.randomUUID().toString();
+		var toolCalls = List.of(
+				new AssistantMessage.ToolCall("call1", "function", "getWeather", "{\"city\":\"Paris\"}"),
+				new AssistantMessage.ToolCall("call2", "function", "getTime", "{}"));
+		var toolCallAssistant = AssistantMessage.builder().toolCalls(toolCalls).build();
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of(toolCallAssistant));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0)).isInstanceOf(AssistantMessage.class);
+		assertThat(results.get(0).getText()).isNull();
+		assertThat(((AssistantMessage) results.get(0)).getToolCalls()).containsExactlyElementsOf(toolCalls);
+	}
+
+	@Test
+	void toolCallOrderIsPreservedWithinAnAssistantMessage() {
+		var conversationId = UUID.randomUUID().toString();
+		var toolCalls = IntStream.range(0, 10)
+			.mapToObj(i -> new AssistantMessage.ToolCall("call" + i, "function", "tool" + i, "{\"index\":" + i + "}"))
+			.toList();
+
+		this.chatMemoryRepository.saveAll(conversationId,
+				List.of(AssistantMessage.builder().toolCalls(toolCalls).build()));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(((AssistantMessage) results.get(0)).getToolCalls()).containsExactlyElementsOf(toolCalls);
+	}
+
+	@Test
+	void toolCallArgumentsWithJsonAndSpecialCharactersAreRoundTripped() {
+		var conversationId = UUID.randomUUID().toString();
+		var arguments = "{\"query\":\"a \\\"quoted\\\" value\",\"nested\":{\"a.b\":1},\"unicode\":\"héllo 世界 🌍\"}";
+		var toolCall = new AssistantMessage.ToolCall("call-1", "function", "search", arguments);
+
+		this.chatMemoryRepository.saveAll(conversationId,
+				List.of(AssistantMessage.builder().toolCalls(List.of(toolCall)).build()));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(((AssistantMessage) results.get(0)).getToolCalls()).containsExactly(toolCall);
+	}
+
+	@Test
+	void toolResponseDataWithSpecialCharactersIsRoundTripped() {
+		var conversationId = UUID.randomUUID().toString();
+		var response = new ToolResponseMessage.ToolResponse("call-1", "search",
+				"line one\nline two\ttabbed \"quoted\" héllo 世界 🌍");
+
+		this.chatMemoryRepository.saveAll(conversationId,
+				List.of(ToolResponseMessage.builder().responses(List.of(response)).build()));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(((ToolResponseMessage) results.get(0)).getResponses()).containsExactly(response);
+	}
+
+	@Test
+	void assistantMessagesWithoutToolCallsAreReadBackWithAnEmptyToolCallList() {
+		var conversationId = UUID.randomUUID().toString();
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of(new AssistantMessage("Just text.")));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		var assistantMessage = (AssistantMessage) results.get(0);
+		assertThat(assistantMessage.getToolCalls()).isEmpty();
+		assertThat(assistantMessage.hasToolCalls()).isFalse();
+	}
+
+	@Test
+	void metadataIsPreservedOnToolCallAndToolResponseMessages() {
+		var conversationId = UUID.randomUUID().toString();
+		var assistant = AssistantMessage.builder()
+			.properties(Map.of("finishReason", "TOOL_CALLS", "attempt", 2))
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}")))
+			.build();
 		var toolResponse = ToolResponseMessage.builder()
-			.responses(List.of(new ToolResponseMessage.ToolResponse("id1", "myTool", "result")))
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call1", "getWeather", "sunny")))
+			.metadata(Map.of("durationMs", 42))
 			.build();
 
-		this.chatMemoryRepository.saveAll(conversationId, List.of(user, toolResponse));
+		this.chatMemoryRepository.saveAll(conversationId, List.of(assistant, toolResponse));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results.get(0).getMetadata()).containsEntry("finishReason", "TOOL_CALLS")
+			.containsEntry("attempt", 2);
+		assertThat(results.get(1).getMetadata()).containsEntry("durationMs", 42);
+	}
+
+	@Test
+	void fullToolCallingTurnIsRoundTrippedInOrder() {
+		var conversationId = UUID.randomUUID().toString();
+		var messages = List.<Message>of(new UserMessage("What is the weather?"),
+				AssistantMessage.builder()
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}")))
+					.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call1", "getWeather", "sunny")))
+					.build(),
+				new AssistantMessage("It is sunny."));
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEqualTo(messages);
+	}
+
+	@Test
+	void parallelToolCallsAndTheirResponsesAreRoundTrippedInOrder() {
+		var conversationId = UUID.randomUUID().toString();
+		var messages = List.<Message>of(new UserMessage("Weather and time in Paris?"), AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{\"city\":\"Paris\"}"),
+					new AssistantMessage.ToolCall("call2", "function", "getTime", "{\"city\":\"Paris\"}")))
+			.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call1", "getWeather", "sunny"),
+							new ToolResponseMessage.ToolResponse("call2", "getTime", "14:00")))
+					.build(),
+				new AssistantMessage("It is sunny and 14:00 in Paris."));
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEqualTo(messages);
+	}
+
+	@Test
+	void multiTurnToolCallingConversationIsRoundTrippedInOrder() {
+		var conversationId = UUID.randomUUID().toString();
+		var messages = List.<Message>of(new SystemMessage("You are a helpful assistant."),
+				new UserMessage("Weather in Paris?"),
+				AssistantMessage.builder()
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}")))
+					.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call1", "getWeather", "sunny")))
+					.build(),
+				new AssistantMessage("It is sunny."), new UserMessage("And in Berlin?"),
+				AssistantMessage.builder()
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call2", "function", "getWeather", "{}")))
+					.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call2", "getWeather", "rainy")))
+					.build(),
+				new AssistantMessage("It is rainy."));
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEqualTo(messages);
+	}
+
+	@Test
+	void savingAgainReplacesThePreviousToolCallingConversation() {
+		var conversationId = UUID.randomUUID().toString();
+		var firstTurn = List.<Message>of(new UserMessage("Weather in Paris?"),
+				AssistantMessage.builder()
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}")))
+					.build());
+		this.chatMemoryRepository.saveAll(conversationId, firstTurn);
+
+		var secondTurn = List.<Message>of(new UserMessage("Weather in Paris?"),
+				AssistantMessage.builder()
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}")))
+					.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call1", "getWeather", "sunny")))
+					.build());
+		this.chatMemoryRepository.saveAll(conversationId, secondTurn);
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEqualTo(secondTurn);
+		assertThat(this.mongoTemplate.query(Conversation.class)
+			.matching(Query.query(Criteria.where("conversationId").is(conversationId)))
+			.all()).hasSize(secondTurn.size());
+	}
+
+	@Test
+	void toolCallsArePersistedAsOrderedSubdocuments() {
+		var conversationId = UUID.randomUUID().toString();
+		var toolCall = new AssistantMessage.ToolCall("call1", "function", "getWeather", "{\"city\":\"Paris\"}");
+
+		this.chatMemoryRepository.saveAll(conversationId,
+				List.of(AssistantMessage.builder().toolCalls(List.of(toolCall)).build()));
+
+		var stored = this.mongoTemplate.query(Conversation.class)
+			.matching(Query.query(Criteria.where("conversationId").is(conversationId)))
+			.firstValue();
+		assertThat(stored).isNotNull();
+		assertThat(stored.message().toolCalls()).containsExactly(toolCall);
+		assertThat(stored.message().toolResponses()).isEmpty();
+		assertThat(stored.sequenceId()).isZero();
+	}
+
+	@Test
+	void sequenceIdentifiersAreAssignedInMessageOrder() {
+		var conversationId = UUID.randomUUID().toString();
+		var messages = List.<Message>of(new UserMessage("One"), new AssistantMessage("Two"), new UserMessage("Three"));
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		var stored = this.mongoTemplate.query(Conversation.class)
+			.matching(Query.query(Criteria.where("conversationId").is(conversationId))
+				.with(Sort.by("sequenceId").ascending()))
+			.all();
+		assertThat(stored).extracting(Conversation::sequenceId).containsExactly(0, 1, 2);
+		// Every message in a batch shares one timestamp, so the sequence identifier is
+		// what makes the ordering deterministic.
+		assertThat(stored).extracting(Conversation::timestamp).containsOnly(stored.get(0).timestamp());
+	}
+
+	@Test
+	void conversationsWithToolCallsAreIsolatedFromEachOther() {
+		var firstConversationId = UUID.randomUUID().toString();
+		var secondConversationId = UUID.randomUUID().toString();
+		this.chatMemoryRepository.saveAll(firstConversationId,
+				List.of(AssistantMessage.builder()
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "first", "{}")))
+					.build()));
+		this.chatMemoryRepository.saveAll(secondConversationId,
+				List.of(AssistantMessage.builder()
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call2", "function", "second", "{}")))
+					.build()));
+
+		assertThat(((AssistantMessage) this.chatMemoryRepository.findByConversationId(firstConversationId).get(0))
+			.getToolCalls()).extracting(AssistantMessage.ToolCall::name).containsExactly("first");
+		assertThat(((AssistantMessage) this.chatMemoryRepository.findByConversationId(secondConversationId).get(0))
+			.getToolCalls()).extracting(AssistantMessage.ToolCall::name).containsExactly("second");
+		assertThat(this.chatMemoryRepository.findConversationIds()).contains(firstConversationId, secondConversationId);
+	}
+
+	@Test
+	void savingAnEmptyMessageListLeavesNoDocuments() {
+		var conversationId = UUID.randomUUID().toString();
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of());
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEmpty();
+	}
+
+	@Test
+	void toolResponseMessagesSavedWithoutResponsesArePreserved() {
+		var conversationId = UUID.randomUUID().toString();
+		// An empty response list is stored as an empty array, which is distinguishable
+		// from a legacy document that has no tool response field at all.
+		var toolResponse = ToolResponseMessage.builder().responses(List.of()).build();
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of(toolResponse));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0)).isInstanceOf(ToolResponseMessage.class);
+		assertThat(((ToolResponseMessage) results.get(0)).getResponses()).isEmpty();
+	}
+
+	@Test
+	void largeToolCallArgumentsAndResponseDataAreRoundTripped() {
+		var conversationId = UUID.randomUUID().toString();
+		var largeValue = "x".repeat(64 * 1024);
+		var toolCall = new AssistantMessage.ToolCall("call1", "function", "bulk",
+				"{\"payload\":\"" + largeValue + "\"}");
+		var toolResponse = new ToolResponseMessage.ToolResponse("call1", "bulk", largeValue);
+
+		this.chatMemoryRepository.saveAll(conversationId,
+				List.of(AssistantMessage.builder().toolCalls(List.of(toolCall)).build(),
+						ToolResponseMessage.builder().responses(List.of(toolResponse)).build()));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(((AssistantMessage) results.get(0)).getToolCalls()).containsExactly(toolCall);
+		assertThat(((ToolResponseMessage) results.get(1)).getResponses()).containsExactly(toolResponse);
+	}
+
+	@Test
+	void toolCallsWithEmptyArgumentsAreRoundTripped() {
+		var conversationId = UUID.randomUUID().toString();
+		var toolCall = new AssistantMessage.ToolCall("call1", "function", "noArgs", "");
+
+		this.chatMemoryRepository.saveAll(conversationId,
+				List.of(AssistantMessage.builder().toolCalls(List.of(toolCall)).build()));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(((AssistantMessage) results.get(0)).getToolCalls()).containsExactly(toolCall);
+	}
+
+	@Test
+	void assistantMessagesWithBothTextAndToolCallsAreRoundTripped() {
+		var conversationId = UUID.randomUUID().toString();
+		var toolCall = new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}");
+		var assistant = AssistantMessage.builder().content("Let me check.").toolCalls(List.of(toolCall)).build();
+
+		this.chatMemoryRepository.saveAll(conversationId, List.of(assistant));
+
+		var results = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(results).containsExactly(assistant);
+		assertThat(results.get(0).getText()).isEqualTo("Let me check.");
+		assertThat(((AssistantMessage) results.get(0)).getToolCalls()).containsExactly(toolCall);
+	}
+
+	@Test
+	void legacyToolDocumentsWithoutToolResponsesAreSkipped() {
+		var conversationId = UUID.randomUUID().toString();
+		var timestamp = Date.from(Instant.now());
+		// Documents written before tool call persistence was supported have neither the
+		// tool response nor the sequence identifier fields.
+		this.mongoTemplate.getCollection("ai_chat_memory")
+			.insertMany(List.of(
+					new Document(Map.of("conversationId", conversationId, "message",
+							new Document(
+									Map.of("content", "Hello", "type", MessageType.USER.name(), "metadata", Map.of())),
+							"timestamp", timestamp)),
+					new Document(Map.of("conversationId", conversationId, "message",
+							new Document(Map.of("content", "", "type", MessageType.TOOL.name(), "metadata", Map.of())),
+							"timestamp", timestamp))));
 
 		var results = this.chatMemoryRepository.findByConversationId(conversationId);
 		assertThat(results).hasSize(1);
@@ -154,19 +478,38 @@ public class MongoChatMemoryRepositoryIT {
 	}
 
 	@Test
-	void assistantMessagesWithToolCallsAreFilteredOnSave() {
+	void legacyAssistantDocumentsWithoutToolCallsAreReadBack() {
 		var conversationId = UUID.randomUUID().toString();
-		var user = new UserMessage("What is the weather?");
-		var toolCallAssistant = AssistantMessage.builder()
-			.toolCalls(List.of(new AssistantMessage.ToolCall("call1", "function", "getWeather", "{}")))
-			.build();
-		var plainAssistant = new AssistantMessage("It is sunny.");
-
-		this.chatMemoryRepository.saveAll(conversationId, List.of(user, toolCallAssistant, plainAssistant));
+		// A document written before tool call persistence was supported has no toolCalls
+		// field at all, which must be read back as an empty list rather than failing.
+		this.mongoTemplate.getCollection("ai_chat_memory")
+			.insertOne(new Document(Map.of(
+					"conversationId", conversationId, "message", new Document(Map.of("content", "Legacy answer", "type",
+							MessageType.ASSISTANT.name(), "metadata", Map.of())),
+					"timestamp", Date.from(Instant.now()))));
 
 		var results = this.chatMemoryRepository.findByConversationId(conversationId);
-		assertThat(results).hasSize(2);
-		assertThat(results).extracting(Message::getText).containsExactly("What is the weather?", "It is sunny.");
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getText()).isEqualTo("Legacy answer");
+		assertThat(((AssistantMessage) results.get(0)).getToolCalls()).isEmpty();
+	}
+
+	@Test
+	void legacyDocumentsAreOrderedBeforeNewlyWrittenOnes() {
+		var conversationId = UUID.randomUUID().toString();
+		this.mongoTemplate.getCollection("ai_chat_memory")
+			.insertOne(new Document(Map.of("conversationId", conversationId, "message",
+					new Document(Map.of("content", "Legacy", "type", MessageType.USER.name(), "metadata", Map.of())),
+					"timestamp", Date.from(Instant.now().minusSeconds(60)))));
+
+		var stored = this.mongoTemplate.query(Conversation.class)
+			.matching(Query.query(Criteria.where("conversationId").is(conversationId)))
+			.firstValue();
+		assertThat(stored).isNotNull();
+		// An absent sequence identifier is read back as zero.
+		assertThat(stored.sequenceId()).isZero();
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).extracting(Message::getText)
+			.containsExactly("Legacy");
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -411,12 +411,9 @@ The Neo4j repository will automatically ensure that indexes are created for conv
 
 Messages are retrieved in ascending timestamp order (oldest-to-newest), which is the expected format for LLM conversation history. This ordering is consistent across all chat memory repository implementations.
 
-[WARNING]
-====
-*`MongoChatMemoryRepository` does not support tool call messages.*
-`AssistantMessage` instances containing tool calls and `ToolResponseMessage` instances are silently filtered out on save and will not appear in the retrieved conversation history.
-If your application uses tool calling, consider the https://spring-ai-community.github.io/spring-ai-session/latest/[Spring AI Session] project and the https://spring-ai-community.github.io/spring-ai-session/latest/session-jdbc/[JDBC session store], which properly persist all message types.
-====
+`MongoChatMemoryRepository` supports tool call messages.
+`AssistantMessage` instances containing tool calls and `ToolResponseMessage` instances are persisted with their tool call identifiers, names, arguments and response data, so a complete tool-calling exchange round-trips unchanged.
+Messages within a conversation are ordered by an explicit sequence identifier, which guarantees that a tool response is always retrieved immediately after the assistant message that requested it.
 
 First, add the following dependency to your project:
 


### PR DESCRIPTION
`MongoChatMemoryRepository` filtered out `ToolResponseMessage` and `AssistantMessage` instances carrying tool calls, because the persisted document had no field to hold tool call identifiers, names, arguments or response data.
Applications using tool calling silently lost part of their conversation history.

This was a stopgap rather than a MongoDB limitation, introduced alongside the equivalent JDBC and Cassandra changes.
Unlike JDBC, MongoDB needs no schema migration to store the missing data, and two built-in repositories already support tool calls, so this brings MongoDB to parity with them.

## Changes

`Conversation.Message` now stores `toolCalls` and `toolResponses`, reusing `AssistantMessage.ToolCall` and `ToolResponseMessage.ToolResponse` the same way `RedisChatMemoryRepository` does, so a complete tool-calling exchange round-trips unchanged.
Null assistant content is preserved rather than coerced to an empty string, which is the usual shape of a message that only carries tool calls.

Messages also gain a sequence identifier.
Every message in a `saveAll` batch shared a single BSON timestamp, which only has millisecond precision, and MongoDB does not guarantee the order of documents with duplicate sort keys.
Reads now sort by timestamp and sequence identifier.
This matters specifically for tool calling, because providers reject a tool response that is not immediately preceded by the assistant message requesting it.
The compound index created by `MongoChatMemoryIndexCreatorAutoConfiguration` was extended so the new sort is still served by the index.

## Backwards compatibility

Documents written by earlier versions have neither new field.

* `sequenceId` stays a primitive `int`. Spring Data passes `null` for an absent field and a record cannot declare a default, so with a plain canonical constructor, reading any pre-existing document fails with `MappingInstantiationException`. A package-private `@PersistenceCreator` constructor taking a nullable `Integer` normalizes the absent value to zero, which keeps the record component and its accessor primitive.
* Assistant documents without `toolCalls` are read back with an empty tool call list.
* Tool documents cannot be reconstructed, so they are still skipped, and empty stubs never reach the LLM context. This is distinguished by the field being absent rather than empty, so a tool message genuinely saved without responses stores an empty array and is preserved.
* The previous constructor signatures are retained as delegating constructors, since both records are public API.

## Tests

`MongoChatMemoryRepositoryIT` grows from 8 to 30 tests, covering round-trips of tool calls and tool responses, ordering within a message and across a conversation, parallel tool calls with correlated responses, multi-turn tool-calling conversations, JSON/unicode/large payloads in arguments and response data, metadata preservation, storage-level document structure, replace semantics, and each of the backwards compatibility paths above using raw legacy BSON documents.

Verified locally with:

```
./mvnw -pl memory-repositories/spring-ai-model-chat-memory-repository-mongodb -am \
  -Pintegration-tests -Dfailsafe.failIfNoSpecifiedTests=false \
  -Dit.test=MongoChatMemoryRepositoryIT verify
```

30/30 pass, along with `MongoChatMemoryAutoConfigurationIT`, `javadoc:javadoc` and `spring-javaformat:validate`.

## Note for reviewers

This reverses the deliberate decision in #6399, which filtered these messages across JDBC, Cassandra and MongoDB, and the reference documentation currently points tool-calling users to the Spring AI Session project.
I am happy to close this if the intent is for `ChatMemoryRepository` to stay tool-call-free, or to extend the same approach to the other repositories if parity is preferred.

The equivalent JDBC and Cassandra limitations are untouched here.
I also noticed two pre-existing issues while comparing implementations, both out of scope for this PR and neither addressed: `MongoChatMemoryRepository` drops media entirely, and `RedisChatMemoryRepository` appears to throw an NPE when reading an assistant message saved with null content, since Gson omits the null `content` key and the read path calls `json.get("content").getAsString()` without a guard.

See #6399

