### PR TITLE
Parse out-of-range integer filter literals as Long

### DIFF
--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
@@ -231,7 +231,13 @@ public class FilterExpressionTextParser {
 
 		@Override
 		public Filter.Operand visitIntegerConstant(FiltersParser.IntegerConstantContext ctx) {
-			return new Filter.Value(Integer.valueOf(ctx.getText()));
+			String literal = ctx.getText();
+			try {
+				return new Filter.Value(Integer.valueOf(literal));
+			}
+			catch (NumberFormatException ex) {
+				return new Filter.Value(Long.valueOf(literal));
+			}
 		}
 
 		@Override

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParserTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParserTests.java
@@ -67,6 +67,28 @@ public class FilterExpressionTextParserTests {
 	}
 
 	@Test
+	public void testIntegerLiterals() {
+		// Literals within the Integer range remain Integer
+		Expression exp = this.parser.parse("timestamp == " + Integer.MAX_VALUE);
+		assertThat(exp.right()).isEqualTo(new Value(Integer.MAX_VALUE));
+
+		// Literals beyond the Integer range fall back to Long
+		exp = this.parser.parse("timestamp == " + Long.MAX_VALUE);
+		assertThat(exp.right()).isEqualTo(new Value(Long.MAX_VALUE));
+
+		exp = this.parser.parse("timestamp == " + Long.MIN_VALUE);
+		assertThat(exp.right()).isEqualTo(new Value(Long.MIN_VALUE));
+
+		// The explicit 'L' suffix keeps producing Long values
+		exp = this.parser.parse("timestamp == 9223372036854775807L");
+		assertThat(exp.right()).isEqualTo(new Value(Long.MAX_VALUE));
+
+		// Large literals are supported inside IN lists
+		exp = this.parser.parse("id in [" + Long.MAX_VALUE + ", 1]");
+		assertThat(exp.right()).isEqualTo(new Value(List.of(Long.MAX_VALUE, 1)));
+	}
+
+	@Test
 	public void tesEqAndGte() {
 		// genre == "drama" AND year >= 2020
 		Expression exp = this.parser.parse("genre == 'drama' && year >= 2020");


### PR DESCRIPTION
## Summary

`FilterExpressionTextParser` parses every unsuffixed integer literal with `Integer.valueOf`, so a filter containing a value outside the int range fails with `NumberFormatException` at parse time - independent of the vector store backend.

```
java.lang.NumberFormatException: For input string: "9223372036854775807"
```

This blocks filtering on `long` metadata values (for example deleting documents by a `long` id), as reported in #4705.

## Changes

- `visitIntegerConstant` keeps parsing with `Integer.valueOf` first, so in-range literals keep producing `Integer` values (fully backward compatible with existing converters and tests).
- When the literal does not fit an `int`, it falls back to `Long.valueOf`, matching the behavior of the already-supported explicit `l`/`L` suffix (`visitLongConstant`).
- Literals beyond the `long` range still raise `NumberFormatException`, unchanged.

## Testing

- Added `testIntegerLiterals` in `FilterExpressionTextParserTests` covering: in-range literals stay `Integer`, `Long.MAX_VALUE`/`Long.MIN_VALUE` parse as `Long`, the explicit `L` suffix keeps working, and large literals work inside `IN` lists.
- `FilterExpressionTextParserTests`: 16/16 pass.
- Full `spring-ai-vector-store` module suite: 163 tests, 0 failures.

Fixes #4705