### PR TITLE
Accept plain text tool results in `GoogleGenAiChatModel`

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -313,7 +313,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 				.map(response -> Part.builder()
 					.functionResponse(FunctionResponse.builder()
 						.name(response.name())
-						.response(parseJsonToMap(response.responseData()))
+						.response(toolResponseToMap(response.responseData()))
 						.build())
 					.build())
 				.toList();
@@ -374,6 +374,23 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		}
 		catch (Exception e) {
 			throw new RuntimeException("Failed to parse JSON: " + json, e);
+		}
+	}
+
+	/**
+	 * Converts a tool response payload to the map structure required by the Gemini API.
+	 * JSON content is converted with {@link #parseJsonToMap(String)}. Plain text that is
+	 * not valid JSON is wrapped as {@code {"result": <text>}}, the same way non-object
+	 * JSON values are wrapped, so the tool result is always accepted by the API.
+	 */
+	private Map<String, Object> toolResponseToMap(String responseData) {
+		try {
+			return parseJsonToMap(responseData);
+		}
+		catch (RuntimeException ex) {
+			Map<String, Object> wrapper = new HashMap<>();
+			wrapper.put("result", responseData);
+			return wrapper;
 		}
 	}
 

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
@@ -820,6 +821,43 @@ public class CreateGeminiRequestTests {
 		assertThat(request.config().serviceTier()).isPresent();
 		assertThat(request.config().serviceTier().get().toString()).isEqualTo("priority");
 
+	}
+
+	@Test
+	public void createRequestWithJsonToolResponse() {
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("1", "tool1", "{\"temperature\": 30}")))
+			.build();
+
+		GeminiRequest request = client
+			.createGeminiRequest(new Prompt(List.of(new UserMessage("Test message content"), toolResponseMessage),
+					GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build()));
+
+		assertThat(request.contents()).hasSize(2);
+		Part part = request.contents().get(1).parts().get().get(0);
+		Map<String, Object> response = part.functionResponse().get().response().get();
+		assertThat(response).containsEntry("temperature", 30);
+	}
+
+	@Test
+	public void createRequestWithPlainTextToolResponse() {
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+		String plainText = "Tool call limit (1) exceeded for tool 'tool1'. No further calls to this tool are allowed in this turn.";
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("1", "tool1", plainText)))
+			.build();
+
+		GeminiRequest request = client
+			.createGeminiRequest(new Prompt(List.of(new UserMessage("Test message content"), toolResponseMessage),
+					GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build()));
+
+		assertThat(request.contents()).hasSize(2);
+		Part part = request.contents().get(1).parts().get().get(0);
+		Map<String, Object> response = part.functionResponse().get().response().get();
+		assertThat(response).containsEntry("result", plainText);
 	}
 
 }


### PR DESCRIPTION
## Motivation

`GoogleGenAiChatModel` converts every tool response payload with a strict JSON parse. Plain text that is not valid JSON - most notably the tool call limit breach message produced with `spring.ai.tools.limits.on-limit-exceeded=RETURN_ERROR_RESPONSE`, but also any custom `ToolCallback` returning raw text - makes the next model call fail with `Failed to parse JSON: ...` instead of letting Gemini see the message. This defeats what `RETURN_ERROR_RESPONSE` promises.

This implements fix 2 proposed in the issue: since the model already wraps non-object JSON values as `{"result": value}`, non-JSON text is now wrapped the same way (`{"result": "<text>"}`), which makes every tool result Gemini-safe regardless of what produced it. Function call arguments coming from the model keep the strict parse.

## Changes

- Route tool response conversion through a new `toolResponseToMap` method that falls back to wrapping the raw text as `{"result": <text>}` when it is not valid JSON.
- Added tests covering both a JSON object tool result (unchanged behavior) and a plain-text tool result (previously threw, now wrapped). The plain-text test fails without the fix.

Fixes #6902
