### PR TITLE
Align augmented tool schema defaults

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/augment/ToolInputSchemaAugmenter.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/augment/ToolInputSchemaAugmenter.java
@@ -43,7 +43,8 @@ public final class ToolInputSchemaAugmenter {
 	/**
 	 * Extracts the tool argument types from a record class annotated with
 	 * {@link ToolParam}. It retrieves the field names, types, descriptions, and required
-	 * status from the record components.
+	 * status from the record components. Components are required by default and have no
+	 * description unless specified with {@link ToolParam}.
 	 * @param recordClass The record class to extract argument types from.
 	 * @return A list of {@link AugmentedArgumentType} representing the tool input
 	 * argument types.
@@ -64,8 +65,7 @@ public final class ToolInputSchemaAugmenter {
 				}
 
 				return new AugmentedArgumentType(c.getName(), c.getGenericType(),
-						toolParam != null ? toolParam.description() : "no description",
-						toolParam != null ? toolParam.required() : false);
+						toolParam != null ? toolParam.description() : "", toolParam == null || toolParam.required());
 			}).toList();
 
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/augment/ToolInputSchemaAugmenterTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/augment/ToolInputSchemaAugmenterTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.util.json.schema.JsonSchemaGenerator;
 import org.springframework.ai.tool.augment.ToolInputSchemaAugmenter.AugmentedArgumentType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,6 +59,25 @@ class ToolInputSchemaAugmenterTest {
 
 	public record MixedAnnotationsRecord(@ToolParam(description = "Annotated field", required = true) String annotated,
 			String notAnnotated) {
+	}
+
+	public record DefaultPolicyRecord(String plain, @ToolParam(description = "Annotated field") String annotated,
+			@ToolParam(required = false) String optional) {
+	}
+
+	@Test
+	void generatedAndAugmentedSchemasUseTheSameDefaults() {
+		JsonMapper mapper = new JsonMapper();
+		JsonNode generated = mapper.readTree(JsonSchemaGenerator.generateForType(DefaultPolicyRecord.class));
+		JsonNode augmented = mapper.readTree(ToolInputSchemaAugmenter.augmentToolInputSchema("{}",
+				ToolInputSchemaAugmenter.toAugmentedArgumentTypes(DefaultPolicyRecord.class)));
+
+		for (String field : List.of("plain", "annotated", "optional")) {
+			assertEquals(generated.path("properties").path(field).get("description"),
+					augmented.path("properties").path(field).get("description"));
+			assertEquals(generated.path("required").valueStream().anyMatch(node -> field.equals(node.asString())),
+					augmented.path("required").valueStream().anyMatch(node -> field.equals(node.asString())));
+		}
 	}
 
 	@Nested
@@ -150,8 +170,8 @@ class ToolInputSchemaAugmenterTest {
 			assertEquals(2, argumentTypes.size());
 
 			for (AugmentedArgumentType argType : argumentTypes) {
-				assertEquals("no description", argType.description());
-				assertFalse(argType.required());
+				assertEquals("", argType.description());
+				assertTrue(argType.required());
 			}
 		}
 
@@ -174,8 +194,8 @@ class ToolInputSchemaAugmenterTest {
 				.filter(arg -> "notAnnotated".equals(arg.name()))
 				.findFirst()
 				.orElseThrow();
-			assertEquals("no description", notAnnotatedArg.description());
-			assertFalse(notAnnotatedArg.required());
+			assertEquals("", notAnnotatedArg.description());
+			assertTrue(notAnnotatedArg.required());
 		}
 
 		@Test


### PR DESCRIPTION
Require unannotated record components and omit placeholder descriptions.

Fixes #6944

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc