### PR TITLE
Add `ReciprocalRankFusionDocumentJoiner`

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
@@ -418,6 +418,53 @@ DocumentJoiner documentJoiner = new ConcatenationDocumentJoiner();
 List<Document> documents = documentJoiner.join(documentsForQuery);
 ----
 
+===== ReciprocalRankFusionDocumentJoiner
+
+A `ReciprocalRankFusionDocumentJoiner` combines documents retrieved based on multiple queries and from multiple data sources
+by merging them based on the rank each document has in each result list, instead of comparing the scores assigned by the
+retrieval strategy that produced it.
+Each list is expected to be sorted by decreasing relevance.
+Documents are aggregated by their id, and a document occurring in several lists accumulates a contribution of
+`1 / (rankConstant + rank)` for each list where it occurs, so that documents found by several queries or data sources are promoted.
+The result is a list of unique documents sorted by their fused score in descending order, using the document id to break ties.
+
+[source,java]
+----
+Map<Query, List<List<Document>>> documentsForQuery = ...
+DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+List<Document> documents = documentJoiner.join(documentsForQuery);
+----
+
+The rank constant controls how much the documents at the top of each list are favoured over the documents below them.
+The lower the value, the more the top ranks matter.
+It defaults to `60` and can be customized.
+
+[source,java]
+----
+DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner(20);
+----
+
+This joiner is typically used together with a query expander, so that the same data source is queried several times and the
+resulting lists are fused.
+
+[source,java]
+----
+Advisor retrievalAugmentationAdvisor = RetrievalAugmentationAdvisor.builder()
+        .queryExpander(MultiQueryExpander.builder()
+                .chatClientBuilder(chatClientBuilder)
+                .build())
+        .documentRetriever(VectorStoreDocumentRetriever.builder()
+                .vectorStore(vectorStore)
+                .build())
+        .documentJoiner(new ReciprocalRankFusionDocumentJoiner())
+        .build();
+----
+
+NOTE: The score of the returned documents is a reciprocal rank fusion score and not a similarity score, so any threshold
+defined for the scores produced by a data source does not apply to it.
+Since documents are aggregated by their id, the lists to join must use consistent document ids, which is the case when the
+same data source is queried several times.
+
 === Post-Retrieval
 
 Post-Retrieval modules are responsible for processing the retrieved documents to achieve the best possible generation results.

