### PR TITLE
Cache tool results in `BedrockProxyChatModel`

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockCacheProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockCacheProperties.java
@@ -28,6 +28,8 @@ public class BedrockCacheProperties {
 
 	private @Nullable BedrockCacheTtl ttl;
 
+	private boolean cacheToolResults;
+
 	public @Nullable BedrockCacheStrategy getStrategy() {
 		return this.strategy;
 	}
@@ -44,8 +46,20 @@ public class BedrockCacheProperties {
 		this.ttl = ttl;
 	}
 
+	public boolean isCacheToolResults() {
+		return this.cacheToolResults;
+	}
+
+	public void setCacheToolResults(boolean cacheToolResults) {
+		this.cacheToolResults = cacheToolResults;
+	}
+
 	public BedrockCacheOptions toOptions() {
-		return BedrockCacheOptions.builder().strategy(this.strategy).ttl(this.ttl).build();
+		return BedrockCacheOptions.builder()
+			.strategy(this.strategy)
+			.ttl(this.ttl)
+			.cacheToolResults(this.cacheToolResults)
+			.build();
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
@@ -99,17 +99,20 @@ public class BedrockConverseProxyChatPropertiesTests {
 	public void cacheOptionsTest() {
 		new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.bedrock.converse.chat.cache-options.strategy=SYSTEM_ONLY",
-					"spring.ai.bedrock.converse.chat.cache-options.ttl=ONE_HOUR")
+					"spring.ai.bedrock.converse.chat.cache-options.ttl=ONE_HOUR",
+					"spring.ai.bedrock.converse.chat.cache-options.cache-tool-results=true")
 			.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class,
 					ToolCallingAutoConfiguration.class))
 			.run(context -> {
 				var chatProperties = context.getBean(BedrockConverseProxyChatProperties.class);
 				assertThat(chatProperties.getCacheOptions().getStrategy()).isEqualTo(BedrockCacheStrategy.SYSTEM_ONLY);
 				assertThat(chatProperties.getCacheOptions().getTtl()).isEqualTo(BedrockCacheTtl.ONE_HOUR);
+				assertThat(chatProperties.getCacheOptions().isCacheToolResults()).isTrue();
 
 				var options = chatProperties.toOptions();
 				assertThat(options.getCacheOptions().getStrategy()).isEqualTo(BedrockCacheStrategy.SYSTEM_ONLY);
 				assertThat(options.getCacheOptions().getTtl()).isEqualTo(BedrockCacheTtl.ONE_HOUR);
+				assertThat(options.getCacheOptions().isCacheToolResults()).isTrue();
 			});
 	}
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -253,6 +253,9 @@ public class BedrockProxyChatModel implements ChatModel {
 		BedrockCacheOptions cacheOptions = options.getCacheOptions();
 		boolean shouldCacheConversationHistory = cacheOptions != null
 				&& cacheOptions.getStrategy() == BedrockCacheStrategy.CONVERSATION_HISTORY;
+		boolean shouldCacheToolResults = cacheOptions != null
+				&& cacheOptions.getStrategy() == BedrockCacheStrategy.CONVERSATION_HISTORY
+				&& cacheOptions.isCacheToolResults();
 
 		// Get all non-system messages
 		List<org.springframework.ai.chat.messages.Message> allNonSystemMessages = prompt.getInstructions()
@@ -275,6 +278,19 @@ public class BedrockProxyChatModel implements ChatModel {
 			}
 		}
 
