### PR TITLE
Preserve advisor context across `ToolCallingAdvisor` iterations

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -16,9 +16,12 @@
 
 package org.springframework.ai.chat.client.advisor;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 
@@ -144,6 +147,8 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		ChatClientResponse chatClientResponse = null;
 		UsageAccumulator usageAccumulator = new UsageAccumulator();
 
+		Map<String, @Nullable Object> context = new HashMap<>(chatClientRequest.context());
+
 		boolean isToolCall = false;
 
 		do {
@@ -151,7 +156,7 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 			// Before Call
 			var processedChatClientRequest = ChatClientRequest.builder()
 				.prompt(new Prompt(instructions, toolCallingChatOptions))
-				.context(chatClientRequest.context())
+				.context(context)
 				.build();
 
 			// Next Call
@@ -210,6 +215,10 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 
 				instructions = this.doGetNextInstructionsForToolCall(processedChatClientRequest, chatClientResponse,
 						toolExecutionResult);
+
+				// Preserve context written by advisors during this iteration for the
+				// next tool-call iteration.
+				context = new HashMap<>(chatClientResponse.context());
 			}
 
 		}
@@ -396,7 +405,13 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 				// Recursive call with updated conversation history
 				List<Message> nextInstructions = this.doGetNextInstructionsForToolCallStream(finalRequest,
 						finalAggregatedResponse, toolExecutionResult);
-				return this.internalStream(streamAdvisorChain, originalRequest, optionsCopy, nextInstructions,
+				// Preserve context written by advisors during this iteration for the
+				// next tool-call iteration, mirroring the call path.
+				ChatClientRequest nextRequest = ChatClientRequest.builder()
+					.prompt(originalRequest.prompt())
+					.context(finalAggregatedResponse.context())
+					.build();
+				return this.internalStream(streamAdvisorChain, nextRequest, optionsCopy, nextInstructions,
 						toolExecutionResult.conversationHistory(), usageAccumulator);
 			}
 		});

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.chat.client.advisor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 import io.micrometer.observation.ObservationRegistry;
@@ -34,6 +35,7 @@ import reactor.core.publisher.Flux;
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
@@ -215,6 +217,88 @@ public class ToolCallingAdvisorTests {
 
 		assertThat(results).isNotNull().hasSize(1);
 		verify(this.toolCallingManager, times(0)).executeToolCalls(any(), any());
+	}
+
+	@Test
+	void adviseCallPreservesAdvisorContextAcrossToolCallIterations() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+
+		// Track how many times the context-setting advisor actually processes
+		AtomicInteger processingCount = new AtomicInteger(0);
+		ContextSettingAdvisor contextAdvisor = new ContextSettingAdvisor(processingCount);
+
+		// Terminal advisor that propagates request context to response
+		// (mimicking real ChatModelCallAdvisor behavior)
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			callCount[0]++;
+			ChatClientResponse mockResponse = callCount[0] == 1 ? createMockResponse(true) : createMockResponse(false);
+			return ChatClientResponse.builder()
+				.chatResponse(mockResponse.chatResponse())
+				.context(req.context())
+				.build();
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, contextAdvisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false));
+
+		advisor.adviseCall(request, realChain);
+
+		// The terminal advisor was called twice (two iterations of the tool call loop)
+		assertThat(callCount[0]).isEqualTo(2);
+
+		// The context-setting advisor should have processed only once, because on the
+		// second iteration the context key written in the first iteration is preserved,
+		// causing it to skip processing.
+		assertThat(processingCount.get()).isEqualTo(1);
+	}
+
+	@Test
+	void adviseStreamPreservesAdvisorContextAcrossToolCallIterations() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+
+		// Track how many times the context-setting advisor actually processes
+		AtomicInteger processingCount = new AtomicInteger(0);
+		ContextSettingAdvisor contextAdvisor = new ContextSettingAdvisor(processingCount);
+
+		// Terminal advisor that propagates request context to response
+		// (mimicking real ChatModelStreamAdvisor behavior)
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			ChatClientResponse mockResponse = callCount[0] == 1 ? createMockResponse(true) : createMockResponse(false);
+			return Flux.just(ChatClientResponse.builder()
+				.chatResponse(mockResponse.chatResponse())
+				.context(req.context())
+				.build());
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, contextAdvisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false));
+
+		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
+
+		assertThat(results).isNotNull();
+
+		// The terminal advisor was called twice (two iterations of the tool call loop)
+		assertThat(callCount[0]).isEqualTo(2);
+
+		// The context-setting advisor should have processed only once, because on the
+		// second iteration the context key written in the first iteration is preserved,
+		// causing it to skip processing.
+		assertThat(processingCount.get()).isEqualTo(1);
 	}
 
 	@Test
@@ -1537,6 +1621,42 @@ public class ToolCallingAdvisorTests {
 			.thenAnswer(invocation -> ChatClientResponse.builder().chatResponse(chatResponse).context(Map.of()));
 
 		return response;
+	}
+
+	/**
+	 * A BaseAdvisor that sets a context key on first processing and skips if the key
+	 * already exists. Used to verify that context is preserved across tool call loop
+	 * iterations.
+	 */
+	private static class ContextSettingAdvisor implements BaseAdvisor {
+
+		private static final String CONTEXT_KEY = "context-set";
+
+		private final AtomicInteger processingCount;
+
+		ContextSettingAdvisor(AtomicInteger processingCount) {
+			this.processingCount = processingCount;
+		}
+
+		@Override
+		public int getOrder() {
+			return 0;
+		}
+
+		@Override
+		public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+			if (chatClientRequest.context().containsKey(CONTEXT_KEY)) {
+				return chatClientRequest;
+			}
+			this.processingCount.incrementAndGet();
+			return chatClientRequest.mutate().context(CONTEXT_KEY, true).build();
+		}
+
+		@Override
+		public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+			return chatClientResponse;
+		}
+
 	}
 
 	private static class TerminalCallAdvisor implements CallAdvisor {


### PR DESCRIPTION
## Motivation

When `ToolCallingAdvisor` runs a multi-round tool-calling loop, advisors nested inside the loop can write state into the advisor context. Currently each iteration rebuilds its request context from the original request's context, so writes from earlier iterations are silently dropped and only the last iteration's writes survive. The reporter observed this in stream mode; on `main` the non-stream call path has the same problem (the regression tests in this PR fail on both paths without the fix).

## Changes

- `adviseCall`: keep a running `context` map, seed each iteration's request from it, and refresh it from the response context after each tool-call iteration - the same approach applied to the deprecated `ToolCallAdvisor` in #5747.
- Streaming path: when recursing into the next tool-call iteration, build the next request from the aggregated response's context instead of reusing the original request's context.
- Added regression tests for both the call and the stream paths, modeled on the test introduced in #5747. Both fail without the fix and pass with it.

Fixes #6903
