### PR TITLE
fix: treat empty string as null for non-String tool parameters

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
@@ -159,6 +159,13 @@ public final class MethodToolCallback implements ToolCallback {
 		if (value == null) {
 			return null;
 		}
+		// An LLM may return an empty string for a parameter it cannot fill.
+		// Attempting to coerce "" into a numeric type (Long, Integer, Double, …)
+		// triggers a NumberFormatException deep inside Jackson/BigDecimal.
+		// Treat an empty string as absent for any target type other than String itself.
+		if (value instanceof String s && s.isEmpty() && !String.class.equals(type)) {
+			return null;
+		}
 		try {
 			if (type instanceof Class<?>) {
 				return jsonHelper.convertToTypedObject(value, (Class<?>) type);

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackExceptionHandlingTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackExceptionHandlingTest.java
@@ -24,6 +24,7 @@ import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.execution.ToolExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -73,11 +74,75 @@ public class MethodToolCallbackExceptionHandlingTest {
 			.hasMessageContaining("Unrecognized token");
 	}
 
+	/**
+	 * Regression test for https://github.com/spring-projects/spring-ai/issues/3884.
+	 *
+	 * When an LLM returns an empty string {@code ""} for a numeric parameter (e.g.
+	 * {@code Long}), Jackson attempts to coerce it through {@code BigDecimal}, which
+	 * throws {@code NumberFormatException}. The fix treats an empty string as absent
+	 * (i.e. {@code null}) for non-String target types, matching the semantic intent of
+	 * "the model produced no value for this argument".
+	 */
+	@Test
+	void emptyStringParameterForNumericTypeMapsToNull() {
+		NumericTools tools = new NumericTools();
+		var callback = MethodToolCallbackProvider.builder().toolObjects(tools).build().getToolCallbacks()[0];
+
+		// LLM responds with an empty string for the Long parameter — must not throw.
+		String toolInput = """
+				{
+					"id": ""
+				}
+				""";
+
+		assertThatCode(() -> callback.call(toolInput)).doesNotThrowAnyException();
+		assertThat(tools.lastId).isNull();
+	}
+
+	@Test
+	void emptyStringParameterPreservedForStringType() {
+		StringTools tools = new StringTools();
+		var callback = MethodToolCallbackProvider.builder().toolObjects(tools).build().getToolCallbacks()[0];
+
+		String toolInput = """
+				{
+					"value": ""
+				}
+				""";
+
+		assertThatCode(() -> callback.call(toolInput)).doesNotThrowAnyException();
+		assertThat(tools.lastValue).isEmpty();
+	}
+
 	public static class TestTools {
 
 		@Tool(description = "Process a list of strings")
 		public String stringList(List<String> strings) {
 			return strings.size() + " strings processed: " + strings;
+		}
+
+	}
+
+	public static class NumericTools {
+
+		Long lastId;
+
+		@Tool(description = "Look up a record by its Long ID")
+		public String findById(Long id) {
+			this.lastId = id;
+			return id == null ? "not found" : "found " + id;
+		}
+
+	}
+
+	public static class StringTools {
+
+		String lastValue;
+
+		@Tool(description = "Echo a string value")
+		public String echo(String value) {
+			this.lastValue = value;
+			return value == null ? "(null)" : value;
 		}
 
 	}


### PR DESCRIPTION
## Problem

Closes #3884.

When an LLM returns an empty string `""` for a parameter typed as `Long`, `Integer`, `Double`, or any other non-String type, `MethodToolCallback.buildTypedArgument` passes it to `JsonHelper.convertToTypedObject`, which delegates to `Jackson.convertValue`. Jackson internally constructs a `BigDecimal` from the empty string, immediately throwing:

```
java.lang.NumberFormatException: For input string: ""
    at java.base/java.math.BigDecimal.<init>(BigDecimal.java:692)
    ...
    at org.springframework.ai.tool.method.MethodToolCallback.buildTypedArgument(MethodToolCallback.java:...)
    at org.springframework.ai.tool.method.MethodToolCallback.buildMethodArguments(MethodToolCallback.java:...)
    at org.springframework.ai.tool.method.MethodToolCallback.call(MethodToolCallback.java:...)
```

This is a real production scenario: an LLM model may legitimately return `""` for an optional numeric parameter it cannot populate (e.g. an entity ID that it doesn't know yet). The exception is neither caught nor wrapped into a helpful error — it surfaces as a raw `NumberFormatException` that aborts the tool loop.

## Fix

In `buildTypedArgument`, detect the case where `value` is an empty `String` and the target type is not `String` itself, and return `null` — matching the existing path taken when the key is absent from the LLM's JSON entirely:

```java
// An LLM may return an empty string for a parameter it cannot fill.
// Attempting to coerce "" into a numeric type (Long, Integer, Double, …)
// triggers a NumberFormatException deep inside Jackson/BigDecimal.
// Treat an empty string as absent for any target type other than String itself.
if (value instanceof String s && s.isEmpty() && !String.class.equals(type)) {
    return null;
}
```

Empty strings are preserved as-is when the target type **is** `String` (the second test below verifies this).

## Tests

Two new cases in `MethodToolCallbackExceptionHandlingTest`:

| Test | Input | Target type | Expected |
|---|---|---|---|
| `emptyStringParameterForNumericTypeMapsToNull` | `{"id": ""}` | `Long` | No exception; `id == null` |
| `emptyStringParameterPreservedForStringType` | `{"value": ""}` | `String` | No exception; `value == ""` |