+		// Find the final tool result message. Placing a cache point after its last
+		// content block caches all prior tool outputs for subsequent tool-calling rounds.
+		int lastToolMessageIndex = -1;
+		if (shouldCacheToolResults) {
+			for (int i = allNonSystemMessages.size() - 1; i >= 0; i--) {
+				if (allNonSystemMessages.get(i).getMessageType() == MessageType.TOOL
+						&& !((ToolResponseMessage) allNonSystemMessages.get(i)).getResponses().isEmpty()) {
+					lastToolMessageIndex = i;
+					break;
+				}
+			}
+		}
+
 		// Build instruction messages with potential caching
 		List<Message> instructionMessages = new ArrayList<>();
 		for (int i = 0; i < allNonSystemMessages.size(); i++) {
@@ -282,7 +298,7 @@ public class BedrockProxyChatModel implements ChatModel {
 
 			// Determine if this message should have a cache point
 			// For CONVERSATION_HISTORY: cache point goes on the last user message
-			boolean shouldApplyCachePoint = shouldCacheConversationHistory && i == lastUserMessageIndex;
+			boolean shouldApplyUserCachePoint = shouldCacheConversationHistory && i == lastUserMessageIndex;
 
 			if (message.getMessageType() == MessageType.USER) {
 				List<ContentBlock> contents = new ArrayList<>();
@@ -305,7 +321,7 @@ public class BedrockProxyChatModel implements ChatModel {
 				}
 
 				// Apply cache point if this is the last user message
-				if (shouldApplyCachePoint) {
+				if (shouldApplyUserCachePoint) {
 					contents.add(ContentBlock.fromCachePoint(buildCachePoint(cacheOptions)));
 					logger.debug("Applied cache point on last user message (conversation history caching)");
 				}
@@ -354,6 +370,14 @@ public class BedrockProxyChatModel implements ChatModel {
 								.build();
 							return ContentBlock.fromToolResult(toolResultBlock);
 						}).toList());
+
+				// ContentBlock is a union: toolResult and cachePoint must be separate
+				// blocks. Avoid emitting a cache-point-only message for an empty
+				// response.
+				if (i == lastToolMessageIndex && !contentBlocks.isEmpty()) {
+					contentBlocks.add(ContentBlock.fromCachePoint(buildCachePoint(cacheOptions)));
+					logger.debug("Applied cache point after last tool result message");
+				}
 
 				instructionMessages.add(Message.builder().content(contentBlocks).role(ConversationRole.USER).build());
 			}

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptions.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptions.java
@@ -59,15 +59,23 @@ public class BedrockCacheOptions {
 
 	private final @Nullable BedrockCacheTtl ttl;
 
+	private final boolean cacheToolResults;
+
 	protected BedrockCacheOptions(@Nullable BedrockCacheStrategy strategy, boolean multiBlockSystemCaching) {
-		this(strategy, multiBlockSystemCaching, null);
+		this(strategy, multiBlockSystemCaching, null, false);
 	}
 
 	protected BedrockCacheOptions(@Nullable BedrockCacheStrategy strategy, boolean multiBlockSystemCaching,
 			@Nullable BedrockCacheTtl ttl) {
+		this(strategy, multiBlockSystemCaching, ttl, false);
+	}
+
+	protected BedrockCacheOptions(@Nullable BedrockCacheStrategy strategy, boolean multiBlockSystemCaching,
+			@Nullable BedrockCacheTtl ttl, boolean cacheToolResults) {
 		this.strategy = (strategy != null ? strategy : BedrockCacheStrategy.NONE);
 		this.multiBlockSystemCaching = multiBlockSystemCaching;
 		this.ttl = ttl;
+		this.cacheToolResults = cacheToolResults;
 	}
 
 	/**
@@ -113,6 +121,18 @@ public class BedrockCacheOptions {
 	}
 
 	/**
+	 * Returns whether prompt caching is enabled for tool result messages. When enabled
+	 * with {@link BedrockCacheStrategy#CONVERSATION_HISTORY}, a cache point is placed
+	 * after the last tool result message in a request so previous tool outputs can be
+	 * reused in subsequent tool-calling rounds. Disabled by default.
+	 * @return {@code true} if tool result caching is enabled; {@code false} otherwise
+	 * @since 2.0.2
+	 */
+	public boolean isCacheToolResults() {
+		return this.cacheToolResults;
+	}
+
+	/**
 	 * Builder for constructing BedrockCacheOptions instances.
 	 */
 	public static class Builder {
@@ -122,6 +142,8 @@ public class BedrockCacheOptions {
 		private boolean multiBlockSystemCaching = false;
 
 		private @Nullable BedrockCacheTtl ttl;
+
+		private boolean cacheToolResults = false;
 
 		/**
 		 * Sets the caching strategy.
@@ -161,11 +183,25 @@ public class BedrockCacheOptions {
 		}
 
 		/**
+		 * Sets whether to cache tool result messages. This option takes effect only with
+		 * {@link BedrockCacheStrategy#CONVERSATION_HISTORY} and defaults to
+		 * {@code false}.
+		 * @param cacheToolResults whether to cache tool result messages
+		 * @return this Builder instance
+		 * @since 2.0.2
+		 */
+		public Builder cacheToolResults(boolean cacheToolResults) {
+			this.cacheToolResults = cacheToolResults;
+			return this;
+		}
+
+		/**
 		 * Builds the BedrockCacheOptions instance.
 		 * @return the configured BedrockCacheOptions
 		 */
 		public BedrockCacheOptions build() {
-			return new BedrockCacheOptions(this.strategy, this.multiBlockSystemCaching, this.ttl);
+			return new BedrockCacheOptions(this.strategy, this.multiBlockSystemCaching, this.ttl,
+					this.cacheToolResults);
 		}
 
 	}

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
@@ -41,6 +41,7 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -780,6 +781,59 @@ class BedrockProxyChatModelIT {
 			assertThat(cacheRead).as("Cache read should meet the 4096 token minimum for Claude Haiku 4.5")
 				.isGreaterThan(4096);
 			assertThat(cacheWrite).as("A cache read hit should not also write").isIn(null, 0);
+		});
+	}
+
+	@Test
+	void testToolResultPromptCachingWithClaude() {
+		// Keep the prefix before the tool result deliberately small. A cache read above
+		// Claude Haiku 4.5's 4096-token minimum therefore demonstrates that the large
+		// tool result is included in the cached prefix.
+		String model = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+		StringBuilder largeToolResult = new StringBuilder("Detailed hourly weather report for San Francisco.\n");
+		for (int hour = 0; hour < 240; hour++) {
+			largeToolResult.append("Hour ")
+				.append(hour)
+				.append(": temperature 18C, humidity 72%, wind 12 km/h from the west, visibility 10 km, ")
+				.append("pressure 1013 hPa, no precipitation expected, UV index moderate.\n");
+		}
+
+		String runMarker = "Session " + System.currentTimeMillis();
+		BedrockCacheOptions cacheOptions = BedrockCacheOptions.builder()
+			.strategy(BedrockCacheStrategy.CONVERSATION_HISTORY)
+			.cacheToolResults(true)
+			.build();
+		BedrockChatOptions chatOptions = BedrockChatOptions.builder()
+			.model(model)
+			.cacheOptions(cacheOptions)
+			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.description("Get current weather for a location")
+				.inputType(MockWeatherService.Request.class)
+				.build()))
+			.maxTokens(80)
+			.build();
+
+		List<Message> conversation = List.of(new SystemMessage("You are a weather assistant. " + runMarker),
+				new UserMessage("What's the detailed weather in San Francisco?"),
+				AssistantMessage.builder()
+					.content("")
+					.toolCalls(List.of(new AssistantMessage.ToolCall("tool_sf_1", "function", "getCurrentWeather",
+							"{\"location\":\"San Francisco, CA\",\"unit\":\"C\"}")))
+					.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("tool_sf_1", "getCurrentWeather",
+							largeToolResult.toString())))
+					.build());
+		Prompt prompt = new Prompt(conversation, chatOptions);
+
+		// Cross-region inference can route the first calls to different regions. Retry
+		// the identical prompt until it reaches a region where the prefix was written.
+		Awaitility.await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(3)).untilAsserted(() -> {
+			ChatResponse response = this.chatModel.call(prompt);
+			assertThat(response.getResults()).hasSize(1);
+			assertThat(response.getResult().getOutput().getText()).isNotEmpty();
+			Integer cacheRead = response.getMetadata().get("cacheReadInputTokens");
+			assertThat(cacheRead).as("Should read the cached tool result prefix").isNotNull().isGreaterThan(4096);
 		});
 	}
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -40,7 +40,9 @@ import org.springframework.ai.bedrock.converse.api.BedrockCacheOptions;
 import org.springframework.ai.bedrock.converse.api.BedrockCacheStrategy;
 import org.springframework.ai.bedrock.converse.api.BedrockCacheTtl;
 import org.springframework.ai.bedrock.converse.api.MediaFetcher;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
