### PR TITLE
Avoid calling multiple times the model to retrieve tool calls to perform while using structured output validation

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
@@ -60,6 +60,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christian Tzolov
  * @author Jewoo Shin
+ * @author Nicolas Krier
  */
 public final class StructuredOutputValidationAdvisor implements CallAdvisor, StreamAdvisor {
 
@@ -121,15 +122,15 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		Assert.notNull(chatClientRequest, "chatClientRequest must not be null");
 
 		ChatClientResponse chatClientResponse = null;
-
-		boolean isValidationSuccess = false;
-
+		var isValidationSuccess = false;
+		var hasToolCalls = false;
 		var processedChatClientRequest = chatClientRequest;
+		var usageAccumulator = new UsageAccumulator();
 
-		UsageAccumulator usageAccumulator = new UsageAccumulator();
-
-		for (var currentAttemptNumber = 1 + this.maxRepeatAttempts; currentAttemptNumber > 0
-				&& !isValidationSuccess; currentAttemptNumber--) {
+		// We should not perform several attempts if there is a validation success or if
+		// there are tool calls.
+		for (var currentAttemptNumber = 1 + this.maxRepeatAttempts; currentAttemptNumber > 0 && !isValidationSuccess
+				&& !hasToolCalls; currentAttemptNumber--) {
 			// Next Call
 			chatClientResponse = callAdvisorChain.copy(this).nextCall(processedChatClientRequest);
 
@@ -137,9 +138,15 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 			ChatResponse chatResponse = chatClientResponse.chatResponse();
 			usageAccumulator.addRoundResponse(chatResponse);
 
+			hasToolCalls = chatResponse != null && chatResponse.hasToolCalls();
+
+			if (hasToolCalls && logger.isDebugEnabled()) {
+				logger.debug("ChatResponse has tool calls.");
+			}
+
 			// We should not validate tool call requests, only the content of the final
 			// response.
-			if (chatResponse == null || !chatResponse.hasToolCalls()) {
+			if (chatResponse == null || !hasToolCalls) {
 				SchemaValidation validationResponse = validateOutputSchema(chatClientResponse,
 						currentAttemptNumber - 1);
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.when;
  *
  * @author Christian Tzolov
  * @author Jewoo Shin
+ * @author Nicolas Krier
  */
 @ExtendWith(MockitoExtension.class)
 class StructuredOutputValidationAdvisorTests {
@@ -876,6 +877,30 @@ class StructuredOutputValidationAdvisorTests {
 		assertThat(advisor.getName()).isEqualTo("Structured Output Validation Advisor");
 	}
 
+	@Test
+	void testNoRetryWithToolCallsResponse() {
+		var chatClientRequest = createMockRequest();
+		var assistantMessage = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("id", "type", "name", "arguments")))
+			.build();
+		var chatClientResponse = createResponse(assistantMessage, new DefaultUsage(1, 2, 3));
+
+		var advisor = StructuredOutputValidationAdvisor.builder().outputType(Person.class).build();
+		int[] callCount = { 0 };
+		var terminalAdvisor = terminalAdvisor((request, chain) -> {
+			callCount[0]++;
+			return chatClientResponse;
+		});
+
+		var callChainAdvisor = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		var chainedChatClientResponse = callChainAdvisor.nextCall(chatClientRequest);
+		assertThat(callCount[0]).isOne();
+		assertThat(chainedChatClientResponse).isEqualTo(chatClientResponse);
+	}
+
 	// Helper methods
 
 	private ChatClientRequest createMockRequest() {
@@ -895,7 +920,10 @@ class StructuredOutputValidationAdvisorTests {
 	}
 
 	private ChatClientResponse createResponse(String jsonOutput, Usage usage) {
-		AssistantMessage assistantMessage = new AssistantMessage(jsonOutput);
+		return createResponse(new AssistantMessage(jsonOutput), usage);
+	}
+
+	private ChatClientResponse createResponse(AssistantMessage assistantMessage, Usage usage) {
 		Generation generation = new Generation(assistantMessage);
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().usage(usage).build();
 		ChatResponse chatResponse = ChatResponse.builder().generations(List.of(generation)).metadata(metadata).build();


### PR DESCRIPTION
## Description

I noticed that the model is called repeatedly on each structured output validation attempt even when the response already contains tool calls to perform. In this scenario, a single call suffices, so this change stops the retry loop as soon as the response contains tool calls.

## Reproduction

I performed some successful tests of these changes with my [tools example](https://github.com/nicolaskrier/spring-ai-examples/tree/main/tools-example) by using Mistral AI and Ollama model providers. You can find below screenshots of what I observed on Phoenix.

### Behavior of my tools example before the fix

<img width="1728" height="1007" alt="Screenshot 2026-09-12 at 17 23 05" src="https://github.com/user-attachments/assets/1e12c182-0a4f-4d53-9bcf-b0809ed24fe7" />

### Behavior of my tools example after the fix

<img width="1728" height="1007" alt="Screenshot 2026-09-12 at 18 24 49" src="https://github.com/user-attachments/assets/a6e77901-b970-43ce-b030-023196111b4f" />

## Testing

I added a unit test in `StructuredOutputValidationAdvisorTests` class.

## Notes

It could be worth testing with other model providers.