### PR TITLE
Close the parsed document in PDF document readers

### DIFF
--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/PagePdfDocumentReader.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/PagePdfDocumentReader.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.reader.pdf;
 
 import java.awt.Rectangle;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,10 +45,14 @@ import org.springframework.util.StringUtils;
  * options. The default configuration is: - pagesPerDocument = 1 - pageTopMargin = 0 -
  * pageBottomMargin = 0
  *
+ * The constructor parses the whole PDF and the reader holds on to it until
+ * {@link #close()} is called, so instances are best used in a try-with-resources block.
+ *
  * @author Christian Tzolov
  * @author Fu Jian
+ * @author chabinhwang
  */
-public class PagePdfDocumentReader implements DocumentReader {
+public class PagePdfDocumentReader implements DocumentReader, Closeable {
 
 	public static final String METADATA_START_PAGE_NUMBER = "page_number";
 
@@ -207,6 +212,18 @@ public class PagePdfDocumentReader implements DocumentReader {
 			doc.getMetadata().put(METADATA_FILE_NAME, this.resourceFileName);
 		}
 		return doc;
+	}
+
+	/**
+	 * Releases the {@link PDDocument} parsed by the constructor, along with the buffered
+	 * document content and the parsed object graph it holds. The reader must not be used
+	 * after it has been closed; closing an already closed reader has no effect.
+	 * @throws IOException if the parsed document cannot be closed
+	 * @since 2.0.2
+	 */
+	@Override
+	public void close() throws IOException {
+		this.document.close();
 	}
 
 }

--- a/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReader.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/main/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReader.java
@@ -17,6 +17,8 @@
 package org.springframework.ai.reader.pdf;
 
 import java.awt.Rectangle;
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,10 +48,14 @@ import org.springframework.util.StringUtils;
  * Apache PDFBox library for parsing PDF content and converting it into text paragraphs.
  * The paragraphs are grouped into {@link Document} objects.
  *
+ * The constructor parses the whole PDF and the reader holds on to it until
+ * {@link #close()} is called, so instances are best used in a try-with-resources block.
+ *
  * @author Christian Tzolov
  * @author Heonwoo Kim
+ * @author chabinhwang
  */
-public class ParagraphPdfDocumentReader implements DocumentReader {
+public class ParagraphPdfDocumentReader implements DocumentReader, Closeable {
 
 	// Constants for metadata keys
 	private static final String METADATA_START_PAGE = "page_number";
@@ -107,22 +113,46 @@ public class ParagraphPdfDocumentReader implements DocumentReader {
 		Assert.isTrue(!config.hasPageRanges(),
 				"Page ranges are not supported by ParagraphPdfDocumentReader; use PagePdfDocumentReader instead.");
 
+		PDDocument parsedDocument = null;
 		try {
 			PDFParser pdfParser = new PDFParser(
 					new org.apache.pdfbox.io.RandomAccessReadBuffer(pdfResource.getInputStream()));
-			this.document = pdfParser.parse();
+			parsedDocument = pdfParser.parse();
 
 			this.config = config;
 
-			this.paragraphTextExtractor = new ParagraphManager(this.document);
+			this.paragraphTextExtractor = new ParagraphManager(parsedDocument);
 
 			this.resourceFileName = pdfResource.getFilename();
+
+			this.document = parsedDocument;
 		}
 		catch (IllegalArgumentException iae) {
+			closeAfterFailedInitialization(parsedDocument, iae);
 			throw iae;
 		}
 		catch (Exception e) {
-			throw new RuntimeException(e);
+			RuntimeException failure = new RuntimeException(e);
+			closeAfterFailedInitialization(parsedDocument, failure);
+			throw failure;
+		}
+	}
+
+	/**
+	 * Releases a document that was parsed before the reader could be fully initialized,
+	 * for example when the PDF has no table of contents. Without this the parsed document
+	 * would stay in memory with no reference left to close it.
+	 * @param parsedDocument the parsed document, or {@code null} if parsing itself failed
+	 * @param failure the exception that is about to be propagated
+	 */
+	private static void closeAfterFailedInitialization(@Nullable PDDocument parsedDocument, Throwable failure) {
+		if (parsedDocument != null) {
+			try {
+				parsedDocument.close();
+			}
+			catch (IOException ex) {
+				failure.addSuppressed(ex);
+			}
 		}
 	}
 
@@ -254,6 +284,18 @@ public class ParagraphPdfDocumentReader implements DocumentReader {
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	/**
+	 * Releases the {@link PDDocument} parsed by the constructor, along with the buffered
+	 * document content and the parsed object graph it holds. The reader must not be used
+	 * after it has been closed; closing an already closed reader has no effect.
+	 * @throws IOException if the parsed document cannot be closed
+	 * @since 2.0.2
+	 */
+	@Override
+	public void close() throws IOException {
+		this.document.close();
 	}
 
 }

--- a/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
@@ -16,9 +16,11 @@
 
 package org.springframework.ai.reader.pdf;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.document.Document;
@@ -26,12 +28,14 @@ import org.springframework.ai.reader.ExtractedTextFormatter;
 import org.springframework.ai.reader.pdf.config.PdfDocumentReaderConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Christian Tzolov
  * @author Tibor Tarnai
  * @author Fu Jian
+ * @author chabinhwang
  */
 class PagePdfDocumentReaderTests {
 
@@ -254,6 +258,46 @@ class PagePdfDocumentReaderTests {
 		assertThat(rangedDocuments).extracting(Document::getText)
 			.containsExactly(fullDocuments.get(9).getText(), fullDocuments.get(10).getText(),
 					fullDocuments.get(11).getText());
+	}
+
+	@Test
+	void closeReleasesTheParsedDocument() throws IOException {
+
+		PagePdfDocumentReader pdfReader = new PagePdfDocumentReader("classpath:/sample1.pdf",
+				PdfDocumentReaderConfig.defaultConfig());
+
+		assertThat(pdfReader.document.getDocument().isClosed()).isFalse();
+
+		pdfReader.close();
+
+		assertThat(pdfReader.document.getDocument().isClosed()).isTrue();
+	}
+
+	@Test
+	void closeCanBeCalledMoreThanOnce() throws IOException {
+
+		PagePdfDocumentReader pdfReader = new PagePdfDocumentReader("classpath:/sample1.pdf",
+				PdfDocumentReaderConfig.defaultConfig());
+
+		pdfReader.close();
+
+		assertThatNoException().isThrownBy(pdfReader::close);
+	}
+
+	@Test
+	void readsAllDocumentsInsideTryWithResources() throws IOException {
+
+		PDDocument parsedDocument;
+		List<Document> docs;
+
+		try (PagePdfDocumentReader pdfReader = new PagePdfDocumentReader("classpath:/sample1.pdf",
+				PdfDocumentReaderConfig.defaultConfig())) {
+			parsedDocument = pdfReader.document;
+			docs = pdfReader.get();
+		}
+
+		assertThat(docs).hasSize(4);
+		assertThat(parsedDocument.getDocument().isClosed()).isTrue();
 	}
 
 }

--- a/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
+++ b/document-readers/spring-ai-pdf-document-reader/src/test/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReaderTests.java
@@ -36,12 +36,14 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * @author Christian Tzolov
  * @author Heonwoo Kim
+ * @author chabinhwang
  */
 public class ParagraphPdfDocumentReaderTests {
 
@@ -112,6 +114,46 @@ public class ParagraphPdfDocumentReaderTests {
 		assertThat(documents).hasSize(2);
 		assertThat(documents.get(0).getMetadata().get("title")).isEqualTo("Chapter 1");
 		assertThat(documents.get(1).getMetadata().get("title")).isEqualTo("Chapter 3");
+	}
+
+	@Test
+	void closeReleasesTheParsedDocument() throws IOException {
+
+		ParagraphPdfDocumentReader pdfReader = new ParagraphPdfDocumentReader("classpath:/sample3.pdf",
+				PdfDocumentReaderConfig.defaultConfig());
+
+		assertThat(pdfReader.document.getDocument().isClosed()).isFalse();
+
+		pdfReader.close();
+
+		assertThat(pdfReader.document.getDocument().isClosed()).isTrue();
+	}
+
+	@Test
+	void closeCanBeCalledMoreThanOnce() throws IOException {
+
+		ParagraphPdfDocumentReader pdfReader = new ParagraphPdfDocumentReader("classpath:/sample3.pdf",
+				PdfDocumentReaderConfig.defaultConfig());
+
+		pdfReader.close();
+
+		assertThatNoException().isThrownBy(pdfReader::close);
+	}
+
+	@Test
+	void readsAllParagraphsInsideTryWithResources() throws IOException {
+
+		PDDocument parsedDocument;
+		List<Document> documents;
+
+		try (ParagraphPdfDocumentReader pdfReader = new ParagraphPdfDocumentReader("classpath:/sample3.pdf",
+				PdfDocumentReaderConfig.defaultConfig())) {
+			parsedDocument = pdfReader.document;
+			documents = pdfReader.get();
+		}
+
+		assertThat(documents).isNotEmpty();
+		assertThat(parsedDocument.getDocument().isClosed()).isTrue();
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/etl-pipeline.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/etl-pipeline.adoc
@@ -524,6 +524,9 @@ The reader preserves formatting like inline code, lists, and text styling within
 === PDF Page
 The `PagePdfDocumentReader` uses Apache PdfBox library to parse PDF documents.
 
+NOTE: The constructor parses the whole PDF and the reader holds on to it until it is closed.
+`PagePdfDocumentReader` implements `Closeable`, so use it in a try-with-resources block to release the parsed document once the documents have been read.
+
 ==== Dependencies
 Add the dependency to your project using Maven or Gradle.
 
@@ -556,18 +559,19 @@ dependencies {
 @Component
 public class MyPagePdfDocumentReader {
 
-	List<Document> getDocsFromPdf() {
+	List<Document> getDocsFromPdf() throws IOException {
 
-		PagePdfDocumentReader pdfReader = new PagePdfDocumentReader("classpath:/sample1.pdf",
+		try (PagePdfDocumentReader pdfReader = new PagePdfDocumentReader("classpath:/sample1.pdf",
 				PdfDocumentReaderConfig.builder()
 					.withPageTopMargin(0)
 					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder()
 						.withNumberOfTopTextLinesToDelete(0)
 						.build())
 					.withPagesPerDocument(1)
-					.build());
+					.build())) {
 
-		return pdfReader.read();
+			return pdfReader.read();
+		}
     }
 
 }
@@ -578,6 +582,9 @@ public class MyPagePdfDocumentReader {
 The `ParagraphPdfDocumentReader` uses the PDF catalog (e.g. TOC) information to split the input PDF into text paragraphs and output a single `Document` per paragraph.
 NOTE: Not all PDF documents contain the PDF catalog.
 
+NOTE: The constructor parses the whole PDF and the reader holds on to it until it is closed.
+`ParagraphPdfDocumentReader` implements `Closeable`, so use it in a try-with-resources block to release the parsed document once the documents have been read.
+
 ==== Dependencies
 Add the dependency to your project using Maven or Gradle.
 
@@ -610,18 +617,19 @@ dependencies {
 @Component
 public class MyPagePdfDocumentReader {
 
-	List<Document> getDocsFromPdfWithCatalog() {
+	List<Document> getDocsFromPdfWithCatalog() throws IOException {
 
-        ParagraphPdfDocumentReader pdfReader = new ParagraphPdfDocumentReader("classpath:/sample1.pdf",
+        try (ParagraphPdfDocumentReader pdfReader = new ParagraphPdfDocumentReader("classpath:/sample1.pdf",
                 PdfDocumentReaderConfig.builder()
                     .withPageTopMargin(0)
                     .withPageExtractedTextFormatter(ExtractedTextFormatter.builder()
                         .withNumberOfTopTextLinesToDelete(0)
                         .build())
                     .withPagesPerDocument(1)
-                    .build());
+                    .build())) {
 
-	    return pdfReader.read();
+            return pdfReader.read();
+        }
     }
 }
 ----


### PR DESCRIPTION
## Problem

`PagePdfDocumentReader` and `ParagraphPdfDocumentReader` parse the whole PDF in their constructor and keep the resulting `PDDocument` in a field:

```java
PDFParser pdfParser = new PDFParser(
        new org.apache.pdfbox.io.RandomAccessReadBuffer(pdfResource.getInputStream()));
this.document = pdfParser.parse();
```

Neither class offers a way to close that document, and there is no `PDDocument.close()` call anywhere in the module. PDFBox buffers the whole file and builds the parsed object graph on top of that buffer, so all of it stays reachable from the reader until the reader itself becomes garbage. An ETL pipeline that creates one reader per file therefore retains every PDF it has read for as long as the readers are referenced, and `PDDocument` is a `Closeable` that is documented to be closed.

`ParagraphPdfDocumentReader` has a second, sharper case. It parses the document and then builds a `ParagraphManager` from it. For a PDF without a table of contents — the case its own error message points users at — the constructor throws *after* the document has been parsed, and the parsed document is dropped with no reference left to close it.

## Fix

Both readers implement `Closeable` and close the document they parsed, so they can be used in a try-with-resources block. `PDDocument.close()` returns immediately for an already closed document, so closing a reader more than once is safe.

`ParagraphPdfDocumentReader` also closes the document it has just parsed when the rest of the initialization fails, attaching a close failure as a suppressed exception to the error being propagated. The exception thrown for a PDF without a TOC is otherwise unchanged, as `testPdfWithoutToc` pins.

Implementing an additional interface is source and binary compatible, and existing callers that never close a reader keep working exactly as before.

## Tests

Three tests per reader:

- `closeReleasesTheParsedDocument` — the parsed document reports open before `close()` and closed after it.
- `closeCanBeCalledMoreThanOnce` — the second `close()` does not throw.
- `readsAllDocumentsInsideTryWithResources` / `readsAllParagraphsInsideTryWithResources` — reading inside a try-with-resources block returns the same documents and leaves the parsed document closed.

The four assertions that check the document state were confirmed to fail against a `close()` that does not release the document. The module suite runs 47 tests with 0 failures (`./mvnw -pl document-readers/spring-ai-pdf-document-reader clean package`, cache disabled so checkstyle and the formatter run).

The two reference documentation examples now use try-with-resources, and each PDF reader section notes that the reader holds the parsed PDF until it is closed.
