### PR TITLE
Cache MCP annotation scans by target class

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessor.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessor.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.mcp.annotation.spring.scan;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
@@ -33,6 +35,8 @@ public abstract class AbstractAnnotatedMethodBeanPostProcessor extends Annotated
 
 	private final AbstractMcpAnnotatedBeans registry;
 
+	private final Map<Class<?>, Set<Class<? extends Annotation>>> annotationCache = new ConcurrentHashMap<>();
+
 	public AbstractAnnotatedMethodBeanPostProcessor(AbstractMcpAnnotatedBeans registry,
 			Set<Class<? extends Annotation>> targetAnnotations) {
 		super(targetAnnotations);
@@ -44,7 +48,7 @@ public abstract class AbstractAnnotatedMethodBeanPostProcessor extends Annotated
 	@Override
 	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 		Class<?> beanClass = AopUtils.getTargetClass(bean); // Handle proxied beans
-		Set<Class<? extends Annotation>> foundAnnotations = scan(beanClass);
+		Set<Class<? extends Annotation>> foundAnnotations = this.annotationCache.computeIfAbsent(beanClass, this::scan);
 		// Register the bean if it has any of our target annotations
 		if (!foundAnnotations.isEmpty()) {
 			this.registry.addMcpAnnotatedBean(bean, foundAnnotations);

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessorTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessorTests.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -141,6 +142,30 @@ class AbstractAnnotatedMethodBeanPostProcessorTests {
 		Set<Class<? extends java.lang.annotation.Annotation>> capturedAnnotations = annotationsCaptor.getValue();
 		assertEquals(1, capturedAnnotations.size());
 		assertTrue(capturedAnnotations.contains(TestAnnotation.class));
+	}
+
+	@Test
+	void scansUnannotatedClassOnlyOnce() {
+		var processor = spy(this.processor);
+		for (int i = 0; i < 100; i++) {
+			NoAnnotationBean bean = new NoAnnotationBean();
+			assertSame(bean, processor.postProcessAfterInitialization(bean, "prototypeBean"));
+		}
+		verify(processor).scan(NoAnnotationBean.class);
+		verify(this.registry, never()).addMcpAnnotatedBean(any(), any());
+	}
+
+	@Test
+	void cachesAnnotationsWhileRegisteringEachBeanInstance() {
+		var processor = spy(this.processor);
+		AnnotatedBean first = new AnnotatedBean();
+		AnnotatedBean second = new AnnotatedBean();
+		processor.postProcessAfterInitialization(first, "first");
+		processor.postProcessAfterInitialization(second, "second");
+
+		verify(processor).scan(AnnotatedBean.class);
+		verify(this.registry).addMcpAnnotatedBean(same(first), any());
+		verify(this.registry).addMcpAnnotatedBean(same(second), any());
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Reuse annotation discovery results for repeated bean classes while preserving registration of each annotated bean instance.

Fixes #6961

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc