### PR TITLE
Support `isNull` and `isNotNull` in `PgVectorFilterExpressionConverter`

### DIFF
--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorFilterExpressionConverter.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  *
  * @author Muthukumaran Navaneethakrishnan
  * @author Christian Tzolov
+ * @author Raviteja Daggupati
  */
 public class PgVectorFilterExpressionConverter extends AbstractFilterExpressionConverter {
 
@@ -55,18 +56,50 @@ public class PgVectorFilterExpressionConverter extends AbstractFilterExpressionC
 
 	@Override
 	protected void doExpression(Expression expression, StringBuilder context) {
-		Assert.state(expression.right() != null, "expression should have a right operand");
-		if (expression.type() == Filter.ExpressionType.IN) {
-			handleIn(expression, context);
+		// ISNULL and ISNOTNULL are unary: they carry no right operand, so the assertion
+		// the other types share cannot be hoisted above them.
+		if (expression.type() == Filter.ExpressionType.ISNULL) {
+			handleIsNull(expression, context);
 		}
-		else if (expression.type() == Filter.ExpressionType.NIN) {
-			handleNotIn(expression, context);
+		else if (expression.type() == Filter.ExpressionType.ISNOTNULL) {
+			handleIsNotNull(expression, context);
 		}
 		else {
-			this.convertOperand(expression.left(), context);
-			context.append(getOperationSymbol(expression));
-			this.convertOperand(expression.right(), context);
+			Assert.state(expression.right() != null, "expression should have a right operand");
+			if (expression.type() == Filter.ExpressionType.IN) {
+				handleIn(expression, context);
+			}
+			else if (expression.type() == Filter.ExpressionType.NIN) {
+				handleNotIn(expression, context);
+			}
+			else {
+				this.convertOperand(expression.left(), context);
+				context.append(getOperationSymbol(expression));
+				this.convertOperand(expression.right(), context);
+			}
 		}
+	}
+
+	// Null means absent from the metadata, or present holding a JSON null. Same
+	// missing-key semantics as SimpleVectorStoreFilterExpressionEvaluator.
+	//
+	// Grouped because JSONPath binds && tighter than ||. Ungrouped, an ISNULL on
+	// the left of an AND would swallow the other conjunct.
+	private void handleIsNull(Expression expression, StringBuilder context) {
+		context.append("(!exists(");
+		this.convertOperand(expression.left(), context);
+		context.append(") || ");
+		this.convertOperand(expression.left(), context);
+		context.append(" == null)");
+	}
+
+	// The exact complement: the key is present and its value is not JSON null.
+	private void handleIsNotNull(Expression expression, StringBuilder context) {
+		context.append("(exists(");
+		this.convertOperand(expression.left(), context);
+		context.append(") && ");
+		this.convertOperand(expression.left(), context);
+		context.append(" != null)");
 	}
 
 	private void handleIn(Expression expression, StringBuilder context) {

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorFilterExpressionConverterTests.java
@@ -26,6 +26,7 @@ import org.springframework.ai.vectorstore.filter.Filter.Expression;
 import org.springframework.ai.vectorstore.filter.Filter.Group;
 import org.springframework.ai.vectorstore.filter.Filter.Key;
 import org.springframework.ai.vectorstore.filter.Filter.Value;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
 import org.springframework.ai.vectorstore.filter.FilterExpressionConverter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser;
 
@@ -35,6 +36,8 @@ import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.EQ
 import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.GT;
 import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.GTE;
 import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.IN;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.ISNOTNULL;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.ISNULL;
 import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.LT;
 import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.LTE;
 import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.NE;
@@ -44,6 +47,7 @@ import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.OR
 /**
  * @author Muthukumaran Navaneethakrishnan
  * @author Christian Tzolov
+ * @author Raviteja Daggupati
  */
 public class PgVectorFilterExpressionConverterTests {
 
@@ -465,6 +469,74 @@ public class PgVectorFilterExpressionConverterTests {
 		assertThat(vectorExpr).contains("$.\"activationDate\"");
 		assertThat(vectorExpr).contains("2024-01-15T10:30:00.000Z");
 		assertThat(vectorExpr).contains("2024-02-20T14:45:00.000Z");
+	}
+
+	// Null checks. ISNULL and ISNOTNULL are unary, so the expression carries no right
+	// operand; a missing key counts as null, matching
+	// SimpleVectorStoreFilterExpressionEvaluator.
+
+	@Test
+	public void testIsNull() {
+		// summary IS NULL
+		String vectorExpr = this.converter.convertExpression(new Expression(ISNULL, new Key("summary"), null));
+		assertThat(vectorExpr).isEqualTo(sqlPredicate("(!exists($.\"summary\") || $.\"summary\" == null)"));
+	}
+
+	@Test
+	public void testIsNotNull() {
+		// summary IS NOT NULL
+		String vectorExpr = this.converter.convertExpression(new Expression(ISNOTNULL, new Key("summary"), null));
+		assertThat(vectorExpr).isEqualTo(sqlPredicate("(exists($.\"summary\") && $.\"summary\" != null)"));
+	}
+
+	@Test
+	public void testIsNullFromFilterExpressionBuilder() {
+		// The public builder path, which previously failed with "expression should have a
+		// right operand"
+		FilterExpressionBuilder b = new FilterExpressionBuilder();
+		assertThat(this.converter.convertExpression((Expression) b.isNull("summary").build()))
+			.isEqualTo(sqlPredicate("(!exists($.\"summary\") || $.\"summary\" == null)"));
+		assertThat(this.converter.convertExpression((Expression) b.isNotNull("summary").build()))
+			.isEqualTo(sqlPredicate("(exists($.\"summary\") && $.\"summary\" != null)"));
+	}
+
+	@Test
+	public void testIsNullCombinedWithAnd() {
+		// summary IS NULL AND year >= 2020
+		//
+		// The group around the ISNULL is what makes this correct: JSONPath binds && more
+		// tightly than ||, so an ungrouped disjunction would swallow the year comparison.
+		String vectorExpr = this.converter
+			.convertExpression(new Expression(AND, new Expression(ISNULL, new Key("summary"), null),
+					new Expression(GTE, new Key("year"), new Value(2020))));
+		assertThat(vectorExpr)
+			.isEqualTo(sqlPredicate("(!exists($.\"summary\") || $.\"summary\" == null) && $.\"year\" >= 2020"));
+	}
+
+	@Test
+	public void testIsNotNullCombinedWithOr() {
+		// country == "BG" OR summary IS NOT NULL
+		String vectorExpr = this.converter
+			.convertExpression(new Expression(OR, new Expression(EQ, new Key("country"), new Value("BG")),
+					new Expression(ISNOTNULL, new Key("summary"), null)));
+		assertThat(vectorExpr)
+			.isEqualTo(sqlPredicate("$.\"country\" == \"BG\" || (exists($.\"summary\") && $.\"summary\" != null)"));
+	}
+
+	@Test
+	public void testIsNullKeyIsEscaped() {
+		// The key is emitted twice, so both occurrences have to be escaped
+		String vectorExpr = this.converter.convertExpression(new Expression(ISNULL, new Key("key\"inject"), null));
+		assertThat(vectorExpr).isEqualTo(sqlPredicate("(!exists($.\"key\\\"inject\") || $.\"key\\\"inject\" == null)"));
+		assertThat(vectorExpr).doesNotContain("$.\"key\"inject\"");
+	}
+
+	@Test
+	public void testIsNullKeyWithSingleQuoteIsSqlEscaped() {
+		String vectorExpr = this.converter.convertExpression(new Expression(ISNULL, new Key("O'Brien"), null));
+		// Both occurrences are SQL-escaped inside the surrounding single-quoted literal
+		assertThat(vectorExpr).isEqualTo(sqlPredicate("(!exists($.\"O'Brien\") || $.\"O'Brien\" == null)"));
+		assertThat(vectorExpr).contains("O''Brien");
 	}
 
 }

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreIT.java
@@ -75,6 +75,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Jihoon Kim
  * @author YeongMin Song
  * @author Eddú Meléndez
+ * @author Raviteja Daggupati
  */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
@@ -121,6 +122,24 @@ public class PgVectorStoreIT extends BaseVectorStoreTests {
 				Arguments.of("year in [2020]", 1), // Numeric Filters In
 				Arguments.of("country not in ['BG']", 1), // String Filter Not In
 				Arguments.of("year not in [2020]", 2) // Numeric Filter Not In
+		);
+	}
+
+	/**
+	 * Null checks against the same three-document fixture, where {@code nlDocument} is
+	 * the only one without a {@code year}. A missing key counts as null, matching
+	 * {@code SimpleVectorStoreFilterExpressionEvaluator}.
+	 * <p>
+	 * The third case is the one that pins the JSONPath grouping down: without a group
+	 * around the null check, {@code &&} binds tighter than {@code ||} and the expression
+	 * degrades to {@code !exists($."year") || (...)}, which matches {@code nlDocument}
+	 * and returns one record instead of none.
+	 */
+	static Stream<Arguments> provideNullFilters() {
+		return Stream.of(Arguments.of("year IS NULL", 1), // missing key counts as null
+				Arguments.of("year IS NOT NULL", 2), //
+				Arguments.of("year IS NULL && country == 'BG'", 0), //
+				Arguments.of("year IS NULL || year >= 2023", 2) //
 		);
 	}
 
@@ -306,6 +325,37 @@ public class PgVectorStoreIT extends BaseVectorStoreTests {
 				assertThat(results).hasSize(expectedRecords);
 
 				// Remove all documents from the store
+				dropTable(context);
+			});
+	}
+
+	@ParameterizedTest(name = "Filter expression {0} should return {1} records ")
+	@MethodSource("provideNullFilters")
+	public void searchWithNullFilter(String expression, Integer expectedRecords) {
+
+		this.contextRunner.withPropertyValues("test.spring.ai.vectorstore.pgvector.distanceType=COSINE_DISTANCE")
+			.run(context -> {
+
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				var bgDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "BG", "year", 2020));
+				var nlDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "NL"));
+				var bgDocument2 = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "BG", "year", 2023));
+
+				vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
+
+				SearchRequest searchRequest = SearchRequest.builder()
+					.query("The World")
+					.filterExpression(expression)
+					.topK(5)
+					.similarityThresholdAll()
+					.build();
+
+				assertThat(vectorStore.similaritySearch(searchRequest)).hasSize(expectedRecords);
+
 				dropTable(context);
 			});
 	}


