### PR TITLE
Map embedded provider errors to OpenAI exceptions

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -38,7 +38,17 @@ import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
 import com.openai.core.RequestOptions;
 import com.openai.core.http.AsyncStreamResponse;
+import com.openai.core.http.Headers;
+import com.openai.errors.BadRequestException;
+import com.openai.errors.InternalServerException;
+import com.openai.errors.NotFoundException;
 import com.openai.errors.OpenAIInvalidDataException;
+import com.openai.errors.PermissionDeniedException;
+import com.openai.errors.RateLimitException;
+import com.openai.errors.UnauthorizedException;
+import com.openai.errors.UnexpectedStatusCodeException;
+import com.openai.errors.UnprocessableEntityException;
+import com.openai.models.ErrorObject;
 import com.openai.models.FunctionDefinition;
 import com.openai.models.FunctionParameters;
 import com.openai.models.ReasoningEffort;
@@ -221,6 +231,7 @@ public final class OpenAiChatModel implements ChatModel {
 			.observe(() -> {
 
 				ChatCompletion chatCompletion = this.openAiClient.chat().completions().create(request, requestOptions);
+				throwIfErrorResponse(chatCompletion);
 
 				List<ChatCompletion.Choice> choices = chatCompletion.choices();
 				if (choices.isEmpty()) {
@@ -255,6 +266,46 @@ public final class OpenAiChatModel implements ChatModel {
 			});
 
 		return response;
+	}
+
+	private static void throwIfErrorResponse(ChatCompletion chatCompletion) {
+		JsonValue errorValue = chatCompletion._additionalProperties().get("error");
+		if (errorValue == null) {
+			return;
+		}
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> error = errorValue.convert(Map.class);
+		Assert.state(error != null, "Provider error must be a JSON object");
+		Object code = error.get("code");
+		int statusCode = code instanceof Number number ? number.intValue() : 500;
+		ErrorObject errorObject = ErrorObject.builder()
+			.message(String.valueOf(error.getOrDefault("message", "OpenAI-compatible provider returned an error")))
+			.type(String.valueOf(error.getOrDefault("type", "provider_error")))
+			.code(Optional.ofNullable(code).map(String::valueOf))
+			.param(Optional.empty())
+			.build();
+		Headers headers = Headers.builder().build();
+
+		throw switch (statusCode) {
+			case 400 -> BadRequestException.builder().headers(headers).error(errorObject).build();
+			case 401 -> UnauthorizedException.builder().headers(headers).error(errorObject).build();
+			case 403 -> PermissionDeniedException.builder().headers(headers).error(errorObject).build();
+			case 404 -> NotFoundException.builder().headers(headers).error(errorObject).build();
+			case 422 -> UnprocessableEntityException.builder().headers(headers).error(errorObject).build();
+			case 429 -> RateLimitException.builder().headers(headers).error(errorObject).build();
+			default -> statusCode >= 500
+					? InternalServerException.builder()
+						.statusCode(statusCode)
+						.headers(headers)
+						.error(errorObject)
+						.build()
+					: UnexpectedStatusCodeException.builder()
+						.statusCode(statusCode)
+						.headers(headers)
+						.error(errorObject)
+						.build();
+		};
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -35,6 +35,7 @@ import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
 import com.openai.core.RequestOptions;
 import com.openai.core.http.AsyncStreamResponse;
+import com.openai.errors.InternalServerException;
 import com.openai.models.FunctionDefinition;
 import com.openai.models.FunctionParameters;
 import com.openai.models.ReasoningEffort;
@@ -100,6 +101,29 @@ class OpenAiChatModelTests {
 
 	@Mock
 	OpenAIClientAsync openAiClientAsync;
+
+	@Test
+	void mapEmbeddedProviderErrorToSdkException() {
+		ChatService chatService = mock(ChatService.class);
+		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
+		ChatCompletion chatCompletion = mock(ChatCompletion.class);
+		when(chatCompletion._additionalProperties()).thenReturn(
+				Map.of("error", JsonValue.from(Map.of("message", "Service temporarily overloaded", "code", 502))));
+		when(this.openAiClient.chat()).thenReturn(chatService);
+		when(chatService.completions()).thenReturn(chatCompletionService);
+		when(chatCompletionService.create(any(ChatCompletionCreateParams.class), any(RequestOptions.class)))
+			.thenReturn(chatCompletion);
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		assertThatThrownBy(() -> chatModel.call(new Prompt("hi", options))).isInstanceOf(InternalServerException.class)
+			.hasMessageContaining("Service temporarily overloaded");
+	}
 
 	@Test
 	void preserveUnmappedRootResponseMetadata() {


### PR DESCRIPTION
OpenAI-compatible providers such as OpenRouter can return a successful HTTP response whose body contains an `error` extension and omits `choices`. Detect that payload before accessing required completion fields and translate its status code into the corresponding openai-java exception type, preserving the provider message for callers.

A regression test covers an embedded 502 response without choices.

Fixes #6900

Tested with: `./mvnw -pl models/spring-ai-openai -Dtest=OpenAiChatModelTests -DargLine=-Djdk.attach.allowAttachSelf=true test`