@@ -464,6 +466,125 @@ class BedrockProxyChatModelTest {
 		return Media.builder()
 			.mimeType(MimeType.valueOf("image/png"))
 			.data(new byte[] { (byte) 0x89, 'P', 'N', 'G' })
+			.build();
+	}
+
+	@Test
+	void cacheToolResultsPlacesCachePointAfterLastToolResultBlock() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(BedrockCacheOptions.builder()
+				.strategy(BedrockCacheStrategy.CONVERSATION_HISTORY)
+				.cacheToolResults(true)
+				.ttl(BedrockCacheTtl.ONE_HOUR)
+				.build())
+			.build();
+
+		List<org.springframework.ai.chat.messages.Message> messages = List.of(
+				new UserMessage("Compare the weather in Paris and Berlin"),
+				assistantToolCalls("tool-1", "Paris", "tool-2", "Berlin"),
+				toolResults("tool-1", "Sunny in Paris", "tool-2", "Cloudy in Berlin"));
+		ConverseRequest request = model.createRequest(new Prompt(messages, options));
+		List<ContentBlock> toolResultContent = request.messages().get(2).content();
+
+		assertThat(toolResultContent).hasSize(3);
+		assertThat(toolResultContent.get(0).toolResult()).isNotNull();
+		assertThat(toolResultContent.get(1).toolResult()).isNotNull();
+		assertThat(toolResultContent.get(2).cachePoint()).isNotNull();
+		assertThat(toolResultContent.get(2).cachePoint().typeAsString()).isEqualTo("default");
+		assertThat(toolResultContent.get(2).cachePoint().ttlAsString()).isEqualTo("1h");
+	}
+
+	@Test
+	void cacheToolResultsDisabledByDefaultLeavesToolResultsUncached() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(BedrockCacheOptions.builder().strategy(BedrockCacheStrategy.CONVERSATION_HISTORY).build())
+			.build();
+
+		ConverseRequest request = model.createRequest(new Prompt(toolCallingConversation(), options));
+		List<ContentBlock> toolResultContent = request.messages().get(2).content();
+
+		assertThat(toolResultContent).hasSize(1);
+		assertThat(toolResultContent.get(0).toolResult()).isNotNull();
+		assertThat(toolResultContent.get(0).cachePoint()).isNull();
+	}
+
+	@Test
+	void cacheToolResultsOnlyCachesLastToolResultMessage() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(BedrockCacheOptions.builder()
+				.strategy(BedrockCacheStrategy.CONVERSATION_HISTORY)
+				.cacheToolResults(true)
+				.build())
+			.build();
+
+		List<org.springframework.ai.chat.messages.Message> messages = List.of(
+				new UserMessage("Compare Paris and Berlin"), assistantToolCall("tool-1", "Paris"),
+				toolResult("tool-1", "Sunny in Paris"), assistantToolCall("tool-2", "Berlin"),
+				toolResult("tool-2", "Cloudy in Berlin"));
+		ConverseRequest request = model.createRequest(new Prompt(messages, options));
+
+		assertThat(request.messages().get(2).content()).hasSize(1);
+		assertThat(request.messages().get(2).content().get(0).toolResult()).isNotNull();
+		assertThat(request.messages().get(4).content()).hasSize(2);
+		assertThat(request.messages().get(4).content().get(0).toolResult()).isNotNull();
+		assertThat(request.messages().get(4).content().get(1).cachePoint()).isNotNull();
+	}
+
+	@Test
+	void cacheToolResultsHasNoEffectOutsideConversationHistoryStrategy() {
+		BedrockProxyChatModel model = newModel();
+
+		BedrockChatOptions options = BedrockChatOptions.builder()
+			.cacheOptions(
+					BedrockCacheOptions.builder().strategy(BedrockCacheStrategy.NONE).cacheToolResults(true).build())
+			.build();
+
+		ConverseRequest request = model.createRequest(new Prompt(toolCallingConversation(), options));
+
+		assertThat(request.messages().get(2).content()).hasSize(1);
+		assertThat(request.messages().get(2).content().get(0).toolResult()).isNotNull();
+	}
+
+	private static List<org.springframework.ai.chat.messages.Message> toolCallingConversation() {
+		return List.of(new UserMessage("What's the weather in Paris?"), assistantToolCall("tool-1", "Paris"),
+				toolResult("tool-1", "Sunny in Paris"));
+	}
+
+	private static AssistantMessage assistantToolCall(String id, String city) {
+		return AssistantMessage.builder()
+			.toolCalls(List
+				.of(new AssistantMessage.ToolCall(id, "function", "getWeather", "{\"location\":\"" + city + "\"}")))
+			.build();
+	}
+
+	private static AssistantMessage assistantToolCalls(String firstId, String firstCity, String secondId,
+			String secondCity) {
+		return AssistantMessage.builder()
+			.toolCalls(List.of(
+					new AssistantMessage.ToolCall(firstId, "function", "getWeather",
+							"{\"location\":\"" + firstCity + "\"}"),
+					new AssistantMessage.ToolCall(secondId, "function", "getWeather",
+							"{\"location\":\"" + secondCity + "\"}")))
+			.build();
+	}
+
+	private static ToolResponseMessage toolResult(String id, String responseData) {
+		return ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse(id, "getWeather", responseData)))
+			.build();
+	}
+
+	private static ToolResponseMessage toolResults(String firstId, String firstResponseData, String secondId,
+			String secondResponseData) {
+		return ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse(firstId, "getWeather", firstResponseData),
+					new ToolResponseMessage.ToolResponse(secondId, "getWeather", secondResponseData)))
 			.build();
 	}
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptionsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/BedrockCacheOptionsTests.java
@@ -32,6 +32,7 @@ class BedrockCacheOptionsTests {
 		BedrockCacheOptions options = BedrockCacheOptions.builder().build();
 		assertThat(options.getStrategy()).isEqualTo(BedrockCacheStrategy.NONE);
 		assertThat(options.isMultiBlockSystemCaching()).isFalse();
+		assertThat(options.isCacheToolResults()).isFalse();
 	}
 
 	@Test
