### PR TITLE
Add per-request headers to `GoogleGenAiChatModel`

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -44,6 +44,7 @@ import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
 import com.google.genai.types.GoogleSearch;
+import com.google.genai.types.HttpOptions;
 import com.google.genai.types.Part;
 import com.google.genai.types.SafetySetting;
 import com.google.genai.types.Schema;
@@ -723,6 +724,9 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 
 		if (requestOptions.getLabels() != null && !requestOptions.getLabels().isEmpty()) {
 			configBuilder.labels(requestOptions.getLabels());
+		}
+		if (!CollectionUtils.isEmpty(requestOptions.getHttpHeaders())) {
+			configBuilder.httpOptions(HttpOptions.builder().headers(requestOptions.getHttpHeaders()).build());
 		}
 
 		if (requestOptions.getServiceTier() != null) {

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
@@ -201,6 +201,11 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	private final @Nullable Map<String, String> labels;
 
 	/**
+	 * Optional. HTTP headers to include in the API request.
+	 */
+	private final @Nullable Map<String, String> httpHeaders;
+
+	/**
 	 * Optional. The service tier to use for the request.
 	 */
 	private final @Nullable GoogleGenAiServiceTier serviceTier;
@@ -218,6 +223,25 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 			@Nullable Boolean googleSearchRetrieval, @Nullable Boolean includeServerSideToolInvocations,
 			@Nullable List<GoogleGenAiSafetySetting> safetySettings, @Nullable Map<String, String> labels,
 			@Nullable GoogleGenAiServiceTier serviceTier) {
+		this(model, frequencyPenalty, maxOutputTokens, presencePenalty, stopSequences, temperature, topK, topP,
+				toolChoice, toolCallbacks, toolContext, candidateCount, responseMimeType, responseSchema,
+				thinkingBudget, includeThoughts, thinkingLevel, includeExtendedUsageMetadata, cachedContentName,
+				useCachedContent, autoCacheThreshold, autoCacheTtl, googleSearchRetrieval,
+				includeServerSideToolInvocations, safetySettings, labels, null, serviceTier);
+	}
+
+	private GoogleGenAiChatOptions(@Nullable String model, @Nullable Double frequencyPenalty,
+			@Nullable Integer maxOutputTokens, @Nullable Double presencePenalty, @Nullable List<String> stopSequences,
+			@Nullable Double temperature, @Nullable Integer topK, @Nullable Double topP,
+			@Nullable ToolChoice toolChoice, @Nullable List<ToolCallback> toolCallbacks,
+			@Nullable Map<String, Object> toolContext, @Nullable Integer candidateCount,
+			@Nullable String responseMimeType, @Nullable String responseSchema, @Nullable Integer thinkingBudget,
+			@Nullable Boolean includeThoughts, @Nullable GoogleGenAiThinkingLevel thinkingLevel,
+			@Nullable Boolean includeExtendedUsageMetadata, @Nullable String cachedContentName,
+			@Nullable Boolean useCachedContent, @Nullable Integer autoCacheThreshold, @Nullable Duration autoCacheTtl,
+			@Nullable Boolean googleSearchRetrieval, @Nullable Boolean includeServerSideToolInvocations,
+			@Nullable List<GoogleGenAiSafetySetting> safetySettings, @Nullable Map<String, String> labels,
+			@Nullable Map<String, String> httpHeaders, @Nullable GoogleGenAiServiceTier serviceTier) {
 		this.model = model != null ? model : ChatModel.GEMINI_2_5_FLASH.getValue();
 		this.frequencyPenalty = frequencyPenalty;
 		this.maxOutputTokens = maxOutputTokens;
@@ -244,6 +268,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		this.includeServerSideToolInvocations = Boolean.TRUE.equals(includeServerSideToolInvocations);
 		this.safetySettings = (safetySettings != null ? List.copyOf(safetySettings) : null);
 		this.labels = (labels != null ? Map.copyOf(labels) : null);
+		this.httpHeaders = (httpHeaders != null ? Map.copyOf(httpHeaders) : null);
 		this.serviceTier = serviceTier;
 	}
 
