### PR TITLE
fix(cassandra): qualify type in schema creation for protocol V4 compatibility

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/main/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryConfig.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-cassandra/src/main/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryConfig.java
@@ -204,14 +204,14 @@ public final class CassandraChatMemoryRepositoryConfig {
 
 	private void ensureMessageTypeExist() {
 
-		SimpleStatement stmt = SchemaBuilder.createType(this.messageUDT)
+		SimpleStatement stmt = SchemaBuilder.createType(this.schema.keyspace(), this.messageUDT)
 			.ifNotExists()
 			.withField(this.messageUdtTimestampColumn, DataTypes.TIMESTAMP)
 			.withField(this.messageUdtTypeColumn, DataTypes.TEXT)
 			.withField(this.messageUdtContentColumn, DataTypes.TEXT)
 			.build();
 
-		this.session.execute(stmt.setKeyspace(this.schema.keyspace));
+		this.session.execute(stmt);
 	}
 
 	private void ensureTableColumnsExist() {


### PR DESCRIPTION
### Summary
Fixes #6877.

`CassandraChatMemoryRepositoryConfig.ensureMessageTypeExist()` previously constructed the `CREATE TYPE` statement using `SchemaBuilder.createType(this.messageUDT)` and executed it via `stmt.setKeyspace(this.schema.keyspace)`.

On native protocol V4, per-request keyspace is not supported by the DataStax Java driver (`Can't use per-request keyspace with protocol V4`).

This PR passes the keyspace directly to the overload `SchemaBuilder.createType(this.schema.keyspace(), this.messageUDT)`, qualifying the type statement explicitly and enabling compatibility across both V4 and V5+ protocols.

Signed-off-by: Raphael Zanarelli <rzanarelli@icloud.com>
