### PR TITLE
Copy message lists when saving in-memory chat history

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/InMemoryChatMemoryRepository.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/InMemoryChatMemoryRepository.java
@@ -51,7 +51,7 @@ public final class InMemoryChatMemoryRepository implements ChatMemoryRepository 
 		Assert.hasText(conversationId, "conversationId cannot be null or empty");
 		Assert.notNull(messages, "messages cannot be null");
 		Assert.noNullElements(messages, "messages cannot contain null elements");
-		this.chatMemoryStore.put(conversationId, messages);
+		this.chatMemoryStore.put(conversationId, List.copyOf(messages));
 	}
 
 	@Override

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/InMemoryChatMemoryRepositoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/InMemoryChatMemoryRepositoryTests.java
@@ -85,6 +85,18 @@ public class InMemoryChatMemoryRepositoryTests {
 	}
 
 	@Test
+	void saveMessagesCopiesCallerOwnedList() {
+		String conversationId = UUID.randomUUID().toString();
+		Message message = new UserMessage("Hello");
+		List<Message> messages = new ArrayList<>(List.of(message));
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+		messages.clear();
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).containsExactly(message);
+	}
+
+	@Test
 	void findNonExistingConversation() {
 		String conversationId = UUID.randomUUID().toString();
 


### PR DESCRIPTION
Fixes #6952

`InMemoryChatMemoryRepository.saveAll` retains a caller-owned list, so clearing or reusing that list after saving silently changes the stored conversation. Store a defensive list snapshot and add a regression test that clears the original list after saving and checks that the saved message remains.

The existing null validation and overwrite behavior are preserved. This snapshots the list structure; it does not deep-copy messages.

Validation: the new regression fails against the unmodified implementation. After the fix, all 31 repository/message-window tests pass. The scoped reactor build passes with formatting and Checkstyle checks:

```text
./mvnw.cmd -B -pl spring-ai-model -am -Dtest=InMemoryChatMemoryRepositoryTests,MessageWindowChatMemoryTests -Dsurefire.failIfNoSpecifiedTests=false clean package
```

This does not include the full repository test suite or external integration tests. Environment: Windows 11, JDK 17.0.20.1, upstream commit `7374b63fcb6fd0e1950e70c9e04192a6826f2f2a`.

AI assistance was used for source inspection, implementation, and test preparation. The contributor reviewed and approved the patch before submission.