### PR TITLE
Handle missing `ChatCompletionChunk` metadata

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -1334,10 +1334,10 @@ public final class OpenAiChatModel implements ChatModel {
 			}).toList();
 
 			return ChatCompletion.builder()
-				.id(chunk.id())
+				.id(chunk._id().asKnown().orElse(""))
 				.choices(choices)
 				.created(getCreated(chunk))
-				.model(chunk.model())
+				.model(chunk._model().asKnown().orElse(""))
 				.usage(chunk.usage()
 					.orElse(CompletionUsage.builder().promptTokens(0).completionTokens(0).totalTokens(0).build()))
 				.putAllAdditionalProperties(chunk._additionalProperties())

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelChunkMergerTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionChunk.Choice;
@@ -169,6 +170,19 @@ class OpenAiChatModelChunkMergerTests {
 		assertThat(functionToolCall.id()).isEqualTo("call_1");
 		assertThat(functionToolCall.function().name()).isEqualTo("get_weather");
 		assertThat(functionToolCall.function().arguments()).isEmpty();
+	}
+
+	@Test // gh-6928
+	void chunkToChatCompletionUsesDefaultsForMissingChunkMetadata() throws Exception {
+		ChatCompletionChunk chunk = JsonMapper.builder()
+			.build()
+			.readValue("{\"choices\":[]}", ChatCompletionChunk.class);
+
+		ChatCompletion completion = OpenAiChatModel.ChunkMerger.chunkToChatCompletion(chunk);
+
+		assertThat(completion.id()).isEmpty();
+		assertThat(completion.model()).isEmpty();
+		assertThat(completion.created()).isZero();
 	}
 
 	private static ChatCompletionChunk chunk(@Nullable FinishReason finishReason, ToolCall... toolCalls) {


### PR DESCRIPTION
Fixes #6928

The OpenAI SDK throws `OpenAIInvalidDataException` when the accessor methods for required stream chunk metadata are called and a provider omits those fields. This change reads `id` and `model` through their raw SDK fields so missing values safely fall back to empty strings, matching the existing fallback for `created`.

A regression test deserializes a provider response without `id`, `model`, or `created` and verifies that conversion completes with safe defaults.

Tests:
- `OpenAiChatModelChunkMergerTests`: 9 passed
- `spring-ai-openai` module: 225 passed
- Checkstyle: passed