### PR TITLE
feat(ollama): split OllamaOptions into OllamaChatOptions and OllamaEmbeddingOptions

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -121,6 +121,29 @@ public class OllamaChatModel implements ChatModel {
 
 	private final RetryTemplate retryTemplate;
 
+	/**
+	 * @deprecated since 1.0.0-M2 in favor of
+	 * {@link #OllamaChatModel(OllamaApi, OllamaChatOptions, ToolCallingManager, ObservationRegistry, ModelManagementOptions)}.
+	 */
+	@Deprecated(since = "1.0.0-M2", forRemoval = false)
+	public OllamaChatModel(OllamaApi ollamaApi, org.springframework.ai.ollama.api.OllamaOptions options,
+			ToolCallingManager toolCallingManager, ObservationRegistry observationRegistry,
+			ModelManagementOptions modelManagementOptions) {
+		this(ollamaApi, (OllamaChatOptions) options, toolCallingManager, observationRegistry, modelManagementOptions);
+	}
+
+	/**
+	 * @deprecated since 1.0.0-M2 in favor of
+	 * {@link #OllamaChatModel(OllamaApi, OllamaChatOptions, ToolCallingManager, ObservationRegistry, ModelManagementOptions, RetryTemplate)}.
+	 */
+	@Deprecated(since = "1.0.0-M2", forRemoval = false)
+	public OllamaChatModel(OllamaApi ollamaApi, org.springframework.ai.ollama.api.OllamaOptions options,
+			ToolCallingManager toolCallingManager, ObservationRegistry observationRegistry,
+			ModelManagementOptions modelManagementOptions, RetryTemplate retryTemplate) {
+		this(ollamaApi, (OllamaChatOptions) options, toolCallingManager, observationRegistry, modelManagementOptions,
+				retryTemplate);
+	}
+
 	public OllamaChatModel(OllamaApi ollamaApi, OllamaChatOptions options, ToolCallingManager toolCallingManager,
 			ObservationRegistry observationRegistry, ModelManagementOptions modelManagementOptions) {
 		this(ollamaApi, options, toolCallingManager, observationRegistry, modelManagementOptions,
@@ -519,6 +542,15 @@ public class OllamaChatModel implements ChatModel {
 
 		public Builder ollamaApi(OllamaApi ollamaApi) {
 			this.ollamaApi = ollamaApi;
+			return this;
+		}
+
+		/**
+		 * @deprecated since 1.0.0-M2 in favor of {@link #options(OllamaChatOptions)}.
+		 */
+		@Deprecated(since = "1.0.0-M2", forRemoval = false)
+		public Builder options(org.springframework.ai.ollama.api.OllamaOptions options) {
+			this.options = options;
 			return this;
 		}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
@@ -74,6 +74,17 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 
 	private EmbeddingModelObservationConvention observationConvention = DEFAULT_OBSERVATION_CONVENTION;
 
+	/**
+	 * @deprecated since 1.0.0-M2 in favor of
+	 * {@link #OllamaEmbeddingModel(OllamaApi, OllamaEmbeddingOptions, ObservationRegistry, ModelManagementOptions)}.
+	 */
+	@Deprecated(since = "1.0.0-M2", forRemoval = false)
+	public OllamaEmbeddingModel(OllamaApi ollamaApi, org.springframework.ai.ollama.api.OllamaOptions options,
+			ObservationRegistry observationRegistry, ModelManagementOptions modelManagementOptions) {
+		this(ollamaApi, options != null ? options.toEmbeddingOptions() : OllamaEmbeddingOptions.builder().build(),
+				observationRegistry, modelManagementOptions);
+	}
+
 	public OllamaEmbeddingModel(OllamaApi ollamaApi, OllamaEmbeddingOptions options,
 			ObservationRegistry observationRegistry, ModelManagementOptions modelManagementOptions) {
 		Assert.notNull(ollamaApi, "ollamaApi must not be null");
@@ -183,6 +194,22 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 				.useMLock(ModelOptionsUtils.mergeOption(ro.getUseMLock(), options.getUseMLock()))
 				.numThread(ModelOptionsUtils.mergeOption(ro.getNumThread(), options.getNumThread()));
 		}
+		else if (requestOptions instanceof org.springframework.ai.ollama.api.OllamaOptions ro) {
+			builder.keepAlive(ModelOptionsUtils.mergeOption(ro.getKeepAlive(), options.getKeepAlive()))
+				.truncate(ModelOptionsUtils.mergeOption(ro.getTruncate(), options.getTruncate()))
+				.useNUMA(ModelOptionsUtils.mergeOption(ro.getUseNUMA(), options.getUseNUMA()))
+				.numCtx(ModelOptionsUtils.mergeOption(ro.getNumCtx(), options.getNumCtx()))
+				.numBatch(ModelOptionsUtils.mergeOption(ro.getNumBatch(), options.getNumBatch()))
+				.numGPU(ModelOptionsUtils.mergeOption(ro.getNumGPU(), options.getNumGPU()))
+				.mainGPU(ModelOptionsUtils.mergeOption(ro.getMainGPU(), options.getMainGPU()))
+				.lowVRAM(ModelOptionsUtils.mergeOption(ro.getLowVRAM(), options.getLowVRAM()))
+				.f16KV(ModelOptionsUtils.mergeOption(ro.getF16KV(), options.getF16KV()))
+				.logitsAll(ModelOptionsUtils.mergeOption(ro.getLogitsAll(), options.getLogitsAll()))
+				.vocabOnly(ModelOptionsUtils.mergeOption(ro.getVocabOnly(), options.getVocabOnly()))
+				.useMMap(ModelOptionsUtils.mergeOption(ro.getUseMMap(), options.getUseMMap()))
+				.useMLock(ModelOptionsUtils.mergeOption(ro.getUseMLock(), options.getUseMLock()))
+				.numThread(ModelOptionsUtils.mergeOption(ro.getNumThread(), options.getNumThread()));
+		}
 
 		return builder.build();
 	}
@@ -234,6 +261,16 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 
 		public Builder ollamaApi(OllamaApi ollamaApi) {
 			this.ollamaApi = ollamaApi;
+			return this;
+		}
+
+		/**
+		 * @deprecated since 1.0.0-M2 in favor of
+		 * {@link #options(OllamaEmbeddingOptions)}.
+		 */
+		@Deprecated(since = "1.0.0-M2", forRemoval = false)
+		public Builder options(org.springframework.ai.ollama.api.OllamaOptions options) {
+			this.options = options != null ? options.toEmbeddingOptions() : OllamaEmbeddingOptions.builder().build();
 			return this;
 		}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.ollama.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.embedding.EmbeddingOptions;
+import org.springframework.ai.tool.ToolCallback;
+
+/**
+ * Helper class for creating strongly-typed Ollama options.
+ *
+ * @author Christian Tzolov
+ * @author Thomas Vitale
+ * @author Ilayaperumal Gopinathan
+ * @author Nicolas Krier
+ * @author Sebastien Deleuze
+ * @author Raphael Zanarelli
+ * @since 0.8.0
+ * @deprecated since 1.0.0-M2 in favor of {@link OllamaChatOptions} for chat completions
+ * and {@link OllamaEmbeddingOptions} for embedding operations. Use
+ * {@link OllamaChatOptions} or {@link OllamaEmbeddingOptions} instead.
+ * @see OllamaChatOptions
+ * @see OllamaEmbeddingOptions
+ * @see <a href=
+ * "https://github.com/ollama/ollama/blob/main/docs/modelfile.mdx#valid-parameters-and-values">Ollama
+ * Valid Parameters and Values</a>
+ * @see <a href="https://github.com/ollama/ollama/blob/main/api/types.go">Ollama Types</a>
+ */
+@Deprecated(since = "1.0.0-M2", forRemoval = false)
+public class OllamaOptions extends OllamaChatOptions implements EmbeddingOptions {
+
+	private final @Nullable Integer dimensions;
+
+	protected OllamaOptions(@Nullable Boolean useNUMA, @Nullable Integer numCtx, @Nullable Integer numBatch,
+			@Nullable Integer numGPU, @Nullable Integer mainGPU, @Nullable Boolean lowVRAM, @Nullable Boolean f16KV,
+			@Nullable Boolean logitsAll, @Nullable Boolean vocabOnly, @Nullable Boolean useMMap,
+			@Nullable Boolean useMLock, @Nullable Integer numThread, @Nullable Integer numKeep, @Nullable Integer seed,
+			@Nullable Integer numPredict, @Nullable Integer topK, @Nullable Double topP, @Nullable Double minP,
+			@Nullable Float tfsZ, @Nullable Float typicalP, @Nullable Integer repeatLastN, @Nullable Double temperature,
+			@Nullable Double repeatPenalty, @Nullable Double presencePenalty, @Nullable Double frequencyPenalty,
+			@Nullable Integer mirostat, @Nullable Float mirostatTau, @Nullable Float mirostatEta,
+			@Nullable Boolean penalizeNewline, @Nullable List<String> stop, @Nullable String model,
+			@Nullable Object format, @Nullable String keepAlive, @Nullable Boolean truncate,
+			@Nullable ThinkOption thinkOption, @Nullable List<ToolCallback> toolCallbacks,
+			@Nullable Map<String, Object> toolContext, @Nullable Integer dimensions) {
+		super(useNUMA, numCtx, numBatch, numGPU, mainGPU, lowVRAM, f16KV, logitsAll, vocabOnly, useMMap, useMLock,
+				numThread, numKeep, seed, numPredict, topK, topP, minP, tfsZ, typicalP, repeatLastN, temperature,
+				repeatPenalty, presencePenalty, frequencyPenalty, mirostat, mirostatTau, mirostatEta, penalizeNewline,
+				stop, model, format, keepAlive, truncate, thinkOption, toolCallbacks, toolContext);
+		this.dimensions = dimensions;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public @Nullable Integer getDimensions() {
+		return this.dimensions;
+	}
+
+	/**
+	 * Convert this {@link OllamaOptions} instance to {@link OllamaEmbeddingOptions}.
+	 * @return a new {@link OllamaEmbeddingOptions} instance populated with matching
+	 * options.
+	 */
+	public OllamaEmbeddingOptions toEmbeddingOptions() {
+		return OllamaEmbeddingOptions.builder()
+			.model(getModel())
+			.keepAlive(getKeepAlive())
+			.dimensions(this.dimensions)
+			.truncate(getTruncate())
+			.useNUMA(getUseNUMA())
+			.numCtx(getNumCtx())
+			.numBatch(getNumBatch())
+			.numGPU(getNumGPU())
+			.mainGPU(getMainGPU())
+			.lowVRAM(getLowVRAM())
+			.f16KV(getF16KV())
+			.logitsAll(getLogitsAll())
+			.vocabOnly(getVocabOnly())
+			.useMMap(getUseMMap())
+			.useMLock(getUseMLock())
+			.numThread(getNumThread())
+			.build();
+	}
+
+	@Override
+	public Map<String, Object> toMap() {
+		Map<String, Object> map = new java.util.HashMap<>(super.toMap());
+		if (this.dimensions != null) {
+			map.put("dimensions", this.dimensions);
+		}
+		return map;
+	}
+
+	@Override
+	public Builder mutate() {
+		return OllamaOptions.builder()
+			.dimensions(this.dimensions)
+			.model(getModel())
+			.frequencyPenalty(getFrequencyPenalty())
+			.maxTokens(getNumPredict())
+			.presencePenalty(getPresencePenalty())
+			.stop(getStop())
+			.temperature(getTemperature())
+			.topK(getTopK())
+			.topP(getTopP())
+			.toolCallbacks(getToolCallbacks())
+			.toolContext(getToolContext())
+			.format(getFormat())
+			.keepAlive(getKeepAlive())
+			.truncate(getTruncate())
+			.thinkOption(getThinkOption())
+			.useNUMA(getUseNUMA())
+			.numCtx(getNumCtx())
+			.numBatch(getNumBatch())
+			.numGPU(getNumGPU())
+			.mainGPU(getMainGPU())
+			.lowVRAM(getLowVRAM())
+			.f16KV(getF16KV())
+			.logitsAll(getLogitsAll())
+			.vocabOnly(getVocabOnly())
+			.useMMap(getUseMMap())
+			.useMLock(getUseMLock())
+			.numThread(getNumThread())
+			.numKeep(getNumKeep())
+			.seed(getSeed())
+			.minP(getMinP())
+			.tfsZ(getTfsZ())
+			.typicalP(getTypicalP())
+			.repeatLastN(getRepeatLastN())
+			.repeatPenalty(getRepeatPenalty())
+			.mirostat(getMirostat())
+			.mirostatTau(getMirostatTau())
+			.mirostatEta(getMirostatEta())
+			.penalizeNewline(getPenalizeNewline());
+	}
+
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		OllamaOptions that = (OllamaOptions) o;
+		return Objects.equals(this.dimensions, that.dimensions);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), this.dimensions);
+	}
+
+	public static class Builder extends OllamaChatOptions.Builder {
+
+		protected @Nullable Integer dimensions;
+
+		public Builder dimensions(@Nullable Integer dimensions) {
+			this.dimensions = dimensions;
+			return this;
+		}
+
+		@Override
+		public Builder model(@Nullable String model) {
+			super.model(model);
+			return this;
+		}
+
+		@Override
+		public Builder temperature(@Nullable Double temperature) {
+			super.temperature(temperature);
+			return this;
+		}
+
+		@Override
+		public Builder topK(@Nullable Integer topK) {
+			super.topK(topK);
+			return this;
+		}
+
+		@Override
+		public Builder topP(@Nullable Double topP) {
+			super.topP(topP);
+			return this;
+		}
+
+		@Override
+		public Builder maxTokens(@Nullable Integer maxTokens) {
+			super.maxTokens(maxTokens);
+			return this;
+		}
+
+		@Override
+		public Builder numPredict(@Nullable Integer numPredict) {
+			super.numPredict(numPredict);
+			return this;
+		}
+
+		@Override
+		public Builder keepAlive(@Nullable String keepAlive) {
+			super.keepAlive(keepAlive);
+			return this;
+		}
+
+		@Override
+		public Builder truncate(@Nullable Boolean truncate) {
+			super.truncate(truncate);
+			return this;
+		}
+
+		@Override
+		public Builder useNUMA(@Nullable Boolean useNUMA) {
+			super.useNUMA(useNUMA);
+			return this;
+		}
+
+		@Override
+		public Builder numCtx(@Nullable Integer numCtx) {
+			super.numCtx(numCtx);
+			return this;
+		}
+
+		@Override
+		public Builder numBatch(@Nullable Integer numBatch) {
+			super.numBatch(numBatch);
+			return this;
+		}
+
+		@Override
+		public Builder numGPU(@Nullable Integer numGPU) {
+			super.numGPU(numGPU);
+			return this;
+		}
+
+		@Override
+		public Builder mainGPU(@Nullable Integer mainGPU) {
+			super.mainGPU(mainGPU);
+			return this;
+		}
+
+		@Override
+		public Builder lowVRAM(@Nullable Boolean lowVRAM) {
+			super.lowVRAM(lowVRAM);
+			return this;
+		}
+
+		@Override
+		public Builder f16KV(@Nullable Boolean f16KV) {
+			super.f16KV(f16KV);
+			return this;
+		}
+
+		@Override
+		public Builder logitsAll(@Nullable Boolean logitsAll) {
+			super.logitsAll(logitsAll);
+			return this;
+		}
+
+		@Override
+		public Builder vocabOnly(@Nullable Boolean vocabOnly) {
+			super.vocabOnly(vocabOnly);
+			return this;
+		}
+
+		@Override
+		public Builder useMMap(@Nullable Boolean useMMap) {
+			super.useMMap(useMMap);
+			return this;
+		}
+
+		@Override
+		public Builder useMLock(@Nullable Boolean useMLock) {
+			super.useMLock(useMLock);
+			return this;
+		}
+
+		@Override
+		public Builder numThread(@Nullable Integer numThread) {
+			super.numThread(numThread);
+			return this;
+		}
+
+		@Override
+		public Builder numKeep(@Nullable Integer numKeep) {
+			super.numKeep(numKeep);
+			return this;
+		}
+
+		@Override
+		public Builder seed(@Nullable Integer seed) {
+			super.seed(seed);
+			return this;
+		}
+
+		@Override
+		public Builder minP(@Nullable Double minP) {
+			super.minP(minP);
+			return this;
+		}
+
+		@Override
+		public Builder tfsZ(@Nullable Float tfsZ) {
+			super.tfsZ(tfsZ);
+			return this;
+		}
+
+		@Override
+		public Builder typicalP(@Nullable Float typicalP) {
+			super.typicalP(typicalP);
+			return this;
+		}
+
+		@Override
+		public Builder repeatLastN(@Nullable Integer repeatLastN) {
+			super.repeatLastN(repeatLastN);
+			return this;
+		}
+
+		@Override
+		public Builder repeatPenalty(@Nullable Double repeatPenalty) {
+			super.repeatPenalty(repeatPenalty);
+			return this;
+		}
+
+		@Override
+		public Builder presencePenalty(@Nullable Double presencePenalty) {
+			super.presencePenalty(presencePenalty);
+			return this;
+		}
+
+		@Override
+		public Builder frequencyPenalty(@Nullable Double frequencyPenalty) {
+			super.frequencyPenalty(frequencyPenalty);
+			return this;
+		}
+
+		@Override
+		public Builder mirostat(@Nullable Integer mirostat) {
+			super.mirostat(mirostat);
+			return this;
+		}
+
+		@Override
+		public Builder mirostatTau(@Nullable Float mirostatTau) {
+			super.mirostatTau(mirostatTau);
+			return this;
+		}
+
+		@Override
+		public Builder mirostatEta(@Nullable Float mirostatEta) {
+			super.mirostatEta(mirostatEta);
+			return this;
+		}
+
+		@Override
+		public Builder penalizeNewline(@Nullable Boolean penalizeNewline) {
+			super.penalizeNewline(penalizeNewline);
+			return this;
+		}
+
+		@Override
+		public Builder stop(@Nullable List<String> stop) {
+			super.stop(stop);
+			return this;
+		}
+
+		@Override
+		public Builder format(@Nullable Object format) {
+			super.format(format);
+			return this;
+		}
+
+		@Override
+		public Builder thinkOption(@Nullable ThinkOption thinkOption) {
+			super.thinkOption(thinkOption);
+			return this;
+		}
+
+		@Override
+		public Builder toolCallbacks(@Nullable List<ToolCallback> toolCallbacks) {
+			super.toolCallbacks(toolCallbacks);
+			return this;
+		}
+
+		@Override
+		public Builder toolContext(@Nullable Map<String, Object> toolContext) {
+			super.toolContext(toolContext);
+			return this;
+		}
+
+		@Override
+		public Builder combineWith(ChatOptions.Builder<?> other) {
+			super.combineWith(other);
+			if (other instanceof Builder options) {
+				if (options.dimensions != null) {
+					this.dimensions = options.dimensions;
+				}
+			}
+			return this;
+		}
+
+		@Override
+		public OllamaOptions build() {
+			return new OllamaOptions(this.useNUMA, this.numCtx, this.numBatch, this.numGPU, this.mainGPU, this.lowVRAM,
+					this.f16KV, this.logitsAll, this.vocabOnly, this.useMMap, this.useMLock, this.numThread,
+					this.numKeep, this.seed, this.maxTokens, this.topK, this.topP, this.minP, this.tfsZ, this.typicalP,
+					this.repeatLastN, this.temperature, this.repeatPenalty, this.presencePenalty, this.frequencyPenalty,
+					this.mirostat, this.mirostatTau, this.mirostatEta, this.penalizeNewline, this.stopSequences,
+					this.model, this.format, this.keepAlive, this.truncate, this.thinkOption, this.toolCallbacks,
+					this.toolContext, this.dimensions);
+		}
+
+	}
+
+}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaOptionsTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaOptionsTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.ollama;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.ai.ollama.api.OllamaEmbeddingOptions;
+import org.springframework.ai.ollama.api.OllamaOptions;
+import org.springframework.ai.retry.RetryUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests verifying {@link OllamaOptions} builder, conversions, and model binding.
+ *
+ * @author Raphael Zanarelli
+ */
+@SuppressWarnings("deprecation")
+class OllamaOptionsTests {
+
+	@Test
+	void testOllamaOptionsBuilderAndGetters() {
+		OllamaOptions options = OllamaOptions.builder()
+			.model("mistral")
+			.temperature(0.7)
+			.topK(40)
+			.topP(0.9)
+			.numPredict(100)
+			.dimensions(768)
+			.keepAlive("5m")
+			.truncate(true)
+			.useNUMA(true)
+			.numCtx(4096)
+			.build();
+
+		assertThat(options.getModel()).isEqualTo("mistral");
+		assertThat(options.getTemperature()).isEqualTo(0.7);
+		assertThat(options.getTopK()).isEqualTo(40);
+		assertThat(options.getTopP()).isEqualTo(0.9);
+		assertThat(options.getMaxTokens()).isEqualTo(100);
+		assertThat(options.getDimensions()).isEqualTo(768);
+		assertThat(options.getKeepAlive()).isEqualTo("5m");
+		assertThat(options.getTruncate()).isTrue();
+		assertThat(options.getUseNUMA()).isTrue();
+		assertThat(options.getNumCtx()).isEqualTo(4096);
+	}
+
+	@Test
+	void testToEmbeddingOptions() {
+		OllamaOptions options = OllamaOptions.builder()
+			.model("nomic-embed-text")
+			.dimensions(768)
+			.keepAlive("10m")
+			.truncate(true)
+			.useNUMA(true)
+			.numCtx(2048)
+			.numBatch(512)
+			.numGPU(1)
+			.mainGPU(0)
+			.lowVRAM(false)
+			.f16KV(true)
+			.logitsAll(false)
+			.vocabOnly(false)
+			.useMMap(true)
+			.useMLock(false)
+			.numThread(8)
+			.build();
+
+		OllamaEmbeddingOptions embeddingOptions = options.toEmbeddingOptions();
+		assertThat(embeddingOptions.getModel()).isEqualTo("nomic-embed-text");
+		assertThat(embeddingOptions.getDimensions()).isEqualTo(768);
+		assertThat(embeddingOptions.getKeepAlive()).isEqualTo("10m");
+		assertThat(embeddingOptions.getTruncate()).isTrue();
+		assertThat(embeddingOptions.getUseNUMA()).isTrue();
+		assertThat(embeddingOptions.getNumCtx()).isEqualTo(2048);
+		assertThat(embeddingOptions.getNumBatch()).isEqualTo(512);
+		assertThat(embeddingOptions.getNumGPU()).isEqualTo(1);
+		assertThat(embeddingOptions.getMainGPU()).isEqualTo(0);
+		assertThat(embeddingOptions.getLowVRAM()).isFalse();
+		assertThat(embeddingOptions.getF16KV()).isTrue();
+		assertThat(embeddingOptions.getLogitsAll()).isFalse();
+		assertThat(embeddingOptions.getVocabOnly()).isFalse();
+		assertThat(embeddingOptions.getUseMMap()).isTrue();
+		assertThat(embeddingOptions.getUseMLock()).isFalse();
+		assertThat(embeddingOptions.getNumThread()).isEqualTo(8);
+	}
+
+	@Test
+	void testToMapIncludesDimensions() {
+		OllamaOptions options = OllamaOptions.builder().model("mistral").dimensions(512).temperature(0.5).build();
+
+		Map<String, Object> map = options.toMap();
+		assertThat(map).containsEntry("model", "mistral");
+		assertThat(map).containsEntry("dimensions", 512);
+		assertThat(map).containsEntry("temperature", 0.5);
+	}
+
+	@Test
+	void testMutatePreservesDimensions() {
+		OllamaOptions original = OllamaOptions.builder().model("llama3").dimensions(1024).temperature(0.8).build();
+
+		OllamaOptions mutated = original.mutate().temperature(0.2).build();
+		assertThat(mutated.getModel()).isEqualTo("llama3");
+		assertThat(mutated.getDimensions()).isEqualTo(1024);
+		assertThat(mutated.getTemperature()).isEqualTo(0.2);
+	}
+
+	@Test
+	void testOllamaChatModelAcceptsLegacyOllamaOptions() {
+		OllamaOptions options = OllamaOptions.builder().model("mistral").temperature(0.6).topK(50).build();
+
+		OllamaChatModel chatModel = OllamaChatModel.builder()
+			.ollamaApi(OllamaApi.builder().build())
+			.options(options)
+			.retryTemplate(RetryUtils.DEFAULT_RETRY_TEMPLATE)
+			.build();
+
+		Prompt prompt = new Prompt("test", options);
+		OllamaApi.ChatRequest request = chatModel.ollamaChatRequest(prompt, false);
+		assertThat(request.model()).isEqualTo("mistral");
+		assertThat(request.options()).containsEntry("temperature", 0.6);
+		assertThat(request.options()).containsEntry("top_k", 50);
+	}
+
+	@Test
+	void testOllamaEmbeddingModelAcceptsLegacyOllamaOptions() {
+		OllamaOptions options = OllamaOptions.builder()
+			.model("nomic-embed-text")
+			.dimensions(512)
+			.keepAlive("2m")
+			.build();
+
+		OllamaEmbeddingModel embeddingModel = OllamaEmbeddingModel.builder()
+			.ollamaApi(OllamaApi.builder().build())
+			.options(options)
+			.build();
+
+		EmbeddingRequest embeddingRequest = new EmbeddingRequest(List.of("test message"), options);
+		OllamaApi.EmbeddingsRequest request = embeddingModel
+			.ollamaEmbeddingRequest(embeddingModel.buildEmbeddingRequest(embeddingRequest));
+
+		assertThat(request.model()).isEqualTo("nomic-embed-text");
+		assertThat(request.dimensions()).isEqualTo(512);
+		assertThat(request.keepAlive()).isEqualTo("2m");
+	}
+
+}


### PR DESCRIPTION
### Summary
Follow up to splitting options between chat and embedding operations.

This PR provides:
1. `OllamaOptions` deprecation bridge marked with `@Deprecated(since = "1.0.0-M2", forRemoval = false)` pointing to `OllamaChatOptions` and `OllamaEmbeddingOptions`.
2. `OllamaOptions.toEmbeddingOptions()` helper for seamless conversion.
3. Backward compatibility constructors and builder methods in `OllamaChatModel` and `OllamaEmbeddingModel`.
4. Option merge handling for legacy `OllamaOptions` in `OllamaEmbeddingModel.mergeOptions()`.

### Related Issue
Fixes #3926

### Tests
- Added unit tests in `OllamaOptionsTests` covering builder getters, `toEmbeddingOptions()`, `toMap()`, `mutate()`, and model integration with legacy options.
- All 126 tests in `models/spring-ai-ollama` pass.