### PR TITLE
Avoid duplicate tool error messages

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -181,11 +181,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 	 * @return A Mono<CallToolResult> representing the error
 	 */
 	protected Mono<CallToolResult> createAsyncErrorResult(Exception e) {
-		Throwable rootCause = findCauseUsingPlainJava(e);
-		return Mono.just(CallToolResult.builder()
-			.isError(true)
-			.addTextContent(e.getMessage() + System.lineSeparator() + rootCause.getMessage())
-			.build());
+		return Mono.just(CallToolResult.builder().isError(true).addTextContent(createErrorResultMessage(e)).build());
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -232,15 +232,24 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 	 * Creates the message for an error {@link CallToolResult}, appending the root cause
 	 * message only when it adds information. An exception with no cause is its own root
 	 * cause, so appending unconditionally would report the same message twice.
+	 * <p>
+	 * Messages may be {@code null}: an exception thrown without one. Only the non-null
+	 * side is used, and when neither side has a message the exception's class name is
+	 * returned, since the text of an error result must not be null.
 	 * @param e The exception that occurred
-	 * @return The error message string
+	 * @return The error message string, never {@code null}
 	 */
 	protected String createErrorResultMessage(Throwable e) {
 		Throwable rootCause = findCauseUsingPlainJava(e);
-		if (rootCause == e || Objects.equals(rootCause.getMessage(), e.getMessage())) {
-			return e.getMessage();
+		String message = e.getMessage();
+		String rootCauseMessage = (rootCause == e) ? null : rootCause.getMessage();
+		if (rootCauseMessage == null || rootCauseMessage.equals(message)) {
+			return (message != null) ? message : e.getClass().getName();
 		}
-		return e.getMessage() + System.lineSeparator() + rootCause.getMessage();
+		if (message == null) {
+			return rootCauseMessage;
+		}
+		return message + System.lineSeparator() + rootCauseMessage;
 	}
 
 	protected abstract RC createRequestContext(T exchange, CallToolRequest request);

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -228,6 +228,21 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 		return rootCause;
 	}
 
+	/**
+	 * Creates the message for an error {@link CallToolResult}, appending the root cause
+	 * message only when it adds information. An exception with no cause is its own root
+	 * cause, so appending unconditionally would report the same message twice.
+	 * @param e The exception that occurred
+	 * @return The error message string
+	 */
+	protected String createErrorResultMessage(Throwable e) {
+		Throwable rootCause = findCauseUsingPlainJava(e);
+		if (rootCause == e || Objects.equals(rootCause.getMessage(), e.getMessage())) {
+			return e.getMessage();
+		}
+		return e.getMessage() + System.lineSeparator() + rootCause.getMessage();
+	}
+
 	protected abstract RC createRequestContext(T exchange, CallToolRequest request);
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractSyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractSyncMcpToolMethodCallback.java
@@ -71,11 +71,7 @@ public abstract class AbstractSyncMcpToolMethodCallback<T, RC extends McpRequest
 	 * @return A CallToolResult representing the error
 	 */
 	protected CallToolResult createSyncErrorResult(Exception e) {
-		Throwable rootCause = findCauseUsingPlainJava(e);
-		return CallToolResult.builder()
-			.isError(true)
-			.addTextContent(e.getMessage() + System.lineSeparator() + rootCause.getMessage())
-			.build();
+		return CallToolResult.builder().isError(true).addTextContent(createErrorResultMessage(e)).build();
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -131,6 +131,48 @@ public class AsyncMcpToolMethodCallbackExceptionHandlingTests {
 	}
 
 	@Test
+	public void exceptionWithoutAnyMessageFallsBackToClassName() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("noMessageTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("no-message-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).isEqualTo("java.lang.IllegalStateException");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void causeWithoutMessageIsNotAppended() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("nullMessageCauseTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("null-message-cause-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).isEqualTo("Outer failure: test");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void nullOuterMessageUsesRootCauseMessage() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("nullOuterMessageTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("null-outer-message-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).isEqualTo("Root cause: test");
+		}).verifyComplete();
+	}
+
+	@Test
 	public void declaredCheckedExceptionBubblesUp() throws Exception {
 		AsyncMcpToolMethodCallback callback = callbackFor("checkedExceptionTool");
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -315,6 +357,21 @@ public class AsyncMcpToolMethodCallbackExceptionHandlingTests {
 		public Mono<String> wrappedExceptionTool(String input) {
 			throw new IllegalStateException("Outer failure: " + input,
 					new IllegalArgumentException("Root cause: " + input));
+		}
+
+		@McpTool(name = "no-message-tool", description = "Throws an exception with no message and no cause")
+		public Mono<String> noMessageTool(String input) {
+			throw new IllegalStateException();
+		}
+
+		@McpTool(name = "null-message-cause-tool", description = "Throws an exception wrapping a cause with no message")
+		public Mono<String> nullMessageCauseTool(String input) {
+			throw new IllegalStateException("Outer failure: " + input, new IllegalArgumentException());
+		}
+
+		@McpTool(name = "null-outer-message-tool", description = "Throws an exception with no message wrapping a cause")
+		public Mono<String> nullOuterMessageTool(String input) {
+			throw new IllegalStateException(null, new IllegalArgumentException("Root cause: " + input));
 		}
 
 		@McpTool(name = "checked-exception-tool", description = "Throws declared checked exception")

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -102,6 +102,35 @@ public class AsyncMcpToolMethodCallbackExceptionHandlingTests {
 	}
 
 	@Test
+	public void exceptionWithoutCauseIsReportedOnce() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("illegalArgumentTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("illegal-argument-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).isEqualTo("Illegal argument: test");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void exceptionWithCauseAppendsRootCauseMessage() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("wrappedExceptionTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("wrapped-exception-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text())
+				.isEqualTo("Outer failure: test" + System.lineSeparator() + "Root cause: test");
+		}).verifyComplete();
+	}
+
+	@Test
 	public void declaredCheckedExceptionBubblesUp() throws Exception {
 		AsyncMcpToolMethodCallback callback = callbackFor("checkedExceptionTool");
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -280,6 +309,12 @@ public class AsyncMcpToolMethodCallbackExceptionHandlingTests {
 		@McpTool(name = "illegal-argument-tool", description = "Throws IllegalArgumentException")
 		public Mono<String> illegalArgumentTool(String input) {
 			throw new IllegalArgumentException("Illegal argument: " + input);
+		}
+
+		@McpTool(name = "wrapped-exception-tool", description = "Throws an exception wrapping a cause")
+		public Mono<String> wrappedExceptionTool(String input) {
+			throw new IllegalStateException("Outer failure: " + input,
+					new IllegalArgumentException("Root cause: " + input));
 		}
 
 		@McpTool(name = "checked-exception-tool", description = "Throws declared checked exception")

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -130,6 +130,46 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 	}
 
 	@Test
+	public void exceptionWithoutAnyMessageFallsBackToClassName() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("noMessageTool");
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("no-message-tool").arguments(Map.of("input", "test")).build();
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result.isError()).isTrue();
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("java.lang.IllegalStateException");
+	}
+
+	@Test
+	public void causeWithoutMessageIsNotAppended() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("nullMessageCauseTool");
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("null-message-cause-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result.isError()).isTrue();
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Outer failure: test");
+	}
+
+	@Test
+	public void nullOuterMessageUsesRootCauseMessage() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("nullOuterMessageTool");
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("null-outer-message-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result.isError()).isTrue();
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Root cause: test");
+	}
+
+	@Test
 	public void declaredCheckedExceptionBubblesUp() throws Exception {
 		SyncMcpToolMethodCallback callback = callbackFor("checkedExceptionTool");
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -252,6 +292,21 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 		public String wrappedExceptionTool(String input) {
 			throw new IllegalStateException("Outer failure: " + input,
 					new IllegalArgumentException("Root cause: " + input));
+		}
+
+		@McpTool(name = "no-message-tool", description = "Throws an exception with no message and no cause")
+		public String noMessageTool(String input) {
+			throw new IllegalStateException();
+		}
+
+		@McpTool(name = "null-message-cause-tool", description = "Throws an exception wrapping a cause with no message")
+		public String nullMessageCauseTool(String input) {
+			throw new IllegalStateException("Outer failure: " + input, new IllegalArgumentException());
+		}
+
+		@McpTool(name = "null-outer-message-tool", description = "Throws an exception with no message wrapping a cause")
+		public String nullOuterMessageTool(String input) {
+			throw new IllegalStateException(null, new IllegalArgumentException("Root cause: " + input));
 		}
 
 		@McpTool(name = "checked-exception-tool", description = "Throws declared checked exception")

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -101,6 +101,35 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 	}
 
 	@Test
