### PR TITLE
Clean `MapOutputConverter` responses with the shared `ResponseTextCleaner`

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -161,12 +161,7 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 	 * @return a composite text cleaner with default cleaning strategies
 	 */
 	private static ResponseTextCleaner createDefaultTextCleaner() {
-		return CompositeResponseTextCleaner.builder()
-			.addCleaner(new WhitespaceCleaner())
-			.addCleaner(new ThinkingTagCleaner())
-			.addCleaner(new MarkdownCodeBlockCleaner())
-			.addCleaner(new WhitespaceCleaner()) // Final trim after all cleanups
-			.build();
+		return ResponseTextCleaner.defaultCleaner();
 	}
 
 	/**

--- a/spring-ai-model/src/main/java/org/springframework/ai/converter/MapOutputConverter.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/converter/MapOutputConverter.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -37,16 +38,27 @@ import org.springframework.messaging.support.MessageBuilder;
  */
 public class MapOutputConverter extends AbstractMessageOutputConverter<Map<String, Object>> {
 
+	private final ResponseTextCleaner textCleaner;
+
 	public MapOutputConverter() {
+		this(null);
+	}
+
+	/**
+	 * @param textCleaner cleaner applied to the response before parsing, or {@code null}
+	 * to use {@link ResponseTextCleaner#defaultCleaner()}
+	 * @since 1.1.0
+	 */
+	public MapOutputConverter(@Nullable ResponseTextCleaner textCleaner) {
 		super(new JacksonJsonMessageConverter(
 				JsonMapper.builder().disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)));
+		this.textCleaner = (textCleaner != null) ? textCleaner : ResponseTextCleaner.defaultCleaner();
 	}
 
 	@Override
 	public Map<String, Object> convert(String text) {
-		if (text.startsWith("```json") && text.endsWith("```")) {
-			text = text.substring(7, text.length() - 3);
-		}
+		String cleaned = this.textCleaner.clean(text);
+		text = (cleaned != null) ? cleaned : text;
 
 		Message<?> message = MessageBuilder.withPayload(text.getBytes(StandardCharsets.UTF_8)).build();
 		Map result = (Map) this.getMessageConverter().fromMessage(message, HashMap.class);

--- a/spring-ai-model/src/main/java/org/springframework/ai/converter/ResponseTextCleaner.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/converter/ResponseTextCleaner.java
@@ -36,4 +36,21 @@ public interface ResponseTextCleaner {
 	 */
 	@Nullable String clean(@Nullable String text);
 
+	/**
+	 * The cleaner applied by the built-in {@link StructuredOutputConverter}
+	 * implementations, handling the response shapes commonly produced by AI models:
+	 * surrounding whitespace, reasoning tags, and markdown code fences.
+	 * @return a cleaner combining {@link WhitespaceCleaner}, {@link ThinkingTagCleaner}
+	 * and {@link MarkdownCodeBlockCleaner}
+	 * @since 1.1.0
+	 */
+	static ResponseTextCleaner defaultCleaner() {
+		return CompositeResponseTextCleaner.builder()
+			.addCleaner(new WhitespaceCleaner())
+			.addCleaner(new ThinkingTagCleaner())
+			.addCleaner(new MarkdownCodeBlockCleaner())
+			.addCleaner(new WhitespaceCleaner()) // Final trim after all cleanups
+			.build();
+	}
+
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/converter/MapOutputConverterTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/converter/MapOutputConverterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.converter;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MapOutputConverterTest {
+
+	private MapOutputConverter mapOutputConverter;
+
+	@BeforeEach
+	void setUp() {
+		this.mapOutputConverter = new MapOutputConverter();
+	}
+
+	@Test
+	void plainJson() {
+		assertThat(this.mapOutputConverter.convert("{\"name\":\"foo\"}")).containsExactly(Map.entry("name", "foo"));
+	}
+
+	/**
+	 * Models wrap the payload in a code fence in a number of shapes: with or without a
+	 * language tag, in either case, and with surrounding whitespace.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "```json\n{\"name\":\"foo\"}\n```", "\n```json\n{\"name\":\"foo\"}\n```\n",
+			"```json\n{\"name\":\"foo\"}\n```   ", "```JSON\n{\"name\":\"foo\"}\n```", "```\n{\"name\":\"foo\"}\n```" })
+	void fencedJson(String text) {
+		assertThat(this.mapOutputConverter.convert(text)).containsExactly(Map.entry("name", "foo"));
+	}
+
+	@Test
+	void thinkingTagIsStripped() {
+		assertThat(this.mapOutputConverter.convert("<think>reasoning</think>\n{\"name\":\"foo\"}"))
+			.containsExactly(Map.entry("name", "foo"));
+	}
+
+	@Test
+	void customCleanerIsUsed() {
+		MapOutputConverter converter = new MapOutputConverter(text -> "{\"name\":\"replaced\"}");
+		assertThat(converter.convert("anything")).containsExactly(Map.entry("name", "replaced"));
+	}
+
+}


### PR DESCRIPTION
`MapOutputConverter` strips code fences with its own inline check:

```java
if (text.startsWith("```json") && text.endsWith("```")) {
    text = text.substring(7, text.length() - 3);
}
```

That only matches one exact shape. `BeanOutputConverter` in the same package already goes through `ResponseTextCleaner`, which handles the rest. Running both over the shapes models actually emit:

| response | `MapOutputConverter` | `BeanOutputConverter` |
|---|---|---|
| ` ```json\n{...}\n``` ` | ok | ok |
| `\n` before/after the fence | **MessageConversionException** | ok |
| trailing spaces after the fence | **MessageConversionException** | ok |
| ` ```JSON ` | **MessageConversionException** | ok |
| ` ``` ` with no language tag | **MessageConversionException** | ok |
| bare JSON, no fence | ok | ok |

A trailing newline is enough to break it, and that is a very ordinary thing for a model to emit. `<think>` blocks aren't handled either, since `ThinkingTagCleaner` is part of the same chain.

So this drops the inline check and runs the response through the cleaner instead. The default chain lived in a private method on `BeanOutputConverter`; I moved it to `ResponseTextCleaner.defaultCleaner()` so both use one definition rather than a second copy drifting from the first, and added a constructor taking a custom cleaner, mirroring `BeanOutputConverter`.

`MapOutputConverter` had no test class, which is presumably how this survived. Added one covering the fenced shapes above, a thinking tag, and a custom cleaner.

`mvn -pl spring-ai-model test` → 844 tests, green.

### Related, not included

`ListOutputConverter` doesn't clean at all, and it fails more quietly — the fence markers become list elements:

```
"```\nfoo, bar, baz\n```"     -> [```, foo, bar, baz, ```]
"```csv\nfoo, bar, baz\n```"  -> [```csv, foo, bar, baz, ```]
```

I left it out because every cleaner in the chain trims, and `ListOutputConverterTest.csvWithOnlyWhitespace` asserts that `"   \t\n   "` converts to a single blank element rather than an empty list. Fixing the fences changes that, so it seemed like your call rather than mine. Happy to do it in a follow-up if you want the behaviour changed, or to scope a fence-only cleaner that preserves it.
