### PR TITLE
Support custom Azure credentials

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/setup/AzureOpenAiCredentials.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/setup/AzureOpenAiCredentials.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.setup;
+
+import com.azure.core.credential.TokenCredential;
+import com.openai.credential.Credential;
+
+import org.springframework.util.Assert;
+
+/**
+ * Factory for adapting Azure credentials for use with OpenAI models hosted on Microsoft
+ * Foundry.
+ *
+ * @author c.kai
+ * @since 2.0.2
+ */
+public final class AzureOpenAiCredentials {
+
+	private AzureOpenAiCredentials() {
+	}
+
+	/**
+	 * Adapt an Azure {@link TokenCredential} to an OpenAI {@link Credential}.
+	 * @param tokenCredential the Azure credential to adapt
+	 * @return an OpenAI credential configured for Microsoft Foundry
+	 */
+	public static Credential from(TokenCredential tokenCredential) {
+		Assert.notNull(tokenCredential, "tokenCredential must not be null");
+		return AzureInternalOpenAiHelper.getAzureCredential(tokenCredential);
+	}
+
+}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/setup/AzureInternalOpenAiHelperTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/setup/AzureInternalOpenAiHelperTests.java
@@ -56,6 +56,16 @@ class AzureInternalOpenAiHelperTests {
 	}
 
 	@Test
+	void publicFactoryAdaptsTokenCredential() {
+		givenTokens(new AccessToken("test-token", OffsetDateTime.now().plusHours(1)));
+
+		Credential azureCredential = AzureOpenAiCredentials.from(this.credential);
+
+		assertThat(azureCredential).isInstanceOf(BearerTokenCredential.class);
+		assertThat(((BearerTokenCredential) azureCredential).token()).isEqualTo("test-token");
+	}
+
+	@Test
 	void getAzureCredentialRequestsCognitiveServicesScope() {
 		givenTokens(new AccessToken("test-token", OffsetDateTime.now().plusHours(1)));
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
@@ -1,3 +1,20 @@
 = Azure OpenAI Chat
 
 As of Spring AI `2.0.0-M5`, xref:api/chat/openai-chat.adoc[OpenAI Chat] should be use to access OpenAI models deployed on Azure / Microsoft Foundry.
+
+== Custom Microsoft Entra credentials
+
+Use `AzureOpenAiCredentials` to authenticate with a custom Azure `TokenCredential`, such as a user-assigned managed identity:
+
+[source,java]
+----
+TokenCredential tokenCredential = new DefaultAzureCredentialBuilder()
+    .managedIdentityClientId(clientId)
+    .build();
+
+OpenAiChatOptions options = OpenAiChatOptions.builder()
+    .credential(AzureOpenAiCredentials.from(tokenCredential))
+    .build();
+----
+
+Add `com.azure:azure-identity` to the application dependencies when using Microsoft Entra authentication.


### PR DESCRIPTION
## Summary

- expose `AzureOpenAiCredentials.from(TokenCredential)` for custom Microsoft Entra credentials
- reuse the existing Cognitive Services scope and token cache
- document user-assigned managed identity usage

Fixes #6935

## Testing

- `.\mvnw.cmd -pl models/spring-ai-openai -am "-Dtest=AzureInternalOpenAiHelperTests" "-Dsurefire.failIfNoSpecifiedTests=false" test`
- `.\mvnw.cmd --no-transfer-progress -pl models/spring-ai-openai -am "-DskipTests" package`
- `.\mvnw.cmd --no-transfer-progress clean package` *(fails in existing `spring-ai-vector-store-advisor` NullAway checks before reaching the changed module: `QuestionAnswerAdvisor.java:114` and `VectorStoreChatMemoryAdvisor.java:137`)*
