### PR TITLE
Emit tool exception messages once when root cause adds nothing

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -181,11 +181,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 	 * @return A Mono<CallToolResult> representing the error
 	 */
 	protected Mono<CallToolResult> createAsyncErrorResult(Exception e) {
-		Throwable rootCause = findCauseUsingPlainJava(e);
-		return Mono.just(CallToolResult.builder()
-			.isError(true)
-			.addTextContent(e.getMessage() + System.lineSeparator() + rootCause.getMessage())
-			.build());
+		return Mono.just(CallToolResult.builder().isError(true).addTextContent(buildErrorText(e)).build());
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -211,6 +211,21 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 	}
 
 	/**
+	 * Builds the text conveyed to the model for an exception thrown by a tool method. The
+	 * root cause message is appended only when it adds information, so an exception
+	 * without a distinct root cause is not reported twice.
+	 * @param e The exception that occurred
+	 * @return The error text
+	 */
+	protected String buildErrorText(Exception e) {
+		Throwable rootCause = findCauseUsingPlainJava(e);
+		if (rootCause == e || Objects.equals(rootCause.getMessage(), e.getMessage())) {
+			return e.getMessage();
+		}
+		return e.getMessage() + System.lineSeparator() + rootCause.getMessage();
+	}
+
+	/**
 	 * Determines if the given parameter type is an exchange or context type that should
 	 * be injected. Subclasses must implement this method to specify which types are
 	 * considered exchange or context types.

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractSyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractSyncMcpToolMethodCallback.java
@@ -71,11 +71,7 @@ public abstract class AbstractSyncMcpToolMethodCallback<T, RC extends McpRequest
 	 * @return A CallToolResult representing the error
 	 */
 	protected CallToolResult createSyncErrorResult(Exception e) {
-		Throwable rootCause = findCauseUsingPlainJava(e);
-		return CallToolResult.builder()
-			.isError(true)
-			.addTextContent(e.getMessage() + System.lineSeparator() + rootCause.getMessage())
-			.build();
+		return CallToolResult.builder().isError(true).addTextContent(buildErrorText(e)).build();
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -102,6 +102,35 @@ public class AsyncMcpToolMethodCallbackExceptionHandlingTests {
 	}
 
 	@Test
+	public void exceptionWithoutCauseIsEmittedOnce() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("bareExceptionTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("bare-exception-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			assertThat(((TextContent) r.content().get(0)).text()).isEqualTo("Bare error: test");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void wrappedExceptionRetainsDistinctRootCauseMessage() throws Exception {
+		AsyncMcpToolMethodCallback callback = callbackFor("wrappedExceptionTool");
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("wrapped-exception-tool", Map.of("input", "test"));
+
+		Mono<CallToolResult> result = callback.apply(exchange, request);
+
+		StepVerifier.create(result).assertNext(r -> {
+			assertThat(r.isError()).isTrue();
+			String text = ((TextContent) r.content().get(0)).text();
+			assertThat(text).contains("Wrapper failed: test").contains("Root failure: test");
+		}).verifyComplete();
+	}
+
+	@Test
 	public void declaredCheckedExceptionBubblesUp() throws Exception {
 		AsyncMcpToolMethodCallback callback = callbackFor("checkedExceptionTool");
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -280,6 +309,17 @@ public class AsyncMcpToolMethodCallbackExceptionHandlingTests {
 		@McpTool(name = "illegal-argument-tool", description = "Throws IllegalArgumentException")
 		public Mono<String> illegalArgumentTool(String input) {
 			throw new IllegalArgumentException("Illegal argument: " + input);
+		}
+
+		@McpTool(name = "bare-exception-tool", description = "Throws an exception without a cause")
+		public Mono<String> bareExceptionTool(String input) {
+			throw new IllegalArgumentException("Bare error: " + input);
+		}
+
+		@McpTool(name = "wrapped-exception-tool", description = "Throws an exception wrapping another")
+		public Mono<String> wrappedExceptionTool(String input) {
+			throw new IllegalStateException("Wrapper failed: " + input,
+					new IllegalArgumentException("Root failure: " + input));
 		}
 
 		@McpTool(name = "checked-exception-tool", description = "Throws declared checked exception")

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -101,6 +101,35 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 	}
 
 	@Test
+	public void exceptionWithoutCauseIsEmittedOnce() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("bareExceptionTool");
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("bare-exception-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result.isError()).isTrue();
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Bare error: test");
+	}
+
+	@Test
+	public void wrappedExceptionRetainsDistinctRootCauseMessage() throws Exception {
+		SyncMcpToolMethodCallback callback = callbackFor("wrappedExceptionTool");
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = CallToolRequest.builder("wrapped-exception-tool")
+			.arguments(Map.of("input", "test"))
+			.build();
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result.isError()).isTrue();
+		String text = ((TextContent) result.content().get(0)).text();
+		assertThat(text).contains("Wrapper failed: test").contains("Root failure: test");
+	}
+
+	@Test
 	public void declaredCheckedExceptionBubblesUp() throws Exception {
 		SyncMcpToolMethodCallback callback = callbackFor("checkedExceptionTool");
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -217,6 +246,17 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 		@McpTool(name = "illegal-argument-tool", description = "Throws IllegalArgumentException")
 		public String illegalArgumentTool(String input) {
 			throw new IllegalArgumentException("Illegal argument: " + input);
+		}
+
+		@McpTool(name = "bare-exception-tool", description = "Throws an exception without a cause")
+		public String bareExceptionTool(String input) {
+			throw new IllegalArgumentException("Bare error: " + input);
+		}
+
+		@McpTool(name = "wrapped-exception-tool", description = "Throws an exception wrapping another")
+		public String wrappedExceptionTool(String input) {
+			throw new IllegalStateException("Wrapper failed: " + input,
+					new IllegalArgumentException("Root failure: " + input));
 		}
 
 		@McpTool(name = "checked-exception-tool", description = "Throws declared checked exception")


### PR DESCRIPTION
## Summary

The `@McpTool` method callbacks build their error text by concatenating the thrown exception's message with its root cause's message. `findCauseUsingPlainJava` returns the exception itself when it has no cause, so a bare exception (for example an `IllegalArgumentException` carrying an actionable validation message) reaches the client **twice**, separated by a line separator - as reported in #6948.

## Changes

- Added `buildErrorText` to `AbstractMcpToolMethodCallback`: it appends the root cause message only when it adds information (root cause differs from the thrown exception and its message differs), and shared it from `AbstractSyncMcpToolMethodCallback#createSyncErrorResult` and `AbstractAsyncMcpToolMethodCallback#createAsyncErrorResult`, which duplicated the same concatenation.
- Wrapped exceptions with a distinct root cause keep the existing two-line output, so no diagnostic information is lost.

## Testing

- Added `exceptionWithoutCauseIsEmittedOnce` (asserts the exact single message) and `wrappedExceptionRetainsDistinctRootCauseMessage` (asserts both messages survive) to `SyncMcpToolMethodCallbackExceptionHandlingTests` and `AsyncMcpToolMethodCallbackExceptionHandlingTests`.
- Full `mcp/mcp-annotations` module suite: 1380 tests, 0 failures.

Fixes #6948