### PR TITLE
Close the resource stream in PDF document readers

### DIFF
--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/PagePdfDocumentReader.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/PagePdfDocumentReader.java
@@ -18,6 +18,7 @@ package org.springframework.ai.reader.pdf;
 
 import java.awt.Rectangle;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -78,9 +79,8 @@ public class PagePdfDocumentReader implements DocumentReader {
 	}
 
 	public PagePdfDocumentReader(Resource pdfResource, PdfDocumentReaderConfig config) {
-		try {
-			PDFParser pdfParser = new PDFParser(
-					new org.apache.pdfbox.io.RandomAccessReadBuffer(pdfResource.getInputStream()));
+		try (InputStream inputStream = pdfResource.getInputStream()) {
+			PDFParser pdfParser = new PDFParser(new org.apache.pdfbox.io.RandomAccessReadBuffer(inputStream));
 			this.document = pdfParser.parse();
 
 			this.resourceFileName = pdfResource.getFilename();

--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReader.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReader.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.reader.pdf;
 
 import java.awt.Rectangle;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -107,9 +108,8 @@ public class ParagraphPdfDocumentReader implements DocumentReader {
 		Assert.isTrue(!config.hasPageRanges(),
 				"Page ranges are not supported by ParagraphPdfDocumentReader; use PagePdfDocumentReader instead.");
 
-		try {
-			PDFParser pdfParser = new PDFParser(
-					new org.apache.pdfbox.io.RandomAccessReadBuffer(pdfResource.getInputStream()));
+		try (InputStream inputStream = pdfResource.getInputStream()) {
+			PDFParser pdfParser = new PDFParser(new org.apache.pdfbox.io.RandomAccessReadBuffer(inputStream));
 			this.document = pdfParser.parse();
 
 			this.config = config;

--- a/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
@@ -16,7 +16,11 @@
 
 package org.springframework.ai.reader.pdf;
 
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +28,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.reader.ExtractedTextFormatter;
 import org.springframework.ai.reader.pdf.config.PdfDocumentReaderConfig;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -254,6 +261,28 @@ class PagePdfDocumentReaderTests {
 		assertThat(rangedDocuments).extracting(Document::getText)
 			.containsExactly(fullDocuments.get(9).getText(), fullDocuments.get(10).getText(),
 					fullDocuments.get(11).getText());
+	}
+
+	@Test
+	void closesTheResourceInputStream() throws IOException {
+
+		AtomicBoolean closed = new AtomicBoolean();
+		Resource resource = new ByteArrayResource(new ClassPathResource("sample1.pdf").getContentAsByteArray()) {
+			@Override
+			public InputStream getInputStream() throws IOException {
+				return new FilterInputStream(super.getInputStream()) {
+					@Override
+					public void close() throws IOException {
+						closed.set(true);
+						super.close();
+					}
+				};
+			}
+		};
+
+		new PagePdfDocumentReader(resource, PdfDocumentReaderConfig.defaultConfig());
+
+		assertThat(closed).isTrue();
 	}
 
 }

--- a/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
@@ -17,9 +17,11 @@
 package org.springframework.ai.reader.pdf;
 
 import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -112,6 +114,28 @@ public class ParagraphPdfDocumentReaderTests {
 		assertThat(documents).hasSize(2);
 		assertThat(documents.get(0).getMetadata().get("title")).isEqualTo("Chapter 1");
 		assertThat(documents.get(1).getMetadata().get("title")).isEqualTo("Chapter 3");
+	}
+
+	@Test
+	void closesTheResourceInputStream() throws IOException {
+
+		AtomicBoolean closed = new AtomicBoolean();
+		Resource resource = new ByteArrayResource(new ClassPathResource("sample3.pdf").getContentAsByteArray()) {
+			@Override
+			public InputStream getInputStream() throws IOException {
+				return new FilterInputStream(super.getInputStream()) {
+					@Override
+					public void close() throws IOException {
+						closed.set(true);
+						super.close();
+					}
+				};
+			}
+		};
+
+		new ParagraphPdfDocumentReader(resource, PdfDocumentReaderConfig.defaultConfig());
+
+		assertThat(closed).isTrue();
 	}
 
 }


### PR DESCRIPTION
## Problem

`PagePdfDocumentReader` and `ParagraphPdfDocumentReader` both pass `pdfResource.getInputStream()` directly into PDFBox's `RandomAccessReadBuffer`:

```java
PDFParser pdfParser = new PDFParser(
        new org.apache.pdfbox.io.RandomAccessReadBuffer(pdfResource.getInputStream()));
```

`RandomAccessReadBuffer` copies the stream's contents into memory but does not close the stream it is handed, and neither reader closes it afterwards. Every reader instance therefore leaks one file descriptor. An ETL pipeline that reads a directory of PDFs holds every descriptor open until garbage collection.

This is the same defect that was fixed for `TextReader` in 91f067f.

## Evidence

Wrapping the resource so that `close()` is observable, before the change:

```
PagePdfDocumentReader      -> stream closed? false
ParagraphPdfDocumentReader -> stream closed? false
```

and after:

```
PagePdfDocumentReader      -> stream closed? true
ParagraphPdfDocumentReader -> stream closed? true
```

`JsonReader` uses a similar inline `getInputStream()` call and was checked as well, but it is not affected: Jackson closes the source by default.

## Fix

Read the resource inside a try-with-resources block. `RandomAccessReadBuffer` has already copied the content by the time its constructor returns, so closing the stream once parsing completes does not affect the parsed document. The existing `IllegalArgumentException` rethrow in `ParagraphPdfDocumentReader` is unchanged.

## Tests

`closesTheResourceInputStream()` is added to both test classes, following the test added alongside the `TextReader` fix. Each test wraps the resource in a `FilterInputStream` that records `close()`.

Both tests were confirmed to fail against the current implementation before the fix was applied, and pass with it. The full module suite runs 43 tests with 0 failures.

## Note on tooling

This change was written with the help of Claude Code and has been reviewed by me; I take responsibility for its correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
