### PR TITLE
Reduce allocations in `TypesenseVectorStore` vector queries

### DIFF
--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -95,6 +94,12 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 	public static final String DEFAULT_COLLECTION_NAME = "vector_store";
 
 	public static final int INVALID_EMBEDDING_DIMENSION = -1;
+
+	/**
+	 * Estimated number of characters a single embedding value contributes to the vector
+	 * query, including its separator, used to pre-size the query buffer.
+	 */
+	private static final int ESTIMATED_CHARS_PER_EMBEDDING_VALUE = 12;
 
 	private static final Log logger = LogFactory.getLog(TypesenseVectorStore.class);
 
@@ -240,11 +245,8 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 		multiSearchCollectionParameters.collection(this.collectionName);
 		multiSearchCollectionParameters.q("*");
 
-		Stream<Float> floatStream = IntStream.range(0, embedding.length).mapToObj(i -> embedding[i]);
 		// typesense uses only cosine similarity
-		String vectorQuery = EMBEDDING_FIELD_NAME + ":(" + "["
-				+ String.join(",", floatStream.map(String::valueOf).toList()) + "], " + "k: " + request.getTopK() + ", "
-				+ "distance_threshold: " + (1 - request.getSimilarityThreshold()) + ")";
+		String vectorQuery = buildVectorQuery(embedding, request.getTopK(), request.getSimilarityThreshold());
 
 		multiSearchCollectionParameters.vectorQuery(vectorQuery);
 		multiSearchCollectionParameters.filterBy(nativeFilterExpressions);
@@ -284,6 +286,30 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 			logger.error("Failed to search documents", e);
 			return List.of();
 		}
+	}
+
+	/**
+	 * Builds the Typesense vector query for the given embedding using a single pre-sized
+	 * {@link StringBuilder}. The estimated capacity assumes about 12 characters per
+	 * value, which is enough for typical embedding values and their separators, so the
+	 * buffer does not have to grow.
+	 */
+	static String buildVectorQuery(float[] embedding, int topK, double similarityThreshold) {
+		StringBuilder vectorQueryBuilder = new StringBuilder(
+				EMBEDDING_FIELD_NAME.length() + embedding.length * ESTIMATED_CHARS_PER_EMBEDDING_VALUE + 64);
+		vectorQueryBuilder.append(EMBEDDING_FIELD_NAME).append(":([");
+		for (int i = 0; i < embedding.length; i++) {
+			if (i > 0) {
+				vectorQueryBuilder.append(',');
+			}
+			vectorQueryBuilder.append(embedding[i]);
+		}
+		return vectorQueryBuilder.append("], k: ")
+			.append(topK)
+			.append(", distance_threshold: ")
+			.append(1 - similarityThreshold)
+			.append(')')
+			.toString();
 	}
 
 	int embeddingDimensions() {

--- a/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStoreTests.java
+++ b/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStoreTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.typesense;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link TypesenseVectorStore}.
+ *
+ * @author chabinhwang
+ */
+class TypesenseVectorStoreTests {
+
+	@Test
+	void buildVectorQuery() {
+		String vectorQuery = TypesenseVectorStore.buildVectorQuery(new float[] { 0.1f, -2.5f, 3.0E-4f }, 7, 0.75);
+
+		assertThat(vectorQuery).isEqualTo("embedding:([0.1,-2.5,3.0E-4], k: 7, distance_threshold: 0.25)");
+	}
+
+	@Test
+	void buildVectorQueryWithEmptyEmbedding() {
+		String vectorQuery = TypesenseVectorStore.buildVectorQuery(new float[0], 3, 0.5);
+
+		assertThat(vectorQuery).isEqualTo("embedding:([], k: 3, distance_threshold: 0.5)");
+	}
+
+	@Test
+	void buildVectorQueryWithSpecialValues() {
+		String vectorQuery = TypesenseVectorStore
+			.buildVectorQuery(new float[] { -0.0f, Float.MIN_VALUE, Float.MAX_VALUE }, 1, 0.0);
+
+		assertThat(vectorQuery).isEqualTo("embedding:([-0.0,1.4E-45,3.4028235E38], k: 1, distance_threshold: 1.0)");
+	}
+
+	@Test
+	void buildVectorQueryKeepsEveryEmbeddingValue() {
+		float[] embedding = new float[TypesenseVectorStore.OPENAI_EMBEDDING_DIMENSION_SIZE];
+		for (int i = 0; i < embedding.length; i++) {
+			embedding[i] = i / 1000.0f;
+		}
+
+		String vectorQuery = TypesenseVectorStore.buildVectorQuery(embedding, 10, 0.75);
+
+		assertThat(vectorQuery).startsWith("embedding:([0.0,0.001,0.002,")
+			.endsWith(",1.535], k: 10, distance_threshold: 0.25)");
+		assertThat(vectorQuery.chars().filter(c -> c == ',').count()).isEqualTo(embedding.length + 1);
+	}
+
+}


### PR DESCRIPTION
Rebased onto current `main`. Supersedes #6707 (and earlier #6151). Same change; the previous PR sat in `waiting-for-triage` and was never reviewed.

## Summary

`TypesenseVectorStore.doSimilaritySearch` built the vector query by boxing every embedding value into a `Stream<Float>`, mapping each one to a `String` and joining an intermediate `List`.
This replaces that with a single pre-sized `StringBuilder`, so the query is written straight from the `float[]`.

The generated query string is byte-identical to the previous one, so Typesense request behavior is unchanged.

## Why

Query construction allocates proportionally to the embedding dimension, once per similarity search.
Measured allocated bytes per constructed query (`ThreadMXBean.getThreadAllocatedBytes`, values warmed up, embedding values uniform in `[-1, 1]`):

| dimensions | before | after | reduction |
| --- | --- | --- | --- |
| 384 | 54,680 B | 9,080 B | 83% |
| 768 | 108,744 B | 17,944 B | 83% |
| 1536 | 216,864 B | 35,728 B | 84% |
| 3072 | 433,144 B | 71,256 B | 84% |

The removed garbage is one `Float` box and one `String` per dimension, plus the intermediate `List` and the `StringJoiner` buffer.
The buffer is pre-sized at 12 characters per value, which is what a typical embedding value plus its separator needs, so the builder does not have to grow. Under-sizing it (for example at 8) costs a resize and lands at roughly 54 KB for 1536 dimensions instead of 36 KB.

This is an allocation measurement, not a JMH benchmark, and the win is small relative to the HTTP round trip that follows.

## Testing

`TypesenseVectorStoreTests` is new and pins the generated query format:

* the documented format for ordinary values
* the empty-embedding edge case
* `-0.0f`, `Float.MIN_VALUE` and `Float.MAX_VALUE`, which exercise the sign and scientific-notation formatting
* a 1536-dimension embedding, asserting that every value and separator is present

Validation run locally:

* `./mvnw -pl vector-stores/spring-ai-typesense-store clean package` — `Tests run: 33, Failures: 0, Errors: 0`, checkstyle and `spring-javaformat` pass
* Old and new construction compared over 20,106 inputs (including `NaN`, `±Infinity`, `-0.0f`, subnormals, `Float.MIN_VALUE`/`MAX_VALUE`, random bit patterns and `topK`/threshold combinations) — identical output in every case

`TypesenseVectorStoreIT` needs a running Typesense instance and was not executed.

## Notes

Supersedes #6151, which was opened against a much older `main` and never triaged. That branch is now stale; this one is rebased on current `main`, adds the extra format tests, and fixes the buffer capacity estimate that was too small to actually avoid the resize.

No associated issue.

