### PR TITLE
Support graceful degradation for MCP clients

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
@@ -23,6 +23,8 @@ import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.ai.mcp.annotation.spring.ClientMcpAsyncHandlersRegistry;
 import org.springframework.ai.mcp.annotation.spring.ClientMcpSyncHandlersRegistry;
@@ -59,6 +61,8 @@ import org.springframework.util.CollectionUtils;
  * <li>{@code spring.ai.mcp.client.request-timeout} - Request timeout duration
  * <li>{@code spring.ai.mcp.client.initialized} - Whether to initialize clients on
  * creation
+ * <li>{@code spring.ai.mcp.client.fail-fast} - Whether client initialization and tool
+ * discovery failures should be fatal (default: true)
  * </ul>
  *
  * <p>
@@ -101,6 +105,8 @@ import org.springframework.util.CollectionUtils;
 @ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
 		matchIfMissing = true)
 public class McpClientAutoConfiguration {
+
+	private static final Log logger = LogFactory.getLog(McpClientAutoConfiguration.class);
 
 	/**
 	 * Create a dynamic client name based on the client name and the name of the server
@@ -187,7 +193,16 @@ public class McpClientAutoConfiguration {
 				var client = customizedSpec.build();
 
 				if (commonProperties.isInitialized()) {
-					client.initialize();
+					try {
+						client.initialize();
+					}
+					catch (RuntimeException ex) {
+						if (commonProperties.isFailFast()) {
+							throw ex;
+						}
+						logger.warn("Failed to initialize MCP client for connection '" + namedTransport.name()
+								+ "'. The client will be retried on demand", ex);
+					}
 				}
 
 				mcpSyncClients.add(client);
@@ -278,7 +293,16 @@ public class McpClientAutoConfiguration {
 				var client = customizedSpec.build();
 
 				if (commonProperties.isInitialized()) {
-					client.initialize().block();
+					try {
+						client.initialize().block();
+					}
+					catch (RuntimeException ex) {
+						if (commonProperties.isFailFast()) {
+							throw ex;
+						}
+						logger.warn("Failed to initialize MCP client for connection '" + namedTransport.name()
+								+ "'. The client will be retried on demand", ex);
+					}
 				}
 
 				mcpAsyncClients.add(client);

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfiguration.java
@@ -63,6 +63,8 @@ public class McpToolCallbackAutoConfiguration {
 	 * filter the discovered tools
 	 * @param syncMcpClients provider of MCP sync clients
 	 * @param mcpToolNamePrefixGenerator the tool name prefix generator
+	 * @param toolContextToMcpMetaConverter the tool context to MCP metadata converter
+	 * @param commonProperties common MCP client properties
 	 * @return list of tool callbacks for MCP integration
 	 */
 	@Bean
@@ -71,7 +73,8 @@ public class McpToolCallbackAutoConfiguration {
 	public SyncMcpToolCallbackProvider mcpToolCallbacks(ObjectProvider<McpToolFilter> syncClientsToolFilter,
 			ObjectProvider<List<McpSyncClient>> syncMcpClients,
 			ObjectProvider<McpToolNamePrefixGenerator> mcpToolNamePrefixGenerator,
-			ObjectProvider<ToolContextToMcpMetaConverter> toolContextToMcpMetaConverter) {
+			ObjectProvider<ToolContextToMcpMetaConverter> toolContextToMcpMetaConverter,
+			McpClientCommonProperties commonProperties) {
 
 		List<McpSyncClient> mcpClients = syncMcpClients.stream().flatMap(List::stream).toList();
 
@@ -82,6 +85,7 @@ public class McpToolCallbackAutoConfiguration {
 					mcpToolNamePrefixGenerator.getIfUnique(() -> McpToolNamePrefixGenerator.noPrefix()))
 			.toolContextToMcpMetaConverter(
 					toolContextToMcpMetaConverter.getIfUnique(() -> ToolContextToMcpMetaConverter.defaultConverter()))
+			.failFast(commonProperties.isFailFast())
 			.build();
 	}
 
@@ -90,7 +94,8 @@ public class McpToolCallbackAutoConfiguration {
 	public AsyncMcpToolCallbackProvider mcpAsyncToolCallbacks(ObjectProvider<McpToolFilter> asyncClientsToolFilter,
 			ObjectProvider<List<McpAsyncClient>> mcpClientsProvider,
 			ObjectProvider<McpToolNamePrefixGenerator> toolNamePrefixGenerator,
-			ObjectProvider<ToolContextToMcpMetaConverter> toolContextToMcpMetaConverter) { // TODO
+			ObjectProvider<ToolContextToMcpMetaConverter> toolContextToMcpMetaConverter,
+			McpClientCommonProperties commonProperties) { // TODO
 		List<McpAsyncClient> mcpClients = mcpClientsProvider.stream().flatMap(List::stream).toList();
 		return AsyncMcpToolCallbackProvider.builder()
 			.toolFilter(asyncClientsToolFilter.getIfUnique(() -> (McpAsyncClient, tool) -> true))
@@ -98,6 +103,7 @@ public class McpToolCallbackAutoConfiguration {
 			.toolContextToMcpMetaConverter(
 					toolContextToMcpMetaConverter.getIfUnique(() -> ToolContextToMcpMetaConverter.defaultConverter()))
 			.mcpClients(mcpClients)
+			.failFast(commonProperties.isFailFast())
 			.build();
 	}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonProperties.java
@@ -56,6 +56,14 @@ public class McpClientCommonProperties {
 	private boolean initialized = true;
 
 	/**
+	 * Whether a failure to initialize a client or discover its tools should be fatal.
+	 * <p>
+	 * When set to false, unavailable clients are skipped and retried on a subsequent
+	 * operation, allowing other clients to remain available.
+	 */
+	private boolean failFast = true;
+
+	/**
 	 * The timeout duration for MCP client requests.
 	 * <p>
 	 * Defaults to 20 seconds.
@@ -135,6 +143,24 @@ public class McpClientCommonProperties {
 
 	public void setInitialized(boolean initialized) {
 		this.initialized = initialized;
+	}
+
+	/**
+	 * Return whether client initialization and tool discovery failures are fatal.
+	 * @return whether failures are fatal
+	 * @since 2.0.2
+	 */
+	public boolean isFailFast() {
+		return this.failFast;
+	}
+
+	/**
+	 * Set whether client initialization and tool discovery failures are fatal.
+	 * @param failFast whether failures are fatal
+	 * @since 2.0.2
+	 */
+	public void setFailFast(boolean failFast) {
+		this.failFast = failFast;
 	}
 
 	public Duration getRequestTimeout() {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfigurationIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.mcp.client.common.autoconfigure;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import io.modelcontextprotocol.client.McpAsyncClient;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.SyncMcpToolCallbackProvider;
 import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpClientAnnotationScannerAutoConfiguration;
 import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpSyncClientConfigurer;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
@@ -133,6 +135,51 @@ public class McpClientAutoConfigurationIT {
 				assertThat(properties.getType()).isEqualTo(McpClientCommonProperties.ClientType.ASYNC);
 				assertThat(properties.getRequestTimeout()).isEqualTo(Duration.ofSeconds(60));
 				assertThat(properties.isInitialized()).isFalse();
+			});
+	}
+
+	@Test
+	void syncClientInitializationFailureIsFatalByDefault() {
+		this.contextRunner.withUserConfiguration(FailingTransportConfiguration.class)
+			.run(context -> assertThat(context).hasFailed());
+	}
+
+	@Test
+	void asyncClientInitializationFailureIsFatalByDefault() {
+		this.contextRunner.withUserConfiguration(FailingTransportConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.type=ASYNC")
+			.run(context -> assertThat(context).hasFailed());
+	}
+
+	@Test
+	void syncClientInitializationFailureCanBeIgnored() {
+		this.contextRunner.withUserConfiguration(FailingTransportConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.fail-fast=false")
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context.getBean("mcpSyncClients", List.class)).hasSize(1);
+			});
+	}
+
+	@Test
+	void asyncClientInitializationFailureCanBeIgnored() {
+		this.contextRunner.withUserConfiguration(FailingTransportConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.type=ASYNC", "spring.ai.mcp.client.fail-fast=false")
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context.getBean("mcpAsyncClients", List.class)).hasSize(1);
+			});
+	}
+
+	@Test
+	void healthyToolsRemainAvailableWhenAnotherClientIsUnavailable() {
+		this.contextRunner.withUserConfiguration(MixedTransportConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.fail-fast=false")
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context.getBean(SyncMcpToolCallbackProvider.class).getToolCallbacks())
+					.extracting(callback -> callback.getToolDefinition().name())
+					.containsExactly("echo");
 			});
 	}
 
