### PR TITLE
Handle missing metadata in OpenAI streaming chunks

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1334,14 +1334,26 @@ public final class OpenAiChatModel implements ChatModel {
 			}).toList();
 
 			return ChatCompletion.builder()
-				.id(chunk.id())
+				.id(getId(chunk))
 				.choices(choices)
 				.created(getCreated(chunk))
-				.model(chunk.model())
+				.model(getModel(chunk))
 				.usage(chunk.usage()
 					.orElse(CompletionUsage.builder().promptTokens(0).completionTokens(0).totalTokens(0).build()))
 				.putAllAdditionalProperties(chunk._additionalProperties())
 				.build();
+		}
+
+		/**
+		 * Extract the id from a ChatCompletionChunk, returning an empty string if absent.
+		 */
+		private static String getId(ChatCompletionChunk chunk) {
+			try {
+				return chunk.id();
+			}
+			catch (OpenAIInvalidDataException ex) {
+				return "";
+			}
 		}
 
 		/**
@@ -1354,6 +1366,19 @@ public final class OpenAiChatModel implements ChatModel {
 			}
 			catch (OpenAIInvalidDataException ex) {
 				return 0L;
+			}
+		}
+
+		/**
+		 * Extract the model from a ChatCompletionChunk, returning an empty string if
+		 * absent.
+		 */
+		private static String getModel(ChatCompletionChunk chunk) {
+			try {
+				return chunk.model();
+			}
+			catch (OpenAIInvalidDataException ex) {
+				return "";
 			}
 		}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai;
 
 import java.util.List;
 
+import com.openai.core.ObjectMappers;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionChunk.Choice;
@@ -169,6 +170,23 @@ class OpenAiChatModelChunkMergerTests {
 		assertThat(functionToolCall.id()).isEqualTo("call_1");
 		assertThat(functionToolCall.function().name()).isEqualTo("get_weather");
 		assertThat(functionToolCall.function().arguments()).isEmpty();
+	}
+
+	@Test // gh-6928
+	void chunkToChatCompletionUsesDefaultsForMissingRequiredFields() throws Exception {
+		String chunkJson = "{\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}";
+		ChatCompletionChunk chunk = ObjectMappers.jsonMapper().readValue(chunkJson, ChatCompletionChunk.class);
+
+		ChatCompletion completion = OpenAiChatModel.ChunkMerger.chunkToChatCompletion(chunk);
+
+		assertThat(completion.id()).isEmpty();
+		assertThat(completion.model()).isEmpty();
+		assertThat(completion.created()).isZero();
+		assertThat(completion.choices()).isEmpty();
+		assertThat(completion.usage()).isPresent();
+		assertThat(completion.usage().orElseThrow().promptTokens()).isEqualTo(10);
+		assertThat(completion.usage().orElseThrow().completionTokens()).isEqualTo(20);
+		assertThat(completion.usage().orElseThrow().totalTokens()).isEqualTo(30);
 	}
 
 	private static ChatCompletionChunk chunk(@Nullable FinishReason finishReason, ToolCall... toolCalls) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -33,6 +33,7 @@ import java.util.function.Consumer;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
+import com.openai.core.ObjectMappers;
 import com.openai.core.RequestOptions;
 import com.openai.core.http.AsyncStreamResponse;
 import com.openai.models.FunctionDefinition;
@@ -922,6 +923,27 @@ class OpenAiChatModelTests {
 			.isEqualTo("Think step one. Think step two.");
 		assertThat(responses.get(2).getResult().getOutput().getMetadata().get("reasoningContent"))
 			.isEqualTo("Think step one. Think step two.");
+	}
+
+	@Test // gh-6928
+	void streamingUsageChunkWithoutRequiredMetadataIsAggregated() throws Exception {
+		ChatCompletionChunk usageChunk = ObjectMappers.jsonMapper().readValue("""
+				{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}
+				""", ChatCompletionChunk.class);
+		List<ChatCompletionChunk> chunks = List.of(
+				streamingChunk(delta -> delta.content("Hello"), ChatCompletionChunk.Choice.FinishReason.STOP),
+				usageChunk);
+
+		AtomicReference<ChatResponse> aggregatedResponse = new AtomicReference<>();
+		new MessageAggregator().aggregate(streamResponses(chunks), aggregatedResponse::set).blockLast();
+
+		assertThat(aggregatedResponse.get()).isNotNull();
+		assertThat(aggregatedResponse.get().getResult().getOutput().getText()).isEqualTo("Hello");
+		assertThat(aggregatedResponse.get().getMetadata().getId()).isEqualTo("chatcmpl-123");
+		assertThat(aggregatedResponse.get().getMetadata().getModel()).isEqualTo("deepseek-reasoner");
+		assertThat(aggregatedResponse.get().getMetadata().getUsage().getPromptTokens()).isEqualTo(10);
+		assertThat(aggregatedResponse.get().getMetadata().getUsage().getCompletionTokens()).isEqualTo(20);
+		assertThat(aggregatedResponse.get().getMetadata().getUsage().getTotalTokens()).isEqualTo(30);
 	}
 
 	private AssistantMessage aggregateStreaming(List<ChatCompletionChunk> chunks) {


### PR DESCRIPTION
## Summary

Some OpenAI-compatible providers omit `id`, `model`, and `created` from the final usage-only streaming chunk, for example:

```json
{
  "choices": [],
  "usage": {
    "prompt_tokens": 10,
    "completion_tokens": 20,
    "total_tokens": 30
  }
}
```

The OpenAI Java SDK treats these fields as required, so accessing them directly throws `OpenAIInvalidDataException` and terminates the stream before the usage information can be processed.

This change:

- defaults missing `id` and `model` to empty strings during chunk conversion;
- reuses the existing fallback behavior for a missing `created` timestamp;
- preserves usage information and previously received response metadata during stream aggregation;
- adds regression coverage at both the chunk-conversion and complete streaming-aggregation levels.

The change is limited to malformed usage-only chunks and does not alter the behavior of valid OpenAI responses or introduce any public API changes.

## Testing

- `./mvnw clean package`
- `./mvnw -pl models/spring-ai-openai -am -Dtest=OpenAiChatModelTests,OpenAiChatModelChunkMergerTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -f models/spring-ai-openai/pom.xml surefire:test`

All tests passed with no failures, errors, or skipped tests. The `spring-ai-openai` module ran 226 unit tests.

Fixes #6928