### PR TITLE
Fix `TokenTextSplitter` line separator handling

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
@@ -18,6 +18,7 @@ package org.springframework.ai.transformer.splitter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import com.knuddels.jtokkit.Encodings;
 import com.knuddels.jtokkit.api.Encoding;
@@ -36,6 +37,12 @@ import org.springframework.util.Assert;
  * @author Jemin Huh
  */
 public class TokenTextSplitter extends TextSplitter {
+
+	/**
+	 * Matches any line break, so that chunks are split the same way regardless of the
+	 * line separator used by the document or by the host operating system.
+	 */
+	private static final Pattern LINE_BREAK = Pattern.compile("\\R");
 
 	private static final int DEFAULT_CHUNK_SIZE = 800;
 
@@ -186,8 +193,7 @@ public class TokenTextSplitter extends TextSplitter {
 				}
 			}
 
-			String chunkTextToAppend = (this.keepSeparator) ? chunkText.trim()
-					: chunkText.replace(System.lineSeparator(), " ").trim();
+			String chunkTextToAppend = (this.keepSeparator) ? chunkText.trim() : replaceLineBreaks(chunkText);
 			if (chunkTextToAppend.length() > this.minChunkLengthToEmbed) {
 				chunks.add(chunkTextToAppend);
 			}
@@ -200,13 +206,19 @@ public class TokenTextSplitter extends TextSplitter {
 
 		// Handle the remaining tokens
 		if (!tokens.isEmpty()) {
-			String remaining_text = decodeTokens(tokens).replace(System.lineSeparator(), " ").trim();
+			String decodedRemainder = decodeTokens(tokens);
+			String remaining_text = (this.keepSeparator) ? decodedRemainder.trim()
+					: replaceLineBreaks(decodedRemainder);
 			if (remaining_text.length() > this.minChunkLengthToEmbed) {
 				chunks.add(remaining_text);
 			}
 		}
 
 		return chunks;
+	}
+
+	private static String replaceLineBreaks(String text) {
+		return LINE_BREAK.matcher(text).replaceAll(" ").trim();
 	}
 
 	protected int getLastPunctuationIndex(String chunkText) {

--- a/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/TokenTextSplitterTest.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/TokenTextSplitterTest.java
@@ -31,8 +31,61 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 /**
  * @author Ricken Bazolo
  * @author Jemin Huh
+ * @author Oleksandr Klymenko
  */
 public class TokenTextSplitterTest {
+
+	private static String threeLines(String lineSeparator) {
+		return "In the end, writing arises when man realizes that memory is not enough." + lineSeparator
+				+ "The most oppressive thing about the labyrinth is that you are constantly being forced to choose."
+				+ lineSeparator + "It isn't the lack of an exit, but the abundance of exits that is so disorienting.";
+	}
+
+	@Test
+	public void shouldRemoveLineFeedWhenSeparatorNotKept() {
+		var splitter = TokenTextSplitter.builder().withKeepSeparator(false).build();
+
+		var chunks = splitter.apply(List.of(new Document(threeLines("\n"))));
+
+		assertThat(chunks).hasSize(1);
+		assertThat(chunks.get(0).getText()).doesNotContain("\n").doesNotContain("  ");
+	}
+
+	@Test
+	public void shouldRemoveCarriageReturnLineFeedWhenSeparatorNotKept() {
+		var splitter = TokenTextSplitter.builder().withKeepSeparator(false).build();
+
+		var chunks = splitter.apply(List.of(new Document(threeLines("\r\n"))));
+
+		assertThat(chunks).hasSize(1);
+		assertThat(chunks.get(0).getText()).doesNotContain("\r").doesNotContain("\n").doesNotContain("  ");
+	}
+
+	@Test
+	public void shouldProduceSameChunksRegardlessOfLineSeparator() {
+		var splitter = TokenTextSplitter.builder().withKeepSeparator(false).build();
+
+		var lineFeed = splitter.apply(List.of(new Document(threeLines("\n"))));
+		var carriageReturnLineFeed = splitter.apply(List.of(new Document(threeLines("\r\n"))));
+
+		assertThat(lineFeed.get(0).getText()).isEqualTo(carriageReturnLineFeed.get(0).getText());
+	}
+
+	@Test
+	public void shouldKeepLineSeparatorInTrailingChunkWhenSeparatorKept() {
+		var splitter = TokenTextSplitter.builder()
+			.withKeepSeparator(true)
+			.withChunkSize(20)
+			.withMaxNumChunks(1)
+			.withMinChunkSizeChars(1)
+			.withMinChunkLengthToEmbed(1)
+			.build();
+
+		var chunks = splitter.apply(List.of(new Document(threeLines("\n"))));
+
+		assertThat(chunks).hasSize(2);
+		assertThat(chunks.get(1).getText()).contains("\n");
+	}
 
 	@Test
 	public void testTokenTextSplitterBuilderWithDefaultValues() {


### PR DESCRIPTION
`TokenTextSplitter` collapses newlines with `String.replace(System.lineSeparator(), " ")`, which matches the line separator of the **host operating system** rather than the one used by the **document**.

Documents almost always use LF, whatever the platform. So on Windows the replacement finds nothing and `withKeepSeparator(false)` silently has no effect at all, while on Linux a CRLF document is left with orphaned carriage returns and doubled spacing. The same document therefore produces different chunks depending on where ingestion runs, which in turn means different embeddings and different vector store content.

This contradicts the reference documentation, which states in `etl-pipeline.adoc` that the splitter "trims the chunk and optionally removes newline characters based on the `keepSeparator` setting".

It is also inconsistent within the class itself: `DEFAULT_PUNCTUATION_MARKS` already holds a literal LF character, so the punctuation logic assumes LF while the newline-collapsing logic assumes the platform separator.

### Change

Match any line break with the `\R` pattern, so LF, CRLF and CR behave identically everywhere. `\R` matches CRLF as a single unit, so a CRLF document collapses to one space rather than two.

The trailing remainder chunk replaced line separators unconditionally and so ignored `keepSeparator`, formatting the last chunk of a document differently from all the others. It now honours the setting like every other chunk.

### Scope

- No public or protected member is added, removed or changed.
- Behaviour on the default settings is unchanged: with `keepSeparator = true` the chunk path is the same `trim()` as before, and the remainder branch is only reached once `maxNumChunks` is exhausted (default 10000). All pre-existing tests pass untouched.

### Verification

The four added tests were written first and fail on current `main`:

```
shouldRemoveLineFeedWhenSeparatorNotKept          FAILED
shouldProduceSameChunksRegardlessOfLineSeparator  FAILED
```

Reverting only the production file while keeping the new tests reproduces exactly those two failures, so the tests exercise the changed code rather than passing vacuously. The other two added tests pass on Windows and fail on Linux, so the four together cover both platforms.

With the change, `./mvnw -Dmaven.build.cache.enabled=false -pl spring-ai-commons clean package` reports 240 tests, 0 failures, with checkstyle and spring-javaformat clean. This code path previously had no test coverage.

### Related

The same argument was accepted for `ExtractedTextFormatter` in #1913.

Note that #4054 introduces `text.replace(System.lineSeparator(), " ")` in new code, so it would reintroduce this behaviour if merged as it stands.
