### PR TITLE
Cache citation documents in Anthropic prompt caching

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -685,6 +685,17 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			}
 		}
 
+		// Citation documents are attached once, to the first user message. Repeating
+		// them on every user turn would re-send the source material on each request
+		// and place it after any cache breakpoint set on the previous turn.
+		int firstUserIndex = -1;
+		for (int i = 0; i < nonSystemMessages.size(); i++) {
+			if (nonSystemMessages.get(i).getMessageType() == MessageType.USER) {
+				firstUserIndex = i;
+				break;
+			}
+		}
+
 		// Pre-compute last user message index for CONVERSATION_HISTORY strategy
 		int lastUserIndex = -1;
 		if (cacheResolver.isCachingEnabled()) {
@@ -715,7 +726,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 			if (message.getMessageType() == MessageType.USER) {
 				UserMessage userMessage = (UserMessage) message;
-				boolean hasCitationDocs = !CollectionUtils.isEmpty(citationDocuments);
+				boolean hasCitationDocs = !CollectionUtils.isEmpty(citationDocuments) && i == firstUserIndex;
 				boolean hasMedia = !CollectionUtils.isEmpty(userMessage.getMedia());
 				boolean isLastUserMessage = (i == lastUserIndex);
 				boolean applyCacheToUser = isLastUserMessage && cacheResolver.isCachingEnabled();
@@ -730,10 +741,21 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				if (hasCitationDocs || hasMedia || userCacheControl != null) {
 					List<ContentBlockParam> contentBlocks = new ArrayList<>();
 
-					// Prepend citation document blocks to the first user message
+					// Prepend citation documents to the first user message. The cache
+					// breakpoint goes on the last document to cover the whole set.
 					if (hasCitationDocs) {
-						for (AnthropicCitationDocument doc : Objects.requireNonNull(citationDocuments)) {
-							contentBlocks.add(ContentBlockParam.ofDocument(doc.toDocumentBlockParam()));
+						List<AnthropicCitationDocument> documents = Objects.requireNonNull(citationDocuments);
+						CacheControlEphemeral documentCacheControl = cacheResolver
+							.resolveCitationDocumentCacheControl();
+						for (int d = 0; d < documents.size(); d++) {
+							DocumentBlockParam.Builder documentBuilder = documents.get(d)
+								.toDocumentBlockParam()
+								.toBuilder();
+							if (documentCacheControl != null && d == documents.size() - 1) {
+								documentBuilder.cacheControl(documentCacheControl);
+								cacheResolver.useCacheBlock();
+							}
+							contentBlocks.add(ContentBlockParam.ofDocument(documentBuilder.build()));
 						}
 					}
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/CacheEligibilityResolver.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/CacheEligibilityResolver.java
@@ -133,6 +133,44 @@ public class CacheEligibilityResolver {
 		return CacheControlEphemeral.builder().ttl(cacheTtl.getSdkTtl()).build();
 	}
 
+	/**
+	 * Resolves the cache control for citation documents. Documents are stable reference
+	 * material in the same way as the system prompt, so they receive a breakpoint under
+	 * every strategy that caches system content, using the {@code SYSTEM} TTL. Under
+	 * {@link AnthropicCacheStrategy#TOOLS_ONLY} documents are not cached, because a
+	 * breakpoint on a document would also cache the system prompt that precedes it.
+	 * @return the cache control to apply to the last document block, or {@code null} if
+	 * documents are not cached under the current strategy or all breakpoints are used
+	 * @since 2.1.0
+	 */
+	public @Nullable CacheControlEphemeral resolveCitationDocumentCacheControl() {
+		if (this.cacheStrategy != AnthropicCacheStrategy.SYSTEM_ONLY
+				&& this.cacheStrategy != AnthropicCacheStrategy.SYSTEM_AND_TOOLS
+				&& this.cacheStrategy != AnthropicCacheStrategy.CONVERSATION_HISTORY) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Caching not enabled for citation documents, cacheStrategy=" + this.cacheStrategy);
+			}
+			return null;
+		}
+
+		if (this.cacheBreakpointTracker.allBreakpointsAreUsed()) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Caching not enabled for citation documents, usedBreakpoints="
+						+ this.cacheBreakpointTracker.getCount());
+			}
+			return null;
+		}
+
+		AnthropicCacheTtl cacheTtl = this.messageTypeTtl.get(MessageType.SYSTEM);
+		Assert.state(cacheTtl != null, "messageTypeTtl must contain a 'system' entry");
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Caching enabled for citation documents, ttl=" + cacheTtl);
+		}
+
+		return CacheControlEphemeral.builder().ttl(cacheTtl.getSdkTtl()).build();
+	}
+
 	public boolean isCachingEnabled() {
 		return this.cacheStrategy != AnthropicCacheStrategy.NONE;
 	}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
@@ -51,6 +51,7 @@ import com.anthropic.models.messages.StopReason;
 import com.anthropic.models.messages.TextBlock;
 import com.anthropic.models.messages.ThinkingBlock;
 import com.anthropic.models.messages.ToolResultBlockParam;
+import com.anthropic.models.messages.ToolUnion;
 import com.anthropic.models.messages.ToolUseBlock;
 import com.anthropic.models.messages.Usage;
 import com.anthropic.services.async.MessageServiceAsync;
@@ -960,6 +961,141 @@ class AnthropicChatModelTests {
 		assertThat(rateLimit.getRequestsRemaining()).isEqualTo(99L);
 		assertThat(rateLimit.getTokensLimit()).isEqualTo(50000L);
 		assertThat(rateLimit.getTokensRemaining()).isEqualTo(49000L);
+	}
+
+	@Test
+	void citationDocumentsAreSentOnlyInFirstUserMessage() {
+		Message mockResponse = createMockMessage("Answer", StopReason.END_TURN);
+		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(mockResponse);
+
+		AnthropicCitationDocument document = AnthropicCitationDocument.builder()
+			.plainText("Reference material")
+			.title("Reference")
+			.citationsEnabled(true)
+			.build();
+		AnthropicChatOptions options = AnthropicChatOptions.builder().citationDocuments(document).build();
+
+		UserMessage user1 = new UserMessage("First question");
+		AssistantMessage assistant1 = new AssistantMessage("First answer");
+		UserMessage user2 = new UserMessage("Second question");
+
+		this.chatModel.call(new Prompt(List.of(user1, assistant1, user2), options));
+
+		ArgumentCaptor<MessageCreateParams> captor = ArgumentCaptor.forClass(MessageCreateParams.class);
+		verify(this.messageService).create(captor.capture());
+
+		List<MessageParam> messages = captor.getValue().messages();
+		assertThat(messages).hasSize(3);
+
+		List<ContentBlockParam> firstUserBlocks = messages.get(0).content().blockParams().orElseThrow();
+		assertThat(firstUserBlocks).hasSize(2);
+		assertThat(firstUserBlocks.get(0).isDocument()).isTrue();
+		assertThat(firstUserBlocks.get(1).asText().text()).isEqualTo("First question");
+
+		assertThat(messages.get(2).content().string()).contains("Second question");
+		assertThat(messages.get(2).content().blockParams()).isEmpty();
+
+		long documentBlocks = messages.stream()
+			.flatMap(message -> message.content().blockParams().stream().flatMap(List::stream))
+			.filter(ContentBlockParam::isDocument)
+			.count();
+		assertThat(documentBlocks).isEqualTo(1);
+	}
+
+	@Test
+	void citationDocumentCacheBreakpointPerStrategy() {
+		assertThat(lastDocumentHasCacheControl(AnthropicCacheStrategy.NONE)).isFalse();
+		assertThat(lastDocumentHasCacheControl(AnthropicCacheStrategy.TOOLS_ONLY)).isFalse();
+		assertThat(lastDocumentHasCacheControl(AnthropicCacheStrategy.SYSTEM_ONLY)).isTrue();
+		assertThat(lastDocumentHasCacheControl(AnthropicCacheStrategy.SYSTEM_AND_TOOLS)).isTrue();
+		assertThat(lastDocumentHasCacheControl(AnthropicCacheStrategy.CONVERSATION_HISTORY)).isTrue();
+	}
+
+	@Test
+	void citationDocumentCacheBreakpointGoesOnLastDocumentOnly() {
+		AnthropicCitationDocument first = AnthropicCitationDocument.builder().plainText("First").build();
+		AnthropicCitationDocument second = AnthropicCitationDocument.builder().plainText("Second").build();
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.citationDocuments(first, second)
+			.cacheOptions(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.SYSTEM_ONLY).build())
+			.build();
+
+		MessageCreateParams request = this.chatModel.createRequest(new Prompt("Question", options), false);
+
+		List<ContentBlockParam> blocks = request.messages().get(0).content().blockParams().orElseThrow();
+		assertThat(blocks).hasSize(3);
+		assertThat(blocks.get(0).asDocument().cacheControl()).isEmpty();
+		assertThat(blocks.get(1).asDocument().cacheControl()).isPresent();
+		// SYSTEM_ONLY does not cache the user text
+		assertThat(blocks.get(2).asText().cacheControl()).isEmpty();
+	}
+
+	@Test
+	void citationDocumentAndUserTextBothCachedUnderConversationHistory() {
+		// Batch Q&A over the same document: each request is a fresh single-turn
+		// prompt, so the document breakpoint is what produces cache hits across
+		// requests while the user text breakpoint changes every time.
+		AnthropicCitationDocument document = AnthropicCitationDocument.builder().plainText("Reference").build();
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.citationDocuments(document)
+			.cacheOptions(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY).build())
+			.build();
+
+		MessageCreateParams request = this.chatModel.createRequest(new Prompt("Question", options), false);
+
+		List<ContentBlockParam> blocks = request.messages().get(0).content().blockParams().orElseThrow();
+		assertThat(blocks).hasSize(2);
+		assertThat(blocks.get(0).asDocument().cacheControl()).isPresent();
+		assertThat(blocks.get(1).asText().cacheControl()).isPresent();
+	}
+
+	@Test
+	void citationDocumentBreakpointTakesPrecedenceOverToolDefinitions() {
+		// System, document, last user text, and last tool result each take a
+		// breakpoint, which is all four. Tool definitions are resolved last and get
+		// none. That is harmless: tools precede the system prompt in the request and
+		// are inside the prefix cached by the system breakpoint.
+		AnthropicCitationDocument document = AnthropicCitationDocument.builder().plainText("Reference").build();
+		AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+			.cacheToolResults(true)
+			.build();
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.citationDocuments(document)
+			.cacheOptions(cacheOptions)
+			.toolCallbacks(List.of(new TestToolCallback("getWeather")))
+			.build();
+
+		List<org.springframework.ai.chat.messages.Message> messages = new java.util.ArrayList<>();
+		messages.add(new SystemMessage("You are a helpful assistant."));
+		messages.addAll(toolCallingConversation());
+
+		MessageCreateParams request = this.chatModel.createRequest(new Prompt(messages, options), false);
+
+		assertThat(request.system().orElseThrow().asTextBlockParams().get(0).cacheControl()).isPresent();
+
+		List<ContentBlockParam> firstUserBlocks = request.messages().get(0).content().blockParams().orElseThrow();
+		assertThat(firstUserBlocks.get(0).asDocument().cacheControl()).isPresent();
+		assertThat(firstUserBlocks.get(1).asText().cacheControl()).isPresent();
+
+		assertThat(lastToolResultBlock(request).cacheControl()).isPresent();
+
+		List<ToolUnion> tools = request.tools().orElseThrow();
+		assertThat(tools).hasSize(1);
+		assertThat(tools.get(0).asTool().cacheControl()).isEmpty();
+	}
+
+	private boolean lastDocumentHasCacheControl(AnthropicCacheStrategy strategy) {
+		AnthropicCitationDocument document = AnthropicCitationDocument.builder().plainText("Reference").build();
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.citationDocuments(document)
+			.cacheOptions(AnthropicCacheOptions.builder().strategy(strategy).build())
+			.build();
+
+		MessageCreateParams request = this.chatModel.createRequest(new Prompt("Question", options), false);
+
+		List<ContentBlockParam> blocks = request.messages().get(0).content().blockParams().orElseThrow();
+		return blocks.get(0).asDocument().cacheControl().isPresent();
 	}
 
 	static class TestToolCallback implements ToolCallback {

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/CacheEligibilityResolverTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/CacheEligibilityResolverTests.java
@@ -255,4 +255,44 @@ class CacheEligibilityResolverTests {
 		assertThat(cc.ttl().get()).isEqualTo(CacheControlEphemeral.Ttl.TTL_1H);
 	}
 
+	@Test
+	void citationDocumentCacheControlRespectsStrategy() {
+		CacheEligibilityResolver none = CacheEligibilityResolver
+			.from(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.NONE).build());
+		assertThat(none.resolveCitationDocumentCacheControl()).isNull();
+
+		// TOOLS_ONLY must not cache documents: a document breakpoint would also cache
+		// the system prompt that precedes it.
+		CacheEligibilityResolver toolsOnly = CacheEligibilityResolver
+			.from(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.TOOLS_ONLY).build());
+		assertThat(toolsOnly.resolveCitationDocumentCacheControl()).isNull();
+
+		CacheEligibilityResolver systemOnly = CacheEligibilityResolver
+			.from(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.SYSTEM_ONLY).build());
+		assertThat(systemOnly.resolveCitationDocumentCacheControl()).isNotNull();
+
+		// Documents use the SYSTEM TTL
+		CacheEligibilityResolver sysAndTools = CacheEligibilityResolver.from(AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.SYSTEM_AND_TOOLS)
+			.messageTypeTtl(MessageType.SYSTEM, AnthropicCacheTtl.ONE_HOUR)
+			.build());
+		CacheControlEphemeral cc = sysAndTools.resolveCitationDocumentCacheControl();
+		assertThat(cc).isNotNull();
+		assertThat(cc.ttl()).contains(CacheControlEphemeral.Ttl.TTL_1H);
+
+		CacheEligibilityResolver history = CacheEligibilityResolver
+			.from(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY).build());
+		assertThat(history.resolveCitationDocumentCacheControl()).isNotNull();
+	}
+
+	@Test
+	void citationDocumentCacheControlRespectsBreakpointLimit() {
+		CacheEligibilityResolver resolver = CacheEligibilityResolver
+			.from(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY).build());
+		for (int i = 0; i < 4; i++) {
+			resolver.useCacheBlock();
+		}
+		assertThat(resolver.resolveCitationDocumentCacheControl()).isNull();
+	}
+
 }

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicPromptCachingIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicPromptCachingIT.java
@@ -31,6 +31,7 @@ import org.springframework.ai.anthropic.AnthropicCacheStrategy;
 import org.springframework.ai.anthropic.AnthropicCacheTtl;
 import org.springframework.ai.anthropic.AnthropicChatModel;
 import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.anthropic.AnthropicCitationDocument;
 import org.springframework.ai.anthropic.AnthropicTestConfiguration;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -458,6 +459,44 @@ class AnthropicPromptCachingIT {
 			.withFailMessage("Expected either cache creation or cache read tokens, but got creation=%d, read=%d",
 					cacheCreation, cacheRead)
 			.isTrue();
+	}
+
+	@Test
+	void shouldCachePdfCitationDocumentAcrossRequests() throws IOException {
+		// Batch Q&A over one PDF: every request is a fresh single-turn prompt, so the
+		// only breakpoint that can produce cache reads is the one on the document.
+		AnthropicCitationDocument document = AnthropicCitationDocument.builder()
+			.pdfFile("src/test/resources/spring-ai-reference-overview.pdf")
+			.title("Spring AI Reference")
+			.citationsEnabled(true)
+			.build();
+
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.model(Model.CLAUDE_SONNET_4_5.asString())
+			.citationDocuments(document)
+			.cacheOptions(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.SYSTEM_ONLY).build())
+			.maxTokens(150)
+			.temperature(0.0)
+			.build();
+
+		ChatResponse first = this.chatModel
+			.call(new Prompt(List.of(new UserMessage("Based only on the document, what is Spring AI?")), options));
+		Usage firstUsage = getSdkUsage(first);
+		assertThat(firstUsage).isNotNull();
+		long firstCreation = firstUsage.cacheCreationInputTokens().orElse(0L);
+		long firstRead = firstUsage.cacheReadInputTokens().orElse(0L);
+		assertThat(firstCreation > 0 || firstRead > 0)
+			.withFailMessage("Expected the document to be written to or read from cache, but got creation=%d, read=%d",
+					firstCreation, firstRead)
+			.isTrue();
+
+		ChatResponse second = this.chatModel.call(new Prompt(
+				List.of(new UserMessage("Based only on the document, which models does it support?")), options));
+		Usage secondUsage = getSdkUsage(second);
+		assertThat(secondUsage).isNotNull();
+		assertThat(secondUsage.cacheReadInputTokens().orElse(0L))
+			.as("Second request should read the document from cache")
+			.isGreaterThan(0);
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -709,6 +709,33 @@ ChatResponse response = chatModel.call(
 );
 ----
 
+=== Caching Citation Documents
+
+Citation documents are sent as part of the first user message and are typically large and identical across requests, which makes them a natural fit for xref:_prompt_caching[prompt caching].
+When a cache strategy other than `NONE` or `TOOLS_ONLY` is active, a cache breakpoint is placed on the last citation document block.
+The breakpoint covers all documents in the request, and Anthropic reads them from cache on subsequent requests that send the same documents.
+
+[source,java]
+----
+AnthropicCitationDocument document = AnthropicCitationDocument.builder()
+    .pdf(pdfBytes)
+    .title("Annual Report")
+    .citationsEnabled(true)
+    .build();
+
+AnthropicChatOptions options = AnthropicChatOptions.builder()
+    .citationDocuments(document)
+    .cacheOptions(AnthropicCacheOptions.builder()
+        .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+        .build())
+    .build();
+----
+
+The document breakpoint uses the `MessageType.SYSTEM` TTL and consumes one of the four cache breakpoints allowed per request.
+`TOOLS_ONLY` does not cache documents, because a breakpoint on a document block would also cache the system prompt that precedes it.
+
+In a multi-turn conversation the documents are attached only to the first user message, so the cached prefix stays stable as the conversation grows.
+
 === Accessing Citations
 
 Citations are returned in the response metadata:
