### PR TITLE
Allow custom `ChatMemory` to use the Redis repository

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/main/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfiguration.java
@@ -20,7 +20,6 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.RedisClient;
 
-import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.memory.repository.redis.RedisChatMemoryRepository;
 import org.springframework.ai.model.chat.memory.autoconfigure.ChatMemoryAutoConfiguration;
@@ -91,7 +90,7 @@ public class RedisChatMemoryRepositoryAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean({ RedisChatMemoryRepository.class, ChatMemory.class, ChatMemoryRepository.class })
+	@ConditionalOnMissingBean(ChatMemoryRepository.class)
 	public RedisChatMemoryRepository redisChatMemoryRepository(RedisClient jedisClient,
 			RedisChatMemoryRepositoryProperties properties) {
 		RedisChatMemoryRepository.Builder builder = RedisChatMemoryRepository.builder().jedisClient(jedisClient);

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfigurationIT.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-redis/src/test/java/org/springframework/ai/model/chat/memory/repository/redis/autoconfigure/RedisChatMemoryRepositoryAutoConfigurationIT.java
@@ -23,11 +23,19 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.memory.repository.redis.RedisChatMemoryRepository;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.model.chat.memory.autoconfigure.ChatMemoryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -87,6 +95,71 @@ class RedisChatMemoryRepositoryAutoConfigurationIT {
 
 			assertThat(repository).isSameAs(redisChatMemory);
 		});
+	}
+
+	@Test
+	void defaultChatMemoryUsesRedisRepository() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(ChatMemoryAutoConfiguration.class)).run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context).hasSingleBean(ChatMemoryRepository.class);
+			assertThat(context).hasSingleBean(RedisChatMemoryRepository.class);
+			assertThat(context).hasSingleBean(ChatMemory.class);
+
+			ChatMemory chatMemory = context.getBean(ChatMemory.class);
+			chatMemory.add("default-chat-memory", new UserMessage("Hello"));
+
+			RedisChatMemoryRepository repository = context.getBean(RedisChatMemoryRepository.class);
+			assertThat(repository.findByConversationId("default-chat-memory")).extracting(Message::getText)
+				.containsExactly("Hello");
+		});
+	}
+
+	@Test
+	void customChatMemoryUsesRedisRepository() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(ChatMemoryAutoConfiguration.class))
+			.withUserConfiguration(CustomChatMemoryConfiguration.class)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context).hasSingleBean(ChatMemoryRepository.class);
+				assertThat(context).hasSingleBean(RedisChatMemoryRepository.class);
+				assertThat(context).hasSingleBean(ChatMemory.class);
+				assertThat(context.getBean(ChatMemory.class)).isSameAs(context.getBean("customChatMemory"));
+
+				ChatMemory chatMemory = context.getBean(ChatMemory.class);
+				chatMemory.add("custom-chat-memory", new UserMessage("Hello"));
+
+				RedisChatMemoryRepository repository = context.getBean(RedisChatMemoryRepository.class);
+				assertThat(repository.findByConversationId("custom-chat-memory")).extracting(Message::getText)
+					.containsExactly("Hello");
+			});
+	}
+
+	@Test
+	void customChatMemoryRepositoryTakesPrecedence() {
+		ChatMemoryRepository repository = new InMemoryChatMemoryRepository();
+		this.contextRunner.withConfiguration(AutoConfigurations.of(ChatMemoryAutoConfiguration.class))
+			.withBean(ChatMemoryRepository.class, () -> repository)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context).hasSingleBean(ChatMemoryRepository.class);
+				assertThat(context).doesNotHaveBean(RedisChatMemoryRepository.class);
+				assertThat(context.getBean(ChatMemoryRepository.class)).isSameAs(repository);
+				assertThat(context).hasSingleBean(ChatMemory.class);
+
+				context.getBean(ChatMemory.class).add("custom-repository", new UserMessage("Hello"));
+				assertThat(repository.findByConversationId("custom-repository")).extracting(Message::getText)
+					.containsExactly("Hello");
+			});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomChatMemoryConfiguration {
+
+		@Bean
+		ChatMemory customChatMemory(RedisChatMemoryRepository repository) {
+			return MessageWindowChatMemory.builder().chatMemoryRepository(repository).maxMessages(10).build();
+		}
+
 	}
 
 }


### PR DESCRIPTION
Defining a custom `ChatMemory` bean that depends on `RedisChatMemoryRepository` prevents the repository from being auto-configured, causing the application context to fail to start.
Restrict the missing-bean condition to `ChatMemoryRepository` so a custom memory can use the auto-configured Redis repository while custom repositories still take precedence.

The integration tests cover custom memory injection, custom repository precedence, and the default memory's use of Redis, including message storage through the selected repository.

Fixes #6926

Validation with Liberica 17.0.19 on macOS aarch64 and Redis Stack:

- The new custom-memory regression test fails with the original condition and passes with the fix.
- Full `./mvnw clean package`: all 169 modules succeeded; 5,668 tests passed and 16 were skipped (15 disabled tests and 1 requiring `GOOGLE_CLOUD_PROJECT`).
- Redis integration verification, including the legacy auto-configuration module: 9 tests passed, none skipped.

```sh
./mvnw clean package

./mvnw -am \
  -pl auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis \
  -Pintegration-tests \
  -Dfailsafe.failIfNoSpecifiedTests=false \
  -Dit.test=RedisChatMemoryRepositoryAutoConfigurationIT,RedisChatMemoryAutoConfigurationIT verify
```
