### PR TITLE
Handle missing fields in `ChunkMerger`

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1334,14 +1334,32 @@ public final class OpenAiChatModel implements ChatModel {
 			}).toList();
 
 			return ChatCompletion.builder()
-				.id(chunk.id())
+				.id(getId(chunk))
 				.choices(choices)
 				.created(getCreated(chunk))
-				.model(chunk.model())
+				.model(getModel(chunk))
 				.usage(chunk.usage()
 					.orElse(CompletionUsage.builder().promptTokens(0).completionTokens(0).totalTokens(0).build()))
 				.putAllAdditionalProperties(chunk._additionalProperties())
 				.build();
+		}
+
+		private static String getId(ChatCompletionChunk chunk) {
+			try {
+				return chunk.id();
+			}
+			catch (OpenAIInvalidDataException ex) {
+				return "";
+			}
+		}
+
+		private static String getModel(ChatCompletionChunk chunk) {
+			try {
+				return chunk.model();
+			}
+			catch (OpenAIInvalidDataException ex) {
+				return "";
+			}
 		}
 
 		/**

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.openai;
 
 import java.util.List;
+import java.util.Map;
 
+import com.openai.core.JsonValue;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionChunk.Choice;
@@ -169,6 +171,17 @@ class OpenAiChatModelChunkMergerTests {
 		assertThat(functionToolCall.id()).isEqualTo("call_1");
 		assertThat(functionToolCall.function().name()).isEqualTo("get_weather");
 		assertThat(functionToolCall.function().arguments()).isEmpty();
+	}
+
+	@Test // gh-6928
+	void chunkToChatCompletionUsesEmptyDefaultsForMissingIdAndModel() {
+		ChatCompletionChunk chunk = JsonValue.from(Map.of("choices", List.of(), "created", 1L))
+			.convert(ChatCompletionChunk.class);
+
+		ChatCompletion completion = OpenAiChatModel.ChunkMerger.chunkToChatCompletion(chunk);
+
+		assertThat(completion.id()).isEmpty();
+		assertThat(completion.model()).isEmpty();
 	}
 
 	private static ChatCompletionChunk chunk(@Nullable FinishReason finishReason, ToolCall... toolCalls) {


### PR DESCRIPTION
ChatCompletionChunk fields can be absent in streamed responses from
OpenAI-compatible providers. Handle missing id and model consistently
with the existing fallback for created.

Adds a regression test using a deserialized chunk without those fields.

Fixes #6928

Tests: ./mvnw -pl models/spring-ai-openai -am `n  -Dtest=OpenAiChatModelChunkMergerTests `n  -Dsurefire.failIfNoSpecifiedTests=false test