### PR DESCRIPTION
`isNull()` and `isNotNull()` from `FilterExpressionBuilder` don't work with
PgVector. They throw when the search runs.

The cause is in `PgVectorFilterExpressionConverter.doExpression`, which starts
with:

```java
Assert.state(expression.right() != null, "expression should have a right operand");
```

`ISNULL` and `ISNOTNULL` have no right operand, so this always fails. The
awkward bit is that it only shows up at query time. The expression itself
builds fine, so any test that stops at building it will pass.

This change handles the two types before that assert. The JSONPath it
generates:

```
ISNULL     (!exists($."k") || $."k" == null)
ISNOTNULL  (exists($."k") && $."k" != null)
```

A key counts as null if it's missing, or if it's there but set to JSON null.
That's the same rule `SimpleVectorStoreFilterExpressionEvaluator` uses.

The Elasticsearch converter does it differently and only checks whether the
field exists. That gives a different answer for a key that exists holding
null, which can happen in JSONB. I went with the `SimpleVectorStore`
behaviour, but happy to switch if you'd rather match Elasticsearch.

The brackets are needed. JSONPath gives `&&` higher precedence than `||`, so
without them `isNull(k) && year >= 2020` would also match a document that has
no `k` and `year` 2019.

One thing this doesn't fix: `NOT(x IS NULL)` still fails with "Unknown
expression type: ISNULL" from `FilterHelper.negate`. That's in core and
affects every store, not just PgVector. I have a fix for it if you want it as
a separate PR.

Tests: 7 unit tests in `PgVectorFilterExpressionConverterTests` and 4 cases in
`PgVectorStoreIT`. I couldn't run the IT locally (no Docker, no OpenAI key),
so I ran the generated SQL against a local Postgres to check the behaviour
instead.