@@ -896,10 +923,10 @@ Five caching strategies are available via `AnthropicCacheStrategy`:
 | Strategy | Description
 
 | `NONE` | No caching (default). No cache control headers are added.
-| `SYSTEM_ONLY` | Cache system message content. Uses 1 cache breakpoint.
+| `SYSTEM_ONLY` | Cache system message content and citation documents. Uses up to 2 cache breakpoints.
 | `TOOLS_ONLY` | Cache tool definitions only. Uses 1 cache breakpoint.
-| `SYSTEM_AND_TOOLS` | Cache both system messages and tool definitions. Uses 2 cache breakpoints.
-| `CONVERSATION_HISTORY` | Cache system messages, tool definitions, and conversation messages. Uses up to 4 cache breakpoints.
+| `SYSTEM_AND_TOOLS` | Cache system messages, tool definitions, and citation documents. Uses up to 3 cache breakpoints.
+| `CONVERSATION_HISTORY` | Cache system messages, tool definitions, citation documents, and conversation messages. Uses up to 4 cache breakpoints.
 |====
 
 NOTE: Anthropic allows a maximum of 4 cache breakpoints per request. The implementation tracks breakpoint usage and stops adding cache control once the limit is reached.
@@ -963,7 +990,9 @@ var cacheOptions = AnthropicCacheOptions.builder()
     .build();
 ----
 
