### PR TITLE
Collect all Flux elements in async MCP tool callbacks

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -18,10 +18,12 @@ package org.springframework.ai.mcp.annotation.method.tool;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.util.List;
 
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Content;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -99,24 +101,30 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			return monoResult.map(this::mapValueToCallToolResult).onErrorResume(this::toErrorResultOrPropagate);
 		}
 
-		// Handle Flux by taking the first element
+		// Handle Flux by collecting all elements
 		if (result instanceof Flux) {
 			Flux<?> fluxResult = (Flux<?>) result;
 
-			// Check if the Flux contains CallToolResult
+			// Check if the Flux contains CallToolResult — merge all emitted results'
+			// content into a single CallToolResult
 			if (ReactiveUtils.isReactiveReturnTypeOfCallToolResult(this.toolMethod)) {
-				return ((Flux<CallToolResult>) fluxResult).next().onErrorResume(this::toErrorResultOrPropagate);
+				return ((Flux<CallToolResult>) fluxResult).collectList()
+					.map(this::mergeCallToolResults)
+					.onErrorResume(this::toErrorResultOrPropagate);
 			}
 
-			// Handle Mono<Void> for VOID return type
+			// Handle Flux<Void> for VOID return type
 			if (ReactiveUtils.isReactiveReturnTypeOfVoid(this.toolMethod)) {
 				return fluxResult
 					.then(Mono.just(CallToolResult.builder().addTextContent(jsonHelper.toJson("Done")).build()))
 					.onErrorResume(this::toErrorResultOrPropagate);
 			}
 
-			// Handle other Flux types by taking the first element and mapping
-			return fluxResult.next().map(this::mapValueToCallToolResult).onErrorResume(this::toErrorResultOrPropagate);
+			// Handle other Flux types by mapping every emitted element to a
+			// CallToolResult and merging their content, instead of only the first
+			return fluxResult.collectList()
+				.map(items -> this.mergeCallToolResults(items.stream().map(this::mapValueToCallToolResult).toList()))
+				.onErrorResume(this::toErrorResultOrPropagate);
 		}
 
 		// Handle other Publisher types
@@ -153,6 +161,23 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 	 */
 	protected CallToolResult mapValueToCallToolResult(Object value) {
 		return convertValueToCallToolResult(value);
+	}
+
+	/**
+	 * Merges the content of multiple {@link CallToolResult}s emitted by a {@link Flux}
+	 * into a single result, so every emitted element reaches the caller instead of only
+	 * the first one.
+	 * @param results the per-element results to merge, in emission order
+	 * @return a single {@link CallToolResult} carrying every result's content
+	 */
+	private CallToolResult mergeCallToolResults(List<CallToolResult> results) {
+		CallToolResult.Builder builder = CallToolResult.builder();
+		for (CallToolResult result : results) {
+			for (Content content : result.content()) {
+				builder.addContent(content);
+			}
+		}
+		return builder.build();
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackTests.java
@@ -475,13 +475,17 @@ public class AsyncMcpToolMethodCallbackTests {
 			.arguments(Map.of("prefix", "item"))
 			.build();
 
-		// Flux tools should take the first element
+		// Flux tools should collect all elements, not just the first
 		StepVerifier.create(callback.apply(exchange, request)).assertNext(result -> {
 			assertThat(result).isNotNull();
 			assertThat(result.isError()).isFalse();
-			assertThat(result.content()).hasSize(1);
+			assertThat(result.content()).hasSize(3);
 			assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
 			assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("item1");
+			assertThat(result.content().get(1)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) result.content().get(1)).text()).isEqualTo("item2");
+			assertThat(result.content().get(2)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) result.content().get(2)).text()).isEqualTo("item3");
 		}).verifyComplete();
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallbackTests.java
@@ -496,13 +496,17 @@ public class AsyncStatelessMcpToolMethodCallbackTests {
 			.arguments(Map.of("prefix", "item"))
 			.build();
 
-		// Flux tools should take the first element
+		// Flux tools should collect all elements, not just the first
 		StepVerifier.create(callback.apply(context, request)).assertNext(result -> {
 			assertThat(result).isNotNull();
 			assertThat(result.isError()).isFalse();
-			assertThat(result.content()).hasSize(1);
+			assertThat(result.content()).hasSize(3);
 			assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
 			assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("item1");
+			assertThat(result.content().get(1)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) result.content().get(1)).text()).isEqualTo("item2");
+			assertThat(result.content().get(2)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) result.content().get(2)).text()).isEqualTo("item3");
 		}).verifyComplete();
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
@@ -534,11 +534,13 @@ public class AsyncMcpToolProviderTests {
 		StepVerifier.create(result).assertNext(callToolResult -> {
 			assertThat(callToolResult).isNotNull();
 			assertThat(callToolResult.isError()).isFalse();
-			assertThat(callToolResult.content()).hasSize(1);
+			assertThat(callToolResult.content()).hasSize(3);
 			assertThat(callToolResult.content().get(0)).isInstanceOf(TextContent.class);
-			// Flux results are typically concatenated or collected into a single response
-			String content = ((TextContent) callToolResult.content().get(0)).text();
-			assertThat(content).contains("test");
+			assertThat(((TextContent) callToolResult.content().get(0)).text()).isEqualTo("Item1: test");
+			assertThat(callToolResult.content().get(1)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) callToolResult.content().get(1)).text()).isEqualTo("Item2: test");
+			assertThat(callToolResult.content().get(2)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) callToolResult.content().get(2)).text()).isEqualTo("Item3: test");
 		}).verifyComplete();
 	}
 
@@ -955,17 +957,13 @@ public class AsyncMcpToolProviderTests {
 
 		assertThat(result).isNotNull();
 		assertThat(result.isError()).isFalse();
-		assertThat(result.content()).hasSize(1);
+		assertThat(result.content()).hasSize(3);
 		assertThat(result.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
-
-		String jsonText = ((TextContent) result.content().get(0)).text();
-
-		// The Flux might be serialized differently than expected, let's check what we
-		// actually get
-		// Based on the error, it seems like we're getting a single object instead of an
-		// array
-		// Let's adjust our assertion to match the actual behavior
-		assertThat(jsonText).contains("Processed: test - Item 1");
+		assertThat(((TextContent) result.content().get(0)).text()).contains("Processed: test - Item 1");
+		assertThat(result.content().get(1)).isInstanceOf(McpSchema.TextContent.class);
+		assertThat(((TextContent) result.content().get(1)).text()).contains("Processed: test - Item 2");
+		assertThat(result.content().get(2)).isInstanceOf(McpSchema.TextContent.class);
+		assertThat(((TextContent) result.content().get(2)).text()).contains("Processed: test - Item 3");
 	}
 
 	@Test

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProviderTests.java
@@ -530,11 +530,13 @@ public class AsyncStatelessMcpToolProviderTests {
 		StepVerifier.create(result).assertNext(callToolResult -> {
 			assertThat(callToolResult).isNotNull();
 			assertThat(callToolResult.isError()).isFalse();
-			assertThat(callToolResult.content()).hasSize(1);
+			assertThat(callToolResult.content()).hasSize(3);
 			assertThat(callToolResult.content().get(0)).isInstanceOf(TextContent.class);
-			// Flux results are typically concatenated or collected into a single response
-			String content = ((TextContent) callToolResult.content().get(0)).text();
-			assertThat(content).contains("test");
+			assertThat(((TextContent) callToolResult.content().get(0)).text()).isEqualTo("Item1: test");
+			assertThat(callToolResult.content().get(1)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) callToolResult.content().get(1)).text()).isEqualTo("Item2: test");
+			assertThat(callToolResult.content().get(2)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) callToolResult.content().get(2)).text()).isEqualTo("Item3: test");
 		}).verifyComplete();
 	}
 


### PR DESCRIPTION
## Summary

`AbstractAsyncMcpToolMethodCallback.convertToCallToolResult()` calls `.next()` on a `Flux` result from an `@McpTool` method, silently discarding every element after the first. A tool method returning `Flux<T>` (or `Flux<CallToolResult>`) with more than one emission therefore only ever delivers a single result to the MCP client, even though the reference docs describe `Flux<T>` as being for "streaming results".

This applies to both the stateful (`AsyncMcpToolMethodCallback`) and stateless (`AsyncStatelessMcpToolMethodCallback`) callbacks, since both extend `AbstractAsyncMcpToolMethodCallback`.

* Collect all emitted elements via `collectList()` instead of `.next()`.
* Merge each element's `CallToolResult` content into a single `CallToolResult` (one content entry per emitted element), via a small shared `mergeCallToolResults` helper, so every emission reaches the caller.
* `Flux<Void>` handling (the VOID return-type case) is unchanged.

## Related

Fixes #4542

There's an existing PR (#6158) for this same issue, but it's been stale since June with no maintainer engagement, bundles an unrelated DeepSeek/MiniMax `ToolChoiceBuilder` change, and predates a refactor of the error-handling path in this file — this PR is scoped to just the `mcp/mcp-annotations` module and rebased on current `main`.

## Test plan

- [x] Updated `AsyncMcpToolMethodCallbackTests.testMultipleFluxTool` and `AsyncStatelessMcpToolMethodCallbackTests.testMultipleFluxTool` to assert all 3 emitted elements are returned instead of just the first.
- [x] Updated `AsyncMcpToolProviderTests` (`testGetToolSpecificationsWithFluxHandling`, `testToolWithFluxReturnType`) and `AsyncStatelessMcpToolProviderTests.testGetToolSpecificationsWithFluxHandling` similarly.
- [x] `./mvnw -pl mcp/mcp-annotations -am test` — 1376 tests, 0 failures, 0 errors, 2 skipped.
- [x] `spring-javaformat:apply` + `checkstyle:check` — 0 violations.