--- a/spring-ai-rag/src/main/java/org/springframework/ai/rag/retrieval/join/ReciprocalRankFusionDocumentJoiner.java
+++ b/spring-ai-rag/src/main/java/org/springframework/ai/rag/retrieval/join/ReciprocalRankFusionDocumentJoiner.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.rag.retrieval.join;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+import org.springframework.util.Assert;
+
+/**
+ * Combines documents retrieved based on multiple queries and from multiple data sources
+ * by applying the reciprocal rank fusion algorithm, which merges the results based on the
+ * rank each document has in each list instead of the scores assigned by the retrieval
+ * strategy that produced it.
+ * <p>
+ * Each list of documents is treated as an independent ranked list, where the first
+ * document is the most relevant one. A document occurring in several lists accumulates a
+ * contribution of {@code 1 / (rankConstant + rank)} for each list where it occurs, so
+ * that documents found by several queries or data sources are promoted. Documents are
+ * aggregated by {@link Document#getId()}, and only the first occurrence of a document
+ * within the same list contributes to the score. The result is a list of unique documents
+ * sorted by their fused score in descending order, using the document id to break ties.
+ * <p>
+ * The score of each returned document is replaced with its fused score. Such a score is
+ * only meaningful when compared with the score of the other documents returned by the
+ * same invocation. It is not a similarity score, so any threshold defined for the scores
+ * produced by a data source does not apply to it.
+ * <p>
+ * The caller is expected to use consistent document ids across the lists to join, which
+ * is the case when the same data source is queried several times. Documents are never
+ * matched based on their content or metadata.
+ *
+ * @author pj991207
+ * @since 2.0.2
+ * @see <a href="https://cormack.uwaterloo.ca/cormack/cormacksigir09-rrf.pdf">Reciprocal
+ * Rank Fusion outperforms Condorcet and individual Rank Learning Methods</a>
+ */
+public class ReciprocalRankFusionDocumentJoiner implements DocumentJoiner {
+
+	/**
+	 * The rank constant used when none is provided, as suggested by the paper introducing
+	 * the reciprocal rank fusion algorithm.
+	 */
+	public static final int DEFAULT_RANK_CONSTANT = 60;
+
+	private static final Log logger = LogFactory.getLog(ReciprocalRankFusionDocumentJoiner.class);
+
+	private final int rankConstant;
+
+	/**
+	 * Creates a joiner using the {@link #DEFAULT_RANK_CONSTANT}.
+	 */
+	public ReciprocalRankFusionDocumentJoiner() {
+		this(DEFAULT_RANK_CONSTANT);
+	}
+
+	/**
+	 * Creates a joiner using the given rank constant. The lower the value, the more the
+	 * documents at the top of each list are favoured over the documents below them.
+	 * @param rankConstant the constant added to each rank, must be greater than 0
+	 */
+	public ReciprocalRankFusionDocumentJoiner(int rankConstant) {
+		Assert.isTrue(rankConstant > 0, "rankConstant must be greater than 0");
+		this.rankConstant = rankConstant;
+	}
+
+	@Override
+	public List<Document> join(Map<Query, List<List<Document>>> documentsForQuery) {
+		Assert.notNull(documentsForQuery, "documentsForQuery cannot be null");
+		Assert.noNullElements(documentsForQuery.keySet(), "documentsForQuery cannot contain null keys");
+		Assert.noNullElements(documentsForQuery.values(), "documentsForQuery cannot contain null values");
+
+		logger.debug("Joining documents by reciprocal rank fusion");
+
+		Map<String, RankedDocument> rankedDocuments = new LinkedHashMap<>();
+		for (List<List<Document>> documentLists : documentsForQuery.values()) {
+			for (List<Document> documents : documentLists) {
+				collectRanks(documents, rankedDocuments);
+			}
+		}
+
+		return rankedDocuments.values()
+			.stream()
+			.map(rankedDocument -> rankedDocument.document.mutate()
+				.score(rankedDocument.computeScore(this.rankConstant))
+				.build())
+			.sorted(Comparator
+				.comparingDouble((Document document) -> document.getScore() != null ? document.getScore() : 0.0)
+				.reversed()
+				.thenComparing(Document::getId))
+			.toList();
+	}
+
+	private static void collectRanks(List<Document> documents, Map<String, RankedDocument> rankedDocuments) {
+		Set<String> idsInDocumentList = new HashSet<>();
+		for (int index = 0; index < documents.size(); index++) {
+			Document document = documents.get(index);
+			if (idsInDocumentList.add(document.getId())) {
+				rankedDocuments.computeIfAbsent(document.getId(), id -> new RankedDocument(document))
+					.addRank(index + 1);
+			}
+		}
+	}
+
+	/**
+	 * Accumulates the ranks a document has across the lists to join, together with the
+	 * first occurrence of the document, used to build the joined document.
+	 */
+	private static final class RankedDocument {
+
+		private final Document document;
+
+		private final List<Integer> ranks = new ArrayList<>();
+
+		private RankedDocument(Document document) {
+			this.document = document;
+		}
+
+		private void addRank(int rank) {
+			this.ranks.add(rank);
+		}
+
+		private double computeScore(int rankConstant) {
+			double score = 0.0;
+			// The ranks are accumulated in a fixed order so that the resulting score does
+			// not depend on the iteration order of the map of documents to join.
+			for (int rank : this.ranks.stream().sorted().toList()) {
+				score += 1.0 / (rankConstant + rank);
+			}
+			return score;
+		}
+
+	}
+
+}

--- a/spring-ai-rag/src/test/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisorTests.java
+++ b/spring-ai-rag/src/test/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisorTests.java
@@ -32,7 +32,9 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.rag.Query;
 import org.springframework.ai.rag.advisor.RetrievalAugmentationAdvisor;
