### PR TITLE
fix: serialize Bedrock tool-use input as proper JSON instead of Document.toString()

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -673,7 +673,8 @@ public class BedrockProxyChatModel implements ChatModel {
 
 				var functionCallId = toolUseContentBlock.toolUse().toolUseId();
 				var functionName = toolUseContentBlock.toolUse().name();
-				var functionArguments = toolUseContentBlock.toolUse().input().toString();
+				var functionArguments = jsonHelper
+					.toJson(ConverseApiUtils.convertDocumentToObject(toolUseContentBlock.toolUse().input()));
 
 				toolCalls
 					.add(new AssistantMessage.ToolCall(functionCallId, "function", functionName, functionArguments));

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.core.document.Document;
 
 /**
@@ -75,6 +76,39 @@ public final class ConverseApiUtils {
 		}
 		else {
 			throw new IllegalArgumentException("Unsupported value type:" + value.getClass().getSimpleName());
+		}
+	}
+
+	/**
+	 * Convert an AWS SDK {@link Document} back into a plain Java value. This is the
+	 * inverse of {@link #convertObjectToDocument(Object)}: null maps to null, STRING to
+	 * String, NUMBER to {@link BigDecimal}, BOOLEAN to Boolean, LIST to List and MAP to
+	 * Map.
+	 */
+	public static @Nullable Object convertDocumentToObject(Document value) {
+		if (value == null || value.isNull()) {
+			return null;
+		}
+		else if (value.isString()) {
+			return value.asString();
+		}
+		else if (value.isBoolean()) {
+			return value.asBoolean();
+		}
+		else if (value.isNumber()) {
+			return value.asNumber().bigDecimalValue();
+		}
+		else if (value.isList()) {
+			return value.asList().stream().map(ConverseApiUtils::convertDocumentToObject).toList();
+		}
+		else if (value.isMap()) {
+			return value.asMap()
+				.entrySet()
+				.stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, e -> convertDocumentToObject(e.getValue())));
+		}
+		else {
+			throw new IllegalArgumentException("Unsupported document type:" + value.getClass().getSimpleName());
 		}
 	}
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -18,6 +18,7 @@ package org.springframework.ai.bedrock.converse;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
@@ -26,31 +27,42 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ConversationRole;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseOutput;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
 import software.amazon.awssdk.services.bedrockruntime.model.Message;
+import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
 import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 import software.amazon.awssdk.services.bedrockruntime.model.Tool;
