### PR TITLE
Fix MariaDB schema validation for default schema

### DIFF
--- a/vector-stores/spring-ai-mariadb-store/pom.xml
+++ b/vector-stores/spring-ai-mariadb-store/pom.xml
@@ -53,6 +53,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
 			<scope>test</scope>

--- a/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
+++ b/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
@@ -45,13 +45,21 @@ public class MariaDBSchemaValidator {
 		this.jdbcTemplate = jdbcTemplate;
 	}
 
-	private boolean isTableExists(@Nullable String schemaName, String tableName) {
+	private String resolveSchemaName(@Nullable String schemaName) {
+		if (schemaName != null) {
+			return schemaName;
+		}
+		String currentSchema = this.jdbcTemplate.queryForObject("SELECT SCHEMA()", String.class);
+		Assert.state(currentSchema != null, "No schema name configured and no schema selected on the connection");
+		return currentSchema;
+	}
+
+	private boolean isTableExists(String schemaName, String tableName) {
 		// schema and table are expected to be escaped
 		String sql = "SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
 		try {
 			// Query for a single integer value, if it exists, table exists
-			this.jdbcTemplate.queryForObject(sql, Integer.class, (schemaName == null) ? "SCHEMA()" : schemaName,
-					tableName);
+			this.jdbcTemplate.queryForObject(sql, Integer.class, schemaName, tableName);
 			return true;
 		}
 		catch (DataAccessException e) {
@@ -62,16 +70,17 @@ public class MariaDBSchemaValidator {
 	void validateTableSchema(@Nullable String schemaName, String tableName, String idFieldName, String contentFieldName,
 			String metadataFieldName, String embeddingFieldName, int embeddingDimensions) {
 
-		if (!isTableExists(schemaName, tableName)) {
+		String resolvedSchemaName = resolveSchemaName(schemaName);
+
+		if (!isTableExists(resolvedSchemaName, tableName)) {
 			throw new IllegalStateException(
-					String.format("Table '%s' does not exist in schema '%s'", tableName, schemaName));
+					String.format("Table '%s' does not exist in schema '%s'", tableName, resolvedSchemaName));
 		}
 
 		// ensure server support VECTORs
 		try {
 			// Query for a single integer value, if it exists, database support vector
-			this.jdbcTemplate.queryForObject("SELECT vec_distance_euclidean(x'0000803f', x'0000803f')", Integer.class,
-					schemaName, tableName);
+			this.jdbcTemplate.queryForObject("SELECT vec_distance_euclidean(x'0000803f', x'0000803f')", Integer.class);
 		}
 		catch (DataAccessException e) {
 			if (logger.isErrorEnabled()) {
@@ -87,7 +96,8 @@ public class MariaDBSchemaValidator {
 
 		try {
 			if (logger.isInfoEnabled()) {
-				logger.info("Validating MariaDBStore schema for table: " + tableName + " in schema: " + schemaName);
+				logger.info(
+						"Validating MariaDBStore schema for table: " + tableName + " in schema: " + resolvedSchemaName);
 			}
 
 			List<String> expectedColumns = new ArrayList<>();
@@ -100,11 +110,12 @@ public class MariaDBSchemaValidator {
 			// Include the schema name in the query to target the correct table
 			String query = "SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS "
 					+ "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
-			List<Map<String, @Nullable Object>> columns = this.jdbcTemplate.queryForList(query, schemaName, tableName);
+			List<Map<String, @Nullable Object>> columns = this.jdbcTemplate.queryForList(query, resolvedSchemaName,
+					tableName);
 
 			if (columns.isEmpty()) {
 				throw new IllegalStateException("Error while validating table schema, Table " + tableName
-						+ " does not exist in schema " + schemaName);
+						+ " does not exist in schema " + resolvedSchemaName);
 			}
 
 			// Check each column against expected fields
@@ -142,9 +153,8 @@ public class MariaDBSchemaValidator {
 										%s JSON,
 										%s VECTOR(%d) NOT NULL,
 										VECTOR INDEX (%s)
-								) ENGINE=InnoDB""", schemaName == null ? tableName : schemaName + "." + tableName,
-								idFieldName, contentFieldName, metadataFieldName, embeddingFieldName,
-								embeddingDimensions, embeddingFieldName)
+								) ENGINE=InnoDB""", resolvedSchemaName + "." + tableName, idFieldName, contentFieldName,
+								metadataFieldName, embeddingFieldName, embeddingDimensions, embeddingFieldName)
 						+ "\n" + "Please adjust these commands based on your specific configuration and the"
 						+ " capabilities of your vector database system.");
 			}

--- a/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidatorIT.java
+++ b/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidatorIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.mariadb;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * @author Junhyeok Park
+ */
+@Testcontainers
+@JdbcTest
+public class MariaDBSchemaValidatorIT {
+
+	@ServiceConnection
+	@Container
+	@SuppressWarnings("resource")
+	static MariaDBContainer<?> mariadbContainer = new MariaDBContainer<>(MariaDBImage.DEFAULT_IMAGE)
+		.withUsername("mariadb")
+		.withPassword("mariadbpwd")
+		.withDatabaseName("testdb");
+
+	@Autowired
+	JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	MariaDBSchemaValidator schemaValidator;
+
+	@BeforeEach
+	void createVectorStoreTable() {
+		this.jdbcTemplate.execute("""
+				CREATE TABLE IF NOT EXISTS vector_store (
+					id UUID NOT NULL DEFAULT uuid() PRIMARY KEY,
+					content TEXT,
+					metadata JSON,
+					embedding VECTOR(1536) NOT NULL,
+					VECTOR INDEX (embedding)
+				) ENGINE=InnoDB""");
+	}
+
+	@Test
+	void validateTableSchemaWithDefaultSchema() {
+		assertThatNoException().isThrownBy(() -> this.schemaValidator.validateTableSchema(null, "vector_store", "id",
+				"content", "metadata", "embedding", 1536));
+	}
+
+	@Test
+	void validateTableSchemaWithExplicitSchemaName() {
+		assertThatNoException().isThrownBy(() -> this.schemaValidator.validateTableSchema("testdb", "vector_store",
+				"id", "content", "metadata", "embedding", 1536));
+	}
+
+	@Test
+	void validateTableSchemaFailsOnMissingTableWithDefaultSchema() {
+		assertThatIllegalStateException()
+			.isThrownBy(() -> this.schemaValidator.validateTableSchema(null, "missing_vector_store", "id", "content",
+					"metadata", "embedding", 1536))
+			.withMessageContaining("Table 'missing_vector_store' does not exist in schema 'testdb'");
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class Config {
+
+		@Bean
+		MariaDBSchemaValidator schemaValidator(JdbcTemplate jdbcTemplate) {
+			return new MariaDBSchemaValidator(jdbcTemplate);
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Problem

`MariaDBSchemaValidator` supports leaving the schema name unset, in which case the
table is expected to live in the connection's default schema. That path never worked.

`isTableExists` bound the literal string `"SCHEMA()"` as a query *parameter*:

```java
this.jdbcTemplate.queryForObject(sql, Integer.class,
        (schemaName == null) ? "SCHEMA()" : schemaName, tableName);
```

A bind parameter is a value, not SQL, so the predicate evaluated as
`TABLE_SCHEMA = 'SCHEMA()'` and matched nothing. The column lookup in
`validateTableSchema` had the same defect from the other direction: it bound
`schemaName` while it was still `null`, so `TABLE_SCHEMA = NULL` would have matched
nothing either, had it been reached — the table check above already threw first.

The result is that with `schemaValidation` enabled and no `schemaName` configured,
`MariaDBVectorStore.afterPropertiesSet()` fails for a table that is present:

```
java.lang.IllegalStateException: Table 'vector_store' does not exist in schema 'null'
```

The workaround is to set `schemaName` explicitly, which should not be required.
Note the `null` in the message — the log and exception messages on this path reported
the unresolved name rather than the schema actually being validated. The `CREATE TABLE`
statement suggested when a column is missing had the opposite problem: it dropped the
schema qualifier entirely, so it never named the schema being validated either.

## Solution

Resolve the schema name once, up front, before any lookup:

```java
private String resolveSchemaName(@Nullable String schemaName) {
    if (schemaName != null) {
        return schemaName;
    }
    String currentSchema = this.jdbcTemplate.queryForObject("SELECT SCHEMA()", String.class);
    Assert.state(currentSchema != null, "No schema name configured and no schema selected on the connection");
    return currentSchema;
}
```

`SELECT SCHEMA()` is evaluated by the server as SQL, which is what the original code
intended. A connection with no database selected returns `NULL` there; that is a
configuration error rather than a missing table, so it fails with a distinct message
instead of being reported as `schema 'null'`.

The resolved name is then used for both `INFORMATION_SCHEMA` queries, for the log and
exception messages, and for the suggested DDL, which is now always schema-qualified.
`isTableExists` now takes a non-null schema name, so the `@Nullable` handling exists in
exactly one place.

This also drops two stray arguments from the vector support probe:

```java
this.jdbcTemplate.queryForObject("SELECT vec_distance_euclidean(x'0000803f', x'0000803f')",
        Integer.class, schemaName, tableName);
```

That statement has no placeholders, so `schemaName` and `tableName` were bound to
nothing. Harmless, but misleading to read.

## Testing

`MariaDBSchemaValidatorIT` starts a MariaDB container, creates a `vector_store` table
in the container's default schema and validates it three ways: with no schema name,
with the schema name given explicitly, and against a table that does not exist — the
last asserting that the message now names the resolved schema.

The IT needs `spring-boot-testcontainers` for `@ServiceConnection`, added as a test
dependency. It requires only Docker, no API key.