@@ -53,6 +54,15 @@ class BedrockCacheOptionsTests {
 			.multiBlockSystemCaching(true)
 			.build();
 		assertThat(options.isMultiBlockSystemCaching()).isTrue();
+	}
+
+	@Test
+	void builderEnablesToolResultCaching() {
+		BedrockCacheOptions options = BedrockCacheOptions.builder()
+			.strategy(BedrockCacheStrategy.CONVERSATION_HISTORY)
+			.cacheToolResults(true)
+			.build();
+		assertThat(options.isCacheToolResults()).isTrue();
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -287,6 +287,39 @@ String response = chatClient.prompt()
     .content();
 ----
 
+==== Tool Result Caching
+
+Multi-round tool calling appends an assistant `toolUse` message and a user `toolResult` message on every round.
+With conversation-history caching alone, those appended tool results remain after the user-message cache point and are processed again on the next request.
+
+Enable `cacheToolResults` to add another cache point after the final tool result message in the request:
+
+[source,java]
+----
+BedrockCacheOptions cacheOptions = BedrockCacheOptions.builder()
+    .strategy(BedrockCacheStrategy.CONVERSATION_HISTORY)
+    .cacheToolResults(true)
+    .build();
+----
+
+The option defaults to `false` and takes effect only with the `CONVERSATION_HISTORY` strategy.
+When multiple tool-calling rounds are present, only the last tool result message receives the additional cache point, allowing all preceding tool outputs to become part of the cached prefix.
+This additional point counts toward AWS Bedrock's per-request cache checkpoint limit.
+
+The same option can be configured through Spring Boot properties:
+
+[source,yaml]
+----
+spring:
+  ai:
+    bedrock:
+      converse:
+        chat:
+          cache-options:
+            strategy: CONVERSATION_HISTORY
+            cache-tool-results: true
+----
+
 ==== Multi-Block System Message Caching
 
 When using advisors (e.g., RAG context injection), your system prompt may consist of multiple `SystemMessage` instances: a static prefix (your base instructions) and a dynamic suffix (advisor-injected context that changes each request).
@@ -1026,4 +1059,3 @@ public class ChatController {
     }
 }
 ----