@@ -370,6 +395,15 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	}
 
 	/**
+	 * Return the HTTP headers to include in the API request.
+	 * @return the request HTTP headers, or {@code null} if none are configured
+	 * @since 2.0.2
+	 */
+	public @Nullable Map<String, String> getHttpHeaders() {
+		return this.httpHeaders;
+	}
+
+	/**
 	 * @since 2.0.0
 	 */
 	public @Nullable GoogleGenAiServiceTier getServiceTier() {
@@ -411,6 +445,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 				&& Objects.equals(this.toolCallbacks, that.toolCallbacks)
 				&& Objects.equals(this.safetySettings, that.safetySettings)
 				&& Objects.equals(this.toolContext, that.toolContext) && Objects.equals(this.labels, that.labels)
+				&& Objects.equals(this.httpHeaders, that.httpHeaders)
 				&& Objects.equals(this.serviceTier, that.serviceTier);
 	}
 
@@ -421,7 +456,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 				this.includeThoughts, this.thinkingLevel, this.maxOutputTokens, this.model, this.responseMimeType,
 				this.responseSchema, this.toolCallbacks, this.googleSearchRetrieval,
 				this.includeServerSideToolInvocations, this.safetySettings, this.toolContext, this.labels,
-				this.serviceTier);
+				this.httpHeaders, this.serviceTier);
 	}
 
 	@Override
@@ -457,6 +492,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 			.includeServerSideToolInvocations(this.includeServerSideToolInvocations)
 			.safetySettings(this.safetySettings)
 			.labels(this.labels)
+			.httpHeaders(this.httpHeaders)
 			.serviceTier(this.serviceTier)
 			.responseMimeType(this.responseMimeType);
 	}
@@ -475,6 +511,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 			B copy = super.clone();
 			copy.safetySettings = this.safetySettings == null ? null : new ArrayList<>(this.safetySettings);
 			copy.labels = this.labels == null ? null : new HashMap<>(this.labels);
+			copy.httpHeaders = this.httpHeaders == null ? null : new HashMap<>(this.httpHeaders);
 			return copy;
 		}
 
@@ -509,6 +546,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		protected @Nullable List<GoogleGenAiSafetySetting> safetySettings;
 
 		protected @Nullable Map<String, String> labels;
+
+		protected @Nullable Map<String, String> httpHeaders;
 
 		protected @Nullable GoogleGenAiServiceTier serviceTier;
 
@@ -596,6 +635,17 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 
 		public B labels(@Nullable Map<String, String> labels) {
 			this.labels = labels;
+			return self();
+		}
+
+		/**
+		 * Configure HTTP headers to include in the API request.
+		 * @param httpHeaders the request HTTP headers
+		 * @return this builder
+		 * @since 2.0.2
+		 */
+		public B httpHeaders(@Nullable Map<String, String> httpHeaders) {
+			this.httpHeaders = httpHeaders;
 			return self();
 		}
 
@@ -689,6 +739,16 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 						this.labels = merged;
 					}
 				}
+				if (that.httpHeaders != null) {
+					if (this.httpHeaders == null) {
+						this.httpHeaders = new HashMap<>(that.httpHeaders);
+					}
+					else {
+						Map<String, String> merged = new HashMap<>(this.httpHeaders);
+						merged.putAll(that.httpHeaders);
+						this.httpHeaders = merged;
+					}
+				}
 				if (that.serviceTier != null) {
 					this.serviceTier = that.serviceTier;
 				}
@@ -707,7 +767,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 					this.thinkingBudget, this.includeThoughts, this.thinkingLevel, this.includeExtendedUsageMetadata,
 					this.cachedContentName, this.useCachedContent, this.autoCacheThreshold, this.autoCacheTtl,
 					this.googleSearchRetrieval, this.includeServerSideToolInvocations, this.safetySettings, this.labels,
-					this.serviceTier);
+					this.httpHeaders, this.serviceTier);
 		}
 
 	}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
@@ -189,6 +189,18 @@ public class CreateGeminiRequestTests {
 	}
 
 	@Test
+	public void createRequestWithHttpHeaders() {
+		Map<String, String> httpHeaders = Map.of("x-some-header-id", "VALUE_123", "x-another-header-id", "VALUE_456");
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder().httpHeaders(httpHeaders).build();
+		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();
+
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content", options));
+
+		assertThat(request.config().httpOptions()).isPresent();
+		assertThat(request.config().httpOptions().get().headers()).hasValue(httpHeaders);
+	}
+
+	@Test
 	public void createRequestWithThinkingBudget() {
 
 		var client = GoogleGenAiChatModel.builder().genAiClient(this.genAiClient).build();

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
@@ -107,6 +107,24 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 	}
 
 	@Test