+	public void exceptionWithoutCauseIsReportedOnce() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("illegalArgumentTool");
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("illegal-argument-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result.isError()).isTrue();
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Illegal argument: test");
+	}
+
+	@Test
+	public void exceptionWithCauseAppendsRootCauseMessage() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("wrappedExceptionTool");
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("wrapped-exception-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result.isError()).isTrue();
+		assertThat(((TextContent) result.content().get(0)).text())
+			.isEqualTo("Outer failure: test" + System.lineSeparator() + "Root cause: test");
+	}
+
+	@Test
 	public void declaredCheckedExceptionBubblesUp() throws Exception {
 		SyncMcpToolMethodCallback callback = callbackFor("checkedExceptionTool");
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -217,6 +246,12 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 		@McpTool(name = "illegal-argument-tool", description = "Throws IllegalArgumentException")
 		public String illegalArgumentTool(String input) {
 			throw new IllegalArgumentException("Illegal argument: " + input);
+		}
+
+		@McpTool(name = "wrapped-exception-tool", description = "Throws an exception wrapping a cause")
+		public String wrappedExceptionTool(String input) {
+			throw new IllegalStateException("Outer failure: " + input,
+					new IllegalArgumentException("Root cause: " + input));
 		}
 
 		@McpTool(name = "checked-exception-tool", description = "Throws declared checked exception")


### PR DESCRIPTION
The `@McpTool` method callbacks built their error text by appending the root cause message to the exception message.
findCauseUsingPlainJava returns the throwable itself when it has no cause, so an exception thrown directly by a tool - the common case for input validation - was reported twice, separated by a line separator.

Append the root cause message only when it adds information, via a shared createErrorResultMessage helper used by both createSyncErrorResult and createAsyncErrorResult.

Fixes #6948