### PR TITLE
Copy metadata defensively in Document.Builder

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/document/Document.java
@@ -475,7 +475,10 @@ public class Document {
 		 */
 		public Builder metadata(Map<String, Object> metadata) {
 			Assert.notNull(metadata, "metadata cannot be null");
-			this.metadata = metadata;
+			// Copy defensively: the supplied map may be owned by another Document (as it
+			// is
+			// for mutate()), and metadata(String, Object) writes into this map.
+			this.metadata = new HashMap<>(metadata);
 			return this;
 		}
 

--- a/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
@@ -18,7 +18,10 @@ package org.springframework.ai.document;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
@@ -29,6 +32,7 @@ import org.springframework.ai.util.JacksonUtils;
 import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DocumentTests {
@@ -277,6 +281,30 @@ public class DocumentTests {
 		assertThat(mutated.getScore()).isEqualTo(0.8);
 		assertThat(mutated.getMetadata()).containsEntry("new", "metadata");
 		assertThat(original.getText()).isEqualTo("Original text"); // Original unchanged
+	}
+
+	@Test
+	void testMutateDoesNotAlterOriginalMetadata() {
+		Document original = Document.builder().text("Original text").metadata("original", "value").build();
+
+		Document mutated = original.mutate().metadata("new", "metadata").build();
+
+		assertThat(mutated.getMetadata()).containsEntry("original", "value").containsEntry("new", "metadata");
+		assertThat(original.getMetadata()).containsExactly(entry("original", "value"));
+	}
+
+	@Test
+	void testMutatedDocumentDoesNotEvictOriginalFromHashSet() {
+		Document original = Document.builder().text("Original text").metadata("original", "value").build();
+		Set<Document> documents = new HashSet<>(List.of(original));
+
+		original.mutate().metadata("new", "metadata").build();
+
+		// metadata participates in equals/hashCode, so mutating a copy must not move the
+		// original within a hash-based collection. Assert on Set#contains rather than
+		// AssertJ's contains, which scans linearly with equals and would not exercise
+		// the hash bucket.
+		assertThat(documents.contains(original)).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
`Document.mutate()` hands the builder the document's live metadata map:

```java
public Builder mutate() {
    return new Builder().id(this.id).text(this.text).media(this.media).metadata(this.metadata).score(this.score);
}
```

`Builder.metadata(Map)` stored that reference as-is, and `Builder.metadata(String, Object)` then does `this.metadata.put(...)` — writing straight into the original document. The private constructor's `new HashMap<>(metadata)` defends only the *new* document; by then the source has already been modified.

```java
Document original = Document.builder().text("t").metadata("original", "value").build();
Document copy = original.mutate().metadata("new", "metadata").build();

original.getMetadata();   // {original=value, new=metadata}  <- source altered
```

The `mutate()` javadoc states it allows "selective modification without altering the original".

`metadata` participates in `equals` and `hashCode`, so a `Document` already held in a `HashSet` or as a `HashMap` key moves bucket and becomes unfindable as soon as anyone mutates a copy of it:

```java
Set<Document> index = new HashSet<>(List.of(original));
original.mutate().metadata("new", "metadata").build();
index.contains(original);   // false
```

The fix copies the map in the builder setter rather than in `mutate()`, so any caller passing a map they still own is covered.

The existing `testMutateWithChanges` asserts only on `getText()`, which is why this went unnoticed; two tests added, both failing before the change. `spring-ai-commons` (238 tests) plus Model, Chat Client, Vector Store, RAG and Template all pass.