+	public void testEqualsAndHashCodeWithHttpHeaders() {
+		GoogleGenAiChatOptions options1 = GoogleGenAiChatOptions.builder()
+			.httpHeaders(Map.of("x-some-header-id", "VALUE_123"))
+			.build();
+		GoogleGenAiChatOptions options2 = GoogleGenAiChatOptions.builder()
+			.httpHeaders(Map.of("x-some-header-id", "VALUE_123"))
+			.build();
+		GoogleGenAiChatOptions options3 = GoogleGenAiChatOptions.builder()
+			.httpHeaders(Map.of("x-some-header-id", "VALUE_456"))
+			.build();
+
+		assertThat(options1).isEqualTo(options2);
+		assertThat(options1.hashCode()).isEqualTo(options2.hashCode());
+		assertThat(options1).isNotEqualTo(options3);
+		assertThat(options1.hashCode()).isNotEqualTo(options3.hashCode());
+	}
+
+	@Test
 	public void testThinkingBudgetWithZeroValue() {
 		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder().thinkingBudget(0).build();
 
@@ -253,6 +271,7 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 			.build();
 		GoogleGenAiChatOptions base = GoogleGenAiChatOptions.builder()
 			.labels(Map.of("base-key", "base-value"))
+			.httpHeaders(Map.of("base-header", "base-value", "shared-header", "base-value"))
 			.safetySettings(List.of(baseSafetySetting))
 			.build();
 
@@ -262,6 +281,7 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 			.build();
 		GoogleGenAiChatOptions override = GoogleGenAiChatOptions.builder()
 			.labels(Map.of("override-key", "override-value"))
+			.httpHeaders(Map.of("override-header", "override-value", "shared-header", "override-value"))
 			.safetySettings(List.of(overrideSafetySetting))
 			.build();
 
@@ -269,6 +289,9 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 
 		assertThat(merged.getLabels()).containsEntry("base-key", "base-value");
 		assertThat(merged.getLabels()).containsEntry("override-key", "override-value");
+		assertThat(merged.getHttpHeaders()).containsEntry("base-header", "base-value")
+			.containsEntry("override-header", "override-value")
+			.containsEntry("shared-header", "override-value");
 		assertThat(merged.getSafetySettings()).containsExactlyInAnyOrder(baseSafetySetting, overrideSafetySetting);
 	}
 
@@ -282,18 +305,25 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 		safetySettings.add(safetySetting);
 		Map<String, String> labels = new HashMap<>();
 		labels.put("key", "value");
+		Map<String, String> httpHeaders = new HashMap<>();
+		httpHeaders.put("x-some-header-id", "VALUE_123");
 
-		Builder source = GoogleGenAiChatOptions.builder().safetySettings(safetySettings).labels(labels);
+		Builder source = GoogleGenAiChatOptions.builder()
+			.safetySettings(safetySettings)
+			.labels(labels)
+			.httpHeaders(httpHeaders);
 		Builder clone = source.clone();
 		safetySettings.add(new GoogleGenAiSafetySetting.Builder()
 			.withCategory(GoogleGenAiSafetySetting.HarmCategory.HARM_CATEGORY_HARASSMENT)
 			.withThreshold(GoogleGenAiSafetySetting.HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE)
 			.build());
 		labels.put("anotherKey", "anotherValue");
+		httpHeaders.put("x-another-header-id", "VALUE_456");
 
 		GoogleGenAiChatOptions cloned = clone.build();
 		assertThat(cloned.getSafetySettings()).containsExactly(safetySetting);
 		assertThat(cloned.getLabels()).containsOnlyKeys("key");
+		assertThat(cloned.getHttpHeaders()).containsOnlyKeys("x-some-header-id");
 	}
 
 	@Test
@@ -301,6 +331,7 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 		GoogleGenAiChatOptions cloned = GoogleGenAiChatOptions.builder().clone().build();
 		assertThat(cloned.getSafetySettings()).isNull();
 		assertThat(cloned.getLabels()).isNull();
+		assertThat(cloned.getHttpHeaders()).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
Add request-scoped HTTP headers to `GoogleGenAiChatOptions` and pass them through `GenerateContentConfig.httpOptions`.
This lets callers vary gateway or proxy headers per prompt while retaining client-level defaults merged by the Google SDK.

The option participates in mutation, cloning, combination, equality, and hash-code behavior, with per-request values overriding defaults.

Tests:

- `./mvnw clean package`
- `./mvnw -pl models/spring-ai-google-genai -DskipTests javadoc:javadoc`

Closes #6920