### PR TITLE
Fix invalid JSON in Bedrock tool-call arguments

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -673,7 +673,11 @@ public class BedrockProxyChatModel implements ChatModel {
 
 				var functionCallId = toolUseContentBlock.toolUse().toolUseId();
 				var functionName = toolUseContentBlock.toolUse().name();
-				var functionArguments = toolUseContentBlock.toolUse().input().toString();
+				// Serialize the tool input as JSON. Document.toString() is not a JSON
+				// serializer: it leaves control characters (e.g. newlines) unescaped,
+				// breaking strict JSON parsing of the arguments downstream.
+				var functionArguments = jsonHelper
+					.toJson(ConverseApiUtils.convertDocumentToObject(toolUseContentBlock.toolUse().input()));
 
 				toolCalls
 					.add(new AssistantMessage.ToolCall(functionCallId, "function", functionName, functionArguments));

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
@@ -19,10 +19,12 @@ package org.springframework.ai.bedrock.converse.api;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.core.document.Document;
 
 /**
@@ -103,6 +105,47 @@ public final class ConverseApiUtils {
 			.collect(Collectors.toMap(e -> e.getKey(), e -> convertObjectToDocument(e.getValue())));
 
 		return Document.fromMap(attr);
+	}
+
+	/**
+	 * Converts an AWS SDK {@link Document} into a plain Java object ({@link Map},
+	 * {@link List}, {@link String}, {@link Boolean}, {@link BigDecimal} or {@code null}).
+	 * <p>
+	 * This is the inverse of {@link #convertObjectToDocument(Object)}. It lets callers
+	 * serialize a document to JSON with a real JSON writer instead of relying on
+	 * {@link Document#toString()}, whose output is not valid JSON (for example, it does
+	 * not escape control characters such as newlines inside string values).
+	 * @param document the document to convert, may be {@code null}
+	 * @return the equivalent plain Java object, or {@code null} for a null document
+	 */
+	public static @Nullable Object convertDocumentToObject(@Nullable Document document) {
+		if (document == null || document.isNull()) {
+			return null;
+		}
+		else if (document.isString()) {
+			return document.asString();
+		}
+		else if (document.isBoolean()) {
+			return document.asBoolean();
+		}
+		else if (document.isNumber()) {
+			return document.asNumber().bigDecimalValue();
+		}
+		else if (document.isList()) {
+			return document.asList().stream().map(ConverseApiUtils::convertDocumentToObject).toList();
+		}
+		else if (document.isMap()) {
+			return convertDocumentToMap(document.asMap());
+		}
+		else {
+			throw new IllegalArgumentException("Unsupported document type: " + document.getClass().getSimpleName());
+		}
+	}
+
+	private static Map<String, Object> convertDocumentToMap(Map<String, Document> document) {
+		Map<String, Object> result = new LinkedHashMap<>();
+		document.forEach((key, value) -> result.put(key, convertDocumentToObject(value)));
+		return result;
 	}
 
 }

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse.api;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.document.Document;
+
+import org.springframework.ai.util.JsonHelper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link ConverseApiUtils#convertDocumentToObject(Document)}.
+ * <p>
+ * The key guarantee is that a tool-use input {@link Document} is turned into a plain Java
+ * object that serializes to valid JSON, so that arguments containing control characters
+ * (such as newlines) survive the strict JSON parsing performed on tool-call arguments.
+ * This is the inverse of {@link ConverseApiUtils#convertObjectToDocument(Object)}.
+ */
+class ConverseApiUtilsTests {
+
+	private final JsonHelper jsonHelper = new JsonHelper();
+
+	@Test
+	void convertsScalarNodeTypes() {
+		assertThat(ConverseApiUtils.convertDocumentToObject(Document.fromNull())).isNull();
+		assertThat(ConverseApiUtils.convertDocumentToObject(null)).isNull();
+		assertThat(ConverseApiUtils.convertDocumentToObject(Document.fromString("hello"))).isEqualTo("hello");
+		assertThat(ConverseApiUtils.convertDocumentToObject(Document.fromBoolean(true))).isEqualTo(true);
+		assertThat(ConverseApiUtils.convertDocumentToObject(Document.fromNumber(42))).isEqualTo(new BigDecimal("42"));
+	}
+
+	@Test
+	void convertsNestedMapsAndLists() {
+		Document document = Document.mapBuilder()
+			.putString("channel", "VIBER_BM")
+			.putList("tags", List.of(Document.fromString("a"), Document.fromString("b")))
+			.putDocument("nested", Document.mapBuilder().putNumber("count", 2).build())
+			.build();
+
+		Object result = ConverseApiUtils.convertDocumentToObject(document);
+
+		assertThat(result).isInstanceOf(Map.class);
+		@SuppressWarnings("unchecked")
+		Map<String, Object> map = (Map<String, Object>) result;
+		assertThat(map).containsEntry("channel", "VIBER_BM");
+		assertThat(map.get("tags")).isEqualTo(List.of("a", "b"));
+		assertThat(map.get("nested")).isEqualTo(Map.of("count", new BigDecimal("2")));
+	}
+
+	@Test
+	void isInverseOfConvertObjectToDocument() {
+		Map<String, Object> original = Map.of("channel", "SMS", "to", "385911234567", "retries", new BigDecimal("3"));
+
+		Object roundTripped = ConverseApiUtils
+			.convertDocumentToObject(ConverseApiUtils.convertObjectToDocument(original));
+
+		assertThat(roundTripped).isEqualTo(original);
+	}
+
+	/**
+	 * Regression: a tool argument whose string value contains a newline and emoji must
+	 * serialize to valid JSON. Previously {@code Document.toString()} left the control
+	 * character unescaped, which broke the strict JSON parsing of tool-call arguments.
+	 */
+	@Test
+	void producesValidJsonForStringValuesWithControlCharacters() {
+		String multilineText = "Line one\nLine two 🌊\tafter tab";
+		Document input = Document.mapBuilder()
+			.putString("channel", "VIBER_BM")
+			.putString("to", "385911234567")
+			.putString("text", multilineText)
+			.build();
+
+		String json = this.jsonHelper.toJson(ConverseApiUtils.convertDocumentToObject(input));
+
+		// The raw control characters must not appear unescaped in the JSON string.
+		assertThat(json).doesNotContain("\n").doesNotContain("\t").contains("\\n").contains("\\t");
+
+		// And the JSON must parse back cleanly, preserving the original text.
+		assertThatCode(() -> {
+			Map<String, Object> parsed = this.jsonHelper.fromJsonToMap(json);
+			assertThat(parsed).containsEntry("text", multilineText).containsEntry("channel", "VIBER_BM");
+		}).doesNotThrowAnyException();
+	}
+
+}


### PR DESCRIPTION
BedrockProxyChatModel serialized the tool-use input via Document.toString(), which is not a JSON serializer and leaves control characters such as newlines unescaped inside string values. The resulting arguments string then failed strict JSON parsing during tool execution (for example when a tool argument contains a multi-line text).

Serialize the tool input with the JSON writer instead, adding the inverse converter ConverseApiUtils.convertDocumentToObject so it is symmetric with the request path that already maps arguments through convertObjectToDocument.

Fixes #6962