### PR TITLE
Surface provider error responses in `OpenAiChatModel`

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -35,10 +35,22 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
+import com.openai.core.JsonField;
 import com.openai.core.JsonValue;
 import com.openai.core.RequestOptions;
 import com.openai.core.http.AsyncStreamResponse;
+import com.openai.core.http.Headers;
+import com.openai.errors.BadRequestException;
+import com.openai.errors.InternalServerException;
+import com.openai.errors.NotFoundException;
 import com.openai.errors.OpenAIInvalidDataException;
+import com.openai.errors.OpenAIServiceException;
+import com.openai.errors.PermissionDeniedException;
+import com.openai.errors.RateLimitException;
+import com.openai.errors.UnauthorizedException;
+import com.openai.errors.UnexpectedStatusCodeException;
+import com.openai.errors.UnprocessableEntityException;
+import com.openai.models.ErrorObject;
 import com.openai.models.FunctionDefinition;
 import com.openai.models.FunctionParameters;
 import com.openai.models.ReasoningEffort;
@@ -222,6 +234,8 @@ public final class OpenAiChatModel implements ChatModel {
 
 				ChatCompletion chatCompletion = this.openAiClient.chat().completions().create(request, requestOptions);
 
+				throwIfErrorResponse(chatCompletion);
+
 				List<ChatCompletion.Choice> choices = chatCompletion.choices();
 				if (choices.isEmpty()) {
 					if (logger.isWarnEnabled()) {
@@ -262,6 +276,62 @@ public final class OpenAiChatModel implements ChatModel {
 		Prompt requestPrompt = buildRequestPrompt(prompt);
 		verifyPromptChatOptions(requestPrompt);
 		return internalStream(requestPrompt);
+	}
+
+	/**
+	 * Some OpenAI API compatible providers, such as OpenRouter, report upstream failures
+	 * with an HTTP 200 response whose body carries an "error" object instead of
+	 * "choices". Accessing the missing "choices" field would fail with a generic
+	 * {@link OpenAIInvalidDataException}, so surface the provider error as the
+	 * corresponding openai-java service exception instead.
+	 * @param chatCompletion the chat completion returned by the provider
+	 */
+	static void throwIfErrorResponse(ChatCompletion chatCompletion) {
+		if (!chatCompletion._choices().isMissing()) {
+			return;
+		}
+		JsonValue error = chatCompletion._additionalProperties().get("error");
+		if (error == null || error.isMissing() || error.isNull()) {
+			return;
+		}
+		Optional<Map<String, JsonValue>> errorFields = error.asObject();
+		String message = errorFields.flatMap(fields -> Optional.ofNullable((JsonField<?>) fields.get("message")))
+			.flatMap(JsonField::asString)
+			.orElseGet(error::toString);
+		int statusCode = errorFields.flatMap(fields -> Optional.ofNullable((JsonField<?>) fields.get("code")))
+			.flatMap(JsonField::asNumber)
+			.map(Number::intValue)
+			.orElse(0);
+		ErrorObject errorObject = ErrorObject.builder()
+			.code(statusCode > 0 ? Optional.of(String.valueOf(statusCode)) : Optional.empty())
+			.message(message)
+			.param(Optional.empty())
+			.type("error")
+			.build();
+		throw buildServiceException(statusCode, errorObject);
+	}
+
+	private static OpenAIServiceException buildServiceException(int statusCode, ErrorObject errorObject) {
+		Headers headers = Headers.builder().build();
+		return switch (statusCode) {
+			case 400 -> BadRequestException.builder().headers(headers).error(errorObject).build();
+			case 401 -> UnauthorizedException.builder().headers(headers).error(errorObject).build();
+			case 403 -> PermissionDeniedException.builder().headers(headers).error(errorObject).build();
+			case 404 -> NotFoundException.builder().headers(headers).error(errorObject).build();
+			case 422 -> UnprocessableEntityException.builder().headers(headers).error(errorObject).build();
+			case 429 -> RateLimitException.builder().headers(headers).error(errorObject).build();
+			default -> (statusCode >= 500 && statusCode < 600)
+					? InternalServerException.builder()
+						.statusCode(statusCode)
+						.headers(headers)
+						.error(errorObject)
+						.build()
+					: UnexpectedStatusCodeException.builder()
+						.statusCode(statusCode)
+						.headers(headers)
+						.error(errorObject)
+						.build();
+		};
 	}
 
 	/**

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelErrorResponseTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelErrorResponseTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai;
+
+import java.util.Map;
+
+import com.openai.core.JsonValue;
+import com.openai.errors.InternalServerException;
+import com.openai.errors.RateLimitException;
+import com.openai.errors.UnexpectedStatusCodeException;
+import com.openai.models.chat.completions.ChatCompletion;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for surfacing error-only responses from OpenAI API compatible providers, such as
+ * OpenRouter, as openai-java service exceptions.
+ *
+ * @see <a href="https://github.com/spring-projects/spring-ai/issues/6900">GH-6900</a>
+ */
+class OpenAiChatModelErrorResponseTests {
+
+	private static ChatCompletion completionFrom(Map<String, Object> body) {
+		return JsonValue.from(body).convert(ChatCompletion.class);
+	}
+
+	@Test
+	void upstreamServerErrorIsSurfacedAsInternalServerException() {
+		ChatCompletion completion = completionFrom(Map.of("id", "gen-x", "error",
+				Map.of("message", "Upstream error from Nvidia: Service temporarily overloaded", "code", 502)));
+
+		assertThatThrownBy(() -> OpenAiChatModel.throwIfErrorResponse(completion))
+			.isInstanceOf(InternalServerException.class)
+			.hasMessageContaining("Upstream error from Nvidia: Service temporarily overloaded");
+	}
+
+	@Test
+	void rateLimitErrorIsSurfacedAsRateLimitException() {
+		ChatCompletion completion = completionFrom(
+				Map.of("id", "gen-x", "error", Map.of("message", "Rate limit exceeded", "code", 429)));
+
+		assertThatThrownBy(() -> OpenAiChatModel.throwIfErrorResponse(completion))
+			.isInstanceOf(RateLimitException.class)
+			.hasMessageContaining("Rate limit exceeded");
+	}
+
+	@Test
+	void errorWithoutCodeIsSurfacedAsUnexpectedStatusCodeException() {
+		ChatCompletion completion = completionFrom(
+				Map.of("id", "gen-x", "error", Map.of("message", "Something went wrong")));
+
+		assertThatThrownBy(() -> OpenAiChatModel.throwIfErrorResponse(completion))
+			.isInstanceOf(UnexpectedStatusCodeException.class)
+			.hasMessageContaining("Something went wrong");
+	}
+
+	@Test
+	void responseWithChoicesIsNotRejected() {
+		ChatCompletion completion = completionFrom(
+				Map.of("id", "chatcmpl-1", "created", 1, "model", "gpt-4o", "object", "chat.completion", "choices",
+						java.util.List.of(Map.of("index", 0, "finish_reason", "stop", "logprobs",
+								new java.util.HashMap<String, Object>(), "message",
+								Map.of("role", "assistant", "content", "Hello", "refusal", "")))));
+
+		assertThatCode(() -> OpenAiChatModel.throwIfErrorResponse(completion)).doesNotThrowAnyException();
+		assertThat(completion.choices()).hasSize(1);
+	}
+
+	@Test
+	void responseWithoutChoicesAndWithoutErrorIsNotRejected() {
+		ChatCompletion completion = completionFrom(Map.of("id", "gen-x"));
+
+		assertThatCode(() -> OpenAiChatModel.throwIfErrorResponse(completion)).doesNotThrowAnyException();
+	}
+
+}


### PR DESCRIPTION
## Motivation

OpenAI API compatible providers such as OpenRouter report upstream failures with an HTTP 200 response whose body carries an `error` object instead of `choices` (see the [OpenRouter error handling docs](https://openrouter.ai/docs/api-reference/errors)). `OpenAiChatModel.internalCall` accessed the missing `choices` field directly, so the call failed with the SDK's generic `OpenAIInvalidDataException: \`choices\` is not set`, hiding the provider's error message and status code and leaving applications nothing to build error handling on.

## Changes

- Before reading `choices`, detect a response with missing `choices` and an `error` additional property, and throw the openai-java service exception corresponding to the reported error code: `RateLimitException` for 429, `InternalServerException` for 5xx, `BadRequestException`/`UnauthorizedException`/etc. for the matching 4xx codes, and `UnexpectedStatusCodeException` otherwise. The exception carries the provider's error message, so rate-limiting and upstream outages can be handled distinctly, as the issue requested ("map to corresponding exceptions from openai-java-core").
- A response with missing `choices` but no `error` payload keeps the existing behavior.
- Added tests covering a 502 upstream error, a 429 rate limit, an error without a code, and the two non-error shapes.

Fixes #6900