@@ -266,6 +313,35 @@ public class McpClientAutoConfigurationIT {
 	}
 
 	@Configuration
+	static class FailingTransportConfiguration {
+
+		@Bean
+		List<NamedClientMcpTransport> failingTransports() {
+			McpClientTransport mockTransport = Mockito.mock(McpClientTransport.class);
+			Mockito.when(mockTransport.protocolVersions()).thenReturn(List.of("2024-11-05"));
+			Mockito.when(mockTransport.connect(Mockito.any()))
+				.thenReturn(Mono.error(new IllegalStateException("Connection unavailable")));
+			return List.of(new NamedClientMcpTransport("unavailable", mockTransport));
+		}
+
+	}
+
+	@Configuration
+	static class MixedTransportConfiguration {
+
+		@Bean
+		List<NamedClientMcpTransport> mixedTransports() {
+			McpClientTransport failingTransport = Mockito.mock(McpClientTransport.class);
+			Mockito.when(failingTransport.protocolVersions()).thenReturn(List.of("2024-11-05"));
+			Mockito.when(failingTransport.connect(Mockito.any()))
+				.thenReturn(Mono.error(new IllegalStateException("Connection unavailable")));
+			return List.of(new NamedClientMcpTransport("healthy", new HealthyClientTransport()),
+					new NamedClientMcpTransport("unavailable", failingTransport));
+		}
+
+	}
+
+	@Configuration
 	static class CustomTransportConfiguration {
 
 		@Bean
@@ -312,6 +388,59 @@ public class McpClientAutoConfigurationIT {
 		@Override
 		public Mono<Void> closeGracefully() {
 			return Mono.empty(); // Test implementation
+		}
+
+	}
+
+	static class HealthyClientTransport implements McpClientTransport {
+
+		private Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> messageHandler = messages -> Mono
+			.empty();
+
+		@Override
+		public Mono<Void> connect(
+				Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> messageHandler) {
+			this.messageHandler = messageHandler;
+			return Mono.empty();
+		}
+
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+			if (!(message instanceof McpSchema.JSONRPCRequest request)) {
+				return Mono.empty();
+			}
+
+			Object result;
+			if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+				McpSchema.InitializeRequest initializeRequest = (McpSchema.InitializeRequest) request.params();
+				result = McpSchema.InitializeResult
+					.builder(initializeRequest.protocolVersion(),
+							McpSchema.ServerCapabilities.builder().tools(false).build(),
+							new McpSchema.Implementation("healthy-server", "1.0.0"))
+					.build();
+			}
+			else if (McpSchema.METHOD_TOOLS_LIST.equals(request.method())) {
+				McpSchema.Tool tool = McpSchema.Tool.builder("echo", Map.of("type", "object"))
+					.description("Echo")
+					.build();
+				result = McpSchema.ListToolsResult.builder(List.of(tool)).build();
+			}
+			else {
+				return Mono.empty();
+			}
+
+			return this.messageHandler.apply(Mono.just(McpSchema.JSONRPCResponse.result(request.id(), result))).then();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return (T) data;
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfigurationTests.java
@@ -24,6 +24,7 @@ import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.mcp.AsyncMcpToolCallbackProvider;
@@ -39,6 +40,7 @@ import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class McpToolCallbackAutoConfigurationTests {
 
@@ -248,6 +250,22 @@ public class McpToolCallbackAutoConfigurationTests {
 		});
 	}
 
+	@Test
+	void failFastPropertyConfiguresSyncToolDiscovery() {
+		this.applicationContext.withUserConfiguration(FailingSyncClientConfig.class)
+			.withPropertyValues("spring.ai.mcp.client.fail-fast=false")
+			.run(context -> assertThat(context.getBean(SyncMcpToolCallbackProvider.class).getToolCallbacks())
+				.isEmpty());
+	}
+
+	@Test
+	void failFastPropertyConfiguresAsyncToolDiscovery() {
+		this.applicationContext.withUserConfiguration(FailingAsyncClientConfig.class)
+			.withPropertyValues("spring.ai.mcp.client.type=ASYNC", "spring.ai.mcp.client.fail-fast=false")
+			.run(context -> assertThat(context.getBean(AsyncMcpToolCallbackProvider.class).getToolCallbacks())
+				.isEmpty());
+	}
+
 	@Configuration
 	static class CustomPrefixGeneratorConfig {
 
@@ -343,6 +361,30 @@ public class McpToolCallbackAutoConfigurationTests {
 		@Bean
 		public McpAsyncClient mcpAsyncClient2() {
 			return mock(McpAsyncClient.class);
+		}
+
+	}
+
+	@Configuration
+	static class FailingSyncClientConfig {
+
+		@Bean
+		List<McpSyncClient> failingSyncClients() {
+			McpSyncClient client = mock(McpSyncClient.class);
+			when(client.listTools()).thenThrow(new IllegalStateException("Connection unavailable"));
+			return List.of(client);
+		}
+
+	}
+
+	@Configuration
+	static class FailingAsyncClientConfig {
+
+		@Bean
+		List<McpAsyncClient> failingAsyncClients() {
+			McpAsyncClient client = mock(McpAsyncClient.class);
+			when(client.listTools()).thenReturn(Mono.error(new IllegalStateException("Connection unavailable")));
+			return List.of(client);
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonPropertiesTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonPropertiesTests.java
@@ -44,6 +44,7 @@ class McpClientCommonPropertiesTests {
 			assertThat(properties.getName()).isEqualTo("spring-ai-mcp-client");
 			assertThat(properties.getVersion()).isEqualTo("1.0.0");
 			assertThat(properties.isInitialized()).isTrue();
+			assertThat(properties.isFailFast()).isTrue();
 			assertThat(properties.getRequestTimeout()).isEqualTo(Duration.ofSeconds(20));
 			assertThat(properties.getType()).isEqualTo(McpClientCommonProperties.ClientType.SYNC);
 			assertThat(properties.isRootChangeNotification()).isTrue();
@@ -55,14 +56,15 @@ class McpClientCommonPropertiesTests {
 		this.contextRunner
 			.withPropertyValues("spring.ai.mcp.client.enabled=false", "spring.ai.mcp.client.name=custom-client",
 					"spring.ai.mcp.client.version=2.0.0", "spring.ai.mcp.client.initialized=false",
-					"spring.ai.mcp.client.request-timeout=30s", "spring.ai.mcp.client.type=ASYNC",
-					"spring.ai.mcp.client.root-change-notification=false")
+					"spring.ai.mcp.client.fail-fast=false", "spring.ai.mcp.client.request-timeout=30s",
+					"spring.ai.mcp.client.type=ASYNC", "spring.ai.mcp.client.root-change-notification=false")
 			.run(context -> {
 				McpClientCommonProperties properties = context.getBean(McpClientCommonProperties.class);
 				assertThat(properties.isEnabled()).isFalse();
 				assertThat(properties.getName()).isEqualTo("custom-client");
 				assertThat(properties.getVersion()).isEqualTo("2.0.0");
 				assertThat(properties.isInitialized()).isFalse();
+				assertThat(properties.isFailFast()).isFalse();
 				assertThat(properties.getRequestTimeout()).isEqualTo(Duration.ofSeconds(30));
 				assertThat(properties.getType()).isEqualTo(McpClientCommonProperties.ClientType.ASYNC);
 				assertThat(properties.isRootChangeNotification()).isFalse();
@@ -88,6 +90,10 @@ class McpClientCommonPropertiesTests {
 		// Test initialized property
 		properties.setInitialized(false);
 		assertThat(properties.isInitialized()).isFalse();
+
+		// Test failFast property
+		properties.setFailFast(false);
+		assertThat(properties.isFailFast()).isFalse();
 
 		// Test requestTimeout property
 		Duration timeout = Duration.ofMinutes(5);

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationTests.java
@@ -31,6 +31,9 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import tools.jackson.databind.json.JsonMapper;
 
+import org.springframework.ai.mcp.SyncMcpToolCallbackProvider;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.httpclient.autoconfigure.StreamableHttpHttpClientTransportAutoConfiguration;
 import org.springframework.ai.mcp.customizer.McpClientCustomizer;
@@ -66,6 +69,19 @@ public class StreamableHttpHttpClientTransportAutoConfigurationTests {
 					List.class);
 			assertThat(transports).isEmpty();
 		});
+	}
+
+	@Test
+	void unavailableConnectionCanDegradeGracefully() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(McpClientAutoConfiguration.class,
+					McpToolCallbackAutoConfiguration.class, StreamableHttpHttpClientTransportAutoConfiguration.class))
+			.withPropertyValues("spring.ai.mcp.client.fail-fast=false", "spring.ai.mcp.client.request-timeout=1s",
+					"spring.ai.mcp.client.streamable-http.connections.unavailable.url=http://localhost:1")
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context.getBean(SyncMcpToolCallbackProvider.class).getToolCallbacks()).isEmpty();
+			});
 	}
 
 	@Test

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProvider.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProvider.java
@@ -17,12 +17,19 @@
 package org.springframework.ai.mcp;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.util.Assert;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.tool.ToolCallback;