-The breakpoint moves to the latest tool result on each round, so the previous rounds' tool outputs are read from cache while the newest is written. This consumes one additional cache breakpoint (Anthropic allows up to four per request), leaving room for the tool, system, and last-user breakpoints under `CONVERSATION_HISTORY`. The TTL and minimum content length are configurable via `messageTypeTtl(MessageType.TOOL, ...)` and `messageTypeMinContentLength(MessageType.TOOL, ...)`.
+The breakpoint moves to the latest tool result on each round, so the previous rounds' tool outputs are read from cache while the newest is written. This consumes one additional cache breakpoint (Anthropic allows up to four per request), leaving room for the tool, system, and last-user breakpoints under `CONVERSATION_HISTORY`.
+If citation documents are also present, five breakpoints compete for four slots and the tool definition breakpoint is dropped.
+This does not affect caching, since tool definitions precede the system prompt in the request and are covered by the system breakpoint. The TTL and minimum content length are configurable via `messageTypeTtl(MessageType.TOOL, ...)` and `messageTypeMinContentLength(MessageType.TOOL, ...)`.
 
 === Multi-Block System Caching
 


### PR DESCRIPTION
Citation documents never got a cache breakpoint. With SYSTEM_ONLY or SYSTEM_AND_TOOLS they sat after the last breakpoint and were sent uncached on every request, which is the opposite of what you want for a large PDF.

Attach the documents to the first user message only. They were repeated on every user message, so multi-turn prompts re-sent the PDF each turn.

Put a breakpoint on the last document block under every strategy that caches system content, using the SYSTEM TTL. TOOLS_ONLY is left out since a breakpoint there would also cache the system prompt.

Fixes #5106