+import software.amazon.awssdk.services.bedrockruntime.model.ToolUseBlock;
 
 import org.springframework.ai.bedrock.converse.api.BedrockCacheOptions;
 import org.springframework.ai.bedrock.converse.api.BedrockCacheStrategy;
 import org.springframework.ai.bedrock.converse.api.BedrockCacheTtl;
 import org.springframework.ai.bedrock.converse.api.MediaFetcher;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.ai.util.JsonHelper;
 import org.springframework.util.MimeType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -413,6 +425,52 @@ class BedrockProxyChatModelTest {
 		assertThat(tools.get(1).cachePoint()).isNotNull();
 		assertThat(tools.get(1).cachePoint().typeAsString()).isEqualTo("default");
 		assertThat(tools.get(1).cachePoint().ttlAsString()).isEqualTo("1h");
+	}
+
+	// -------------------------------------------------------------------------
+	// Tool-use arguments serialization (gh-6962)
+	// -------------------------------------------------------------------------
+
+	@Test
+	void toolUseArgumentsWithControlCharactersRoundTripAsValidJson() {
+		BedrockProxyChatModel model = newModel();
+
+		String multilineLocation = "Paris\nÎle-de-France\tFrance";
+		Document toolInput = Document.fromMap(
+				Map.of("location", Document.fromString(multilineLocation), "unit", Document.fromString("celsius")));
+		ConverseResponse toolUseResponse = converseResponse(ContentBlock.builder()
+			.toolUse(ToolUseBlock.builder().toolUseId("toolu-1").name("getCurrentWeather").input(toolInput).build())
+			.build(), StopReason.TOOL_USE);
+
+		when(this.syncClient.converse(any(ConverseRequest.class))).thenReturn(toolUseResponse);
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("What's the weather?")),
+				BedrockChatOptions.builder().build());
+
+		ChatResponse response = model.call(prompt);
+
+		AssistantMessage.ToolCall toolCall = response.getResults()
+			.stream()
+			.map(org.springframework.ai.chat.model.Generation::getOutput)
+			.filter(output -> !output.getToolCalls().isEmpty())
+			.findFirst()
+			.orElseThrow()
+			.getToolCalls()
+			.get(0);
+		assertThat(toolCall.name()).isEqualTo("getCurrentWeather");
+		Map<String, Object> arguments = new JsonHelper().fromJsonToMap(toolCall.arguments());
+		assertThat(arguments.get("location")).isEqualTo(multilineLocation);
+		assertThat(arguments.get("unit")).isEqualTo("celsius");
+	}
+
+	private ConverseResponse converseResponse(ContentBlock contentBlock, StopReason stopReason) {
+		return ConverseResponse.builder()
+			.output(ConverseOutput.builder()
+				.message(Message.builder().role(ConversationRole.ASSISTANT).content(List.of(contentBlock)).build())
+				.build())
+			.stopReason(stopReason)
+			.usage(TokenUsage.builder().inputTokens(1).outputTokens(1).totalTokens(2).build())
+			.build();
 	}
 
 	// -------------------------------------------------------------------------

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtilsTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.bedrock.converse.api;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.document.Document;
+
+import org.springframework.ai.util.JsonHelper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConverseApiUtils#convertDocumentToObject(Document)}.
+ */
+class ConverseApiUtilsTests {
+
+	private final JsonHelper jsonHelper = new JsonHelper();
+
+	@Test
+	void convertDocumentToObjectReturnsNullForNullOrNullDocument() {
+		assertThat(ConverseApiUtils.convertDocumentToObject(null)).isNull();
+		assertThat(ConverseApiUtils.convertDocumentToObject(Document.fromNull())).isNull();
+	}
+
+	@Test
+	void convertDocumentToObjectMapsScalarValues() {
+		assertThat(ConverseApiUtils.convertDocumentToObject(Document.fromString("hello"))).isEqualTo("hello");
+		assertThat(ConverseApiUtils.convertDocumentToObject(Document.fromBoolean(true))).isEqualTo(true);
+		assertThat(ConverseApiUtils.convertDocumentToObject(Document.fromNumber(42))).isEqualTo(new BigDecimal(42));
+	}
+
+	@Test
+	void convertDocumentToObjectMapsListsAndMapsRecursively() {
+		Document document = Document
+			.fromMap(Map.of("items", Document.fromList(List.of(Document.fromString("a"), Document.fromNumber(1)))));
+
+		Object converted = ConverseApiUtils.convertDocumentToObject(document);
+
+		assertThat(converted).isEqualTo(Map.of("items", List.of("a", new BigDecimal(1))));
+	}
+
+	@Test
+	void documentRoundTripPreservesControlCharactersInStringValues() {
+		Map<String, Object> input = new LinkedHashMap<>();
+		input.put("text", "line1\nline2\twith tab");
+		input.put("nested", Map.of("list", List.of("a\nb", "c")));
+
+		Document document = ConverseApiUtils.convertObjectToDocument(input);
+		Object converted = ConverseApiUtils.convertDocumentToObject(document);
+
+		assertThat(converted).isEqualTo(input);
+
+		// The serialized form must be valid JSON: control characters escaped, not raw.
+		String json = this.jsonHelper.toJson(converted);
+		assertThat(json).doesNotContain("\n").doesNotContain("\t");
+		assertThat(this.jsonHelper.fromJsonToMap(json)).isEqualTo(input);
+	}
+
+}


### PR DESCRIPTION
Closes gh-6962 (https://github.com/spring-projects/spring-ai/issues/6962)

`BedrockProxyChatModel` serialized tool-use input via the AWS SDK `Document.toString()`, which does not escape control characters. Tool arguments containing a newline were stored as invalid JSON in `AssistantMessage.ToolCall#arguments` and failed to parse during tool execution (`Illegal unquoted character ((CTRL-CHAR, code 10))` with Jackson 3).

This adds the inverse converter `ConverseApiUtils.convertDocumentToObject(Document)` and serializes the input with `jsonHelper.toJson(...)`, symmetric with the existing request path `convertObjectToDocument`. Numbers are restored as `BigDecimal`, mirroring `SdkNumber`.

How I verified: the model-level regression test (`toolUseArgumentsWithControlCharactersRoundTripAsValidJson`) reproduces the exact `Illegal unquoted character` failure against the current code and passes with this fix; new `ConverseApiUtilsTests` cover the converter round-trip including control characters, lists and maps. `mvn test` on the module: 27/27 passing.