@@ -44,6 +51,8 @@ import org.springframework.util.CollectionUtils;
  */
 public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider, ApplicationListener<McpToolsChangedEvent> {
 
+	private static final Log logger = LogFactory.getLog(AsyncMcpToolCallbackProvider.class);
+
 	private final McpToolFilter toolFilter;
 
 	private final List<McpAsyncClient> mcpClients;
@@ -52,9 +61,17 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider, Appli
 
 	private final ToolContextToMcpMetaConverter toolContextToMcpMetaConverter;
 
+	private final boolean failFast;
+
 	private volatile boolean invalidateCache = true;
 
 	private volatile List<ToolCallback> cachedToolCallbacks = List.of();
+
+	private final Map<Integer, List<ToolCallback>> toolCallbacksByClient = new HashMap<>();
+
+	private final Set<Integer> failedClients = new HashSet<>();
+
+	private volatile boolean retryFailedClients;
 
 	private final Lock lock = new ReentrantLock();
 
@@ -67,7 +84,7 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider, Appli
 	@Deprecated
 	public AsyncMcpToolCallbackProvider(McpToolFilter toolFilter, List<McpAsyncClient> mcpClients) {
 		this(toolFilter, McpToolNamePrefixGenerator.noPrefix(), ToolContextToMcpMetaConverter.defaultConverter(),
-				mcpClients);
+				mcpClients, true);
 	}
 
 	/**
@@ -76,9 +93,11 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider, Appli
 	 * @param toolNamePrefixGenerator generates prefixes for tool names
 	 * @param toolContextToMcpMetaConverter converts tool context to MCP metadata
 	 * @param mcpClients MCP clients for tool discovery
+	 * @param failFast whether tool discovery failures are fatal
 	 */
 	private AsyncMcpToolCallbackProvider(McpToolFilter toolFilter, McpToolNamePrefixGenerator toolNamePrefixGenerator,
-			ToolContextToMcpMetaConverter toolContextToMcpMetaConverter, List<McpAsyncClient> mcpClients) {
+			ToolContextToMcpMetaConverter toolContextToMcpMetaConverter, List<McpAsyncClient> mcpClients,
+			boolean failFast) {
 		Assert.notNull(mcpClients, "MCP clients must not be null");
 		Assert.notNull(toolFilter, "Tool filter must not be null");
 		Assert.notNull(toolNamePrefixGenerator, "Tool name prefix generator must not be null");
@@ -87,6 +106,7 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider, Appli
 		this.mcpClients = mcpClients;
 		this.toolNamePrefixGenerator = toolNamePrefixGenerator;
 		this.toolContextToMcpMetaConverter = toolContextToMcpMetaConverter;
+		this.failFast = failFast;
 	}
 
 	/**
@@ -132,36 +152,64 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider, Appli
 	@Override
 	public ToolCallback[] getToolCallbacks() {
 
-		if (this.invalidateCache) {
+		if (this.invalidateCache || this.retryFailedClients) {
 			this.lock.lock();
 			try {
-				if (this.invalidateCache) {
-					List<ToolCallback> toolCallbackList = new ArrayList<>();
+				if (this.invalidateCache || this.retryFailedClients) {
+					boolean refreshAll = this.invalidateCache;
+					Set<Integer> clientsToRetry = new HashSet<>(this.failedClients);
 
-					for (McpAsyncClient mcpClient : this.mcpClients) {
+					for (int i = 0; i < this.mcpClients.size(); i++) {
+						if (!refreshAll && !clientsToRetry.contains(i)) {
+							continue;
+						}
 
-						ToolCallback[] toolCallbacks = mcpClient.listTools()
-							.map(response -> response.tools()
-								.stream()
-								.filter(tool -> this.toolFilter.test(connectionInfo(mcpClient), tool))
-								.<ToolCallback>map(tool -> AsyncMcpToolCallback.builder()
-									.mcpClient(mcpClient)
-									.tool(tool)
-									.prefixedToolName(this.toolNamePrefixGenerator
-										.prefixedToolName(connectionInfo(mcpClient), tool))
-									.toolContextToMcpMetaConverter(this.toolContextToMcpMetaConverter)
-									.build())
-								.toArray(ToolCallback[]::new))
-							.block();
+						McpAsyncClient mcpClient = this.mcpClients.get(i);
+						McpSchema.ListToolsResult listToolsResult;
+						try {
+							listToolsResult = mcpClient.listTools()
+								.blockOptional()
+								.orElseThrow(() -> new IllegalStateException("MCP client returned no tools result"));
+						}
+						catch (RuntimeException ex) {
+							if (this.failFast) {
+								throw ex;
+							}
+							boolean firstFailure = this.failedClients.add(i);
+							this.toolCallbacksByClient.remove(i);
+							if (firstFailure) {
+								logger.warn("Failed to discover tools from MCP client '" + clientName(mcpClient)
+										+ "'. The client will be retried on the next discovery attempt", ex);
+							}
+							continue;
+						}
 
-						toolCallbackList.addAll(List.of(toolCallbacks));
+						List<ToolCallback> clientToolCallbacks = listToolsResult.tools()
+							.stream()
+							.filter(tool -> this.toolFilter.test(connectionInfo(mcpClient), tool))
+							.<ToolCallback>map(tool -> AsyncMcpToolCallback.builder()
+								.mcpClient(mcpClient)
+								.tool(tool)
+								.prefixedToolName(
+										this.toolNamePrefixGenerator.prefixedToolName(connectionInfo(mcpClient), tool))
+								.toolContextToMcpMetaConverter(this.toolContextToMcpMetaConverter)
+								.build())
+							.toList();
+
+						this.toolCallbacksByClient.put(i, clientToolCallbacks);
+						this.failedClients.remove(i);
 					}
 
+					List<ToolCallback> toolCallbackList = new ArrayList<>();
+					for (int i = 0; i < this.mcpClients.size(); i++) {
+						toolCallbackList.addAll(this.toolCallbacksByClient.getOrDefault(i, List.of()));
+					}
 					this.cachedToolCallbacks = toolCallbackList;
 
 					this.validateToolCallbacks(this.cachedToolCallbacks);
 
 					this.invalidateCache = false;
+					this.retryFailedClients = !this.failedClients.isEmpty();
 				}
 			}
 			finally {
@@ -190,6 +238,11 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider, Appli
 			.clientInfo(mcpClient.getClientInfo())
 			.initializeResult(mcpClient.getCurrentInitializationResult())
 			.build();
+	}
+
+	private static String clientName(McpAsyncClient mcpClient) {
+		var clientInfo = mcpClient.getClientInfo();
+		return clientInfo != null ? clientInfo.name() : "unknown";
 	}
 
 	/**
@@ -242,6 +295,8 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider, Appli
 
 		private ToolContextToMcpMetaConverter toolContextToMcpMetaConverter = ToolContextToMcpMetaConverter
 			.defaultConverter();
+
+		private boolean failFast = true;
 
 		private Builder() {
 		}
@@ -301,9 +356,21 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider, Appli
 			return this;
 		}
 
+		/**
+		 * Configures whether a tool discovery failure from one MCP client should abort
+		 * discovery for all clients. Defaults to {@code true}.
+		 * @param failFast whether to fail immediately on a client error
+		 * @return this builder
+		 * @since 2.0.2
+		 */
+		public Builder failFast(boolean failFast) {
+			this.failFast = failFast;
+			return this;
+		}
+
 		public AsyncMcpToolCallbackProvider build() {
 			return new AsyncMcpToolCallbackProvider(this.toolFilter, this.toolNamePrefixGenerator,
-					this.toolContextToMcpMetaConverter, this.mcpClients);
+					this.toolContextToMcpMetaConverter, this.mcpClients, this.failFast);
 		}
 
 	}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallbackProvider.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallbackProvider.java