-


### PR DESCRIPTION
## Summary

- add an opt-in `cacheToolResults` setting to `BedrockCacheOptions`
- append a separate Bedrock `cachePoint` content block after the final non-empty tool result message when `CONVERSATION_HISTORY` caching is enabled
- preserve the existing default behavior by keeping the option disabled by default
- expose the setting as `spring.ai.bedrock.converse.chat.cache-options.cache-tool-results`
- document the Java and Spring Boot configuration and the Bedrock cache checkpoint implication

## Rationale

During multi-round tool calling, each new `toolResult` is appended after the existing user-message cache point. Without a cache point after the latest tool result, prior tool outputs are processed again on the following round. This change lets applications opt into extending the cached prefix through the final tool result while reusing the existing cache TTL behavior.

The implementation mirrors the Anthropic `cacheToolResults` behavior added for #6261: only the last tool result message receives a breakpoint. Bedrock content blocks are unions, so the cache point is emitted as a separate block after the final `toolResult`, rather than being attached to the `toolResult` block itself.

Fixes #6938

## Test coverage

- default-off and strategy-gating behavior
- multiple tool-calling rounds: only the final tool result message is cached
- multiple tool results in one message: the cache point follows the final result block
- configured TTL propagation to the added cache point
- Spring Boot property binding through `BedrockCacheProperties`
- AWS integration scenario with a small pre-tool prefix and a >4096-token tool result, so a cache read demonstrates that the tool result is included in the cached prefix

## Verification

- `./mvnw -ntp -B -pl models/spring-ai-bedrock-converse -Dtest=BedrockProxyChatModelTest,BedrockCacheOptionsTests test` — 28 tests passed
- `./mvnw -pl auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai -am -Dtest=BedrockConverseProxyChatPropertiesTests -Dsurefire.failIfNoSpecifiedTests=false test` — 3 property-binding tests passed
- `./mvnw -ntp -B -U package` — full 169-module reactor passed

The AWS integration scenario is guarded by the existing `@RequiresAwsCredentials` condition and is compiled as part of the full build.