+import org.springframework.ai.rag.preretrieval.query.expansion.QueryExpander;
 import org.springframework.ai.rag.preretrieval.query.transformation.QueryTransformer;
+import org.springframework.ai.rag.retrieval.join.ReciprocalRankFusionDocumentJoiner;
 import org.springframework.ai.rag.retrieval.search.DocumentRetriever;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,6 +48,7 @@ import static org.mockito.Mockito.when;
  *
  * @author Thomas Vitale
  * @author Sebastien Deleuze
+ * @author pj991207
  */
 class RetrievalAugmentationAdvisorTests {
 
@@ -127,6 +130,63 @@ class RetrievalAugmentationAdvisorTests {
 				Query: What would I get if I added a pinch of Moonstone to a dash of powdered Gold?
 
 				Answer:
+				""");
+	}
+
+	@Test
+	void theOneWithTheReciprocalRankFusionDocumentJoiner() {
+		// Chat Model
+		var chatModel = mock(ChatModel.class);
+		when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
+		var promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		given(chatModel.call(promptCaptor.capture())).willReturn(ChatResponse.builder()
+			.generations(List.of(new Generation(new AssistantMessage("Felix Felicis"))))
+			.build());
+
+		// Query Expander
+		var moonstoneQuery = new Query("What is a Moonstone?");
+		var goldQuery = new Query("What is powdered Gold?");
+		QueryExpander queryExpander = query -> List.of(moonstoneQuery, goldQuery);
+
+		// Document Retriever
+		var documentOne = Document.builder().id("1").text("doc1").build();
+		var documentTwo = Document.builder().id("2").text("doc2").build();
+		var documentThree = Document.builder().id("3").text("doc3").build();
+		var documentRetriever = Mockito.mock(DocumentRetriever.class);
+		given(documentRetriever.retrieve(moonstoneQuery)).willReturn(List.of(documentOne, documentTwo));
+		given(documentRetriever.retrieve(goldQuery)).willReturn(List.of(documentTwo, documentThree));
+
+		// Advisor
+		var advisor = RetrievalAugmentationAdvisor.builder()
+			.queryExpander(queryExpander)
+			.documentRetriever(documentRetriever)
+			.documentJoiner(new ReciprocalRankFusionDocumentJoiner())
+			.build();
+
+		// Chat Client
+		var chatClient = ChatClient.builder(chatModel)
+			.defaultAdvisors(advisor)
+			.defaultSystem("You are a wizard!")
+			.build();
+
+		// Call
+		var chatResponse = chatClient.prompt()
+			.user("What would I get if I added a pinch of Moonstone to a dash of powdered Gold?")
+			.call()
+			.chatResponse();
+
+		// Verify: "doc2" is retrieved by both queries, so it is ranked first.
+		assertThat(chatResponse.getMetadata().<List<Document>>get(RetrievalAugmentationAdvisor.DOCUMENT_CONTEXT))
+			.extracting(Document::getId)
+			.containsExactly("2", "1", "3");
+
+		var prompt = promptCaptor.getValue();
+		assertThat(prompt.getContents()).containsIgnoringNewLines("""
+				---------------------
+				doc2
+				doc1
+				doc3
+				---------------------
 				""");
 	}
 

--- a/spring-ai-rag/src/test/java/org/springframework/ai/rag/retrieval/join/ReciprocalRankFusionDocumentJoinerTests.java
+++ b/spring-ai-rag/src/test/java/org/springframework/ai/rag/retrieval/join/ReciprocalRankFusionDocumentJoinerTests.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.rag.retrieval.join;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Unit tests for {@link ReciprocalRankFusionDocumentJoiner}.
+ *
+ * @author pj991207
+ */
+class ReciprocalRankFusionDocumentJoinerTests {
+
+	@Test
+	void whenDocumentsForQueryIsNullThenThrow() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		assertThatThrownBy(() -> documentJoiner.apply(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("documentsForQuery cannot be null");
+	}
+
+	@Test
+	void whenDocumentsForQueryContainsNullKeysThenThrow() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(null, List.of());
+		assertThatThrownBy(() -> documentJoiner.apply(documentsForQuery)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("documentsForQuery cannot contain null keys");
+	}
+
+	@Test
+	void whenDocumentsForQueryContainsNullValuesThenThrow() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("test"), null);
+		assertThatThrownBy(() -> documentJoiner.apply(documentsForQuery)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("documentsForQuery cannot contain null values");
+	}
+
+	@Test
+	void whenRankConstantIsNotPositiveThenThrow() {
+		assertThatThrownBy(() -> new ReciprocalRankFusionDocumentJoiner(0)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("rankConstant must be greater than 0");
+	}
+
+	@Test
+	void whenDocumentsForQueryIsEmptyThenReturnEmptyList() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+
+		List<Document> result = documentJoiner.join(new HashMap<>());
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void whenAllDocumentListsAreEmptyThenReturnEmptyList() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"), List.of(List.of()));
+		documentsForQuery.put(new Query("query2"), List.of());
+
+		List<Document> result = documentJoiner.join(documentsForQuery);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void shouldRankDocumentsBySumOfReciprocalRanks() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"), List.of(List.of(document("a"), document("b"), document("c"))));
+		documentsForQuery.put(new Query("query2"), List.of(List.of(document("b"), document("d"), document("a"))));
+
+		List<Document> result = documentJoiner.join(documentsForQuery);
+
+		assertThat(result).extracting(Document::getId).containsExactly("b", "a", "d", "c");
+		assertThat(scoreOf(result, "b")).isCloseTo(1.0 / 61 + 1.0 / 62, within(1e-12));
+		assertThat(scoreOf(result, "a")).isCloseTo(1.0 / 61 + 1.0 / 63, within(1e-12));
+		assertThat(scoreOf(result, "d")).isCloseTo(1.0 / 62, within(1e-12));
+		assertThat(scoreOf(result, "c")).isCloseTo(1.0 / 63, within(1e-12));
+	}
+
+	@Test
+	void whenDocumentIsRetrievedByMultipleQueriesThenItIsReturnedOnce() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"), List.of(List.of(document("a"), document("b"))));
+		documentsForQuery.put(new Query("query2"), List.of(List.of(document("a"), document("c"))));
+
+		List<Document> result = documentJoiner.join(documentsForQuery);
+
+		assertThat(result).extracting(Document::getId).containsExactly("a", "b", "c");
+		assertThat(scoreOf(result, "a")).isCloseTo(1.0 / 61 + 1.0 / 61, within(1e-12));
+	}
+
+	@Test
+	void whenDocumentIsDuplicatedWithinOneListThenOnlyItsFirstRankContributes() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"), List.of(List.of(document("a"), document("a"), document("b"))));
+
+		List<Document> result = documentJoiner.join(documentsForQuery);
+
+		assertThat(result).extracting(Document::getId).containsExactly("a", "b");
+		assertThat(scoreOf(result, "a")).isCloseTo(1.0 / 61, within(1e-12));
+		assertThat(scoreOf(result, "b")).isCloseTo(1.0 / 63, within(1e-12));
+	}
+
+	@Test
+	void whenScoresAreEqualThenDocumentsAreSortedById() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"), List.of(List.of(document("b"), document("a"))));
+		documentsForQuery.put(new Query("query2"), List.of(List.of(document("a"), document("b"))));
+
+		List<Document> result = documentJoiner.join(documentsForQuery);
+
+		assertThat(result).extracting(Document::getId).containsExactly("a", "b");
+		assertThat(scoreOf(result, "a")).isEqualTo(scoreOf(result, "b"));
+	}
+
+	@Test
+	void shouldRankDocumentsTheSameRegardlessOfMapIterationOrder() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var query1 = new Query("query1");
+		var query2 = new Query("query2");
+		var query3 = new Query("query3");
+		// "a" is ranked first, first and second, a combination whose contributions are
+		// not summed to the same double when they are accumulated in a different order.
+		// "c" and "d" end up with the same score, so their order only depends on their
+		// id.
+		var documents1 = List.of(List.of(document("a"), document("c")));
+		var documents2 = List.of(List.of(document("a"), document("d")));
+		var documents3 = List.of(List.of(document("b"), document("a")));
+
+		var oneOrder = new LinkedHashMap<Query, List<List<Document>>>();
+		oneOrder.put(query1, documents1);
+		oneOrder.put(query2, documents2);
+		oneOrder.put(query3, documents3);
+
+		var otherOrder = new LinkedHashMap<Query, List<List<Document>>>();
+		otherOrder.put(query3, documents3);
+		otherOrder.put(query2, documents2);
+		otherOrder.put(query1, documents1);
+
+		List<Document> result = documentJoiner.join(oneOrder);
+		List<Document> reversedResult = documentJoiner.join(otherOrder);
+
+		assertThat(ids(result)).containsExactly("a", "b", "c", "d");
+		assertThat(ids(reversedResult)).containsExactlyElementsOf(ids(result));
+		assertThat(scores(reversedResult)).containsExactlyElementsOf(scores(result));
+	}
+
+	@Test
+	void whenSingleDocumentListThenOriginalOrderIsPreserved() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"),
+				List.of(List.of(document("c"), document("a"), document("b"), document("d"))));
+
+		List<Document> result = documentJoiner.join(documentsForQuery);
+
+		assertThat(result).extracting(Document::getId).containsExactly("c", "a", "b", "d");
+	}
+
+	@Test
+	void shouldUseTheGivenRankConstant() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner(1);
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"), List.of(List.of(document("a"), document("b"))));
+
+		List<Document> result = documentJoiner.join(documentsForQuery);
+
+		assertThat(scoreOf(result, "a")).isCloseTo(1.0 / 2, within(1e-12));
+		assertThat(scoreOf(result, "b")).isCloseTo(1.0 / 3, within(1e-12));
+	}
+
+	@Test
+	void shouldNotModifyTheInputDocuments() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var original = Document.builder().id("a").text("Content a").score(0.42).build();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"), List.of(List.of(original, document("b"))));
+
+		documentJoiner.join(documentsForQuery);
+
+		assertThat(original.getScore()).isEqualTo(0.42);
+		assertThat(documentsForQuery.get(new Query("query1")).get(0)).containsExactly(original, document("b"));
+	}
+
+	@Test
+	void shouldPreserveTheDocumentFieldsAndReplaceOnlyTheScore() {
+		DocumentJoiner documentJoiner = new ReciprocalRankFusionDocumentJoiner();
+		var original = Document.builder()
+			.id("a")
+			.text("Content a")
+			.metadata(Map.of("source", "example"))
+			.score(0.42)
+			.build();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"), List.of(List.of(original)));
+
+		List<Document> result = documentJoiner.join(documentsForQuery);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).getId()).isEqualTo("a");
+		assertThat(result.get(0).getText()).isEqualTo("Content a");
+		assertThat(result.get(0).getMetadata()).containsEntry("source", "example");
+		assertThat(result.get(0).getScore()).isCloseTo(1.0 / 61, within(1e-12));
+	}
+
+	private static Document document(String id) {
+		return Document.builder().id(id).text("Content " + id).build();
+	}
+
+	private static Double scoreOf(List<Document> documents, String id) {
+		return documents.stream().filter(document -> document.getId().equals(id)).findFirst().orElseThrow().getScore();
+	}
+
+	private static List<String> ids(List<Document> documents) {
+		return documents.stream().map(Document::getId).toList();
+	}
+
+	private static List<Double> scores(List<Document> documents) {
+		return documents.stream().map(Document::getScore).toList();
+	}
+
+}


### PR DESCRIPTION
## Motivation

When a `RetrievalAugmentationAdvisor` is configured with a query expander, or when documents are retrieved from several data sources, the results arrive as several independent ranked lists. Merging them requires deciding how a document that appears in more than one list should be ranked.

The `DocumentJoiner` contract already mentions this:

> As part of the joining process, it can also handle duplicate documents **and reciprocal ranking strategies**.

but `ConcatenationDocumentJoiner` is currently the only implementation. It keeps the first occurrence of a duplicate and sorts by the score assigned by the retrieval strategy that produced it. Those scores are not comparable across queries or data sources — a cosine similarity from one vector store and a BM25-style score from another live on different scales — and the fact that a document was found by several retrieval paths is discarded rather than used.

## What this adds

`ReciprocalRankFusionDocumentJoiner`, an opt-in `DocumentJoiner` that merges the lists by rank instead of by score. Documents are aggregated by `Document.getId()` and accumulate a contribution of `1 / (rankConstant + rank)` for every list where they occur.

Given two result lists:

```text
query 1: A, B, C
query 2: B, D, A
```

`ConcatenationDocumentJoiner` returns the union in an order driven by the original scores. The new joiner returns `B, A, D, C`, because `B` was found near the top of both lists:

| document | contributions (rankConstant = 60) | score |
| --- | --- | ---: |
| B | 1/61 + 1/62 | 0.03252247 |
| A | 1/61 + 1/63 | 0.03226646 |
| D | 1/62 | 0.01612903 |
| C | 1/63 | 0.01587302 |

## Usage

```java
Advisor retrievalAugmentationAdvisor = RetrievalAugmentationAdvisor.builder()
        .queryExpander(MultiQueryExpander.builder()
                .chatClientBuilder(chatClientBuilder)
                .build())
        .documentRetriever(VectorStoreDocumentRetriever.builder()
                .vectorStore(vectorStore)
                .build())
        .documentJoiner(new ReciprocalRankFusionDocumentJoiner())
        .build();
```

The rank constant defaults to `60`, as in the original paper, and can be customized with `new ReciprocalRankFusionDocumentJoiner(20)`. The lower the value, the more the top of each list is favoured.

## Behaviour and limits

- Each inner `List<Document>` is treated as an independent ranked list, sorted by decreasing relevance — which is what `RetrievalAugmentationAdvisor` produces today, one list per expanded query.
- Documents are aggregated by id only. Nothing is inferred from content or metadata, so the lists to join must use consistent ids. That holds when the same data source is queried several times; joining ids from unrelated stores is out of scope here.
- Within a single list, only the first occurrence of an id contributes, and the positions of the documents after it are unchanged.
- Ties are broken by document id, and the ranks of a document are accumulated in a fixed order, so the returned scores and the resulting order do not depend on the iteration order of the given map (the advisor builds it with `Collectors.toMap`, so that order is not stable).
- The returned documents are copies with the fused score; the input map, lists and documents are left untouched.
- **The fused score is not a similarity score.** It is only meaningful relative to the other documents returned by the same call, so thresholds defined for a data source's scores do not carry over. This is called out in the Javadoc and in the reference documentation.

Nothing existing changes: the advisor keeps `ConcatenationDocumentJoiner` as its default, no interface is modified, and no dependency is added.

This PR makes no claim about retrieval quality or answer accuracy. Whether rank fusion improves results depends on the data and on how diverse the expanded queries are, and demonstrating it would require a separate evaluation against relevance labels with a fixed document budget.

## Testing

- `ReciprocalRankFusionDocumentJoinerTests` — 15 tests covering the scoring formula, aggregation across lists, duplicates within a list, tie-breaking, stability across map iteration orders, empty and invalid input, the custom rank constant, and the fact that input documents are not modified.
- `RetrievalAugmentationAdvisorTests.theOneWithTheReciprocalRankFusionDocumentJoiner` — wires the joiner into the advisor through `ChatClient` with a query expander, and asserts the fused order reaches the augmented prompt. It fails if the default joiner is used instead.

No API key, vector store or container is needed by any of them.

```text
./mvnw -pl spring-ai-rag -Dmaven.build.cache.enabled=false clean test
  Tests run: 81, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS

./mvnw clean package -Dmaven.javadoc.skip=true
  BUILD SUCCESS (263 modules)
```

The javadoc jars were skipped locally: on a non-UTF-8 Windows locale, `javadoc` cannot read the argument file the plugin generates for a module whose Maven name contains a non-ASCII character, which fails an unrelated module. That is an environment issue, not something this change touches.

## Notes

`ConcatenationDocumentJoiner` takes no configuration, so this joiner exposes plain constructors rather than a builder. Happy to switch to a builder if that fits the module's direction better.
