### PR TITLE
Copy the metadata map in `Document.mutate()`

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/document/Document.java
@@ -357,7 +357,11 @@ public class Document {
 	 * @return a builder initialised from this document's state
 	 */
 	public Builder mutate() {
-		return new Builder().id(this.id).text(this.text).media(this.media).metadata(this.metadata).score(this.score);
+		return new Builder().id(this.id)
+			.text(this.text)
+			.media(this.media)
+			.metadata(new HashMap<>(this.metadata))
+			.score(this.score);
 	}
 
 	@Override

--- a/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/document/DocumentTests.java
@@ -280,6 +280,16 @@ public class DocumentTests {
 	}
 
 	@Test
+	void testMutateDoesNotAlterOriginalMetadata() {
+		Document original = Document.builder().text("Original text").metadata("original", "value").build();
+
+		Document mutated = original.mutate().metadata("new", "metadata").build();
+
+		assertThat(mutated.getMetadata()).containsEntry("original", "value").containsEntry("new", "metadata");
+		assertThat(original.getMetadata()).doesNotContainKey("new"); // Original unchanged
+	}
+
+	@Test
 	void testDocumentEqualityWithDifferentScores() {
 		Document doc1 = Document.builder().id("sameId").text("Same text").score(0.5).build();
 


### PR DESCRIPTION
## Motivation

`Document.mutate()` is documented as "allowing selective modification without altering the original", but it passes the document's internal metadata map to the new builder by reference. `Builder.metadata(key, value)` puts directly into that map, so mutating the builder silently mutates the original document's metadata.

## Changes

- `mutate()` now seeds the builder with a copy of the metadata map.
- Added a regression test asserting the original document is unchanged after `mutate().metadata(...)`. It fails on `main` and passes with the fix; the full `spring-ai-commons` module test suite passes (237 tests).

Fixes #6910