### PR TITLE
fix(openai): propagate per-request custom headers

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
@@ -49,6 +49,7 @@ import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomiz
 import org.springframework.ai.openai.metadata.OpenAiAudioSpeechResponseMetadata;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -294,6 +295,9 @@ public final class OpenAiAudioSpeechModel implements TextToSpeechModel {
 
 		if (streaming) {
 			paramsBuilder.streamFormat(SpeechCreateParams.StreamFormat.AUDIO);
+		}
+		if (!CollectionUtils.isEmpty(mergedOptions.getCustomHeaders())) {
+			mergedOptions.getCustomHeaders().forEach(paramsBuilder::putAdditionalHeader);
 		}
 
 		return paramsBuilder.build();

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -223,6 +223,9 @@ public final class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 		if (!CollectionUtils.isEmpty(options.getKnownSpeakerReferences())) {
 			builder.knownSpeakerReferences(options.getKnownSpeakerReferences());
 		}
+		if (!CollectionUtils.isEmpty(options.getCustomHeaders())) {
+			options.getCustomHeaders().forEach(builder::putAdditionalHeader);
+		}
 		return builder.build();
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
@@ -40,6 +40,7 @@ import org.springframework.ai.moderation.ModerationResult;
 import org.springframework.ai.openai.http.okhttp.OpenAiHttpClientBuilderCustomizer;
 import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 /**
  * OpenAI SDK Moderation Model implementation.
@@ -107,6 +108,9 @@ public final class OpenAiModerationModel implements ModerationModel {
 		}
 		Assert.notNull(model, "Model must not be null");
 		builder.model(com.openai.models.moderations.ModerationModel.of(model));
+		if (!CollectionUtils.isEmpty(options.getCustomHeaders())) {
+			options.getCustomHeaders().forEach(builder::putAdditionalHeader);
+		}
 
 		ModerationCreateParams params = builder.build();
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/OpenAiAudioSpeechModelTests.java
@@ -24,6 +24,7 @@ import java.io.InterruptedIOException;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -621,6 +622,26 @@ class OpenAiAudioSpeechModelTests {
 		RequestOptions value = argumentCaptor.getValue();
 		assertThat(value.getTimeout()).isNotNull();
 		assertThat(value.getTimeout().request()).isEqualTo(expectedTimeout);
+	}
+
+	@Test
+	void testPropagatesPerRequestCustomHeaders() {
+		OpenAIClient mockClient = mock(OpenAIClient.class, RETURNS_DEEP_STUBS);
+		HttpResponse mockResponse = mock(HttpResponse.class);
+		when(mockResponse.body()).thenReturn(new ByteArrayInputStream(new byte[0]));
+		when(mockClient.audio().speech().create(any(SpeechCreateParams.class), any(RequestOptions.class)))
+			.thenReturn(mockResponse);
+
+		OpenAiAudioSpeechModel model = OpenAiAudioSpeechModel.builder().openAiClient(mockClient).build();
+		OpenAiAudioSpeechOptions options = OpenAiAudioSpeechOptions.builder()
+			.customHeaders(Map.of("x-request-id", "VALUE_123"))
+			.build();
+
+		model.call(new TextToSpeechPrompt("hello", options));
+
+		ArgumentCaptor<SpeechCreateParams> paramsCaptor = ArgumentCaptor.forClass(SpeechCreateParams.class);
+		verify(mockClient.audio().speech()).create(paramsCaptor.capture(), any(RequestOptions.class));
+		assertThat(paramsCaptor.getValue()._additionalHeaders().values("x-request-id")).containsExactly("VALUE_123");
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/moderation/OpenAiModerationModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/moderation/OpenAiModerationModelTests.java
@@ -268,4 +268,22 @@ class OpenAiModerationModelTests {
 		assertThat(value.getTimeout().request()).isEqualTo(expectedTimeout);
 	}
 
+	@Test
+	void testPropagatesPerRequestCustomHeaders() {
+		OpenAIClient mockClient = mock(OpenAIClient.class, RETURNS_DEEP_STUBS);
+		when(mockClient.moderations().create(any(ModerationCreateParams.class), any(RequestOptions.class))).thenReturn(
+				ModerationCreateResponse.builder().id("TEST_ID").model("TEST_MODEL").results(List.of()).build());
+
+		OpenAiModerationModel model = OpenAiModerationModel.builder().openAiClient(mockClient).build();
+		OpenAiModerationOptions options = OpenAiModerationOptions.builder()
+			.customHeaders(Map.of("x-request-id", "VALUE_123"))
+			.build();
+
+		model.call(new ModerationPrompt("hi", options));
+
+		ArgumentCaptor<ModerationCreateParams> paramsCaptor = ArgumentCaptor.forClass(ModerationCreateParams.class);
+		verify(mockClient.moderations()).create(paramsCaptor.capture(), any(RequestOptions.class));
+		assertThat(paramsCaptor.getValue()._additionalHeaders().values("x-request-id")).containsExactly("VALUE_123");
+	}
+
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/transcription/OpenAiAudioTranscriptionModelTests.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -581,6 +582,30 @@ class OpenAiAudioTranscriptionModelTests {
 		assertThat(sentParams.knownSpeakerNames()).contains(List.of("Alice", "Bob"));
 		assertThat(sentParams.knownSpeakerReferences())
 			.contains(List.of("data:audio/wav;base64,AAAA", "data:audio/wav;base64,BBBB"));
+	}
+
+	@Test
+	void callPropagatesPerRequestCustomHeaders() {
+		ArgumentCaptor<TranscriptionCreateParams> paramsCaptor = ArgumentCaptor
+			.forClass(TranscriptionCreateParams.class);
+		OpenAIClient client = mock(OpenAIClient.class);
+		AudioService audioService = mock(AudioService.class);
+		TranscriptionService transcriptionService = mock(TranscriptionService.class);
+		when(client.audio()).thenReturn(audioService);
+		when(audioService.transcriptions()).thenReturn(transcriptionService);
+		when(transcriptionService.create(paramsCaptor.capture(), any(RequestOptions.class))).thenReturn(
+				TranscriptionCreateResponse.ofTranscription(Transcription.builder().text("Hello world").build()));
+
+		OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+			.openAiClient(client)
+			.openAiClientAsync(mock(OpenAIClientAsync.class))
+			.build();
+
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(new ClassPathResource("/speech.flac"),
+				OpenAiAudioTranscriptionOptions.builder().customHeaders(Map.of("x-request-id", "VALUE_123")).build());
+		model.call(prompt);
+
+		assertThat(paramsCaptor.getValue()._additionalHeaders().values("x-request-id")).containsExactly("VALUE_123");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #6922

## Summary

`OpenAiAudioTranscriptionModel`, `OpenAiAudioSpeechModel`, and `OpenAiModerationModel` merge per-request options but previously did not copy `customHeaders` into the corresponding OpenAI SDK request parameters. As a result, request-scoped headers were silently dropped for these three APIs.

This change adds request-local `putAdditionalHeader` propagation for all three builders. It does not mutate the shared OpenAI client and preserves existing client-level header behavior.

## Tests

Added focused client-mock regression tests that capture each SDK parameter object and assert the request header is present.

Verification with JDK 21 and public Maven Central:

```text
./mvnw -s /Users/yohanes/.m2/settings-public-central.xml \\
  -pl models/spring-ai-openai \\
  -Dtest='OpenAiAudioTranscriptionModelTests,OpenAiAudioSpeechModelTests,OpenAiModerationModelTests' \\
  -Dsurefire.failIfNoSpecifiedTests=false test

Tests run: 73, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Formatting verification:

```text
./mvnw -s /Users/yohanes/.m2/settings-public-central.xml \\
  -pl models/spring-ai-openai process-sources

BUILD SUCCESS
```
