### PR TITLE
Make DefaultUsage nativeUsage serialization tolerant

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/DefaultUsage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/DefaultUsage.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Default implementation of the {@link Usage} interface.
@@ -157,6 +158,7 @@ public class DefaultUsage implements Usage {
 	@Override
 	@JsonProperty("nativeUsage")
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonSerialize(using = NativeUsageSerializer.class)
 	public @Nullable Object getNativeUsage() {
 		return this.nativeUsage;
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/NativeUsageSerializer.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/NativeUsageSerializer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.metadata;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.util.TokenBuffer;
+
+/**
+ * Jackson serializer for {@link DefaultUsage#getNativeUsage()} that never fails.
+ * <p>
+ * The native usage object is an opaque, provider-specific type (an SDK model class, a
+ * protobuf message, ...) that is not guaranteed to be serializable by Jackson. This
+ * serializer first writes the value into a {@link TokenBuffer}. If that succeeds, the
+ * buffered tokens are copied to the target generator, producing exactly the output the
+ * default serializer would have produced. If it fails, the value's {@code toString()}
+ * representation is written instead, so that a non-serializable native usage object can
+ * never break serialization of the enclosing {@code ChatResponse}.
+ *
+ * @author Soby Chacko
+ * @since 2.0.2
+ */
+class NativeUsageSerializer extends ValueSerializer<Object> {
+
+	private static final Log logger = LogFactory.getLog(NativeUsageSerializer.class);
+
+	@Override
+	public void serialize(Object value, JsonGenerator gen, SerializationContext ctxt) {
+		TokenBuffer buffer = new TokenBuffer(ctxt, false);
+		try {
+			ctxt.writeValue(buffer, value);
+		}
+		catch (RuntimeException ex) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Native usage of type " + value.getClass().getName()
+						+ " is not JSON serializable, falling back to toString()", ex);
+			}
+			gen.writeString(String.valueOf(value));
+			return;
+		}
+		buffer.serialize(gen);
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/metadata/DefaultUsageTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/metadata/DefaultUsageTests.java
@@ -17,10 +17,16 @@
 package org.springframework.ai.chat.metadata;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.util.JacksonUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -302,6 +308,91 @@ public class DefaultUsageTests {
 		assertThat(usageWithExplicitTotal.getTotalTokens()).isEqualTo(200); // Should use
 																			// explicit
 																			// value
+	}
+
+	@Test
+	void testSerializationFallsBackToToStringForNonSerializableNativeUsage() throws Exception {
+		DefaultUsage usage = new DefaultUsage(100, 50, 150, new ThrowingNativeUsage());
+		String json = JsonMapper.shared().writeValueAsString(usage);
+		assertThat(json).isEqualTo(
+				"{\"promptTokens\":100,\"completionTokens\":50,\"totalTokens\":150,\"nativeUsage\":\"ThrowingNativeUsage{tokens=7}\"}");
+	}
+
+	@Test
+	void testSerializationFallsBackToToStringForSelfReferencingNativeUsage() throws Exception {
+		DefaultUsage usage = new DefaultUsage(100, 50, 150, new SelfReferencingNativeUsage());
+		String json = JsonMapper.shared().writeValueAsString(usage);
+		assertThat(json).isEqualTo(
+				"{\"promptTokens\":100,\"completionTokens\":50,\"totalTokens\":150,\"nativeUsage\":\"SelfReferencingNativeUsage\"}");
+	}
+
+	@Test
+	void testSerializationOfSerializableNativeUsageIsUnchanged() throws Exception {
+		DefaultUsage usage = new DefaultUsage(100, 50, 150, new PlainNativeUsage(7));
+		String json = JsonMapper.shared().writeValueAsString(usage);
+		assertThat(json).isEqualTo(
+				"{\"promptTokens\":100,\"completionTokens\":50,\"totalTokens\":150,\"nativeUsage\":{\"tokens\":7}}");
+	}
+
+	@Test
+	void testChatResponseWithNonSerializableNativeUsageIsSerializable() throws Exception {
+		DefaultUsage usage = new DefaultUsage(100, 50, 150, new ThrowingNativeUsage());
+		ChatResponse chatResponse = ChatResponse.builder()
+			.generations(List.of(new Generation(new AssistantMessage("Hello"))))
+			.metadata(ChatResponseMetadata.builder().usage(usage).build())
+			.build();
+
+		// Mirrors SimpleLoggerAdvisor.DEFAULT_RESPONSE_TO_STRING
+		String json = JacksonUtils.getDefaultJsonMapper()
+			.writerWithDefaultPrettyPrinter()
+			.writeValueAsString(chatResponse);
+
+		assertThat(json).contains("\"nativeUsage\" : \"ThrowingNativeUsage{tokens=7}\"");
+		assertThat(json).contains("\"promptTokens\" : 100");
+	}
+
+	/**
+	 * Simulates a provider-native usage object (e.g. a protobuf message) whose accessors
+	 * cannot be introspected by Jackson.
+	 */
+	static class ThrowingNativeUsage {
+
+		public int getTokens() {
+			throw new UnsupportedOperationException("not serializable");
+		}
+
+		@Override
+		public String toString() {
+			return "ThrowingNativeUsage{tokens=7}";
+		}
+
+	}
+
+	static class SelfReferencingNativeUsage {
+
+		public SelfReferencingNativeUsage getSelf() {
+			return this;
+		}
+
+		@Override
+		public String toString() {
+			return "SelfReferencingNativeUsage";
+		}
+
+	}
+
+	static class PlainNativeUsage {
+
+		private final int tokens;
+
+		PlainNativeUsage(int tokens) {
+			this.tokens = tokens;
+		}
+
+		public int getTokens() {
+			return this.tokens;
+		}
+
 	}
 
 }


### PR DESCRIPTION
nativeUsage holds an opaque provider object that Jackson may not be able to serialize, which breaks any JSON view of a ChatResponse such as SimpleLoggerAdvisor output or a controller response.

Serialize the value into a TokenBuffer first and fall back to its toString() representation if that fails, so the enclosing response always serializes. Output for already serializable values is unchanged.

Fixes #2535
Fixes #5682