### PR TITLE
Copy excluded metadata key lists in `DefaultContentFormatter.Builder`

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/document/DefaultContentFormatter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/document/DefaultContentFormatter.java
@@ -230,7 +230,7 @@ public final class DefaultContentFormatter implements ContentFormatter {
 		 */
 		public Builder withExcludedInferenceMetadataKeys(List<String> excludedInferenceMetadataKeys) {
 			Assert.notNull(excludedInferenceMetadataKeys, "Excluded inference metadata keys must not be null");
-			this.excludedInferenceMetadataKeys = excludedInferenceMetadataKeys;
+			this.excludedInferenceMetadataKeys = new ArrayList<>(excludedInferenceMetadataKeys);
 			return this;
 		}
 
@@ -247,7 +247,7 @@ public final class DefaultContentFormatter implements ContentFormatter {
 		 */
 		public Builder withExcludedEmbedMetadataKeys(List<String> excludedEmbedMetadataKeys) {
 			Assert.notNull(excludedEmbedMetadataKeys, "Excluded Embed metadata keys must not be null");
-			this.excludedEmbedMetadataKeys = excludedEmbedMetadataKeys;
+			this.excludedEmbedMetadataKeys = new ArrayList<>(excludedEmbedMetadataKeys);
 			return this;
 		}
 

--- a/spring-ai-commons/src/test/java/org/springframework/ai/document/ContentFormatterTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/document/ContentFormatterTests.java
@@ -69,6 +69,21 @@ class ContentFormatterTests {
 	}
 
 	@Test
+	void builderFromFormatterAllowsAddingExcludedKeys() {
+
+		DefaultContentFormatter baseFormatter = DefaultContentFormatter.defaultConfig();
+
+		DefaultContentFormatter derivedFormatter = DefaultContentFormatter.builder()
+			.from(baseFormatter)
+			.withExcludedEmbedMetadataKeys("newEmbedKey")
+			.withExcludedInferenceMetadataKeys("newInferenceKey")
+			.build();
+
+		assertThat(derivedFormatter.getExcludedEmbedMetadataKeys()).contains("newEmbedKey");
+		assertThat(derivedFormatter.getExcludedInferenceMetadataKeys()).contains("newInferenceKey");
+	}
+
+	@Test
 	void shouldThrowWhenIdIsNull() {
 		assertThatThrownBy(() -> new Document(null, "text", new HashMap<>()))
 			.isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
## Motivation

`DefaultContentFormatter.Builder.from(formatter)` seeds the builder with the unmodifiable list views returned by the formatter's getters, and the list-based `withExcluded*MetadataKeys(List)` setters store them by reference. The varargs overloads then call `addAll` on the stored list, so any customization after `from(...)` throws `UnsupportedOperationException` — defeating the purpose of `from(...)`. Storing the caller's list by reference also lets later varargs calls mutate a caller-supplied list.

## Changes

- The list-based setters now store a mutable copy (`new ArrayList<>(...)`).
- Added a regression test building a customized formatter from `defaultConfig()`. It fails on `main` with `UnsupportedOperationException` and passes with the fix; the full `spring-ai-commons` module test suite passes (237 tests).

Fixes #6911