@@ -17,11 +17,18 @@
 package org.springframework.ai.mcp;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -42,6 +49,8 @@ import org.springframework.util.CollectionUtils;
  */
 public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, ApplicationListener<McpToolsChangedEvent> {
 
+	private static final Log logger = LogFactory.getLog(SyncMcpToolCallbackProvider.class);
+
 	private final List<McpSyncClient> mcpClients;
 
 	private final McpToolFilter toolFilter;
@@ -50,9 +59,17 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 
 	private final ToolContextToMcpMetaConverter toolContextToMcpMetaConverter;
 
+	private final boolean failFast;
+
 	private volatile boolean invalidateCache = true;
 
 	private volatile List<ToolCallback> cachedToolCallbacks = List.of();
+
+	private final Map<Integer, List<ToolCallback>> toolCallbacksByClient = new HashMap<>();
+
+	private final Set<Integer> failedClients = new HashSet<>();
+
+	private volatile boolean retryFailedClients;
 
 	private final Lock lock = new ReentrantLock();
 
@@ -65,7 +82,7 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 	@Deprecated
 	public SyncMcpToolCallbackProvider(McpToolFilter toolFilter, List<McpSyncClient> mcpClients) {
 		this(toolFilter, McpToolNamePrefixGenerator.noPrefix(), mcpClients,
-				ToolContextToMcpMetaConverter.defaultConverter());
+				ToolContextToMcpMetaConverter.defaultConverter(), true);
 	}
 
 	/**
@@ -74,9 +91,11 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 	 * @param toolNamePrefixGenerator generates prefixes for tool names
 	 * @param toolFilter filter for discovered tools
 	 * @param toolContextToMcpMetaConverter converts tool context to MCP metadata
+	 * @param failFast whether tool discovery failures are fatal
 	 */
 	private SyncMcpToolCallbackProvider(McpToolFilter toolFilter, McpToolNamePrefixGenerator toolNamePrefixGenerator,
-			List<McpSyncClient> mcpClients, ToolContextToMcpMetaConverter toolContextToMcpMetaConverter) {
+			List<McpSyncClient> mcpClients, ToolContextToMcpMetaConverter toolContextToMcpMetaConverter,
+			boolean failFast) {
 		Assert.notNull(mcpClients, "MCP clients must not be null");
 		Assert.notNull(toolFilter, "Tool filter must not be null");
 		Assert.notNull(toolNamePrefixGenerator, "Tool name prefix generator must not be null");
@@ -85,6 +104,7 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 		this.toolFilter = toolFilter;
 		this.toolNamePrefixGenerator = toolNamePrefixGenerator;
 		this.toolContextToMcpMetaConverter = toolContextToMcpMetaConverter;
+		this.failFast = failFast;
 	}
 
 	/**
@@ -107,8 +127,8 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 	@Deprecated
 	public SyncMcpToolCallbackProvider(McpToolFilter toolFilter, McpToolNamePrefixGenerator toolNamePrefixGenerator,
 			McpSyncClient... mcpClients) {
-		this(toolFilter, toolNamePrefixGenerator, List.of(mcpClients),
-				ToolContextToMcpMetaConverter.defaultConverter());
+		this(toolFilter, toolNamePrefixGenerator, List.of(mcpClients), ToolContextToMcpMetaConverter.defaultConverter(),
+				true);
 	}
 
 	/**
@@ -124,13 +144,37 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 	@Override
 	public ToolCallback[] getToolCallbacks() {
 
-		if (this.invalidateCache) {
+		if (this.invalidateCache || this.retryFailedClients) {
 			this.lock.lock();
 			try {
-				if (this.invalidateCache) {
-					this.cachedToolCallbacks = this.mcpClients.stream()
-						.flatMap(mcpClient -> mcpClient.listTools()
-							.tools()
+				if (this.invalidateCache || this.retryFailedClients) {
+					boolean refreshAll = this.invalidateCache;
+					Set<Integer> clientsToRetry = new HashSet<>(this.failedClients);
+
+					for (int i = 0; i < this.mcpClients.size(); i++) {
+						if (!refreshAll && !clientsToRetry.contains(i)) {
+							continue;
+						}
+
+						McpSyncClient mcpClient = this.mcpClients.get(i);
+						McpSchema.ListToolsResult listToolsResult;
+						try {
+							listToolsResult = mcpClient.listTools();
+						}
+						catch (RuntimeException ex) {
+							if (this.failFast) {
+								throw ex;
+							}
+							boolean firstFailure = this.failedClients.add(i);
+							this.toolCallbacksByClient.remove(i);
+							if (firstFailure) {
+								logger.warn("Failed to discover tools from MCP client '" + clientName(mcpClient)
+										+ "'. The client will be retried on the next discovery attempt", ex);
+							}
+							continue;
+						}
+
+						List<ToolCallback> clientToolCallbacks = listToolsResult.tools()
 							.stream()
 							.filter(tool -> this.toolFilter.test(connectionInfo(mcpClient), tool))
 							.<ToolCallback>map(tool -> SyncMcpToolCallback.builder()
@@ -139,11 +183,22 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 								.prefixedToolName(
 										this.toolNamePrefixGenerator.prefixedToolName(connectionInfo(mcpClient), tool))
 								.toolContextToMcpMetaConverter(this.toolContextToMcpMetaConverter)
-								.build()))
-						.toList();
+								.build())
+							.toList();
+
+						this.toolCallbacksByClient.put(i, clientToolCallbacks);
+						this.failedClients.remove(i);
+					}
+
+					List<ToolCallback> toolCallbacks = new ArrayList<>();
+					for (int i = 0; i < this.mcpClients.size(); i++) {
+						toolCallbacks.addAll(this.toolCallbacksByClient.getOrDefault(i, List.of()));
+					}
+					this.cachedToolCallbacks = toolCallbacks;
 
 					this.validateToolCallbacks(this.cachedToolCallbacks);
 					this.invalidateCache = false;
+					this.retryFailedClients = !this.failedClients.isEmpty();
 				}
 			}
 			finally {
@@ -172,6 +227,11 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 			.clientInfo(mcpClient.getClientInfo())
 			.initializeResult(mcpClient.getCurrentInitializationResult())
 			.build();
+	}
+
+	private static String clientName(McpSyncClient mcpClient) {
+		var clientInfo = mcpClient.getClientInfo();
+		return clientInfo != null ? clientInfo.name() : "unknown";
 	}
 
 	/**
@@ -224,6 +284,8 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 
 		private ToolContextToMcpMetaConverter toolContextToMcpMetaConverter = ToolContextToMcpMetaConverter
 			.defaultConverter();
+
+		private boolean failFast = true;
 
 		/**
 		 * Sets MCP clients for tool discovery (replaces existing).
@@ -293,6 +355,18 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 		}
 
 		/**
+		 * Configures whether a tool discovery failure from one MCP client should abort
+		 * discovery for all clients. Defaults to {@code true}.
+		 * @param failFast whether to fail immediately on a client error
+		 * @return this builder
+		 * @since 2.0.2
+		 */
+		public Builder failFast(boolean failFast) {
+			this.failFast = failFast;
+			return this;
+		}
+
+		/**
 		 * Builds the provider with configured parameters.
 		 * @return configured {@code SyncMcpToolCallbackProvider}
 		 */
