### PR TITLE
Fix Neo4j chat memory index properties

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/main/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryConfig.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/main/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryConfig.java
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
  *
  * @author Enrico Rampazzo
  * @author Soby Chacko
+ * @author chabinhwang
  */
 public final class Neo4jChatMemoryRepositoryConfig {
 
@@ -117,21 +118,21 @@ public final class Neo4jChatMemoryRepositoryConfig {
 	}
 
 	/**
-	 * Ensures that indexes exist on conversationId for Session nodes and index for
-	 * Message nodes. This improves query performance for lookups and ordering.
+	 * Ensures that indexes exist on the properties the repository queries: {@code id} on
+	 * Session nodes, which every conversation is looked up and merged by, and {@code idx}
+	 * on Message nodes, which the messages of a conversation are ordered by.
 	 */
 	private void ensureIndexes() {
 		try (var session = this.driver.session()) {
-			// Index for conversationId on Session nodes
-			String sessionIndexCypher = String.format(
-					"CREATE INDEX session_conversation_id_index IF NOT EXISTS FOR (n:%s) ON (n.conversationId)",
-					this.sessionLabel);
-			// Index for index on Message nodes
+			// Index for id on Session nodes
+			String sessionIndexCypher = String
+				.format("CREATE INDEX session_id_index IF NOT EXISTS FOR (n:%s) ON (n.id)", this.sessionLabel);
+			// Index for idx on Message nodes
 			String messageIndexCypher = String
-				.format("CREATE INDEX message_index_index IF NOT EXISTS FOR (n:%s) ON (n.index)", this.messageLabel);
+				.format("CREATE INDEX message_idx_index IF NOT EXISTS FOR (n:%s) ON (n.idx)", this.messageLabel);
 			session.run(sessionIndexCypher);
 			session.run(messageIndexCypher);
-			logger.info("Ensured Neo4j indexes for conversationId and message index.");
+			logger.info("Ensured Neo4j indexes for session id and message idx.");
 		}
 		catch (Exception e) {
 			if (logger.isWarnEnabled()) {

--- a/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4JChatMemoryRepositoryConfigIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4JChatMemoryRepositoryConfigIT.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.chat.memory.repository.neo4j;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
@@ -29,6 +32,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.Value;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -40,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Integration tests for {@link Neo4jChatMemoryRepositoryConfig}.
  *
  * @author Soby Chacko
+ * @author chabinhwang
  */
 @Testcontainers
 class Neo4JChatMemoryRepositoryConfigIT {
@@ -64,26 +69,22 @@ class Neo4JChatMemoryRepositoryConfigIT {
 	@Test
 	void shouldCreateRequiredIndexes() {
 		// Given
-		Neo4jChatMemoryRepositoryConfig config = Neo4jChatMemoryRepositoryConfig.builder().withDriver(driver).build();
+		Neo4jChatMemoryRepositoryConfig.builder().withDriver(driver).build();
 		// When
+		Map<String, List<String>> indexedProperties = new HashMap<>();
 		try (Session session = driver.session()) {
 			Result result = session.run("SHOW INDEXES");
-			boolean sessionIndexFound = false;
-			boolean messageIndexFound = false;
 			while (result.hasNext()) {
 				var record = result.next();
-				String name = record.get("name").asString();
-				if ("session_conversation_id_index".equals(name)) {
-					sessionIndexFound = true;
-				}
-				if ("message_index_index".equals(name)) {
-					messageIndexFound = true;
-				}
+				Value properties = record.get("properties");
+				indexedProperties.put(record.get("name").asString(),
+						properties.isNull() ? List.of() : properties.asList(Value::asString));
 			}
-			// Then
-			assertThat(sessionIndexFound).isTrue();
-			assertThat(messageIndexFound).isTrue();
 		}
+		// Then the indexes cover the properties the repository queries: Session nodes are
+		// matched by id, Message nodes are ordered by idx.
+		assertThat(indexedProperties).containsEntry("session_id_index", List.of("id"))
+			.containsEntry("message_idx_index", List.of("idx"));
 	}
 
 	@Test

--- a/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryConfigTests.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryConfigTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.neo4j;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the indexes {@link Neo4jChatMemoryRepositoryConfig} creates.
+ *
+ * @author chabinhwang
+ */
+class Neo4jChatMemoryRepositoryConfigTests {
+
+	@Test
+	void indexesThePropertiesTheRepositoryQueries() {
+
+		Session session = mock(Session.class);
+		Driver driver = mock(Driver.class);
+		given(driver.session()).willReturn(session);
+
+		Neo4jChatMemoryRepositoryConfig.builder().withDriver(driver).build();
+
+		// Sessions are looked up and merged by id, messages are ordered by idx.
+		assertThat(indexStatements(session)).satisfiesExactly(
+				sessionIndex -> assertThat(sessionIndex).contains("CREATE INDEX session_id_index")
+					.contains("FOR (n:Session) ON (n.id)"),
+				messageIndex -> assertThat(messageIndex).contains("CREATE INDEX message_idx_index")
+					.contains("FOR (n:Message) ON (n.idx)"));
+	}
+
+	@Test
+	void indexesTheConfiguredLabels() {
+
+		Session session = mock(Session.class);
+		Driver driver = mock(Driver.class);
+		given(driver.session()).willReturn(session);
+
+		Neo4jChatMemoryRepositoryConfig.builder()
+			.withDriver(driver)
+			.withSessionLabel("ChatSession")
+			.withMessageLabel("ChatMessage")
+			.build();
+
+		assertThat(indexStatements(session)).satisfiesExactly(
+				sessionIndex -> assertThat(sessionIndex).contains("FOR (n:ChatSession) ON (n.id)"),
+				messageIndex -> assertThat(messageIndex).contains("FOR (n:ChatMessage) ON (n.idx)"));
+	}
+
+	private static Iterable<String> indexStatements(Session session) {
+		ArgumentCaptor<String> statements = ArgumentCaptor.forClass(String.class);
+		verify(session, times(2)).run(statements.capture());
+		return statements.getAllValues();
+	}
+
+}


### PR DESCRIPTION
## Problem

`Neo4jChatMemoryRepositoryConfig` creates two indexes at startup:

```java
"CREATE INDEX session_conversation_id_index IF NOT EXISTS FOR (n:Session) ON (n.conversationId)"
"CREATE INDEX message_index_index IF NOT EXISTS FOR (n:Message) ON (n.index)"
```

Neither property is ever written by `Neo4jChatMemoryRepository`:

- Sessions are created and matched as `MERGE (s:Session {id:$conversationId})` / `MATCH (s:Session {id:$conversationId})`, and `findConversationIds` returns `conversation.id`. The property is `id`, not `conversationId`.
- Messages are written with `SET msg.idx = totalMsg + 1` and read back `ORDER BY m.idx ASC`. The property is `idx`, not `index`.

Both indexes therefore cover a property that no node has. They stay empty, and `findByConversationId`, `saveAll` and `deleteByConversationId` — which all start by matching a `Session` by its id — fall back to a label scan over every session in the database. It is invisible on a handful of conversations and grows linearly with the number of stored conversations.

## Fix

The indexes are created on `Session.id` and `Message.idx`.

They are also renamed to `session_id_index` and `message_idx_index`. This matters for existing deployments: `CREATE INDEX ... IF NOT EXISTS` is a no-op when an index with the same name already exists, so keeping the old names would silently skip creation and leave those databases with the old, empty index. The empty index left behind by earlier versions is harmless — no node carries the property, so it indexes nothing — and can be removed with `DROP INDEX session_conversation_id_index IF EXISTS` and `DROP INDEX message_index_index IF EXISTS`.

## Tests

`Neo4JChatMemoryRepositoryConfigIT.shouldCreateRequiredIndexes` only checked that indexes with those two names existed, which is why the properties could drift away from the queries unnoticed. It now reads `properties` from `SHOW INDEXES` and asserts the indexed property of each index.

`Neo4jChatMemoryRepositoryConfigTests` is new and covers the same guarantee without a database, by capturing the statements issued against a mocked driver: the session index is on the label's `id`, the message index on `idx`, and both follow the configured labels. Both tests fail against the previous statements and pass with the fix (`./mvnw -pl memory-repositories/spring-ai-model-chat-memory-repository-neo4j clean package`, build cache disabled so checkstyle and the formatter run).

The integration test requires a Neo4j container and was not run locally.