@@ -300,7 +374,7 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider, Applic
 			// Assert.notEmpty(this.mcpClients, "At least one MCP client must be
 			// provided");
 			return new SyncMcpToolCallbackProvider(this.toolFilter, this.toolNamePrefixGenerator, this.mcpClients,
-					this.toolContextToMcpMetaConverter);
+					this.toolContextToMcpMetaConverter, this.failFast);
 		}
 
 	}

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProviderTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProviderTests.java
@@ -35,6 +35,8 @@ import org.springframework.ai.tool.ToolCallback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,6 +67,74 @@ class AsyncMcpToolCallbackProviderTests {
 		var callbacks = provider.getToolCallbacks();
 
 		assertThat(callbacks).isEmpty();
+	}
+
+	@Test
+	void getToolCallbacksShouldFailFastByDefault() {
+		when(this.mcpClient.listTools()).thenReturn(Mono.error(new IllegalStateException("Connection unavailable")));
+
+		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder()
+			.mcpClients(this.mcpClient)
+			.build();
+
+		assertThatThrownBy(provider::getToolCallbacks).isInstanceOf(IllegalStateException.class)
+			.hasMessage("Connection unavailable");
+	}
+
+	@Test
+	void getToolCallbacksShouldIsolateFailuresAndRetry() {
+		McpAsyncClient healthyClient = mock(McpAsyncClient.class);
+		McpAsyncClient unavailableClient = mock(McpAsyncClient.class);
+		Tool healthyTool = mock(Tool.class);
+		Tool recoveredTool = mock(Tool.class);
+		when(healthyTool.name()).thenReturn("healthy");
+		when(recoveredTool.name()).thenReturn("recovered");
+
+		ListToolsResult healthyResult = mock(ListToolsResult.class);
+		ListToolsResult recoveredResult = mock(ListToolsResult.class);
+		when(healthyResult.tools()).thenReturn(List.of(healthyTool));
+		when(recoveredResult.tools()).thenReturn(List.of(recoveredTool));
+		when(healthyClient.listTools()).thenReturn(Mono.just(healthyResult));
+		when(unavailableClient.listTools()).thenReturn(Mono.error(new IllegalStateException("Connection unavailable")),
+				Mono.just(recoveredResult));
+
+		when(healthyClient.getClientInfo()).thenReturn(Implementation.builder("healthy-client", "1.0.0").build());
+		when(unavailableClient.getClientInfo())
+			.thenReturn(Implementation.builder("unavailable-client", "1.0.0").build());
+		ClientCapabilities capabilities = new ClientCapabilities(null, null, null, null);
+		when(healthyClient.getClientCapabilities()).thenReturn(capabilities);
+		when(unavailableClient.getClientCapabilities()).thenReturn(capabilities);
+
+		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder()
+			.mcpClients(healthyClient, unavailableClient)
+			.failFast(false)
+			.build();
+
+		assertThat(provider.getToolCallbacks()).hasSize(1);
+		assertThat(provider.getToolCallbacks()).hasSize(2);
+		verify(healthyClient).listTools();
+		verify(unavailableClient, times(2)).listTools();
+	}
+
+	@Test
+	void getToolCallbacksShouldNotSuppressToolFilterFailures() {
+		Tool tool = mock(Tool.class);
+		ListToolsResult result = mock(ListToolsResult.class);
+		when(result.tools()).thenReturn(List.of(tool));
+		when(this.mcpClient.listTools()).thenReturn(Mono.just(result));
+		when(this.mcpClient.getClientInfo()).thenReturn(Implementation.builder("test-client", "1.0.0").build());
+		when(this.mcpClient.getClientCapabilities()).thenReturn(new ClientCapabilities(null, null, null, null));
+
+		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder()
+			.mcpClients(this.mcpClient)
+			.toolFilter((client, candidate) -> {
+				throw new IllegalStateException("Filter failure");
+			})
+			.failFast(false)
+			.build();
+
+		assertThatThrownBy(provider::getToolCallbacks).isInstanceOf(IllegalStateException.class)
+			.hasMessage("Filter failure");
 	}
 
 	@Test

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderTests.java
@@ -31,6 +31,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,6 +61,72 @@ class SyncMcpToolCallbackProviderTests {
 		var callbacks = provider.getToolCallbacks();
 
 		assertThat(callbacks).isEmpty();
+	}
+
+	@Test
+	void getToolCallbacksShouldFailFastByDefault() {
+		when(this.mcpClient.listTools()).thenThrow(new IllegalStateException("Connection unavailable"));
+
+		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder().mcpClients(this.mcpClient).build();
+
+		assertThatThrownBy(provider::getToolCallbacks).isInstanceOf(IllegalStateException.class)
+			.hasMessage("Connection unavailable");
+	}
+
+	@Test
+	void getToolCallbacksShouldIsolateFailuresAndRetry() {
+		McpSyncClient healthyClient = mock(McpSyncClient.class);
+		McpSyncClient unavailableClient = mock(McpSyncClient.class);
+		Tool healthyTool = mock(Tool.class);
+		Tool recoveredTool = mock(Tool.class);
+		when(healthyTool.name()).thenReturn("healthy");
+		when(recoveredTool.name()).thenReturn("recovered");
+
+		ListToolsResult healthyResult = mock(ListToolsResult.class);
+		ListToolsResult recoveredResult = mock(ListToolsResult.class);
+		when(healthyResult.tools()).thenReturn(List.of(healthyTool));
+		when(recoveredResult.tools()).thenReturn(List.of(recoveredTool));
+		when(healthyClient.listTools()).thenReturn(healthyResult);
+		when(unavailableClient.listTools()).thenThrow(new IllegalStateException("Connection unavailable"))
+			.thenReturn(recoveredResult);
+
+		when(healthyClient.getClientInfo()).thenReturn(Implementation.builder("healthy-client", "1.0.0").build());
+		when(unavailableClient.getClientInfo())
+			.thenReturn(Implementation.builder("unavailable-client", "1.0.0").build());
+		ClientCapabilities capabilities = new ClientCapabilities(null, null, null, null);
+		when(healthyClient.getClientCapabilities()).thenReturn(capabilities);
+		when(unavailableClient.getClientCapabilities()).thenReturn(capabilities);
+
+		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
+			.mcpClients(healthyClient, unavailableClient)
+			.failFast(false)
+			.build();
+
+		assertThat(provider.getToolCallbacks()).hasSize(1);
+		assertThat(provider.getToolCallbacks()).hasSize(2);
+		verify(healthyClient).listTools();
+		verify(unavailableClient, times(2)).listTools();
+	}
+
+	@Test
+	void getToolCallbacksShouldNotSuppressToolFilterFailures() {
+		Tool tool = mock(Tool.class);
+		ListToolsResult result = mock(ListToolsResult.class);
+		when(result.tools()).thenReturn(List.of(tool));
+		when(this.mcpClient.listTools()).thenReturn(result);
+		when(this.mcpClient.getClientInfo()).thenReturn(Implementation.builder("test-client", "1.0.0").build());
+		when(this.mcpClient.getClientCapabilities()).thenReturn(new ClientCapabilities(null, null, null, null));
+
+		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
+			.mcpClients(this.mcpClient)
+			.toolFilter((client, candidate) -> {
+				throw new IllegalStateException("Filter failure");
+			})
+			.failFast(false)
+			.build();
+
+		assertThatThrownBy(provider::getToolCallbacks).isInstanceOf(IllegalStateException.class)
+			.hasMessage("Filter failure");
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -70,6 +70,10 @@ The common properties are prefixed with `spring.ai.mcp.client`:
 |Whether to initialize clients on creation
 |`true`
 
+|`fail-fast`
+|Whether a failure to initialize a client or discover its tools should be fatal. Set to `false` to skip unavailable clients and retry them on a subsequent operation
+|`true`
+
 |`request-timeout`
 |Timeout duration for MCP client requests
 |`20s`
@@ -86,6 +90,22 @@ The common properties are prefixed with `spring.ai.mcp.client`:
 |Enable/disable the MCP tool callback integration with Spring AI's tool execution framework
 |`true`
 |===
+
+By default, MCP clients connect during application startup and any connection failure prevents the application from starting.
+To defer connections until tools are first discovered, while allowing available clients to keep working when another client is unavailable, disable both initialization and fail-fast behavior:
+
+[source,yaml]
+----
+spring:
+  ai:
+    mcp:
+      client:
+        initialized: false
+        fail-fast: false
+----
+
+With `fail-fast=false`, unavailable clients are logged and retried on subsequent tool discovery operations.
+Available clients remain cached while retries are attempted.
 
 === MCP Annotations Properties
 


### PR DESCRIPTION
Fixes #6930

When multiple MCP clients are configured, an initialization or tool discovery failure from one client currently prevents the application from starting or makes tools from every configured client unavailable.

This change adds the `spring.ai.mcp.client.fail-fast` property. It defaults to `true`, preserving the existing fail-fast behavior.

When fail-fast behavior is disabled:

- initialization failures are logged without aborting application startup
- tool discovery failures are isolated to the affected client
- tools from available clients remain accessible
- failed clients are retried on subsequent discovery attempts
- successful client results remain cached while failed clients are retried

The behavior is implemented consistently for synchronous and asynchronous MCP clients. Only client initialization and remote tool discovery failures are isolated. Aggregate validation errors, such as duplicate tool names, remain fatal.

The new option is deliberately defined as a common policy for all configured MCP clients, keeping this change focused and backward-compatible. Per-connection optionality can be added independently if finer-grained control is needed.

The reference documentation explains how to combine `initialized=false` and `fail-fast=false` to defer connections and allow unavailable clients to degrade gracefully.

Testing:

- 93 targeted MCP tests passed with no failures, errors, or skips
- the full Maven reactor completed successfully
- source formatting and diff checks passed
- `./mvnw -pl spring-ai-docs antora` was attempted, but the Antora collector extension could not spawn a subprocess in the local Windows environment (`spawn EINVAL`)